### PR TITLE
SyntaxGenerator: check for nodes in trivia

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2973,31 +2973,38 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 return this.RemoveNode(root, declaration);
             }
 
-            var newFullDecl = this.AsIsolatedDeclaration(newDeclaration);
-            var fullDecl = this.GetFullDeclaration(declaration);
-
-            // special handling for replacing at location of sub-declaration
-            if (fullDecl != declaration)
+            if (root.Span.Contains(declaration.Span))
             {
-                // try to replace inline if possible
-                if (fullDecl.IsKind(newFullDecl.Kind()) && GetDeclarationCount(newFullDecl) == 1)
+                var newFullDecl = this.AsIsolatedDeclaration(newDeclaration);
+                var fullDecl = this.GetFullDeclaration(declaration);
+
+                // special handling for replacing at location of sub-declaration
+                if (fullDecl != declaration)
                 {
-                    var newSubDecl = this.GetSubDeclarations(newFullDecl)[0];
-                    if (AreInlineReplaceableSubDeclarations(declaration, newSubDecl))
+                    // try to replace inline if possible
+                    if (fullDecl.IsKind(newFullDecl.Kind()) && GetDeclarationCount(newFullDecl) == 1)
                     {
-                        return base.ReplaceNode(root, declaration, newSubDecl);
+                        var newSubDecl = this.GetSubDeclarations(newFullDecl)[0];
+                        if (AreInlineReplaceableSubDeclarations(declaration, newSubDecl))
+                        {
+                            return base.ReplaceNode(root, declaration, newSubDecl);
+                        }
                     }
+
+                    // replace sub declaration by splitting full declaration and inserting between
+                    var index = IndexOf(this.GetSubDeclarations(fullDecl), declaration);
+
+                    // replace declaration with multiple declarations
+                    return ReplaceRange(root, fullDecl, this.SplitAndReplace(fullDecl, index, new[] { newDeclaration }));
                 }
 
-                // replace sub declaration by splitting full declaration and inserting between
-                var index = IndexOf(this.GetSubDeclarations(fullDecl), declaration);
-
-                // replace declaration with multiple declarations
-                return ReplaceRange(root, fullDecl, this.SplitAndReplace(fullDecl, index, new[] { newDeclaration }));
+                // attempt normal replace
+                return base.ReplaceNode(root, declaration, newFullDecl);
             }
-
-            // attempt normal replace
-            return base.ReplaceNode(root, declaration, newFullDecl);
+            else
+            {
+                return base.ReplaceNode(root, declaration, newDeclaration);
+            }
         }
 
         // returns true if one sub-declaration can be replaced inline with another sub-declaration
@@ -3098,7 +3105,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNodesBefore(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
         {
-            return Isolate(root.TrackNodes(declaration), r => InsertNodesBeforeInternal(r, r.GetCurrentNode(declaration), newDeclarations));
+            if (root.Span.Contains(declaration.Span))
+            {
+                return Isolate(root.TrackNodes(declaration), r => InsertNodesBeforeInternal(r, r.GetCurrentNode(declaration), newDeclarations));
+            }
+            else
+            {
+                return base.InsertNodesBefore(root, declaration, newDeclarations);
+            }
         }
 
         private SyntaxNode InsertNodesBeforeInternal(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
@@ -3124,7 +3138,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNodesAfter(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
         {
-            return Isolate(root.TrackNodes(declaration), r => InsertNodesAfterInternal(r, r.GetCurrentNode(declaration), newDeclarations));
+            if (root.Span.Contains(declaration.Span))
+            {
+                return Isolate(root.TrackNodes(declaration), r => InsertNodesAfterInternal(r, r.GetCurrentNode(declaration), newDeclarations));
+            }
+            else
+            {
+                return base.InsertNodesAfter(root, declaration, newDeclarations);
+            }
         }
 
         private SyntaxNode InsertNodesAfterInternal(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
@@ -3182,9 +3203,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        public override SyntaxNode RemoveNode(SyntaxNode root, SyntaxNode declaration)
+        public override SyntaxNode RemoveNode(SyntaxNode root, SyntaxNode node)
         {
-            return this.Isolate(root.TrackNodes(declaration), r => RemoveNodeInternal(r, r.GetCurrentNode(declaration)));
+            if (root.Span.Contains(node.Span))
+            {
+                // node exists within normal span of the root (not in trivia)
+                return this.Isolate(root.TrackNodes(node), r => RemoveNodeInternal(r, r.GetCurrentNode(node)));
+            }
+            else
+            {
+                return RemoveNodeInternal(root, node);
+            }
         }
 
         private SyntaxNode RemoveNodeInternal(SyntaxNode root, SyntaxNode declaration)

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -44,6 +44,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editting
             Assert.Equal(expectedText, normalized);
         }
 
+        private void VerifySyntaxRaw<TSyntax>(SyntaxNode node, string expectedText) where TSyntax : SyntaxNode
+        {
+            Assert.IsAssignableFrom(typeof(TSyntax), node);
+            var normalized = node.ToFullString();
+            Assert.Equal(expectedText, normalized);
+        }
+
         #region Expressions and Statements
         [Fact]
         public void TestLiteralExpressions()
@@ -1549,6 +1556,101 @@ public class C { } // end").Members[0];
         {
             var newDecl = _g.RemoveNode(declaration, _g.GetNamespaceImports(declaration).First(m => _g.GetName(m) == name));
             AssertNamesEqual(remainingNames, _g.GetNamespaceImports(newDecl));
+        }
+
+        [Fact]
+        public void TestRemoveNodeInTrivia()
+        {
+            var code = @"
+///<summary> ... </summary>
+public class C
+{
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+            var summary = cls.DescendantNodes(descendIntoTrivia: true).OfType<XmlElementSyntax>().First();
+
+            var newCu = _g.RemoveNode(cu, summary);
+
+            VerifySyntaxRaw<CompilationUnitSyntax>(
+                newCu,
+                @"
+
+public class C
+{
+}");
+        }
+
+        [Fact]
+        public void TestReplaceNodeInTrivia()
+        {
+            var code = @"
+///<summary> ... </summary>
+public class C
+{
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+            var summary = cls.DescendantNodes(descendIntoTrivia: true).OfType<XmlElementSyntax>().First();
+
+            var summary2 = summary.WithContent(default(SyntaxList<XmlNodeSyntax>));
+
+            var newCu = _g.ReplaceNode(cu, summary, summary2);
+
+            VerifySyntaxRaw<CompilationUnitSyntax>(
+                newCu, @"
+///<summary></summary>
+public class C
+{
+}");
+        }
+
+        [Fact]
+        public void TestInsertAfterNodeInTrivia()
+        {
+            var code = @"
+///<summary> ... </summary>
+public class C
+{
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+            var text = cls.DescendantNodes(descendIntoTrivia: true).OfType<XmlTextSyntax>().First();
+
+            var newCu = _g.InsertNodesAfter(cu, text, new SyntaxNode[] { text });
+
+            VerifySyntaxRaw<CompilationUnitSyntax>(
+                newCu, @"
+///<summary> ...  ... </summary>
+public class C
+{
+}");
+        }
+
+        [Fact]
+        public void TestInsertBeforeNodeInTrivia()
+        {
+            var code = @"
+///<summary> ... </summary>
+public class C
+{
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+            var text = cls.DescendantNodes(descendIntoTrivia: true).OfType<XmlTextSyntax>().First();
+
+            var newCu = _g.InsertNodesBefore(cu, text, new SyntaxNode[] { text });
+
+            VerifySyntaxRaw<CompilationUnitSyntax>(
+                newCu, @"
+///<summary> ...  ... </summary>
+public class C
+{
+}");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #3887

Add special case for nodes that are actually part of the root's trivia for SyntaxGenerator methods RemoveNode, ReplaceNode, InsertNodesAfter and InsertNodesBefore.  If the node is part of the trivia, then the implementation falls back to the node's own implementation which doesn't try to remove/add trivia across the operation.

@Pilchie @jasonmalinowski @DustinCampbell @rchande @dpoeschl @CyrusNajmabadi  please review
