### PR TITLE
Remove constraints for private interface method implementations

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -357,7 +357,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return PreserveTrivia(declaration, d =>
             {
                 d = AsImplementation(d, Accessibility.Public);
-                d = WithoutConstraints(d);
 
                 if (interfaceMemberName != null)
                 {
@@ -366,18 +365,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
                 return WithInterfaceSpecifier(d, null);
             });
-        }
-
-        public interface Foo
-        {
-            void Moo<T>() where T : IEnumerable<T>;
-        }
-
-        public class Bar : Foo
-        {
-            public void Moo<T>() where T : IEnumerable<T>
-            {
-            }
         }
 
         public override SyntaxNode AsPrivateInterfaceImplementation(SyntaxNode declaration, SyntaxNode interfaceTypeName, string interfaceMemberName)

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -926,6 +926,27 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
                 "t i2.m2()\r\n{\r\n}");
         }
 
+        [WorkItem(3928, "https://github.com/dotnet/roslyn/issues/3928")]
+        [Fact]
+        public void TestAsPrivateInterfaceImplementationRemovesConstraints()
+        {
+            var code = @"
+public interface IFace
+{
+    void Method<T>() where T : class;
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var iface = cu.Members[0];
+            var method = _g.GetMembers(iface)[0];
+
+            var privateMethod = _g.AsPrivateInterfaceImplementation(method, _g.IdentifierName("IFace"));
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                privateMethod,
+                "void IFace.Method<T>()\r\n{\r\n}");
+        }
+
         [Fact]
         public void TestClassDeclarations()
         {


### PR DESCRIPTION
Fix for #3928

C# explicit interface implementations cannot specify constraints. This changes makes it so any method declaration being converted to a explicit implementation via AsPrivateInterfaceImplementation has any/all constraints removed.

@Pilchie @dpoeschl @rchande @DustinCampbell @CyrusNajmabadi please review