### PR TITLE
Move all IInteractiveWindowOperations implementations to UIThreadOnly

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -263,7 +263,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
         void IInteractiveWindowOperations.ExecuteInput()
         {
-            UIThread(uiOnly => uiOnly.ExecuteInputAsync().GetAwaiter().GetResult());
+            UIThread(uiOnly => uiOnly.ExecuteInputAsync());
         }
 
         /// <summary>

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -9,17 +9,14 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
-using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Utilities;
 
@@ -65,7 +62,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         private bool _adornmentToMinimize;
 
         private readonly IWpfTextView _textView;
-        private readonly History _history;
 
         public event EventHandler<SubmissionBufferAddedEventArgs> SubmissionBufferAdded;
 
@@ -92,14 +88,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         private readonly IContentType _inertType;
 
         private ITextBuffer _currentLanguageBuffer;
-        private string _historySearch;
 
         ////
         //// Standard input.
         ////
 
         // non-null if reading from stdin - position in the _inputBuffer where we map stdin
-        private int? _stdInputStart; // TODO (tomat): this variable is not used in thread-safe manner
+        private int? _stdInputStart; // TODO (https://github.com/dotnet/roslyn/issues/4044): this variable is not used in thread-safe manner
         private SnapshotSpan? _inputValue;
         private readonly AutoResetEvent _inputEvent = new AutoResetEvent(false);
 
@@ -112,7 +107,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         private readonly InteractiveWindowWriter _errorOutputWriter;
 
         private readonly string _lineBreakString;
-        private readonly IRtfBuilderService _rtfBuilderService;
 
         private const string BoxSelectionCutCopyTag = "MSDEVColumnSelect";
 
@@ -251,7 +245,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
         void IInteractiveWindowOperations.ClearHistory()
         {
-            UIThread(uiOnly => _history.Clear());
+            UIThread(uiOnly => uiOnly.History.Clear());
         }
 
         void IInteractiveWindowOperations.ClearView()
@@ -330,103 +324,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         void IInteractiveWindowOperations.SelectAll()
         {
             UIThread(uiOnly => uiOnly.SelectAll());
-        }
-
-        private bool ReportAndPropagateException(Exception e)
-        {
-            FatalError.ReportWithoutCrashUnlessCanceled(e); // Drop return value.
-
-            ((IInteractiveWindow)this).WriteErrorLine(InteractiveWindowResources.InternalError);
-
-            return false; // Never consider the exception handled.
-        }
-
-        /// <summary>
-        /// Given a point in projection buffer calculate a span that includes the point and comprises of 
-        /// subsequent projection spans forming a region, i.e. a sequence of output spans in between two subsequent submissions,
-        /// a language input block, or standard input block.
-        /// </summary>
-        private SnapshotSpan? GetContainingRegion(SnapshotPoint point)
-        {
-            var sourceSpans = GetSourceSpans(point.Snapshot);
-            int promptIndex = GetPromptIndexForPoint(sourceSpans, point);
-            if (promptIndex < 0)
-            {
-                return null;
-            }
-
-            // Grab the span following the prompt (either language or standard input).
-            var projectionSpan = sourceSpans[promptIndex + 1];
-            var inputSnapshot = projectionSpan.Snapshot;
-            var kind = GetSpanKind(projectionSpan);
-
-            Debug.Assert(kind == ReplSpanKind.Language || kind == ReplSpanKind.StandardInput);
-
-            // Language input block is a projection of the entire snapshot;
-            // std input block is a projection of a single span:
-            SnapshotPoint inputBufferEnd = (kind == ReplSpanKind.Language) ?
-                new SnapshotPoint(inputSnapshot, inputSnapshot.Length) :
-                projectionSpan.End;
-
-            var bufferGraph = _textView.BufferGraph;
-            var textBuffer = TextBuffer;
-
-            SnapshotPoint projectedInputBufferEnd = bufferGraph.MapUpToBuffer(
-                inputBufferEnd,
-                PointTrackingMode.Positive,
-                PositionAffinity.Predecessor,
-                textBuffer).Value;
-
-            // point is between the primary prompt (including) and the last character of the corresponding language/stdin buffer:
-            if (point <= projectedInputBufferEnd)
-            {
-                var projectedLanguageBufferStart = bufferGraph.MapUpToBuffer(
-                    new SnapshotPoint(inputSnapshot, 0),
-                    PointTrackingMode.Positive,
-                    PositionAffinity.Successor,
-                    textBuffer).Value;
-
-                var promptProjectionSpan = sourceSpans[promptIndex];
-                if (point < projectedLanguageBufferStart - promptProjectionSpan.Length)
-                {
-                    // cursor is before the first language buffer:
-                    return new SnapshotSpan(new SnapshotPoint(textBuffer.CurrentSnapshot, 0), projectedLanguageBufferStart - promptProjectionSpan.Length);
-                }
-
-                // cursor is within the language buffer:
-                return new SnapshotSpan(projectedLanguageBufferStart, projectedInputBufferEnd);
-            }
-
-            int nextPromptIndex = -1;
-            for (int i = promptIndex + 1; i < sourceSpans.Count; i++)
-            {
-                if (IsPrompt(sourceSpans[i]))
-                {
-                    nextPromptIndex = i;
-                    break;
-                }
-            }
-
-            // this was the last primary/stdin prompt - select the part of the projection buffer behind the end of the language/stdin buffer:
-            if (nextPromptIndex < 0)
-            {
-                var currentSnapshot = textBuffer.CurrentSnapshot;
-                return new SnapshotSpan(
-                    projectedInputBufferEnd,
-                    new SnapshotPoint(currentSnapshot, currentSnapshot.Length));
-            }
-
-            var lastSpanBeforeNextPrompt = sourceSpans[nextPromptIndex - 1];
-            Debug.Assert(GetSpanKind(lastSpanBeforeNextPrompt) == ReplSpanKind.Output);
-
-            // select all text in between the language buffer and the next prompt:
-            return new SnapshotSpan(
-                projectedInputBufferEnd,
-                bufferGraph.MapUpToBuffer(
-                    lastSpanBeforeNextPrompt.End,
-                    PointTrackingMode.Positive,
-                    PositionAffinity.Predecessor,
-                    textBuffer).Value);
         }
 
         /// <summary>
@@ -531,297 +428,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             return textToInsert;
         }
 
-        /// <summary>
-        /// Deletes characters preceding the current caret position in the current language buffer.
-        /// </summary>
-        private void DeletePreviousCharacter()
-        {
-            SnapshotPoint? point = MapToEditableBuffer(_textView.Caret.Position.BufferPosition);
-
-            // We are not in an editable buffer, or we are at the start of the buffer, nothing to delete.
-            if (point == null || point.Value == 0)
-            {
-                return;
-            }
-
-            var line = point.Value.GetContainingLine();
-            int characterSize;
-            if (line.Start.Position == point.Value.Position)
-            {
-                Debug.Assert(line.LineNumber != 0);
-                characterSize = line.Snapshot.GetLineFromLineNumber(line.LineNumber - 1).LineBreakLength;
-            }
-            else
-            {
-                characterSize = 1;
-            }
-
-            point.Value.Snapshot.TextBuffer.Delete(new Span(point.Value.Position - characterSize, characterSize));
-
-            UIThread(uiOnly => uiOnly.ScrollToCaret());
-        }
-
-        private void CutOrDeleteCurrentLine(bool isCut)
-        {
-            ITextSnapshotLine line;
-            int column;
-            _textView.Caret.Position.VirtualBufferPosition.GetLineAndColumn(out line, out column);
-
-            CutOrDelete(new[] { line.ExtentIncludingLineBreak }, isCut);
-
-            _textView.Caret.MoveTo(new VirtualSnapshotPoint(_textView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(line.LineNumber), column));
-        }
-
-        /// <summary>
-        /// Deletes currently selected text from the language buffer and optionally saves it to the clipboard.
-        /// </summary>
-        private void CutOrDeleteSelection(bool isCut)
-        {
-            CutOrDelete(_textView.Selection.SelectedSpans, isCut);
-
-            // if the selection spans over prompts the prompts remain selected, so clear manually:
-            _textView.Selection.Clear();
-        }
-
-        private void CutOrDelete(IEnumerable<SnapshotSpan> projectionSpans, bool isCut)
-        {
-            Debug.Assert(_currentLanguageBuffer != null);
-
-            StringBuilder deletedText = null;
-
-            // split into multiple deletes that only affect the language/input buffer:
-            ITextBuffer affectedBuffer = (_stdInputStart != null) ? _standardInputBuffer : _currentLanguageBuffer;
-            using (var edit = affectedBuffer.CreateEdit())
-            {
-                foreach (var projectionSpan in projectionSpans)
-                {
-                    var spans = _textView.BufferGraph.MapDownToBuffer(projectionSpan, SpanTrackingMode.EdgeInclusive, affectedBuffer);
-                    foreach (var span in spans)
-                    {
-                        if (isCut)
-                        {
-                            if (deletedText == null)
-                            {
-                                deletedText = new StringBuilder();
-                            }
-
-                            deletedText.Append(span.GetText());
-                        }
-
-                        edit.Delete(span);
-                    }
-                }
-
-                edit.Apply();
-            }
-
-            // copy the deleted text to the clipboard:
-            if (deletedText != null)
-            {
-                var data = new DataObject();
-                if (_textView.Selection.Mode == TextSelectionMode.Box)
-                {
-                    data.SetData(BoxSelectionCutCopyTag, new object());
-                }
-
-                data.SetText(deletedText.ToString());
-                Clipboard.SetDataObject(data, true);
-            }
-        }
-
-        /// <summary>
-        /// Copy the entire selection to the clipboard for RTF format and
-        /// copy the selection minus any prompt text for other formats.
-        /// That allows paste into code editors of just the code and
-        /// paste of the entire content for editors that support RTF.
-        /// </summary>
-        private void CopySelection()
-        {
-            var spans = GetSelectionSpans(_textView);
-            var data = Copy(spans);
-            Clipboard.SetDataObject(data, true);
-        }
-
-        private static NormalizedSnapshotSpanCollection GetSelectionSpans(ITextView textView)
-        {
-            var selection = textView.Selection;
-            if (selection.IsEmpty)
-            {
-                // Use the current line as the selection.
-                var snapshotLine = textView.Caret.Position.VirtualBufferPosition.Position.GetContainingLine();
-                var span = new SnapshotSpan(snapshotLine.Start, snapshotLine.LengthIncludingLineBreak);
-                return new NormalizedSnapshotSpanCollection(span);
-            }
-            return selection.SelectedSpans;
-        }
-
-        private DataObject Copy(NormalizedSnapshotSpanCollection spans)
-        {
-            var text = spans.Aggregate(new StringBuilder(), GetTextWithoutPrompts, b => b.ToString());
-            var rtf = _rtfBuilderService.GenerateRtf(spans, _textView);
-            var data = new DataObject();
-            data.SetData(DataFormats.StringFormat, text);
-            data.SetData(DataFormats.Text, text);
-            data.SetData(DataFormats.UnicodeText, text);
-            data.SetData(DataFormats.Rtf, rtf);
-            return data;
-        }
-
-        private StringBuilder GetTextWithoutPrompts(StringBuilder builder, SnapshotSpan span)
-        {
-            // Find the range of source spans that cover the span.
-            var sourceSpans = GetSourceSpans(span.Snapshot);
-            int n = sourceSpans.Count;
-            int index = GetSourceSpanIndex(sourceSpans, span.Start);
-            if (index == n)
-            {
-                index--;
-            }
-
-            // Add the text for all non-prompt spans within the range.
-            for (; index < n; index++)
-            {
-                var sourceSpan = sourceSpans[index];
-                if (sourceSpan.IsEmpty)
-                {
-                    continue;
-                }
-                if (!IsPrompt(sourceSpan))
-                {
-                    var sourceSnapshot = sourceSpan.Snapshot;
-                    var mappedSpans = _textView.BufferGraph.MapDownToBuffer(span, SpanTrackingMode.EdgeExclusive, sourceSnapshot.TextBuffer);
-                    bool added = false;
-                    foreach (var mappedSpan in mappedSpans)
-                    {
-                        var intersection = sourceSpan.Span.Intersection(mappedSpan);
-                        if (intersection.HasValue)
-                        {
-                            builder.Append(sourceSnapshot.GetText(intersection.Value));
-                            added = true;
-                        }
-                    }
-                    if (!added)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return builder;
-        }
-
-        private bool ReduceBoxSelectionToEditableBox(bool isDelete = true)
-        {
-            Debug.Assert(_textView.Selection.Mode == TextSelectionMode.Box);
-
-            VirtualSnapshotPoint anchor = _textView.Selection.AnchorPoint;
-            VirtualSnapshotPoint active = _textView.Selection.ActivePoint;
-
-            bool result;
-            if (active < anchor)
-            {
-                result = ReduceBoxSelectionToEditableBox(ref active, ref anchor, isDelete);
-            }
-            else
-            {
-                result = ReduceBoxSelectionToEditableBox(ref anchor, ref active, isDelete);
-            }
-
-            _textView.Selection.Select(anchor, active);
-            _textView.Caret.MoveTo(active);
-
-            return result;
-        }
-
-        private bool ReduceBoxSelectionToEditableBox(ref VirtualSnapshotPoint selectionTop, ref VirtualSnapshotPoint selectionBottom, bool isDelete)
-        {
-            int selectionTopColumn, selectionBottomColumn;
-            ITextSnapshotLine selectionTopLine, selectionBottomLine;
-            selectionTop.GetLineAndColumn(out selectionTopLine, out selectionTopColumn);
-            selectionBottom.GetLineAndColumn(out selectionBottomLine, out selectionBottomColumn);
-
-            int selectionLeftColumn, selectionRightColumn;
-            bool horizontallyReversed = selectionTopColumn > selectionBottomColumn;
-
-            if (horizontallyReversed)
-            {
-                // bottom-left <-> top-right 
-                selectionLeftColumn = selectionBottomColumn;
-                selectionRightColumn = selectionTopColumn;
-            }
-            else
-            {
-                // top-left <-> bottom-right
-                selectionLeftColumn = selectionTopColumn;
-                selectionRightColumn = selectionBottomColumn;
-            }
-
-            var selectionTopLeft = new VirtualSnapshotPoint(selectionTopLine, selectionLeftColumn);
-            var selectionBottomRight = new VirtualSnapshotPoint(selectionBottomLine, selectionRightColumn);
-
-            SnapshotPoint editable = GetClosestEditablePoint(selectionTopLeft.Position);
-            int editableColumn;
-            ITextSnapshotLine editableLine;
-            editable.GetLineAndColumn(out editableLine, out editableColumn);
-
-            Debug.Assert(selectionLeftColumn <= selectionRightColumn);
-            Debug.Assert(selectionTopLine.LineNumber <= selectionBottomLine.LineNumber);
-
-            if (editable > selectionBottomRight.Position)
-            {
-                // entirely within readonly output region:
-                return false;
-            }
-
-            int minPromptLength, maxPromptLength;
-            MeasurePrompts(editableLine.LineNumber, selectionBottomLine.LineNumber + 1, out minPromptLength, out maxPromptLength);
-
-            bool result = true;
-            if (isDelete)
-            {
-                if (selectionLeftColumn > maxPromptLength || maxPromptLength == minPromptLength)
-                {
-                    selectionTopLine = editableLine;
-                    selectionLeftColumn = Math.Max(selectionLeftColumn, maxPromptLength);
-                    result = false;
-                }
-            }
-            else
-            {
-                if (selectionRightColumn < minPromptLength)
-                {
-                    // entirely within readonly prompt region:
-                    result = false;
-                }
-                else if (maxPromptLength > selectionRightColumn)
-                {
-                    selectionTopLine = editableLine;
-                    selectionLeftColumn = maxPromptLength;
-                    selectionRightColumn = maxPromptLength;
-                }
-                else
-                {
-                    selectionTopLine = editableLine;
-                    selectionLeftColumn = Math.Max(maxPromptLength, selectionLeftColumn);
-                }
-            }
-
-            if (horizontallyReversed)
-            {
-                // bottom-left <-> top-right 
-                selectionTop = new VirtualSnapshotPoint(selectionTopLine, selectionRightColumn);
-                selectionBottom = new VirtualSnapshotPoint(selectionBottomLine, selectionLeftColumn);
-            }
-            else
-            {
-                // top-left <-> bottom-right
-                selectionTop = new VirtualSnapshotPoint(selectionTopLine, selectionLeftColumn);
-                selectionBottom = new VirtualSnapshotPoint(selectionBottomLine, selectionRightColumn);
-            }
-
-            return result;
-        }
-
         #endregion
 
         #region Keyboard Commands
@@ -911,107 +517,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
         private ITextCaret Caret => _textView.Caret;
 
-        private void MoveCaretToClosestEditableBuffer()
-        {
-            SnapshotPoint currentPosition = _textView.Caret.Position.BufferPosition;
-            SnapshotPoint newPosition = GetClosestEditablePoint(currentPosition);
-            if (currentPosition != newPosition)
-            {
-                _textView.Caret.MoveTo(newPosition);
-            }
-        }
-
-        /// <summary>
-        /// Finds a point in an editable buffer that is the closest towards the end to the given projection point.
-        /// </summary>
-        private SnapshotPoint GetClosestEditablePoint(SnapshotPoint projectionPoint)
-        {
-            ITextBuffer editableBuffer = (_stdInputStart != null) ? _standardInputBuffer : _currentLanguageBuffer;
-
-            if (editableBuffer == null)
-            {
-                return new SnapshotPoint(_projectionBuffer.CurrentSnapshot, _projectionBuffer.CurrentSnapshot.Length);
-            }
-
-            SnapshotPoint? point = GetPositionInBuffer(projectionPoint, editableBuffer);
-            if (point != null)
-            {
-                return projectionPoint;
-            }
-
-            var projectionLine = projectionPoint.GetContainingLine();
-
-            SnapshotPoint? lineEnd = _textView.BufferGraph.MapDownToBuffer(
-                projectionLine.End,
-                PointTrackingMode.Positive,
-                editableBuffer,
-                PositionAffinity.Successor);
-
-            SnapshotPoint editablePoint;
-            if (lineEnd == null)
-            {
-                editablePoint = new SnapshotPoint(editableBuffer.CurrentSnapshot, 0);
-            }
-            else
-            {
-                editablePoint = lineEnd.Value.GetContainingLine().Start;
-            }
-
-            return _textView.BufferGraph.MapUpToBuffer(
-                editablePoint,
-                PointTrackingMode.Positive,
-                PositionAffinity.Successor,
-                _projectionBuffer).Value;
-        }
-
-        /// <summary>
-        /// Maps point to the current language buffer or standard input buffer.
-        /// </summary>
-        private SnapshotPoint? MapToEditableBuffer(SnapshotPoint projectionPoint)
-        {
-            SnapshotPoint? result = null;
-
-            if (_currentLanguageBuffer != null)
-            {
-                result = GetPositionInLanguageBuffer(projectionPoint);
-            }
-
-            if (result != null)
-            {
-                return result;
-            }
-
-            if (_standardInputBuffer != null)
-            {
-                result = GetPositionInStdInputBuffer(projectionPoint);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Returns the insertion point relative to the current language buffer.
-        /// </summary>
-        private int GetActiveCodeInsertionPosition()
-        {
-            Debug.Assert(_currentLanguageBuffer != null);
-
-            var langPoint = _textView.BufferGraph.MapDownToBuffer(
-                new SnapshotPoint(
-                    _projectionBuffer.CurrentSnapshot,
-                    Caret.Position.BufferPosition.Position),
-                PointTrackingMode.Positive,
-                _currentLanguageBuffer,
-                PositionAffinity.Predecessor);
-
-            if (langPoint != null)
-            {
-                return langPoint.Value;
-            }
-
-            return _currentLanguageBuffer.CurrentSnapshot.Length;
-        }
-
         private void CaretPositionChanged(object sender, CaretPositionChangedEventArgs e)
         {
             // make sure language buffer exist
@@ -1066,54 +571,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
         #region Active Code and Standard Input
 
-        /// <summary>
-        /// Returns the full text of the current active input.
-        /// </summary>
-        private string GetActiveCode()
-        {
-            return _currentLanguageBuffer.CurrentSnapshot.GetText();
-        }
-
-        /// <summary>
-        /// Sets the active code to the specified text w/o executing it.
-        /// </summary>
-        private void SetActiveCode(string text)
-        {
-            // TODO (tomat): this should be handled by the language intellisense provider, not here:
-            var completionSession = this.SessionStack.TopSession;
-            if (completionSession != null)
-            {
-                completionSession.Dismiss();
-            }
-
-            using (var edit = _currentLanguageBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, editTag: null))
-            {
-                edit.Replace(new Span(0, _currentLanguageBuffer.CurrentSnapshot.Length), text);
-                edit.Apply();
-            }
-        }
-
-        /// <summary>
-        /// Sets the active code to the specified history entry.
-        /// </summary>
-        /// <param name="entry"></param>
-        private void SetActiveCodeToHistory(History.Entry entry)
-        {
-            SetActiveCode(entry.Text);
-        }
-
-        private void ClearInput()
-        {
-            if (_stdInputStart != null)
-            {
-                _standardInputBuffer.Delete(Span.FromBounds(_stdInputStart.Value, _standardInputBuffer.CurrentSnapshot.Length));
-            }
-            else
-            {
-                _currentLanguageBuffer.Delete(new Span(0, _currentLanguageBuffer.CurrentSnapshot.Length));
-            }
-        }
-
         // TODO: What happens if multiple non-UI threads call this method? (https://github.com/dotnet/roslyn/issues/3984)
         TextReader IInteractiveWindow.ReadStandardInput()
         {
@@ -1140,7 +597,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     }
                 }
 
-                AddStandardInputSpan();
+                uiOnly.AddStandardInputSpan();
 
                 Caret.EnsureVisible();
                 uiOnly.ResetCursor();
@@ -1186,31 +643,14 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             // input has been cancelled:
             if (_inputValue.HasValue)
             {
-                _history.Add(_inputValue.Value);
-                return new StringReader(_inputValue.Value.GetText());
+                var value = _inputValue.GetValueOrDefault();
+                UIThread(uiOnly => uiOnly.History.Add(value));
+                return new StringReader(value.GetText());
             }
             else
             {
                 return null;
             }
-        }
-
-        private bool InStandardInputRegion(SnapshotPoint point)
-        {
-            if (_stdInputStart == null)
-            {
-                return false;
-            }
-
-            var stdInputPoint = GetPositionInStdInputBuffer(point);
-            return stdInputPoint != null && stdInputPoint.Value.Position >= _stdInputStart.Value;
-        }
-
-        private void SubmitStandardInput()
-        {
-            AppendLineNoPromptInjection(_standardInputBuffer);
-            _inputValue = new SnapshotSpan(_standardInputBuffer.CurrentSnapshot, Span.FromBounds(_stdInputStart.Value, _standardInputBuffer.CurrentSnapshot.Length));
-            _inputEvent.Set();
         }
 
 #endregion
@@ -1270,35 +710,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
 #endregion
 
-#region Execution
-
-        private bool CanExecuteActiveCode()
-        {
-            Debug.Assert(_currentLanguageBuffer != null);
-
-            var input = GetActiveCode();
-            if (string.IsNullOrWhiteSpace(input))
-            {
-                // Always allow "execution" of a blank line.
-                // This will just close the current prompt and start a new one
-                return true;
-            }
-
-            // Ignore any whitespace past the insertion point when determining
-            // whether or not we're at the end of the input
-            var pt = GetActiveCodeInsertionPosition();
-            var isEnd = (pt == input.Length) || (pt >= 0 && input.Substring(pt).Trim().Length == 0);
-            if (!isEnd)
-            {
-                return false;
-            }
-
-            // If this throws, VS shows a dialog.
-            return _evaluator.CanExecuteCode(input);
-        }
-
-#endregion
-
 #region Buffers, Spans and Prompts
         private object CreateStandardInputPrompt()
         {
@@ -1314,22 +725,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         {
             // TODO (crwilcox) format prompt used to get a blank here but now gets "> " from get prompt.
             return _evaluator.GetPrompt();
-        }
-
-        /// <summary>
-        /// Returns the lengths of the longest and shortest prompts within the specified range of lines of the current submission buffer.
-        /// </summary>
-        private void MeasurePrompts(int startLine, int endLine, out int minPromptLength, out int maxPromptLength)
-        {
-            Debug.Assert(endLine > startLine);
-
-            var projectionSnapshot = _projectionBuffer.CurrentSnapshot;
-            var sourceSpans = projectionSnapshot.GetSourceSpans();
-            var promptSpanIndex = GetProjectionSpanIndexFromEditableBufferPosition(projectionSnapshot, sourceSpans.Count, startLine) - 1;
-            var promptSpan = sourceSpans[promptSpanIndex];
-            Debug.Assert(IsPrompt(promptSpan));
-
-            minPromptLength = maxPromptLength = promptSpan.Length;
         }
 
         private ReplSpanKind GetSpanKind(SnapshotSpan span)
@@ -1453,21 +848,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 result = point.CompareTo(mappedSpan.End);
                 return (result < 0) ? 0 : 1;
             }
-        }
-
-        /// <summary>
-        /// Add a zero-width tracking span at the end of the projection buffer mapping to the end of the standard input buffer.
-        /// </summary>
-        private void AddStandardInputSpan()
-        {
-            var promptSpan = CreateStandardInputPrompt();
-            var currentSnapshot = _standardInputBuffer.CurrentSnapshot;
-            var inputSpan = new CustomTrackingSpan(
-                currentSnapshot,
-                new Span(currentSnapshot.Length, 0),
-                PointTrackingMode.Negative,
-                PointTrackingMode.Positive);
-            AppendProjectionSpans(promptSpan, inputSpan);
         }
 
         private const int SpansPerLineOfInput = 2;
@@ -1702,21 +1082,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 lastLine ? PointTrackingMode.Positive : PointTrackingMode.Negative);
         }
 
-        private void AppendLineNoPromptInjection(ITextBuffer buffer)
-        {
-            using (var edit = buffer.CreateEdit(EditOptions.None, null, s_suppressPromptInjectionTag))
-            {
-                edit.Insert(buffer.CurrentSnapshot.Length, _lineBreakString);
-                edit.Apply();
-            }
-        }
-
-        private void AppendProjectionSpans(object span1, object span2)
-        {
-            int index = _projectionBuffer.CurrentSnapshot.SpanCount;
-            _projectionBuffer.ReplaceSpans(index, 0, new[] { span1, span2 }, EditOptions.None, editTag: s_suppressPromptInjectionTag);
-        }
-
         // Verify spans and GetSourceSpanIndex.
         [Conditional("DEBUG")]
         private void CheckProjectionSpans()
@@ -1764,30 +1129,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             }
         }
 
-#endregion
-
-#region Editor Helpers
-
-        private static ITextSnapshotLine GetLastLine(ITextSnapshot snapshot)
-        {
-            return snapshot.GetLineFromLineNumber(snapshot.LineCount - 1);
-        }
-
-        private static int IndexOfNonWhiteSpaceCharacter(ITextSnapshotLine line)
-        {
-            var snapshot = line.Snapshot;
-            int start = line.Start.Position;
-            int count = line.Length;
-            for (int i = 0; i < count; i++)
-            {
-                if (!char.IsWhiteSpace(snapshot[start + i]))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
+        #endregion
 
         private sealed class EditResolver : IProjectionEditResolver
         {
@@ -1865,9 +1207,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             }
         }
 
-#endregion
-
-#region UI Dispatcher Helpers
+        #region UI Dispatcher Helpers
 
         private Dispatcher Dispatcher => ((FrameworkElement)_textView).Dispatcher;
 

--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -49,10 +50,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 throw new ArgumentNullException(nameof(evaluator));
             }
 
-            _dangerous_uiOnly = new UIThreadOnly(this, host);
+            _dangerous_uiOnly = new UIThreadOnly(this, host, rtfBuilderService);
 
             this.Properties = new PropertyCollection();
-            _history = new History();
 
             _intellisenseSessionStackMap = intellisenseSessionStackMap;
             _smartIndenterService = smartIndenterService;
@@ -103,8 +103,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             _errorOutputWriter = new InteractiveWindowWriter(this, errorSpans);
             OutputClassifierProvider.AttachToBuffer(_outputBuffer, errorSpans);
 
-            _rtfBuilderService = rtfBuilderService;
-
             RequiresUIThread();
             evaluator.CurrentWindow = this;
             _evaluator = evaluator;
@@ -142,6 +140,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             }
         }
 
+        private bool ReportAndPropagateException(Exception e)
+        {
+            FatalError.ReportWithoutCrashUnlessCanceled(e); // Drop return value.
+
+            ((IInteractiveWindow)this).WriteErrorLine(InteractiveWindowResources.InternalError);
+
+            return false; // Never consider the exception handled.
+        }
+
         #endregion
 
         private sealed class UIThreadOnly
@@ -152,6 +159,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             private readonly IReadOnlyRegion[] _outputProtection;
 
+            public readonly History History;
+            private string _historySearch;
+
             // Pending submissions to be processed whenever the REPL is ready to accept submissions.
             private readonly Queue<PendingSubmission> _pendingSubmissions;
 
@@ -159,6 +169,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             private Cursor _oldCursor;
             private int _currentOutputProjectionSpan;
             private int _outputTrackingCaretPosition;
+
+            private readonly IRtfBuilderService _rtfBuilderService;
 
             // Read-only regions protecting initial span of the corresponding buffers:
             public readonly IReadOnlyRegion[] StandardInputProtection;
@@ -195,10 +207,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
             }
 
-            public UIThreadOnly(InteractiveWindow window, IInteractiveWindowEditorFactoryService host)
+            public UIThreadOnly(InteractiveWindow window, IInteractiveWindowEditorFactoryService host, IRtfBuilderService rtfBuilderService)
             {
                 _window = window;
                 _host = host;
+                _rtfBuilderService = rtfBuilderService;
+                History = new History();
                 StandardInputProtection = new IReadOnlyRegion[2];
                 _outputProtection = new IReadOnlyRegion[2];
                 _pendingSubmissions = new Queue<PendingSubmission>();
@@ -285,7 +299,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 // 2) We need at least one non-inert span due to bugs in projection buffer.
                 AppendNewOutputProjectionBuffer();
 
-                _window._history.ForgetOriginalBuffers();
+                History.ForgetOriginalBuffers();
 
                 // If we were waiting for input, we need to restore the prompt that we just cleared.
                 // If we are in any other state, then we'll let normal transitions trigger the next prompt.
@@ -297,9 +311,18 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             private void CancelStandardInput()
             {
-                _window.AppendLineNoPromptInjection(_window._standardInputBuffer);
+                AppendLineNoPromptInjection(_window._standardInputBuffer);
                 _window._inputValue = null;
                 _window._inputEvent.Set();
+            }
+
+            private void AppendLineNoPromptInjection(ITextBuffer buffer)
+            {
+                using (var edit = buffer.CreateEdit(EditOptions.None, null, s_suppressPromptInjectionTag))
+                {
+                    edit.Insert(buffer.CurrentSnapshot.Length, _window._lineBreakString);
+                    edit.Apply();
+                }
             }
 
             public void InsertCode(string text)
@@ -317,7 +340,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 {
                     if (!_window._textView.Selection.IsEmpty)
                     {
-                        _window.CutOrDeleteSelection(isCut: false);
+                        CutOrDeleteSelection(isCut: false);
                     }
 
                     EditorOperations.InsertText(text);
@@ -345,12 +368,20 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             {
                 if (UncommittedInput == null)
                 {
-                    string activeCode = _window.GetActiveCode();
+                    string activeCode = GetActiveCode();
                     if (!string.IsNullOrEmpty(activeCode))
                     {
                         UncommittedInput = activeCode;
                     }
                 }
+            }
+
+            /// <summary>
+            /// Returns the full text of the current active input.
+            /// </summary>
+            private string GetActiveCode()
+            {
+                return _window._currentLanguageBuffer.CurrentSnapshot.GetText();
             }
 
             private void PendSubmissions(IEnumerable<PendingSubmission> inputs)
@@ -380,12 +411,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 else
                 {
                     StoreUncommittedInput();
-                    _window.SetActiveCode(command);
+                    SetActiveCode(command);
                 }
 
                 // Add command to history before calling FinishCurrentSubmissionInput as it adds newline 
                 // to the end of the command.
-                _window._history.Add(_window._currentLanguageBuffer.CurrentSnapshot.GetExtent());
+                History.Add(_window._currentLanguageBuffer.CurrentSnapshot.GetExtent());
                 FinishCurrentSubmissionInput();
             }
 
@@ -409,7 +440,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             {
                 if (UncommittedInput != null)
                 {
-                    _window.SetActiveCode(UncommittedInput);
+                    SetActiveCode(UncommittedInput);
                     UncommittedInput = null;
                 }
             }
@@ -419,7 +450,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             /// </summary>
             public bool Paste()
             {
-                _window.MoveCaretToClosestEditableBuffer();
+                MoveCaretToClosestEditableBuffer();
 
                 string format = _window._evaluator.FormatClipboard();
                 if (format != null)
@@ -436,6 +467,59 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
 
                 return true;
+            }
+
+            private void MoveCaretToClosestEditableBuffer()
+            {
+                SnapshotPoint currentPosition = _window._textView.Caret.Position.BufferPosition;
+                SnapshotPoint newPosition = GetClosestEditablePoint(currentPosition);
+                if (currentPosition != newPosition)
+                {
+                    _window._textView.Caret.MoveTo(newPosition);
+                }
+            }
+
+            /// <summary>
+            /// Finds a point in an editable buffer that is the closest towards the end to the given projection point.
+            /// </summary>
+            private SnapshotPoint GetClosestEditablePoint(SnapshotPoint projectionPoint)
+            {
+                ITextBuffer editableBuffer = (_window._stdInputStart != null) ? _window._standardInputBuffer : _window._currentLanguageBuffer;
+
+                if (editableBuffer == null)
+                {
+                    return new SnapshotPoint(_window._projectionBuffer.CurrentSnapshot, _window._projectionBuffer.CurrentSnapshot.Length);
+                }
+
+                SnapshotPoint? point = _window.GetPositionInBuffer(projectionPoint, editableBuffer);
+                if (point != null)
+                {
+                    return projectionPoint;
+                }
+
+                var projectionLine = projectionPoint.GetContainingLine();
+
+                SnapshotPoint? lineEnd = _window._textView.BufferGraph.MapDownToBuffer(
+                    projectionLine.End,
+                    PointTrackingMode.Positive,
+                    editableBuffer,
+                    PositionAffinity.Successor);
+
+                SnapshotPoint editablePoint;
+                if (lineEnd == null)
+                {
+                    editablePoint = new SnapshotPoint(editableBuffer.CurrentSnapshot, 0);
+                }
+                else
+                {
+                    editablePoint = lineEnd.Value.GetContainingLine().Start;
+                }
+
+                return _window._textView.BufferGraph.MapUpToBuffer(
+                    editablePoint,
+                    PointTrackingMode.Positive,
+                    PositionAffinity.Successor,
+                    _window._projectionBuffer).Value;
             }
 
             /// <summary>
@@ -501,7 +585,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
 
                 var submission = _pendingSubmissions.Dequeue();
-                _window.SetActiveCode(submission.Input);
+                SetActiveCode(submission.Input);
                 Debug.Assert(submission.Task == null, "Someone set PendingSubmission.Task before it was dequeued.");
                 submission.Task = SubmitAsync();
                 if (submission.Completion != null)
@@ -513,6 +597,31 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     submission.Task.ContinueWith(_ => submission.Completion.SetResult(null), TaskScheduler.Current);
                 }
             }
+
+            #region Editor Helpers
+
+            private static ITextSnapshotLine GetLastLine(ITextSnapshot snapshot)
+            {
+                return snapshot.GetLineFromLineNumber(snapshot.LineCount - 1);
+            }
+
+            private static int IndexOfNonWhiteSpaceCharacter(ITextSnapshotLine line)
+            {
+                var snapshot = line.Snapshot;
+                int start = line.Start.Position;
+                int count = line.Length;
+                for (int i = 0; i < count; i++)
+                {
+                    if (!char.IsWhiteSpace(snapshot[start + i]))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+
+            #endregion
 
             public async Task SubmitAsync()
             {
@@ -534,7 +643,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     var historySpan = _window._currentLanguageBuffer.CurrentSnapshot.GetExtent();
                     FinishCurrentSubmissionInput();
 
-                    _window._history.UncommittedInput = null;
+                    History.UncommittedInput = null;
 
                     var snapshotSpan = _window._currentLanguageBuffer.CurrentSnapshot.GetExtent();
                     var trimmedSpan = snapshotSpan.TrimEnd();
@@ -547,7 +656,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     }
                     else
                     {
-                        _window._history.Add(historySpan);
+                        History.Add(historySpan);
                         State = State.ExecutingInput;
 
                         StartCursorTimer();
@@ -581,7 +690,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             private void FinishCurrentSubmissionInput()
             {
-                _window.AppendLineNoPromptInjection(_window._currentLanguageBuffer);
+                AppendLineNoPromptInjection(_window._currentLanguageBuffer);
                 ApplyProtection(_window._currentLanguageBuffer, regions: null);
 
                 if (_window._adornmentToMinimize)
@@ -764,9 +873,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             {
                 ResetCursor();
 
-                if (!succeeded && _window._history.Last != null)
+                if (!succeeded && History.Last != null)
                 {
-                    _window._history.Last.Failed = true;
+                    History.Last.Failed = true;
                 }
 
                 PrepareForInput();
@@ -980,7 +1089,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     PointTrackingMode.Positive);
 
                 // projection buffer update must be the last operation as it might trigger event that accesses prompt line mapping:
-                _window.AppendProjectionSpans(promptSpan, languageSpan);
+                AppendProjectionSpans(promptSpan, languageSpan);
+            }
+
+            private void AppendProjectionSpans(object span1, object span2)
+            {
+                int index = _window._projectionBuffer.CurrentSnapshot.SpanCount;
+                _window._projectionBuffer.ReplaceSpans(index, 0, new[] { span1, span2 }, EditOptions.None, editTag: s_suppressPromptInjectionTag);
             }
 
             public void ScrollToCaret()
@@ -993,10 +1108,22 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             public void Cancel()
             {
-                _window.ClearInput();
+                ClearInput();
                 EditorOperations.MoveToEndOfDocument(false);
                 UncommittedInput = null;
-                _window._historySearch = null;
+                _historySearch = null;
+            }
+
+            private void ClearInput()
+            {
+                if (_window._stdInputStart != null)
+                {
+                    _window._standardInputBuffer.Delete(Span.FromBounds(_window._stdInputStart.Value, _window._standardInputBuffer.CurrentSnapshot.Length));
+                }
+                else
+                {
+                    _window._currentLanguageBuffer.Delete(new Span(0, _window._currentLanguageBuffer.CurrentSnapshot.Length));
+                }
             }
 
             public void HistoryPrevious(string search)
@@ -1006,7 +1133,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     return;
                 }
 
-                var previous = _window._history.GetPrevious(search);
+                var previous = History.GetPrevious(search);
                 if (previous != null)
                 {
                     if (string.IsNullOrWhiteSpace(search))
@@ -1015,7 +1142,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                         StoreUncommittedInputForHistory();
                     }
 
-                    _window.SetActiveCodeToHistory(previous);
+                    SetActiveCodeToHistory(previous);
                     EditorOperations.MoveToEndOfDocument(false);
                 }
             }
@@ -1027,7 +1154,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     return;
                 }
 
-                var next = _window._history.GetNext(search);
+                var next = History.GetNext(search);
                 if (next != null)
                 {
                     if (string.IsNullOrWhiteSpace(search))
@@ -1036,49 +1163,77 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                         StoreUncommittedInputForHistory();
                     }
 
-                    _window.SetActiveCodeToHistory(next);
+                    SetActiveCodeToHistory(next);
                     EditorOperations.MoveToEndOfDocument(false);
                 }
                 else
                 {
-                    string code = _window._history.UncommittedInput;
-                    _window._history.UncommittedInput = null;
+                    string code = History.UncommittedInput;
+                    History.UncommittedInput = null;
                     if (!string.IsNullOrEmpty(code))
                     {
-                        _window.SetActiveCode(code);
+                        SetActiveCode(code);
                         EditorOperations.MoveToEndOfDocument(false);
                     }
+                }
+            }
+
+            /// <summary>
+            /// Sets the active code to the specified history entry.
+            /// </summary>
+            /// <param name="entry"></param>
+            private void SetActiveCodeToHistory(History.Entry entry)
+            {
+                SetActiveCode(entry.Text);
+            }
+
+            /// <summary>
+            /// Sets the active code to the specified text w/o executing it.
+            /// </summary>
+            private void SetActiveCode(string text)
+            {
+                // TODO (tomat): this should be handled by the language intellisense provider, not here:
+                var completionSession = _window.SessionStack.TopSession;
+                if (completionSession != null)
+                {
+                    completionSession.Dismiss();
+                }
+
+                using (var edit = _window._currentLanguageBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, editTag: null))
+                {
+                    edit.Replace(new Span(0, _window._currentLanguageBuffer.CurrentSnapshot.Length), text);
+                    edit.Apply();
                 }
             }
 
             public void HistorySearchNext()
             {
                 EnsureHistorySearch();
-                HistoryNext(_window._historySearch);
+                HistoryNext(_historySearch);
             }
 
             public void HistorySearchPrevious()
             {
                 EnsureHistorySearch();
-                HistoryPrevious(_window._historySearch);
+                HistoryPrevious(_historySearch);
             }
 
             private void EnsureHistorySearch()
             {
-                if (_window._historySearch == null)
+                if (_historySearch == null)
                 {
-                    _window._historySearch = _window._currentLanguageBuffer.CurrentSnapshot.GetText();
+                    _historySearch = _window._currentLanguageBuffer.CurrentSnapshot.GetText();
                 }
             }
 
             private void StoreUncommittedInputForHistory()
             {
-                if (_window._history.UncommittedInput == null)
+                if (History.UncommittedInput == null)
                 {
-                    string activeCode = _window.GetActiveCode();
+                    string activeCode = GetActiveCode();
                     if (activeCode.Length > 0)
                     {
-                        _window._history.UncommittedInput = activeCode;
+                        History.UncommittedInput = activeCode;
                     }
                 }
             }
@@ -1175,7 +1330,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             public void SelectAll()
             {
-                SnapshotSpan? span = _window.GetContainingRegion(_window._textView.Caret.Position.BufferPosition);
+                SnapshotSpan? span = GetContainingRegion(_window._textView.Caret.Position.BufferPosition);
 
                 var selection = _window._textView.Selection;
 
@@ -1189,16 +1344,104 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 _window._textView.Selection.Select(span.Value, isReversed: false);
             }
 
+            /// <summary>
+            /// Given a point in projection buffer calculate a span that includes the point and comprises of 
+            /// subsequent projection spans forming a region, i.e. a sequence of output spans in between two subsequent submissions,
+            /// a language input block, or standard input block.
+            /// </summary>
+            private SnapshotSpan? GetContainingRegion(SnapshotPoint point)
+            {
+                var sourceSpans = GetSourceSpans(point.Snapshot);
+                int promptIndex = _window.GetPromptIndexForPoint(sourceSpans, point);
+                if (promptIndex < 0)
+                {
+                    return null;
+                }
+
+                // Grab the span following the prompt (either language or standard input).
+                var projectionSpan = sourceSpans[promptIndex + 1];
+                var inputSnapshot = projectionSpan.Snapshot;
+                var kind = _window.GetSpanKind(projectionSpan);
+
+                Debug.Assert(kind == ReplSpanKind.Language || kind == ReplSpanKind.StandardInput);
+
+                // Language input block is a projection of the entire snapshot;
+                // std input block is a projection of a single span:
+                SnapshotPoint inputBufferEnd = (kind == ReplSpanKind.Language) ?
+                    new SnapshotPoint(inputSnapshot, inputSnapshot.Length) :
+                    projectionSpan.End;
+
+                var bufferGraph = _window._textView.BufferGraph;
+                var textBuffer = _window.TextBuffer;
+
+                SnapshotPoint projectedInputBufferEnd = bufferGraph.MapUpToBuffer(
+                    inputBufferEnd,
+                    PointTrackingMode.Positive,
+                    PositionAffinity.Predecessor,
+                    textBuffer).Value;
+
+                // point is between the primary prompt (including) and the last character of the corresponding language/stdin buffer:
+                if (point <= projectedInputBufferEnd)
+                {
+                    var projectedLanguageBufferStart = bufferGraph.MapUpToBuffer(
+                        new SnapshotPoint(inputSnapshot, 0),
+                        PointTrackingMode.Positive,
+                        PositionAffinity.Successor,
+                        textBuffer).Value;
+
+                    var promptProjectionSpan = sourceSpans[promptIndex];
+                    if (point < projectedLanguageBufferStart - promptProjectionSpan.Length)
+                    {
+                        // cursor is before the first language buffer:
+                        return new SnapshotSpan(new SnapshotPoint(textBuffer.CurrentSnapshot, 0), projectedLanguageBufferStart - promptProjectionSpan.Length);
+                    }
+
+                    // cursor is within the language buffer:
+                    return new SnapshotSpan(projectedLanguageBufferStart, projectedInputBufferEnd);
+                }
+
+                int nextPromptIndex = -1;
+                for (int i = promptIndex + 1; i < sourceSpans.Count; i++)
+                {
+                    if (_window.IsPrompt(sourceSpans[i]))
+                    {
+                        nextPromptIndex = i;
+                        break;
+                    }
+                }
+
+                // this was the last primary/stdin prompt - select the part of the projection buffer behind the end of the language/stdin buffer:
+                if (nextPromptIndex < 0)
+                {
+                    var currentSnapshot = textBuffer.CurrentSnapshot;
+                    return new SnapshotSpan(
+                        projectedInputBufferEnd,
+                        new SnapshotPoint(currentSnapshot, currentSnapshot.Length));
+                }
+
+                var lastSpanBeforeNextPrompt = sourceSpans[nextPromptIndex - 1];
+                Debug.Assert(_window.GetSpanKind(lastSpanBeforeNextPrompt) == ReplSpanKind.Output);
+
+                // select all text in between the language buffer and the next prompt:
+                return new SnapshotSpan(
+                    projectedInputBufferEnd,
+                    bufferGraph.MapUpToBuffer(
+                        lastSpanBeforeNextPrompt.End,
+                        PointTrackingMode.Positive,
+                        PositionAffinity.Predecessor,
+                        textBuffer).Value);
+            }
+
             public bool Delete()
             {
-                _window._historySearch = null;
+                _historySearch = null;
                 bool handled = false;
                 if (!_window._textView.Selection.IsEmpty)
                 {
-                    if (_window._textView.Selection.Mode == TextSelectionMode.Stream || _window.ReduceBoxSelectionToEditableBox())
+                    if (_window._textView.Selection.Mode == TextSelectionMode.Stream || ReduceBoxSelectionToEditableBox())
                     {
-                        _window.CutOrDeleteSelection(isCut: false);
-                        _window.MoveCaretToClosestEditableBuffer();
+                        CutOrDeleteSelection(isCut: false);
+                        MoveCaretToClosestEditableBuffer();
                         handled = true;
                     }
                 }
@@ -1206,23 +1449,300 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 return handled;
             }
 
+            private bool ReduceBoxSelectionToEditableBox(bool isDelete = true)
+            {
+                Debug.Assert(_window._textView.Selection.Mode == TextSelectionMode.Box);
+
+                VirtualSnapshotPoint anchor = _window._textView.Selection.AnchorPoint;
+                VirtualSnapshotPoint active = _window._textView.Selection.ActivePoint;
+
+                bool result;
+                if (active < anchor)
+                {
+                    result = ReduceBoxSelectionToEditableBox(ref active, ref anchor, isDelete);
+                }
+                else
+                {
+                    result = ReduceBoxSelectionToEditableBox(ref anchor, ref active, isDelete);
+                }
+
+                _window._textView.Selection.Select(anchor, active);
+                _window._textView.Caret.MoveTo(active);
+
+                return result;
+            }
+
+            private bool ReduceBoxSelectionToEditableBox(ref VirtualSnapshotPoint selectionTop, ref VirtualSnapshotPoint selectionBottom, bool isDelete)
+            {
+                int selectionTopColumn, selectionBottomColumn;
+                ITextSnapshotLine selectionTopLine, selectionBottomLine;
+                selectionTop.GetLineAndColumn(out selectionTopLine, out selectionTopColumn);
+                selectionBottom.GetLineAndColumn(out selectionBottomLine, out selectionBottomColumn);
+
+                int selectionLeftColumn, selectionRightColumn;
+                bool horizontallyReversed = selectionTopColumn > selectionBottomColumn;
+
+                if (horizontallyReversed)
+                {
+                    // bottom-left <-> top-right 
+                    selectionLeftColumn = selectionBottomColumn;
+                    selectionRightColumn = selectionTopColumn;
+                }
+                else
+                {
+                    // top-left <-> bottom-right
+                    selectionLeftColumn = selectionTopColumn;
+                    selectionRightColumn = selectionBottomColumn;
+                }
+
+                var selectionTopLeft = new VirtualSnapshotPoint(selectionTopLine, selectionLeftColumn);
+                var selectionBottomRight = new VirtualSnapshotPoint(selectionBottomLine, selectionRightColumn);
+
+                SnapshotPoint editable = GetClosestEditablePoint(selectionTopLeft.Position);
+                int editableColumn;
+                ITextSnapshotLine editableLine;
+                editable.GetLineAndColumn(out editableLine, out editableColumn);
+
+                Debug.Assert(selectionLeftColumn <= selectionRightColumn);
+                Debug.Assert(selectionTopLine.LineNumber <= selectionBottomLine.LineNumber);
+
+                if (editable > selectionBottomRight.Position)
+                {
+                    // entirely within readonly output region:
+                    return false;
+                }
+
+                int minPromptLength, maxPromptLength;
+                MeasurePrompts(editableLine.LineNumber, selectionBottomLine.LineNumber + 1, out minPromptLength, out maxPromptLength);
+
+                bool result = true;
+                if (isDelete)
+                {
+                    if (selectionLeftColumn > maxPromptLength || maxPromptLength == minPromptLength)
+                    {
+                        selectionTopLine = editableLine;
+                        selectionLeftColumn = Math.Max(selectionLeftColumn, maxPromptLength);
+                        result = false;
+                    }
+                }
+                else
+                {
+                    if (selectionRightColumn < minPromptLength)
+                    {
+                        // entirely within readonly prompt region:
+                        result = false;
+                    }
+                    else if (maxPromptLength > selectionRightColumn)
+                    {
+                        selectionTopLine = editableLine;
+                        selectionLeftColumn = maxPromptLength;
+                        selectionRightColumn = maxPromptLength;
+                    }
+                    else
+                    {
+                        selectionTopLine = editableLine;
+                        selectionLeftColumn = Math.Max(maxPromptLength, selectionLeftColumn);
+                    }
+                }
+
+                if (horizontallyReversed)
+                {
+                    // bottom-left <-> top-right 
+                    selectionTop = new VirtualSnapshotPoint(selectionTopLine, selectionRightColumn);
+                    selectionBottom = new VirtualSnapshotPoint(selectionBottomLine, selectionLeftColumn);
+                }
+                else
+                {
+                    // top-left <-> bottom-right
+                    selectionTop = new VirtualSnapshotPoint(selectionTopLine, selectionLeftColumn);
+                    selectionBottom = new VirtualSnapshotPoint(selectionBottomLine, selectionRightColumn);
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Returns the lengths of the longest and shortest prompts within the specified range of lines of the current submission buffer.
+            /// </summary>
+            private void MeasurePrompts(int startLine, int endLine, out int minPromptLength, out int maxPromptLength)
+            {
+                Debug.Assert(endLine > startLine);
+
+                var projectionSnapshot = _window._projectionBuffer.CurrentSnapshot;
+                var sourceSpans = projectionSnapshot.GetSourceSpans();
+                var promptSpanIndex = _window.GetProjectionSpanIndexFromEditableBufferPosition(projectionSnapshot, sourceSpans.Count, startLine) - 1;
+                var promptSpan = sourceSpans[promptSpanIndex];
+                Debug.Assert(_window.IsPrompt(promptSpan));
+
+                minPromptLength = maxPromptLength = promptSpan.Length;
+            }
+
             public void Cut()
             {
                 if (_window._textView.Selection.IsEmpty)
                 {
-                    _window.CutOrDeleteCurrentLine(isCut: true);
+                    CutOrDeleteCurrentLine(isCut: true);
                 }
                 else
                 {
-                    _window.CutOrDeleteSelection(isCut: true);
+                    CutOrDeleteSelection(isCut: true);
                 }
 
-                _window.MoveCaretToClosestEditableBuffer();
+                MoveCaretToClosestEditableBuffer();
+            }
+
+            private void CutOrDeleteCurrentLine(bool isCut)
+            {
+                ITextSnapshotLine line;
+                int column;
+                _window._textView.Caret.Position.VirtualBufferPosition.GetLineAndColumn(out line, out column);
+
+                CutOrDelete(new[] { line.ExtentIncludingLineBreak }, isCut);
+
+                _window._textView.Caret.MoveTo(new VirtualSnapshotPoint(_window._textView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(line.LineNumber), column));
+            }
+
+            /// <summary>
+            /// Deletes currently selected text from the language buffer and optionally saves it to the clipboard.
+            /// </summary>
+            private void CutOrDeleteSelection(bool isCut)
+            {
+                CutOrDelete(_window._textView.Selection.SelectedSpans, isCut);
+
+                // if the selection spans over prompts the prompts remain selected, so clear manually:
+                _window._textView.Selection.Clear();
+            }
+
+            private void CutOrDelete(IEnumerable<SnapshotSpan> projectionSpans, bool isCut)
+            {
+                Debug.Assert(_window._currentLanguageBuffer != null);
+
+                StringBuilder deletedText = null;
+
+                // split into multiple deletes that only affect the language/input buffer:
+                ITextBuffer affectedBuffer = (_window._stdInputStart != null) ? _window._standardInputBuffer : _window._currentLanguageBuffer;
+                using (var edit = affectedBuffer.CreateEdit())
+                {
+                    foreach (var projectionSpan in projectionSpans)
+                    {
+                        var spans = _window._textView.BufferGraph.MapDownToBuffer(projectionSpan, SpanTrackingMode.EdgeInclusive, affectedBuffer);
+                        foreach (var span in spans)
+                        {
+                            if (isCut)
+                            {
+                                if (deletedText == null)
+                                {
+                                    deletedText = new StringBuilder();
+                                }
+
+                                deletedText.Append(span.GetText());
+                            }
+
+                            edit.Delete(span);
+                        }
+                    }
+
+                    edit.Apply();
+                }
+
+                // copy the deleted text to the clipboard:
+                if (deletedText != null)
+                {
+                    var data = new DataObject();
+                    if (_window._textView.Selection.Mode == TextSelectionMode.Box)
+                    {
+                        data.SetData(BoxSelectionCutCopyTag, new object());
+                    }
+
+                    data.SetText(deletedText.ToString());
+                    Clipboard.SetDataObject(data, true);
+                }
             }
 
             public void Copy()
             {
-                _window.CopySelection();
+                CopySelection();
+            }
+
+            /// <summary>
+            /// Copy the entire selection to the clipboard for RTF format and
+            /// copy the selection minus any prompt text for other formats.
+            /// That allows paste into code editors of just the code and
+            /// paste of the entire content for editors that support RTF.
+            /// </summary>
+            private void CopySelection()
+            {
+                var spans = GetSelectionSpans(_window._textView);
+                var data = Copy(spans);
+                Clipboard.SetDataObject(data, true);
+            }
+
+            private static NormalizedSnapshotSpanCollection GetSelectionSpans(ITextView textView)
+            {
+                var selection = textView.Selection;
+                if (selection.IsEmpty)
+                {
+                    // Use the current line as the selection.
+                    var snapshotLine = textView.Caret.Position.VirtualBufferPosition.Position.GetContainingLine();
+                    var span = new SnapshotSpan(snapshotLine.Start, snapshotLine.LengthIncludingLineBreak);
+                    return new NormalizedSnapshotSpanCollection(span);
+                }
+                return selection.SelectedSpans;
+            }
+
+            private DataObject Copy(NormalizedSnapshotSpanCollection spans)
+            {
+                var text = spans.Aggregate(new StringBuilder(), GetTextWithoutPrompts, b => b.ToString());
+                var rtf = _rtfBuilderService.GenerateRtf(spans, _window._textView);
+                var data = new DataObject();
+                data.SetData(DataFormats.StringFormat, text);
+                data.SetData(DataFormats.Text, text);
+                data.SetData(DataFormats.UnicodeText, text);
+                data.SetData(DataFormats.Rtf, rtf);
+                return data;
+            }
+
+            private StringBuilder GetTextWithoutPrompts(StringBuilder builder, SnapshotSpan span)
+            {
+                // Find the range of source spans that cover the span.
+                var sourceSpans = GetSourceSpans(span.Snapshot);
+                int n = sourceSpans.Count;
+                int index = _window.GetSourceSpanIndex(sourceSpans, span.Start);
+                if (index == n)
+                {
+                    index--;
+                }
+
+                // Add the text for all non-prompt spans within the range.
+                for (; index < n; index++)
+                {
+                    var sourceSpan = sourceSpans[index];
+                    if (sourceSpan.IsEmpty)
+                    {
+                        continue;
+                    }
+                    if (!_window.IsPrompt(sourceSpan))
+                    {
+                        var sourceSnapshot = sourceSpan.Snapshot;
+                        var mappedSpans = _window._textView.BufferGraph.MapDownToBuffer(span, SpanTrackingMode.EdgeExclusive, sourceSnapshot.TextBuffer);
+                        bool added = false;
+                        foreach (var mappedSpan in mappedSpans)
+                        {
+                            var intersection = sourceSpan.Span.Intersection(mappedSpan);
+                            if (intersection.HasValue)
+                            {
+                                builder.Append(sourceSnapshot.GetText(intersection.Value));
+                                added = true;
+                            }
+                        }
+                        if (!added)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                return builder;
             }
 
             public bool Backspace()
@@ -1230,36 +1750,124 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 bool handled = false;
                 if (!_window._textView.Selection.IsEmpty)
                 {
-                    if (_window._textView.Selection.Mode == TextSelectionMode.Stream || _window.ReduceBoxSelectionToEditableBox())
+                    if (_window._textView.Selection.Mode == TextSelectionMode.Stream || ReduceBoxSelectionToEditableBox())
                     {
-                        _window.CutOrDeleteSelection(isCut: false);
-                        _window.MoveCaretToClosestEditableBuffer();
+                        CutOrDeleteSelection(isCut: false);
+                        MoveCaretToClosestEditableBuffer();
                         handled = true;
                     }
                 }
                 else if (_window._textView.Caret.Position.VirtualSpaces == 0)
                 {
-                    _window.DeletePreviousCharacter();
+                    DeletePreviousCharacter();
                     handled = true;
                 }
 
                 return handled;
             }
 
+            /// <summary>
+            /// Deletes characters preceding the current caret position in the current language buffer.
+            /// </summary>
+            private void DeletePreviousCharacter()
+            {
+                SnapshotPoint? point = MapToEditableBuffer(_window._textView.Caret.Position.BufferPosition);
+
+                // We are not in an editable buffer, or we are at the start of the buffer, nothing to delete.
+                if (point == null || point.Value == 0)
+                {
+                    return;
+                }
+
+                var line = point.Value.GetContainingLine();
+                int characterSize;
+                if (line.Start.Position == point.Value.Position)
+                {
+                    Debug.Assert(line.LineNumber != 0);
+                    characterSize = line.Snapshot.GetLineFromLineNumber(line.LineNumber - 1).LineBreakLength;
+                }
+                else
+                {
+                    characterSize = 1;
+                }
+
+                point.Value.Snapshot.TextBuffer.Delete(new Span(point.Value.Position - characterSize, characterSize));
+
+                ScrollToCaret();
+            }
+
+            /// <summary>
+            /// Maps point to the current language buffer or standard input buffer.
+            /// </summary>
+            private SnapshotPoint? MapToEditableBuffer(SnapshotPoint projectionPoint)
+            {
+                SnapshotPoint? result = null;
+
+                if (_window._currentLanguageBuffer != null)
+                {
+                    result = _window.GetPositionInLanguageBuffer(projectionPoint);
+                }
+
+                if (result != null)
+                {
+                    return result;
+                }
+
+                if (_window._standardInputBuffer != null)
+                {
+                    result = _window.GetPositionInStdInputBuffer(projectionPoint);
+                }
+
+                return result;
+            }
+
             public bool TrySubmitStandardInput()
             {
-                _window._historySearch = null;
+                _historySearch = null;
                 if (_window._stdInputStart != null)
                 {
-                    if (_window.InStandardInputRegion(_window._textView.Caret.Position.BufferPosition))
+                    if (InStandardInputRegion(_window._textView.Caret.Position.BufferPosition))
                     {
-                        _window.SubmitStandardInput();
+                        SubmitStandardInput();
                     }
 
                     return true;
                 }
 
                 return false;
+            }
+
+            private void SubmitStandardInput()
+            {
+                AppendLineNoPromptInjection(_window._standardInputBuffer);
+                _window._inputValue = new SnapshotSpan(_window._standardInputBuffer.CurrentSnapshot, Span.FromBounds(_window._stdInputStart.Value, _window._standardInputBuffer.CurrentSnapshot.Length));
+                _window._inputEvent.Set();
+            }
+
+            private bool InStandardInputRegion(SnapshotPoint point)
+            {
+                if (_window._stdInputStart == null)
+                {
+                    return false;
+                }
+
+                var stdInputPoint = _window.GetPositionInStdInputBuffer(point);
+                return stdInputPoint != null && stdInputPoint.Value.Position >= _window._stdInputStart.Value;
+            }
+
+            /// <summary>
+            /// Add a zero-width tracking span at the end of the projection buffer mapping to the end of the standard input buffer.
+            /// </summary>
+            public void AddStandardInputSpan()
+            {
+                var promptSpan = _window.CreateStandardInputPrompt();
+                var currentSnapshot = _window._standardInputBuffer.CurrentSnapshot;
+                var inputSpan = new CustomTrackingSpan(
+                    currentSnapshot,
+                    new Span(currentSnapshot.Length, 0),
+                    PointTrackingMode.Negative,
+                    PointTrackingMode.Positive);
+                AppendProjectionSpans(promptSpan, inputSpan);
             }
 
             public bool BreakLine()
@@ -1269,7 +1877,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
             public bool Return()
             {
-                _window._historySearch = null;
+                _historySearch = null;
                 return HandlePostServicesReturn(true);
             }
 
@@ -1287,7 +1895,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     int caretPosition = langCaret.Value.Position;
 
                     // note that caret might be located in virtual space behind the current buffer end:
-                    if (trySubmit && caretPosition >= _window._currentLanguageBuffer.CurrentSnapshot.Length && _window.CanExecuteActiveCode())
+                    if (trySubmit && caretPosition >= _window._currentLanguageBuffer.CurrentSnapshot.Length && CanExecuteActiveCode())
                     {
                         SubmitAsync().GetAwaiter().GetResult();
                         return true;
@@ -1302,10 +1910,58 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
                 else
                 {
-                    _window.MoveCaretToClosestEditableBuffer();
+                    MoveCaretToClosestEditableBuffer();
                 }
 
                 return false;
+            }
+
+            private bool CanExecuteActiveCode()
+            {
+                Debug.Assert(_window._currentLanguageBuffer != null);
+
+                var input = GetActiveCode();
+                if (string.IsNullOrWhiteSpace(input))
+                {
+                    // Always allow "execution" of a blank line.
+                    // This will just close the current prompt and start a new one
+                    return true;
+                }
+
+                // Ignore any whitespace past the insertion point when determining
+                // whether or not we're at the end of the input
+                var pt = GetActiveCodeInsertionPosition();
+                var isEnd = (pt == input.Length) || (pt >= 0 && input.Substring(pt).Trim().Length == 0);
+                if (!isEnd)
+                {
+                    return false;
+                }
+
+                // If this throws, VS shows a dialog.
+                return _window._evaluator.CanExecuteCode(input);
+            }
+
+            /// <summary>
+            /// Returns the insertion point relative to the current language buffer.
+            /// </summary>
+            private int GetActiveCodeInsertionPosition()
+            {
+                Debug.Assert(_window._currentLanguageBuffer != null);
+
+                var langPoint = _window._textView.BufferGraph.MapDownToBuffer(
+                    new SnapshotPoint(
+                        _window._projectionBuffer.CurrentSnapshot,
+                        _window.Caret.Position.BufferPosition.Position),
+                    PointTrackingMode.Positive,
+                    _window._currentLanguageBuffer,
+                    PositionAffinity.Predecessor);
+
+                if (langPoint != null)
+                {
+                    return langPoint.Value;
+                }
+
+                return _window._currentLanguageBuffer.CurrentSnapshot.Length;
             }
         }
 

--- a/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow_UIThread.cs
@@ -1897,7 +1897,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     // note that caret might be located in virtual space behind the current buffer end:
                     if (trySubmit && caretPosition >= _window._currentLanguageBuffer.CurrentSnapshot.Length && CanExecuteActiveCode())
                     {
-                        SubmitAsync().GetAwaiter().GetResult();
+                        var dummy = SubmitAsync();
                         return true;
                     }
 


### PR DESCRIPTION
They all intuitively correspond to UI operations and are not intended to be run in parallel with each other.

This is the first part of  #4044.