### PR TITLE
Don't infer 'Object?' in an null coalescing expression.

### DIFF
--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -1638,5 +1638,50 @@ public class C
 }";
             Test(text, "System.Boolean");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [WorkItem(4483, "https://github.com/dotnet/roslyn/issues/4483")]
+        public void TestNullCoalescingOperator1()
+        {
+            var text =
+    @"class C
+{
+    void M()
+    {
+        object z = [|a|]?? null;
+    }
+}";
+            Test(text, "System.Object");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [WorkItem(4483, "https://github.com/dotnet/roslyn/issues/4483")]
+        public void TestNullCoalescingOperator2()
+        {
+            var text =
+    @"class C
+{
+    void M()
+    {
+        object z = [|a|] ?? b ?? c;
+    }
+}";
+            Test(text, "System.Object");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [WorkItem(4483, "https://github.com/dotnet/roslyn/issues/4483")]
+        public void TestNullCoalescingOperator3()
+        {
+            var text =
+    @"class C
+{
+    void M()
+    {
+        object z = a ?? [|b|] ?? c;
+    }
+}";
+            Test(text, "System.Object");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1009,9 +1009,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var rightTypes = GetTypes(coalesceExpression.Right);
                 if (!rightTypes.Any())
                 {
-                    return SpecializedCollections.SingletonEnumerable(
-                        this.Compilation.GetSpecialType(SpecialType.System_Nullable_T)
-                            .Construct(Compilation.GetSpecialType(SpecialType.System_Object)));
+                    return SpecializedCollections.SingletonEnumerable(Compilation.GetSpecialType(SpecialType.System_Object));
                 }
 
                 return rightTypes


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/4483