### PR TITLE
Make Metadata as Source more cancellable

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyProvider.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
         {
             var compilation = project.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var resolution = id.Resolve(compilation, cancellationToken: cancellationToken);
-            project.Solution.Workspace.Services.GetService<ISymbolNavigationService>().TryNavigateToSymbol(resolution.Symbol, project, usePreviewTab: true, cancellationToken: CancellationToken.None);
+            project.Solution.Workspace.Services.GetService<ISymbolNavigationService>().TryNavigateToSymbol(resolution.Symbol, project, usePreviewTab: true, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyProvider.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
         {
             var compilation = project.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var resolution = id.Resolve(compilation, cancellationToken: cancellationToken);
-            project.Solution.Workspace.Services.GetService<ISymbolNavigationService>().TryNavigateToSymbol(resolution.Symbol, project, usePreviewTab: true);
+            project.Solution.Workspace.Services.GetService<ISymbolNavigationService>().TryNavigateToSymbol(resolution.Symbol, project, usePreviewTab: true, cancellationToken: CancellationToken.None);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
                 // to a metadata-as-source view.
 
                 var symbolNavigationService = solution.Workspace.Services.GetService<ISymbolNavigationService>();
-                return symbolNavigationService.TryNavigateToSymbol(symbol, project, cancellationToken: cancellationToken, usePreviewTab: true);
+                return symbolNavigationService.TryNavigateToSymbol(symbol, project, usePreviewTab: true, cancellationToken: cancellationToken);
             }
 
             // If we have a single location, then just navigate to it.

--- a/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
                 // to a metadata-as-source view.
 
                 var symbolNavigationService = solution.Workspace.Services.GetService<ISymbolNavigationService>();
-                return symbolNavigationService.TryNavigateToSymbol(symbol, project, usePreviewTab: true);
+                return symbolNavigationService.TryNavigateToSymbol(symbol, project, usePreviewTab: true, cancellationToken: cancellationToken);
             }
 
             // If we have a single location, then just navigate to it.

--- a/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
                 // to a metadata-as-source view.
 
                 var symbolNavigationService = solution.Workspace.Services.GetService<ISymbolNavigationService>();
-                return symbolNavigationService.TryNavigateToSymbol(symbol, project, usePreviewTab: true, cancellationToken: cancellationToken);
+                return symbolNavigationService.TryNavigateToSymbol(symbol, project, cancellationToken: cancellationToken, usePreviewTab: true);
             }
 
             // If we have a single location, then just navigate to it.

--- a/src/EditorFeatures/Test2/Utilities/MockSymbolNavigationServiceProvider.vb
+++ b/src/EditorFeatures/Test2/Utilities/MockSymbolNavigationServiceProvider.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Composition
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Navigation
@@ -36,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             Public NavigationLineNumberReturnValue As Integer = 0
             Public NavigationCharOffsetReturnValue As Integer = 0
 
-            Public Function TryNavigateToSymbol(symbol As ISymbol, project As Project, Optional usePreviewTab As Boolean = False) As Boolean Implements ISymbolNavigationService.TryNavigateToSymbol
+            Public Function TryNavigateToSymbol(symbol As ISymbol, project As Project, Optional usePreviewTab As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As Boolean Implements ISymbolNavigationService.TryNavigateToSymbol
                 Me.TryNavigateToSymbolProvidedSymbol = symbol
                 Me.TryNavigateToSymbolProvidedProject = project
                 Me.TryNavigateToSymbolProvidedUsePreviewTab = usePreviewTab

--- a/src/EditorFeatures/Test2/Utilities/MockSymbolNavigationServiceProvider.vb
+++ b/src/EditorFeatures/Test2/Utilities/MockSymbolNavigationServiceProvider.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             Public NavigationLineNumberReturnValue As Integer = 0
             Public NavigationCharOffsetReturnValue As Integer = 0
 
-            Public Function TryNavigateToSymbol(symbol As ISymbol, project As Project, cancellationToken As CancellationToken, Optional usePreviewTab As Boolean = False) As Boolean Implements ISymbolNavigationService.TryNavigateToSymbol
+            Public Function TryNavigateToSymbol(symbol As ISymbol, project As Project, Optional usePreviewTab As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As Boolean Implements ISymbolNavigationService.TryNavigateToSymbol
                 Me.TryNavigateToSymbolProvidedSymbol = symbol
                 Me.TryNavigateToSymbolProvidedProject = project
                 Me.TryNavigateToSymbolProvidedUsePreviewTab = usePreviewTab

--- a/src/EditorFeatures/Test2/Utilities/MockSymbolNavigationServiceProvider.vb
+++ b/src/EditorFeatures/Test2/Utilities/MockSymbolNavigationServiceProvider.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             Public NavigationLineNumberReturnValue As Integer = 0
             Public NavigationCharOffsetReturnValue As Integer = 0
 
-            Public Function TryNavigateToSymbol(symbol As ISymbol, project As Project, Optional usePreviewTab As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As Boolean Implements ISymbolNavigationService.TryNavigateToSymbol
+            Public Function TryNavigateToSymbol(symbol As ISymbol, project As Project, cancellationToken As CancellationToken, Optional usePreviewTab As Boolean = False) As Boolean Implements ISymbolNavigationService.TryNavigateToSymbol
                 Me.TryNavigateToSymbolProvidedSymbol = symbol
                 Me.TryNavigateToSymbolProvidedProject = project
                 Me.TryNavigateToSymbolProvidedUsePreviewTab = usePreviewTab

--- a/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.Navigation
 {
     internal class DefaultSymbolNavigationService : ISymbolNavigationService
     {
-        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken))
+        public bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken = default(CancellationToken), bool usePreviewTab = false)
         {
             return false;
         }

--- a/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.Navigation
 {
     internal class DefaultSymbolNavigationService : ISymbolNavigationService
     {
-        public bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken = default(CancellationToken), bool usePreviewTab = false)
+        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return false;
         }

--- a/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.CodeAnalysis.Navigation
 {
     internal class DefaultSymbolNavigationService : ISymbolNavigationService
     {
-        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false)
+        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return false;
         }

--- a/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// <param name="symbol">The symbol to navigate to</param>
         /// <param name="usePreviewTab">Indicates whether a preview tab should be used if the
         /// containing document is opened in a new tab. Defaults to false.</param>
-        bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken));
+        bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken, bool usePreviewTab = false);
 
         /// <returns>True if the navigation was handled, indicating that the caller should not 
         /// perform the navigation.</returns>

--- a/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// <param name="usePreviewTab">Indicates whether a preview tab should be used if the
         /// containing document is opened in a new tab. Defaults to false.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to check.</param>
-        bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken));
+        bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken, bool usePreviewTab = false);
 
         /// <returns>True if the navigation was handled, indicating that the caller should not 
         /// perform the navigation.</returns>

--- a/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// <param name="project">A project context with which to generate source for symbol
         /// if it has no source locations</param>
         /// <param name="symbol">The symbol to navigate to</param>
+        /// <param name="cancellationToken">The token to check for cancellation</param>
         /// <param name="usePreviewTab">Indicates whether a preview tab should be used if the
         /// containing document is opened in a new tab. Defaults to false.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to check.</param>
         bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken, bool usePreviewTab = false);
 
         /// <returns>True if the navigation was handled, indicating that the caller should not 

--- a/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Host;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Navigation
 {
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// <param name="symbol">The symbol to navigate to</param>
         /// <param name="usePreviewTab">Indicates whether a preview tab should be used if the
         /// containing document is opened in a new tab. Defaults to false.</param>
-        bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false);
+        bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <returns>True if the navigation was handled, indicating that the caller should not 
         /// perform the navigation.</returns>

--- a/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
@@ -15,7 +15,8 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// <param name="symbol">The symbol to navigate to</param>
         /// <param name="usePreviewTab">Indicates whether a preview tab should be used if the
         /// containing document is opened in a new tab. Defaults to false.</param>
-        bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken, bool usePreviewTab = false);
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to check.</param>
+        bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <returns>True if the navigation was handled, indicating that the caller should not 
         /// perform the navigation.</returns>

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
             if (symbol != null && referencingProject != null)
             {
                 var navigationService = _workspace.Services.GetService<ISymbolNavigationService>();
-                return navigationService.TryNavigateToSymbol(symbol, referencingProject)
+                return navigationService.TryNavigateToSymbol(symbol, referencingProject, CancellationToken.None)
                     ? VSConstants.S_OK
                     : VSConstants.E_FAIL;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _metadataAsSourceFileService = componentModel.GetService<IMetadataAsSourceFileService>();
         }
 
-        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false)
+        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (project == null || symbol == null)
             {
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             // Generate new source or retrieve existing source for the symbol in question
-            var result = _metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol).WaitAndGetResult(CancellationToken.None);
+            var result = _metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, cancellationToken).WaitAndGetResult(cancellationToken);
 
             var vsRunningDocumentTable4 = GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>();
             var fileAlreadyOpen = vsRunningDocumentTable4.IsMonikerValid(result.FilePath);

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -49,11 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _metadataAsSourceFileService = componentModel.GetService<IMetadataAsSourceFileService>();
         }
 
-<<<<<<< HEAD
-        public bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken = default(CancellationToken), bool usePreviewTab = false)
-=======
-        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Make Metadata as Source more cancellable
+        public bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken, bool usePreviewTab = false)
         {
             if (project == null || symbol == null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _metadataAsSourceFileService = componentModel.GetService<IMetadataAsSourceFileService>();
         }
 
-        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken))
+        public bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken = default(CancellationToken), bool usePreviewTab = false)
         {
             if (project == null || symbol == null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -49,7 +49,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _metadataAsSourceFileService = componentModel.GetService<IMetadataAsSourceFileService>();
         }
 
+<<<<<<< HEAD
         public bool TryNavigateToSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken = default(CancellationToken), bool usePreviewTab = false)
+=======
+        public bool TryNavigateToSymbol(ISymbol symbol, Project project, bool usePreviewTab = false, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Make Metadata as Source more cancellable
         {
             if (project == null || symbol == null)
             {

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationService.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationService.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     options = CreateOptionsForMultipleMembers(options);
                 }
 
-                return AddMembers(destination, members, availableIndices, options);
+                return AddMembers(destination, members, availableIndices, options, CancellationToken.None);
             }
 
             if (destination is TypeDeclarationSyntax)
@@ -202,35 +202,35 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        protected override TDeclarationNode AddNamedType<TDeclarationNode>(TDeclarationNode destination, INamedTypeSymbol namedType, CodeGenerationOptions options, IList<bool> availableIndices)
+        protected override TDeclarationNode AddNamedType<TDeclarationNode>(TDeclarationNode destination, INamedTypeSymbol namedType, CodeGenerationOptions options, IList<bool> availableIndices, CancellationToken cancellationToken)
         {
             CheckDeclarationNode<TypeDeclarationSyntax, NamespaceDeclarationSyntax, CompilationUnitSyntax>(destination);
 
             if (destination is TypeDeclarationSyntax)
             {
-                return Cast<TDeclarationNode>(NamedTypeGenerator.AddNamedTypeTo(this, Cast<TypeDeclarationSyntax>(destination), namedType, options, availableIndices));
+                return Cast<TDeclarationNode>(NamedTypeGenerator.AddNamedTypeTo(this, Cast<TypeDeclarationSyntax>(destination), namedType, options, availableIndices, cancellationToken));
             }
             else if (destination is NamespaceDeclarationSyntax)
             {
-                return Cast<TDeclarationNode>(NamedTypeGenerator.AddNamedTypeTo(this, Cast<NamespaceDeclarationSyntax>(destination), namedType, options, availableIndices));
+                return Cast<TDeclarationNode>(NamedTypeGenerator.AddNamedTypeTo(this, Cast<NamespaceDeclarationSyntax>(destination), namedType, options, availableIndices, cancellationToken));
             }
             else
             {
-                return Cast<TDeclarationNode>(NamedTypeGenerator.AddNamedTypeTo(this, Cast<CompilationUnitSyntax>(destination), namedType, options, availableIndices));
+                return Cast<TDeclarationNode>(NamedTypeGenerator.AddNamedTypeTo(this, Cast<CompilationUnitSyntax>(destination), namedType, options, availableIndices, cancellationToken));
             }
         }
 
-        protected override TDeclarationNode AddNamespace<TDeclarationNode>(TDeclarationNode destination, INamespaceSymbol @namespace, CodeGenerationOptions options, IList<bool> availableIndices)
+        protected override TDeclarationNode AddNamespace<TDeclarationNode>(TDeclarationNode destination, INamespaceSymbol @namespace, CodeGenerationOptions options, IList<bool> availableIndices, CancellationToken cancellationToken)
         {
             CheckDeclarationNode<CompilationUnitSyntax, NamespaceDeclarationSyntax>(destination);
 
             if (destination is CompilationUnitSyntax)
             {
-                return Cast<TDeclarationNode>(NamespaceGenerator.AddNamespaceTo(this, Cast<CompilationUnitSyntax>(destination), @namespace, options, availableIndices));
+                return Cast<TDeclarationNode>(NamespaceGenerator.AddNamespaceTo(this, Cast<CompilationUnitSyntax>(destination), @namespace, options, availableIndices, cancellationToken));
             }
             else
             {
-                return Cast<TDeclarationNode>(NamespaceGenerator.AddNamespaceTo(this, Cast<NamespaceDeclarationSyntax>(destination), @namespace, options, availableIndices));
+                return Cast<TDeclarationNode>(NamespaceGenerator.AddNamespaceTo(this, Cast<NamespaceDeclarationSyntax>(destination), @namespace, options, availableIndices, cancellationToken));
             }
         }
 
@@ -604,15 +604,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         public override SyntaxNode CreateNamedTypeDeclaration(
-            INamedTypeSymbol namedType, CodeGenerationDestination destination, CodeGenerationOptions options)
+            INamedTypeSymbol namedType, CodeGenerationDestination destination, CodeGenerationOptions options, CancellationToken cancellationToken)
         {
-            return NamedTypeGenerator.GenerateNamedTypeDeclaration(this, namedType, destination, options);
+            return NamedTypeGenerator.GenerateNamedTypeDeclaration(this, namedType, destination, options, cancellationToken);
         }
 
         public override SyntaxNode CreateNamespaceDeclaration(
-            INamespaceSymbol @namespace, CodeGenerationDestination destination, CodeGenerationOptions options)
+            INamespaceSymbol @namespace, CodeGenerationDestination destination, CodeGenerationOptions options, CancellationToken cancellationToken)
         {
-            return NamespaceGenerator.GenerateNamespaceDeclaration(this, @namespace, options);
+            return NamespaceGenerator.GenerateNamespaceDeclaration(this, @namespace, options, cancellationToken);
         }
 
         private static TDeclarationNode UpdateDeclarationModifiers<TDeclarationNode>(TDeclarationNode declaration, Func<SyntaxTokenList, SyntaxTokenList> computeNewModifiersList, CodeGenerationOptions options, CancellationToken cancellationToken)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
@@ -19,9 +19,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             TypeDeclarationSyntax destination,
             INamedTypeSymbol namedType,
             CodeGenerationOptions options,
-            IList<bool> availableIndices)
+            IList<bool> availableIndices, 
+            CancellationToken cancellationToken)
         {
-            var declaration = GenerateNamedTypeDeclaration(service, namedType, GetDestination(destination), options);
+            var declaration = GenerateNamedTypeDeclaration(service, namedType, GetDestination(destination), options, cancellationToken);
             var members = Insert(destination.Members, declaration, options, availableIndices);
 
             return AddMembersTo(destination, members);
@@ -32,9 +33,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             NamespaceDeclarationSyntax destination,
             INamedTypeSymbol namedType,
             CodeGenerationOptions options,
-            IList<bool> availableIndices)
+            IList<bool> availableIndices,
+            CancellationToken cancellationToken)
         {
-            var declaration = GenerateNamedTypeDeclaration(service, namedType, CodeGenerationDestination.Namespace, options);
+            var declaration = GenerateNamedTypeDeclaration(service, namedType, CodeGenerationDestination.Namespace, options, cancellationToken);
             var members = Insert(destination.Members, declaration, options, availableIndices);
             return ConditionallyAddFormattingAnnotationTo(
                 destination.WithMembers(members),
@@ -46,9 +48,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             CompilationUnitSyntax destination,
             INamedTypeSymbol namedType,
             CodeGenerationOptions options,
-            IList<bool> availableIndices)
+            IList<bool> availableIndices, 
+            CancellationToken cancellationToken)
         {
-            var declaration = GenerateNamedTypeDeclaration(service, namedType, CodeGenerationDestination.CompilationUnit, options);
+            var declaration = GenerateNamedTypeDeclaration(service, namedType, CodeGenerationDestination.CompilationUnit, options, cancellationToken);
             var members = Insert(destination.Members, declaration, options, availableIndices);
             return destination.WithMembers(members);
         }
@@ -57,7 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             ICodeGenerationService service,
             INamedTypeSymbol namedType,
             CodeGenerationDestination destination,
-            CodeGenerationOptions options)
+            CodeGenerationOptions options, 
+            CancellationToken cancellationToken)
         {
             options = options ?? CodeGenerationOptions.Default;
 
@@ -70,7 +74,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             declaration = options.GenerateMembers && namedType.TypeKind != TypeKind.Delegate
                 ? service.AddMembers(declaration,
                                      GetMembers(namedType).Where(s => s.Kind != SymbolKind.Property || PropertyGenerator.CanBeGenerated((IPropertySymbol)s)),
-                                     options)
+                                     options, 
+                                     cancellationToken)
                 : declaration;
 
             return AddCleanupAnnotationsTo(ConditionallyAddDocumentationCommentTo(declaration, namedType, options));

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/NamespaceGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/NamespaceGenerator.cs
@@ -21,9 +21,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             NamespaceDeclarationSyntax destination,
             INamespaceSymbol @namespace,
             CodeGenerationOptions options,
-            IList<bool> availableIndices)
+            IList<bool> availableIndices,
+            CancellationToken cancellationToken)
         {
-            var declaration = GenerateNamespaceDeclaration(service, @namespace, options);
+            var declaration = GenerateNamespaceDeclaration(service, @namespace, options, cancellationToken);
             if (!(declaration is NamespaceDeclarationSyntax))
             {
                 throw new ArgumentException(CSharpWorkspaceResources.NamespaceCanNotBeAddedIn);
@@ -38,9 +39,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             CompilationUnitSyntax destination,
             INamespaceSymbol @namespace,
             CodeGenerationOptions options,
-            IList<bool> availableIndices)
+            IList<bool> availableIndices, 
+            CancellationToken cancellationToken)
         {
-            var declaration = GenerateNamespaceDeclaration(service, @namespace, options);
+            var declaration = GenerateNamespaceDeclaration(service, @namespace, options, cancellationToken);
             if (!(declaration is NamespaceDeclarationSyntax))
             {
                 throw new ArgumentException(CSharpWorkspaceResources.NamespaceCanNotBeAddedIn);
@@ -53,7 +55,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal static SyntaxNode GenerateNamespaceDeclaration(
             ICodeGenerationService service,
             INamespaceSymbol @namespace,
-            CodeGenerationOptions options)
+            CodeGenerationOptions options,
+            CancellationToken cancellationToken)
         {
             options = options ?? CodeGenerationOptions.Default;
 
@@ -64,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var declaration = GetDeclarationSyntaxWithoutMembers(@namespace, innermostNamespace, name, options);
 
             declaration = options.GenerateMembers
-                    ? service.AddMembers(declaration, innermostNamespace.GetMembers(), options)
+                    ? service.AddMembers(declaration, innermostNamespace.GetMembers(), options, cancellationToken)
                     : declaration;
 
             return AddCleanupAnnotationsTo(declaration);

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return GetEditAsync(
                 solution,
                 destination,
-                (t, opts, ai, _) => AddEvent(t, @event, opts, ai),
+                (t, opts, ai, ct) => AddEvent(t, @event, opts, ai),
                 options,
                 new[] { @event },
                 cancellationToken);
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return GetEditAsync(
                 solution,
                 destination,
-                (t, opts, ai, _) => AddField(t, field, opts, ai),
+                (t, opts, ai, ct) => AddField(t, field, opts, ai),
                 options,
                 new[] { field },
                 cancellationToken);
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai, _) => AddProperty(t, property, opts, ai),
+                (t, opts, ai, ct) => AddProperty(t, property, opts, ai),
                 options, new[] { property },
                 cancellationToken);
         }
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai, _) => AddNamedType(t, namedType, opts, ai, _),
+                (t, opts, ai, ct) => AddNamedType(t, namedType, opts, ai, ct),
                 options, new[] { namedType },
                 cancellationToken);
         }
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai, _) => AddMethod(t, method, opts, ai),
+                (t, opts, ai, ct) => AddMethod(t, method, opts, ai),
                 options, new[] { method }, cancellationToken);
         }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
@@ -46,26 +46,26 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public TDeclarationNode AddNamedType<TDeclarationNode>(TDeclarationNode destination, INamedTypeSymbol namedType, CodeGenerationOptions options, CancellationToken cancellationToken) where TDeclarationNode : SyntaxNode
         {
-            return AddNamedType(destination, namedType, options ?? CodeGenerationOptions.Default, GetAvailableInsertionIndices(destination, cancellationToken));
+            return AddNamedType(destination, namedType, options ?? CodeGenerationOptions.Default, GetAvailableInsertionIndices(destination, cancellationToken), cancellationToken);
         }
 
         public TDeclarationNode AddNamespace<TDeclarationNode>(TDeclarationNode destination, INamespaceSymbol @namespace, CodeGenerationOptions options, CancellationToken cancellationToken) where TDeclarationNode : SyntaxNode
         {
-            return AddNamespace(destination, @namespace, options ?? CodeGenerationOptions.Default, GetAvailableInsertionIndices(destination, cancellationToken));
+            return AddNamespace(destination, @namespace, options ?? CodeGenerationOptions.Default, GetAvailableInsertionIndices(destination, cancellationToken), cancellationToken);
         }
 
         public TDeclarationNode AddMembers<TDeclarationNode>(TDeclarationNode destination, IEnumerable<ISymbol> members, CodeGenerationOptions options, CancellationToken cancellationToken)
             where TDeclarationNode : SyntaxNode
         {
-            return AddMembers(destination, members, GetAvailableInsertionIndices(destination, cancellationToken), options ?? CodeGenerationOptions.Default);
+            return AddMembers(destination, members, GetAvailableInsertionIndices(destination, cancellationToken), options ?? CodeGenerationOptions.Default, cancellationToken);
         }
 
         protected abstract TDeclarationNode AddEvent<TDeclarationNode>(TDeclarationNode destination, IEventSymbol @event, CodeGenerationOptions options, IList<bool> availableIndices) where TDeclarationNode : SyntaxNode;
         protected abstract TDeclarationNode AddField<TDeclarationNode>(TDeclarationNode destination, IFieldSymbol field, CodeGenerationOptions options, IList<bool> availableIndices) where TDeclarationNode : SyntaxNode;
         protected abstract TDeclarationNode AddMethod<TDeclarationNode>(TDeclarationNode destination, IMethodSymbol method, CodeGenerationOptions options, IList<bool> availableIndices) where TDeclarationNode : SyntaxNode;
         protected abstract TDeclarationNode AddProperty<TDeclarationNode>(TDeclarationNode destination, IPropertySymbol property, CodeGenerationOptions options, IList<bool> availableIndices) where TDeclarationNode : SyntaxNode;
-        protected abstract TDeclarationNode AddNamedType<TDeclarationNode>(TDeclarationNode destination, INamedTypeSymbol namedType, CodeGenerationOptions options, IList<bool> availableIndices) where TDeclarationNode : SyntaxNode;
-        protected abstract TDeclarationNode AddNamespace<TDeclarationNode>(TDeclarationNode destination, INamespaceSymbol @namespace, CodeGenerationOptions options, IList<bool> availableIndices) where TDeclarationNode : SyntaxNode;
+        protected abstract TDeclarationNode AddNamedType<TDeclarationNode>(TDeclarationNode destination, INamedTypeSymbol namedType, CodeGenerationOptions options, IList<bool> availableIndices, CancellationToken cancellationToken) where TDeclarationNode : SyntaxNode;
+        protected abstract TDeclarationNode AddNamespace<TDeclarationNode>(TDeclarationNode destination, INamespaceSymbol @namespace, CodeGenerationOptions options, IList<bool> availableIndices, CancellationToken cancellationToken) where TDeclarationNode : SyntaxNode;
         protected abstract TDeclarationNode AddMembers<TDeclarationNode>(TDeclarationNode destination, IEnumerable<SyntaxNode> members) where TDeclarationNode : SyntaxNode;
 
         public abstract TDeclarationNode AddParameters<TDeclarationNode>(TDeclarationNode destinationMember, IEnumerable<IParameterSymbol> parameters, CodeGenerationOptions options, CancellationToken cancellationToken) where TDeclarationNode : SyntaxNode;
@@ -84,8 +84,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public abstract SyntaxNode CreateFieldDeclaration(IFieldSymbol field, CodeGenerationDestination destination, CodeGenerationOptions options);
         public abstract SyntaxNode CreateMethodDeclaration(IMethodSymbol method, CodeGenerationDestination destination, CodeGenerationOptions options);
         public abstract SyntaxNode CreatePropertyDeclaration(IPropertySymbol property, CodeGenerationDestination destination, CodeGenerationOptions options);
-        public abstract SyntaxNode CreateNamedTypeDeclaration(INamedTypeSymbol namedType, CodeGenerationDestination destination, CodeGenerationOptions options);
-        public abstract SyntaxNode CreateNamespaceDeclaration(INamespaceSymbol @namespace, CodeGenerationDestination destination, CodeGenerationOptions options);
+        public abstract SyntaxNode CreateNamedTypeDeclaration(INamedTypeSymbol namedType, CodeGenerationDestination destination, CodeGenerationOptions options, CancellationToken cancellationToken);
+        public abstract SyntaxNode CreateNamespaceDeclaration(INamespaceSymbol @namespace, CodeGenerationDestination destination, CodeGenerationOptions options, CancellationToken cancellationToken);
 
         protected abstract AbstractImportsAdder CreateImportsAdder(Document document);
 
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private async Task<Document> GetEditAsync(
             Solution solution,
             INamespaceOrTypeSymbol destination,
-            Func<SyntaxNode, CodeGenerationOptions, IList<bool>, SyntaxNode> declarationTransform,
+            Func<SyntaxNode, CodeGenerationOptions, IList<bool>, CancellationToken, SyntaxNode> declarationTransform,
             CodeGenerationOptions options,
             IEnumerable<ISymbol> members,
             CancellationToken cancellationToken)
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 throw new ArgumentException(WorkspacesResources.CouldNotFindLocationToGen);
             }
 
-            var transformedDeclaration = declarationTransform(destinationDeclaration, options, availableIndices);
+            var transformedDeclaration = declarationTransform(destinationDeclaration, options, availableIndices, cancellationToken);
 
             var destinationTree = destinationDeclaration.SyntaxTree;
 
@@ -209,7 +209,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             TDeclarationNode destination,
             IEnumerable<ISymbol> members,
             IList<bool> availableIndices,
-            CodeGenerationOptions options)
+            CodeGenerationOptions options,
+            CancellationToken cancellationToken)
             where TDeclarationNode : SyntaxNode
         {
             var membersList = members.ToList();
@@ -228,13 +229,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             {
                 foreach (var member in filteredMembers)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     currentDestination = member.TypeSwitch(
                         (IEventSymbol @event) => this.AddEvent(currentDestination, @event, options, availableIndices),
                         (IFieldSymbol field) => this.AddField(currentDestination, field, options, availableIndices),
                         (IPropertySymbol property) => this.AddProperty(currentDestination, property, options, availableIndices),
                         (IMethodSymbol method) => this.AddMethod(currentDestination, method, options, availableIndices),
-                        (INamedTypeSymbol namedType) => this.AddNamedType(currentDestination, namedType, options, availableIndices),
-                        (INamespaceSymbol @namespace) => this.AddNamespace(currentDestination, @namespace, options, availableIndices),
+                        (INamedTypeSymbol namedType) => this.AddNamedType(currentDestination, namedType, options, availableIndices, cancellationToken),
+                        (INamespaceSymbol @namespace) => this.AddNamespace(currentDestination, @namespace, options, availableIndices, cancellationToken),
                         _ => currentDestination);
                 }
             }
@@ -244,13 +246,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 var codeGenerationDestination = GetDestination(destination);
                 foreach (var member in filteredMembers)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     var newMember = member.TypeSwitch(
                         (IEventSymbol @event) => this.CreateEventDeclaration(@event, codeGenerationDestination, options),
                         (IFieldSymbol field) => this.CreateFieldDeclaration(field, codeGenerationDestination, options),
                         (IPropertySymbol property) => this.CreatePropertyDeclaration(property, codeGenerationDestination, options),
                         (IMethodSymbol method) => this.CreateMethodDeclaration(method, codeGenerationDestination, options),
-                        (INamedTypeSymbol namedType) => this.CreateNamedTypeDeclaration(namedType, codeGenerationDestination, options),
-                        (INamespaceSymbol @namespace) => this.CreateNamespaceDeclaration(@namespace, codeGenerationDestination, options),
+                        (INamedTypeSymbol namedType) => this.CreateNamedTypeDeclaration(namedType, codeGenerationDestination, options, cancellationToken),
+                        (INamespaceSymbol @namespace) => this.CreateNamespaceDeclaration(@namespace, codeGenerationDestination, options, cancellationToken),
                         _ => null);
 
                     if (newMember != null)
@@ -300,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return GetEditAsync(
                 solution,
                 destination,
-                (t, opts, ai) => AddEvent(t, @event, opts, ai),
+                (t, opts, ai, _) => AddEvent(t, @event, opts, ai),
                 options,
                 new[] { @event },
                 cancellationToken);
@@ -311,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return GetEditAsync(
                 solution,
                 destination,
-                (t, opts, ai) => AddField(t, field, opts, ai),
+                (t, opts, ai, _) => AddField(t, field, opts, ai),
                 options,
                 new[] { field },
                 cancellationToken);
@@ -321,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai) => AddProperty(t, property, opts, ai),
+                (t, opts, ai, _) => AddProperty(t, property, opts, ai),
                 options, new[] { property },
                 cancellationToken);
         }
@@ -330,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai) => AddNamedType(t, namedType, opts, ai),
+                (t, opts, ai, _) => AddNamedType(t, namedType, opts, ai, _),
                 options, new[] { namedType },
                 cancellationToken);
         }
@@ -339,7 +342,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai) => AddNamedType(t, namedType, opts, ai),
+                (t, opts, ai, ct) => AddNamedType(t, namedType, opts, ai, ct),
                 options, new[] { namedType }, cancellationToken);
         }
 
@@ -347,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai) => AddNamespace(t, @namespace, opts, ai),
+                (t, opts, ai, ct) => AddNamespace(t, @namespace, opts, ai, ct),
                 options, new[] { @namespace }, cancellationToken);
         }
 
@@ -355,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai) => AddMethod(t, method, opts, ai),
+                (t, opts, ai, _) => AddMethod(t, method, opts, ai),
                 options, new[] { method }, cancellationToken);
         }
 
@@ -363,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return GetEditAsync(
                 solution, destination,
-                (t, opts, ai) => AddMembers(t, members, ai, opts),
+                (t, opts, ai, ct) => AddMembers(t, members, ai, opts, ct),
                 options, members, cancellationToken);
         }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/ICodeGenerationService.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/ICodeGenerationService.cs
@@ -34,12 +34,12 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// <summary>
         /// Returns a newly created named type declaration node from the provided named type.
         /// </summary>
-        SyntaxNode CreateNamedTypeDeclaration(INamedTypeSymbol namedType, CodeGenerationDestination destination = CodeGenerationDestination.Unspecified, CodeGenerationOptions options = null);
+        SyntaxNode CreateNamedTypeDeclaration(INamedTypeSymbol namedType, CodeGenerationDestination destination = CodeGenerationDestination.Unspecified, CodeGenerationOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Returns a newly created namespace declaration node from the provided namespace.
         /// </summary>
-        SyntaxNode CreateNamespaceDeclaration(INamespaceSymbol @namespace, CodeGenerationDestination destination = CodeGenerationDestination.Unspecified, CodeGenerationOptions options = null);
+        SyntaxNode CreateNamespaceDeclaration(INamespaceSymbol @namespace, CodeGenerationDestination destination = CodeGenerationDestination.Unspecified, CodeGenerationOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Adds an event into destination.

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamedTypeGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamedTypeGenerator.vb
@@ -13,8 +13,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     destination As TypeBlockSyntax,
                                     namedType As INamedTypeSymbol,
                                     options As CodeGenerationOptions,
-                                    availableIndices As IList(Of Boolean)) As TypeBlockSyntax
-            Dim declaration = GenerateNamedTypeDeclaration(service, namedType, options)
+                                    availableIndices As IList(Of Boolean),
+                                    cancellationToken As CancellationToken) As TypeBlockSyntax
+            Dim declaration = GenerateNamedTypeDeclaration(service, namedType, options, cancellationToken)
             Dim members = Insert(destination.Members, declaration, options, availableIndices)
             Return FixTerminators(destination.WithMembers(members))
         End Function
@@ -23,8 +24,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     destination As NamespaceBlockSyntax,
                                     namedType As INamedTypeSymbol,
                                     options As CodeGenerationOptions,
-                                    availableIndices As IList(Of Boolean)) As NamespaceBlockSyntax
-            Dim declaration = GenerateNamedTypeDeclaration(service, namedType, options)
+                                    availableIndices As IList(Of Boolean),
+                                       cancellationToken As CancellationToken) As NamespaceBlockSyntax
+            Dim declaration = GenerateNamedTypeDeclaration(service, namedType, options, cancellationToken)
             Dim members = Insert(destination.Members, declaration, options, availableIndices)
             Return destination.WithMembers(members)
         End Function
@@ -33,21 +35,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     destination As CompilationUnitSyntax,
                                     namedType As INamedTypeSymbol,
                                     options As CodeGenerationOptions,
-                                    availableIndices As IList(Of Boolean)) As CompilationUnitSyntax
-            Dim declaration = GenerateNamedTypeDeclaration(service, namedType, options)
+                                    availableIndices As IList(Of Boolean),
+                                       cancellationToken As CancellationToken) As CompilationUnitSyntax
+            Dim declaration = GenerateNamedTypeDeclaration(service, namedType, options, cancellationToken)
             Dim members = Insert(destination.Members, declaration, options, availableIndices)
             Return destination.WithMembers(members)
         End Function
 
         Public Function GenerateNamedTypeDeclaration(service As ICodeGenerationService,
                                     namedType As INamedTypeSymbol,
-                                    options As CodeGenerationOptions) As StatementSyntax
+                                    options As CodeGenerationOptions,
+                                    cancellationToken As CancellationToken) As StatementSyntax
             options = If(options, CodeGenerationOptions.Default)
 
             Dim declaration = GetDeclarationSyntaxWithoutMembers(namedType, options)
 
             declaration = If(options.GenerateMembers AndAlso namedType.TypeKind <> TypeKind.Delegate,
-                service.AddMembers(declaration, GetMembers(namedType), options),
+                service.AddMembers(declaration, GetMembers(namedType), options, cancellationToken),
                 declaration)
 
             Return AddCleanupAnnotationsTo(ConditionallyAddDocumentationCommentTo(declaration, namedType, options))

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
@@ -14,8 +14,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     destination As CompilationUnitSyntax,
                                     [namespace] As INamespaceSymbol,
                                     options As CodeGenerationOptions,
-                                    availableIndices As IList(Of Boolean)) As CompilationUnitSyntax
-            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options)
+                                    availableIndices As IList(Of Boolean),
+                                       cancellationToken As CancellationToken) As CompilationUnitSyntax
+            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options, cancellationToken)
             If Not TypeOf declaration Is NamespaceBlockSyntax Then
                 Throw New ArgumentException(VBWorkspaceResources.NamespaceCannotBeAdded)
             End If
@@ -28,8 +29,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     destination As NamespaceBlockSyntax,
                                     [namespace] As INamespaceSymbol,
                                     options As CodeGenerationOptions,
-                                    availableIndices As IList(Of Boolean)) As NamespaceBlockSyntax
-            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options)
+                                    availableIndices As IList(Of Boolean),
+                                    cancellationToken As CancellationToken) As NamespaceBlockSyntax
+            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options, cancellationToken)
             If Not TypeOf declaration Is NamespaceBlockSyntax Then
                 Throw New ArgumentException(VBWorkspaceResources.NamespaceCannotBeAdded)
             End If
@@ -38,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Return destination.WithMembers(members)
         End Function
 
-        Public Function GenerateNamespaceDeclaration(service As ICodeGenerationService, [namespace] As INamespaceSymbol, options As CodeGenerationOptions) As SyntaxNode
+        Public Function GenerateNamespaceDeclaration(service As ICodeGenerationService, [namespace] As INamespaceSymbol, options As CodeGenerationOptions, cancellationToken As CancellationToken) As SyntaxNode
             Dim name As String = Nothing
             Dim innermostNamespace As INamespaceSymbol = Nothing
             options = If(options, CodeGenerationOptions.Default)
@@ -47,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Dim declaration = GetDeclarationSyntaxWithoutMembers([namespace], innermostNamespace, name, options)
 
             declaration = If(options.GenerateMembers,
-                service.AddMembers(declaration, innermostNamespace.GetMembers().AsEnumerable(), options),
+                service.AddMembers(declaration, innermostNamespace.GetMembers().AsEnumerable(), options, cancellationToken),
                 declaration)
 
             Return AddCleanupAnnotationsTo(declaration)

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
@@ -15,8 +15,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     [namespace] As INamespaceSymbol,
                                     options As CodeGenerationOptions,
                                     availableIndices As IList(Of Boolean),
-                                    cancellationToken As CancellationToken) As CompilationUnitSyntax
-            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options, cancellationToken)
+                                    CancellationToken As CancellationToken) As CompilationUnitSyntax
+            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options, CancellationToken)
             If Not TypeOf declaration Is NamespaceBlockSyntax Then
                 Throw New ArgumentException(VBWorkspaceResources.NamespaceCannotBeAdded)
             End If

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
@@ -15,8 +15,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     [namespace] As INamespaceSymbol,
                                     options As CodeGenerationOptions,
                                     availableIndices As IList(Of Boolean),
-                                    CancellationToken As CancellationToken) As CompilationUnitSyntax
-            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options, CancellationToken)
+                                    cancellationToken As CancellationToken) As CompilationUnitSyntax
+            Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options, cancellationToken)
             If Not TypeOf declaration Is NamespaceBlockSyntax Then
                 Throw New ArgumentException(VBWorkspaceResources.NamespaceCannotBeAdded)
             End If

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/NamespaceGenerator.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                     [namespace] As INamespaceSymbol,
                                     options As CodeGenerationOptions,
                                     availableIndices As IList(Of Boolean),
-                                       cancellationToken As CancellationToken) As CompilationUnitSyntax
+                                    cancellationToken As CancellationToken) As CompilationUnitSyntax
             Dim declaration = GenerateNamespaceDeclaration(service, [namespace], options, cancellationToken)
             If Not TypeOf declaration Is NamespaceBlockSyntax Then
                 Throw New ArgumentException(VBWorkspaceResources.NamespaceCannotBeAdded)

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
@@ -158,15 +158,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 destination As TDeclarationNode,
                 namedType As INamedTypeSymbol,
                 options As CodeGenerationOptions,
-                availableIndices As IList(Of Boolean)) As TDeclarationNode
+                availableIndices As IList(Of Boolean),
+                cancellationToken As CancellationToken) As TDeclarationNode
             CheckDeclarationNode(Of TypeBlockSyntax, NamespaceBlockSyntax, CompilationUnitSyntax)(destination)
             options = If(options, CodeGenerationOptions.Default)
             If TypeOf destination Is TypeBlockSyntax Then
-                Return Cast(Of TDeclarationNode)(NamedTypeGenerator.AddNamedTypeTo(Me, Cast(Of TypeBlockSyntax)(destination), namedType, options, availableIndices))
+                Return Cast(Of TDeclarationNode)(NamedTypeGenerator.AddNamedTypeTo(Me, Cast(Of TypeBlockSyntax)(destination), namedType, options, availableIndices, cancellationToken))
             ElseIf TypeOf destination Is NamespaceBlockSyntax Then
-                Return Cast(Of TDeclarationNode)(NamedTypeGenerator.AddNamedTypeTo(Me, Cast(Of NamespaceBlockSyntax)(destination), namedType, options, availableIndices))
+                Return Cast(Of TDeclarationNode)(NamedTypeGenerator.AddNamedTypeTo(Me, Cast(Of NamespaceBlockSyntax)(destination), namedType, options, availableIndices, cancellationToken))
             Else
-                Return Cast(Of TDeclarationNode)(NamedTypeGenerator.AddNamedTypeTo(Me, Cast(Of CompilationUnitSyntax)(destination), namedType, options, availableIndices))
+                Return Cast(Of TDeclarationNode)(NamedTypeGenerator.AddNamedTypeTo(Me, Cast(Of CompilationUnitSyntax)(destination), namedType, options, availableIndices, cancellationToken))
             End If
         End Function
 
@@ -174,13 +175,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 destination As TDeclarationNode,
                 [namespace] As INamespaceSymbol,
                 options As CodeGenerationOptions,
-                availableIndices As IList(Of Boolean)) As TDeclarationNode
+                availableIndices As IList(Of Boolean),
+                cancellationToken As CancellationToken) As TDeclarationNode
             CheckDeclarationNode(Of CompilationUnitSyntax, NamespaceBlockSyntax)(destination)
 
             If TypeOf destination Is CompilationUnitSyntax Then
-                Return Cast(Of TDeclarationNode)(NamespaceGenerator.AddNamespaceTo(Me, Cast(Of CompilationUnitSyntax)(destination), [namespace], options, availableIndices))
+                Return Cast(Of TDeclarationNode)(NamespaceGenerator.AddNamespaceTo(Me, Cast(Of CompilationUnitSyntax)(destination), [namespace], options, availableIndices, cancellationToken))
             Else
-                Return Cast(Of TDeclarationNode)(NamespaceGenerator.AddNamespaceTo(Me, Cast(Of NamespaceBlockSyntax)(destination), [namespace], options, availableIndices))
+                Return Cast(Of TDeclarationNode)(NamespaceGenerator.AddNamespaceTo(Me, Cast(Of NamespaceBlockSyntax)(destination), [namespace], options, availableIndices, cancellationToken))
             End If
         End Function
 
@@ -538,14 +540,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overrides Function CreateNamedTypeDeclaration(namedType As INamedTypeSymbol,
                                                              destination As CodeGenerationDestination,
-                                                             options As CodeGenerationOptions) As SyntaxNode
-            Return NamedTypeGenerator.GenerateNamedTypeDeclaration(Me, namedType, options)
+                                                             options As CodeGenerationOptions,
+                                                             cancellationToken As CancellationToken) As SyntaxNode
+            Return NamedTypeGenerator.GenerateNamedTypeDeclaration(Me, namedType, options, cancellationToken)
         End Function
 
         Public Overrides Function CreateNamespaceDeclaration([namespace] As INamespaceSymbol,
                                                              destination As CodeGenerationDestination,
-                                                             options As CodeGenerationOptions) As SyntaxNode
-            Return NamespaceGenerator.GenerateNamespaceDeclaration(Me, [namespace], options)
+                                                             options As CodeGenerationOptions,
+                                                             cancellationToken As CancellationToken) As SyntaxNode
+            Return NamespaceGenerator.GenerateNamespaceDeclaration(Me, [namespace], options, cancellationToken)
         End Function
 
         Private Overloads Shared Function UpdateDeclarationModifiers(Of TDeclarationNode As SyntaxNode)(declaration As TDeclarationNode, computeNewModifiersList As Func(Of SyntaxTokenList, SyntaxTokenList), options As CodeGenerationOptions, cancellationToken As CancellationToken) As TDeclarationNode


### PR DESCRIPTION
Pass CancellationTokens through from Go To Definition. Pass cancellation tokens through type and namespace generation, since those operations can do large amounts of work.