### PR TITLE
Whitespace after the caret should not be removed When inserting slashes on ENTER in XML doc comments

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1084,6 +1084,36 @@ static void Main(string[] args)
             VerifyPressingEnter(code, expected);
         }
 
+        [WorkItem(2091, "https://github.com/dotnet/roslyn/issues/2091")]
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void PressingEnter_InTextBeforeSpace()
+        {
+            const string code =
+@"class C
+{
+    /// <summary>
+    /// hello$$ world
+    /// </summary>
+    void M()
+    {
+    }
+}";
+
+            const string expected =
+@"class C
+{
+    /// <summary>
+    /// hello
+    /// $$world
+    /// </summary>
+    void M()
+    {
+    }
+}";
+
+            VerifyPressingEnter(code, expected);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void Command_Class()
         {

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -373,17 +373,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
                 return false;
             }
 
-            var tabSize = subjectBuffer.GetOption(FormattingOptions.TabSize);
-            var previousLineOffset = previousLine.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(tabSize);
-            var currentLineOffset = currentLine.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(tabSize);
-            var indentText = currentLineOffset < previousLineOffset
-                ? (previousLineOffset - currentLineOffset).CreateIndentationString(subjectBuffer.GetOption(FormattingOptions.UseTabs), tabSize)
-                : string.Empty;
-
-            var newText = indentText + ExteriorTriviaText + " ";
-            subjectBuffer.Insert(position, newText);
-
-            textView.TryMoveCaretToAndEnsureVisible(subjectBuffer.CurrentSnapshot.GetPoint(position + newText.Length));
+            InsertExteriorTrivia(textView, subjectBuffer, currentLine, previousLine);
 
             return true;
         }
@@ -662,6 +652,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
                 return;
             }
 
+            InsertExteriorTrivia(view, subjectBuffer, currentLine, previousLine);
+        }
+
+        private void InsertExteriorTrivia(ITextView view, ITextBuffer subjectBuffer, TextLine currentLine, TextLine previousLine)
+        {
             var useTabs = subjectBuffer.GetOption(FormattingOptions.UseTabs);
             var tabSize = subjectBuffer.GetOption(FormattingOptions.TabSize);
 
@@ -670,7 +665,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 
             var firstNonWhitespaceOffset = currentLine.GetFirstNonWhitespaceOffset();
             var replaceSpan = firstNonWhitespaceOffset != null
-                ? TextSpan.FromBounds(currentLine.Start, firstNonWhitespaceOffset.Value)
+                ? TextSpan.FromBounds(currentLine.Start, currentLine.Start + firstNonWhitespaceOffset.Value)
                 : currentLine.Span;
 
             subjectBuffer.Replace(replaceSpan.ToSpan(), indentText);

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -586,6 +586,31 @@ $$''' <summary>
             VerifyPressingEnter(code, expected)
         End Sub
 
+        <WorkItem(2091, "https://github.com/dotnet/roslyn/issues/2091")>
+        <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        Public Sub PressingEnter_InTextBeforeSpace()
+            Const code = "
+Class C
+    ''' <summary>
+    ''' hello$$ world
+    ''' </summary>
+    Sub M()
+    End Sub
+End Class
+"
+            Const expected = "
+Class C
+    ''' <summary>
+    ''' hello
+    ''' $$world
+    ''' </summary>
+    Sub M()
+    End Sub
+End Class
+"
+            VerifyPressingEnter(code, expected)
+        End Sub
+
         <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
         Public Sub Command_Class()
             Const code = "


### PR DESCRIPTION
Fixes #2091 

Reviewers: @CyrusNajmabadi, @Pilchie, @jasonmalinowski, @rchande, @dpoeschl, @balajikris, @jmarolf, @davkean, @brettfo