### PR TITLE
Address a performance regression in the v2 analyzer driver

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
@@ -142,6 +142,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return TryStartProcessingEntity(decl.GetSyntax(), _pendingDeclarations, _declarationAnalyzerStateDataPool, out state);
             }
 
+            public bool IsDeclarationComplete(SyntaxNode decl)
+            {
+                return IsEntityFullyProcessed(decl, _pendingDeclarations);
+            }
+
             public void MarkDeclarationComplete(SyntaxReference decl)
             {
                 MarkEntityProcessed(decl.GetSyntax(), _pendingDeclarations, _declarationAnalyzerStateDataPool);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _pendingNonSourceEvents = new HashSet<CompilationEvent>();
             _lazyAnalyzerActionCountsMap = null;
             _semanticModelsMap = new ConditionalWeakTable<SyntaxTree, SemanticModel>();
-            _compilationEventsPool = new ObjectPool<HashSet<CompilationEvent>>(() => new HashSet<CompilationEvent>());            
+            _compilationEventsPool = new ObjectPool<HashSet<CompilationEvent>>(() => new HashSet<CompilationEvent>());
         }
 
         private static ImmutableDictionary<DiagnosticAnalyzer, PerAnalyzerState> CreateAnalyzerStateMap(ImmutableArray<DiagnosticAnalyzer> analyzers)
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 t =>
                 {
                     var mappedModel = compilation.GetSemanticModel(t);
-                    
+
                     // Invoke GetDiagnostics to populate the compilation's CompilationEvent queue.
                     mappedModel.GetDiagnostics(null, cancellationToken);
 
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             // Add the events to our global pending events map.
             AddToEventsMap_NoLock(compilationEvents);
-            
+
             // Mark the events for analysis for each analyzer.
             foreach (var kvp in _analyzerStateMap)
             {
@@ -528,6 +528,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public bool TryStartAnalyzingDeclaration(SyntaxReference decl, DiagnosticAnalyzer analyzer, out DeclarationAnalyzerStateData state)
         {
             return _analyzerStateMap[analyzer].TryStartAnalyzingDeclaration(decl, out state);
+        }
+
+        /// <summary>
+        /// True if the given symbol declaration is fully analyzed.
+        /// </summary>
+        public bool IsDeclarationComplete(SyntaxNode decl)
+        {
+            foreach (var analyzerState in _analyzerStateMap.Values)
+            {
+                if (!analyzerState.IsDeclarationComplete(decl))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -488,6 +488,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return true;
             }
 
+            // PERF: Don't query descriptors for compiler analyzer, always execute it.
+            if (analyzer.IsCompilerAnalyzer())
+            {
+                return true;
+            }
+
             return Owner.GetDiagnosticDescriptors(analyzer).Any(d => GetEffectiveSeverity(d, options) != ReportDiagnostic.Hidden);
         }
 
@@ -523,6 +529,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private static bool ShouldRunAnalyzerForStateType(DiagnosticAnalyzer analyzer, StateType stateTypeId,
             ImmutableHashSet<string> diagnosticIds = null, Func<DiagnosticAnalyzer, ImmutableArray<DiagnosticDescriptor>> getDescriptors = null)
         {
+            // PERF: Don't query descriptors for compiler analyzer, always execute it for all state types.
+            if (analyzer.IsCompilerAnalyzer())
+            {
+                return true;
+            }
+
             if (diagnosticIds != null && getDescriptors(analyzer).All(d => !diagnosticIds.Contains(d.Id)))
             {
                 return false;


### PR DESCRIPTION
1. Perf traces show large GC activity during diagnostic analysis. Switched a ConditionalWeakTable added in the v2 driver change from being keyed on SyntaxReference to being keyed on Compilation, with the value being a dictionary keyed on SyntaxReference's Location. Also added cache cleanup logic to ensure entries from this dictionary get cleared as declarations are analyzed across all analyzers.

2. With the v2 driver refactoring, we stopped using the descriptor cache for analyzers in the IDE. This change re-introduces the cache and also adds logic to avoid realizing all the compiler diagnostic descriptors during diagnostic analysis.