### PR TITLE
Add default ToString to SyntaxTree

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.ParsedSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.ParsedSyntaxTree.cs
@@ -100,11 +100,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new SimpleSyntaxReference(node);
             }
 
-            public override string ToString()
-            {
-                return this.GetText(CancellationToken.None).ToString();
-            }
-
             public override SyntaxTree WithRootAndOptions(SyntaxNode root, ParseOptions options)
             {
                 if (ReferenceEquals(_root, root) && ReferenceEquals(_options, options))

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -43,6 +43,7 @@ Microsoft.CodeAnalysis.MetadataReference.MetadataReference(Microsoft.CodeAnalysi
 Microsoft.CodeAnalysis.ParseOptions.WithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
 Microsoft.CodeAnalysis.StrongNameProvider.StrongNameProvider() -> void
 abstract Microsoft.CodeAnalysis.ParseOptions.CommonWithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
+override Microsoft.CodeAnalysis.SyntaxTree.ToString() -> string
 static Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzerExtensions.WithAnalyzers(this Microsoft.CodeAnalysis.Compilation compilation, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers, Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzersOptions analysisOptions) -> Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers
 static Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetry.GetAnalyzerActionCountsAsync(this Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers compilationWithAnalyzers, Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer analyzer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetry.ActionCounts>
 static Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetry.GetAnalyzerExecutionTime(this Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers compilationWithAnalyzers, Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer analyzer) -> System.TimeSpan

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
@@ -341,5 +341,13 @@ namespace Microsoft.CodeAnalysis
         /// Returns a new tree whose <see cref="FilePath"/> is the specified node and other properties are copied from the current tree.
         /// </summary>
         public abstract SyntaxTree WithFilePath(string path);
+
+        /// <summary>
+        /// Returns a <see cref="String" /> that represents the entire source text of this <see cref="SyntaxTree"/>.
+        /// </summary>
+        public override string ToString()
+        {
+            return this.GetText(CancellationToken.None).ToString();
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.ParsedSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.ParsedSyntaxTree.vb
@@ -123,13 +123,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return New SimpleSyntaxReference(Me, node)
             End Function
 
-            ''' <summary>
-            ''' Returns a <see cref="String" /> that represents the source code of this parsed tree.
-            ''' </summary>
-            Public Overrides Function ToString() As String
-                Return Me.GetText().ToString()
-            End Function
-
             Public Overrides Function WithRootAndOptions(root As SyntaxNode, options As ParseOptions) As SyntaxTree
                 If Me._root Is root AndAlso Me._options Is options Then
                     Return Me


### PR DESCRIPTION
Fixes #3886

This change puts a default implementation of ToString in the common SyntaxTree base class, and removes the duplicate implementation in CSharp and VB syntax tree implementations.  Now all implementations get the correct default.

@DustinCampbell @Pilchie @rchande @dpoeschl @CyrusNajmabadi please review