### PR TITLE
Handle corrupted default values in metadata

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -58,9 +58,9 @@ done
 
 restore_nuget()
 {
-    curl -O https://dotnetci.blob.core.windows.net/roslyn/nuget.3.zip
-    unzip nuget.3.zip
-    rm nuget.3.zip
+    curl -O https://dotnetci.blob.core.windows.net/roslyn/nuget.4.zip
+    unzip nuget.4.zip
+    rm nuget.4.zip
 }
 
 run_msbuild()

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -874,8 +874,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(parameter.IsOptional);
             ConstantValue defaultConstantValue = parameter.ExplicitDefaultConstantValue;
             BoundExpression defaultValue;
-
             SourceLocation callerSourceLocation;
+
+            // For compatibility with the native compiler we treat all bad imported constant
+            // values as default(T).  
+            if (defaultConstantValue != null && defaultConstantValue.IsBad)
+            {
+                defaultConstantValue = ConstantValue.Null;
+            }
 
             if (parameter.IsCallerLineNumber && ((callerSourceLocation = GetCallerLocation(syntax, enableCallerInfo)) != null))
             {

--- a/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
@@ -85,7 +85,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/CommandLine/packages.config
+++ b/src/Compilers/CSharp/Test/CommandLine/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -184,7 +184,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/Emit/packages.config
+++ b/src/Compilers/CSharp/Test/Emit/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -138,7 +138,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/Semantic/packages.config
+++ b/src/Compilers/CSharp/Test/Semantic/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
@@ -50,7 +50,7 @@
   <ItemGroup Label="File References">
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection.Metadata.dll">
       <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>

--- a/src/Compilers/CSharp/Test/Symbol/packages.config
+++ b/src/Compilers/CSharp/Test/Symbol/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
+++ b/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
@@ -164,7 +164,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Compilers/CSharp/Test/Syntax/packages.config
+++ b/src/Compilers/CSharp/Test/Syntax/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/CSharp/Test/WinRT/CSharpWinRTTest.csproj
+++ b/src/Compilers/CSharp/Test/WinRT/CSharpWinRTTest.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary">
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=$(SystemCollectionsImmutableAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Compilers/CSharp/Test/WinRT/packages.config
+++ b/src/Compilers/CSharp/Test/WinRT/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -94,7 +94,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/src/Compilers/Core/CodeAnalysisTest/packages.config
+++ b/src/Compilers/Core/CodeAnalysisTest/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
@@ -93,7 +93,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/src/Compilers/Core/MSBuildTaskTests/packages.config
+++ b/src/Compilers/Core/MSBuildTaskTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Core/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -113,7 +113,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/src/Compilers/Core/VBCSCompilerTests/packages.config
+++ b/src/Compilers/Core/VBCSCompilerTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -3104,50 +3104,51 @@ ProduceBoundNode:
                     End If
                 End If
 
-                ' Only consider optional parameters when the constant value is good.  Bad constant values are ignored and result in an 
-                ' argument mismatch error.
-                If Not defaultConstantValue.IsBad Then
+                ' For compatibility with the native compiler bad metadata constants should be treated as default(T).  This 
+                ' is a possible outcome of running an obfuscator over a valid DLL 
+                If defaultConstantValue.IsBad Then
+                    defaultConstantValue = ConstantValue.Null
+                End If
 
-                    Dim defaultSpecialType = defaultConstantValue.SpecialType
-                    Dim defaultArgumentType As TypeSymbol = Nothing
+                Dim defaultSpecialType = defaultConstantValue.SpecialType
+                Dim defaultArgumentType As TypeSymbol = Nothing
 
-                    ' Constant has a type.
-                    Dim paramNullableUnderlyingTypeOrSelf As TypeSymbol = param.Type.GetNullableUnderlyingTypeOrSelf()
+                ' Constant has a type.
+                Dim paramNullableUnderlyingTypeOrSelf As TypeSymbol = param.Type.GetNullableUnderlyingTypeOrSelf()
 
-                    If param.HasOptionCompare Then
+                If param.HasOptionCompare Then
 
-                        ' If the argument has the OptionCompareAttribute
-                        ' then use the setting for Option Compare [Binary|Text]
-                        ' Other languages will use the default value specified.
+                    ' If the argument has the OptionCompareAttribute
+                    ' then use the setting for Option Compare [Binary|Text]
+                    ' Other languages will use the default value specified.
 
-                        If Me.OptionCompareText Then
-                            defaultConstantValue = ConstantValue.Create(1)
-                        Else
-                            defaultConstantValue = ConstantValue.Default(SpecialType.System_Int32)
-                        End If
-
-                        If paramNullableUnderlyingTypeOrSelf.GetEnumUnderlyingTypeOrSelf().SpecialType = SpecialType.System_Int32 Then
-                            defaultArgumentType = paramNullableUnderlyingTypeOrSelf
-                        Else
-                            defaultArgumentType = GetSpecialType(SpecialType.System_Int32, syntax, diagnostics)
-                        End If
-
-                    ElseIf defaultSpecialType <> SpecialType.None Then
-                        If paramNullableUnderlyingTypeOrSelf.GetEnumUnderlyingTypeOrSelf().SpecialType = defaultSpecialType Then
-                            ' Enum default values are encoded as the underlying primitive type.  If the underlying types match then
-                            ' use the parameter's enum type.
-                            defaultArgumentType = paramNullableUnderlyingTypeOrSelf
-                        Else
-                            'Use the primitive type.
-                            defaultArgumentType = GetSpecialType(defaultSpecialType, syntax, diagnostics)
-                        End If
+                    If Me.OptionCompareText Then
+                        defaultConstantValue = ConstantValue.Create(1)
                     Else
-                        ' No type in constant.  Constant should be nothing
-                        Debug.Assert(defaultConstantValue.IsNothing)
+                        defaultConstantValue = ConstantValue.Default(SpecialType.System_Int32)
                     End If
 
-                    defaultArgument = New BoundLiteral(syntax, defaultConstantValue, defaultArgumentType)
+                    If paramNullableUnderlyingTypeOrSelf.GetEnumUnderlyingTypeOrSelf().SpecialType = SpecialType.System_Int32 Then
+                        defaultArgumentType = paramNullableUnderlyingTypeOrSelf
+                    Else
+                        defaultArgumentType = GetSpecialType(SpecialType.System_Int32, syntax, diagnostics)
+                    End If
+
+                ElseIf defaultSpecialType <> SpecialType.None Then
+                    If paramNullableUnderlyingTypeOrSelf.GetEnumUnderlyingTypeOrSelf().SpecialType = defaultSpecialType Then
+                        ' Enum default values are encoded as the underlying primitive type.  If the underlying types match then
+                        ' use the parameter's enum type.
+                        defaultArgumentType = paramNullableUnderlyingTypeOrSelf
+                    Else
+                        'Use the primitive type.
+                        defaultArgumentType = GetSpecialType(defaultSpecialType, syntax, diagnostics)
+                    End If
+                Else
+                    ' No type in constant.  Constant should be nothing
+                    Debug.Assert(defaultConstantValue.IsNothing)
                 End If
+
+                defaultArgument = New BoundLiteral(syntax, defaultConstantValue, defaultArgumentType)
 
             ElseIf param.IsOptional Then
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
@@ -56,7 +56,7 @@
   <ItemGroup Label="File References">
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection.Metadata.dll">
       <HintPath>..\..\..\..\..\packages\System.Reflection.Metadata.$(SystemReflectionMetadataVersion)\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>

--- a/src/Compilers/VisualBasic/Test/CommandLine/packages.config
+++ b/src/Compilers/VisualBasic/Test/CommandLine/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -84,7 +84,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -12850,5 +12850,34 @@ BC42104: Variable 'blah1' is used before it has been assigned a value. A null re
 </errors>)
 
         End Sub
+
+        <Fact>
+        <WorkItem(4196, "https://github.com/dotnet/roslyn/issues/4196")>
+        Public Sub BadDefaultParameterValue()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+Imports BadDefaultParameterValue
+Module C
+    Sub Main
+        Util.M("test")
+    End Sub
+End Module
+    </file>
+</compilation>
+
+            Dim testReference = AssemblyMetadata.CreateFromImage(TestResources.Repros.BadDefaultParameterValue).GetReference()
+            Dim compilation = CompileAndVerify(source, additionalRefs:=New MetadataReference() {testReference})
+            compilation.VerifyIL("C.Main",
+            <![CDATA[
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldstr      "test"
+  IL_0005:  ldnull
+  IL_0006:  call       "Sub BadDefaultParameterValue.Util.M(String, String)"
+  IL_000b:  ret
+}]]>)
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/packages.config
+++ b/src/Compilers/VisualBasic/Test/Emit/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
@@ -83,7 +83,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Compilers/VisualBasic/Test/Semantic/packages.config
+++ b/src/Compilers/VisualBasic/Test/Semantic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Symbol/BasicCompilerSymbolTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Symbol/BasicCompilerSymbolTest.vbproj
@@ -83,7 +83,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Compilers/VisualBasic/Test/Symbol/packages.config
+++ b/src/Compilers/VisualBasic/Test/Symbol/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
@@ -94,7 +94,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Compilers/VisualBasic/Test/Syntax/packages.config
+++ b/src/Compilers/VisualBasic/Test/Syntax/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -13,7 +13,7 @@
   <ItemGroup Label="File References">
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>

--- a/src/EditorFeatures/CSharpTest/packages.config
+++ b/src/EditorFeatures/CSharpTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -20,7 +20,7 @@
   <ItemGroup Label="File References">
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>

--- a/src/EditorFeatures/VisualBasicTest/packages.config
+++ b/src/EditorFeatures/VisualBasicTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net451" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Test/Utilities/Desktop/TestUtilities.Desktop.csproj
+++ b/src/Test/Utilities/Desktop/TestUtilities.Desktop.csproj
@@ -93,7 +93,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="xunit">
       <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/src/Test/Utilities/Desktop/packages.config
+++ b/src/Test/Utilities/Desktop/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Test/Utilities/Portable.FX45/TestUtilities.FX45.csproj
+++ b/src/Test/Utilities/Portable.FX45/TestUtilities.FX45.csproj
@@ -91,7 +91,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Test/Utilities/Portable.FX45/packages.config
+++ b/src/Test/Utilities/Portable.FX45/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150716-08" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Test.Resources.Proprietary" version="1.1.0-beta1-20150824-02" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150716-08\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.CodeAnalysis.Test.Resources.Proprietary.1.1.0-beta1-20150824-02\lib\net45\Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection.Metadata, Version=$(SystemReflectionMetadataAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
The native compiler handled corrupted default parameter values by
substituting in default(T).  It's unclear if this was intentional
behavior in the compiler or not.

Either way though obfuscators took advantage of this behavior and at
least one prominent one will corrupt default parameter values when the
value is null.  Enough prominent libraries have shipped using such
obfuscators that it is a blocker to upgrading.  Hence we need to emulate
the native compiler behavior here.

This change is a bit large because I needed to update the test resources
with a corrupted DLL in order to test out the changes.

closes #4196