### PR TITLE
Fix inserting using inside namespace

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -2007,6 +2007,119 @@ namespace A.C
 @"using System . Linq ; using X ; class C { static void Main ( string [ ] args ) { var a = new int ? ( ) ; int ? i = a ? . All ( ) ; } } namespace X { static class E { public static int ? All ( this int ? o ) => 0 ; } } ");
         }
 
+        [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestNestedNamespaceSimplified()
+        {
+            Test(
+@"namespace Microsoft . MyApp { using Win32 ; class Program { static void Main ( string [ ] args ) { [|SafeRegistryHandle|] h ; } } } ",
+@"namespace Microsoft . MyApp { using Win32 ; using Win32 . SafeHandles ; class Program { static void Main ( string [ ] args ) { SafeRegistryHandle h ; } } } ");
+        }
+
+        [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestNestedNamespaceSimplified2()
+        {
+            Test(
+@"namespace Microsoft . MyApp { using Zin32 ; class Program { static void Main ( string [ ] args ) { [|SafeRegistryHandle|] h ; } } } ",
+@"namespace Microsoft . MyApp { using Win32 . SafeHandles ; using Zin32 ; class Program { static void Main ( string [ ] args ) { SafeRegistryHandle h ; } } } ");
+        }
+
+        [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestNestedNamespaceSimplified3()
+        {
+            Test(
+@"namespace Microsoft . MyApp { using System ; using Win32 ; class Program { static void Main ( string [ ] args ) { [|SafeRegistryHandle|] h ; } } } ",
+@"namespace Microsoft . MyApp { using System ; using Win32 ; using Win32 . SafeHandles ; class Program { static void Main ( string [ ] args ) { SafeRegistryHandle h ; } } } ");
+        }
+
+        [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestNestedNamespaceSimplified4()
+        {
+            Test(
+@"namespace Microsoft . MyApp { using System ; using Zin32 ; class Program { static void Main ( string [ ] args ) { [|SafeRegistryHandle|] h ; } } } ",
+@"namespace Microsoft . MyApp { using System ; using Win32 . SafeHandles ; using Zin32 ; class Program { static void Main ( string [ ] args ) { SafeRegistryHandle h ; } } } ");
+        }
+
+        [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestNestedNamespaceSimplified5()
+        {
+            Test(
+@"namespace Microsoft.MyApp
+{
+#if true
+    using Win32;
+#else
+    using System;
+#endif
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            [|SafeRegistryHandle|] h;
+        }
+    }
+}",
+@"namespace Microsoft.MyApp
+{
+#if true
+    using Win32;
+    using Win32.SafeHandles;
+#else
+    using System;
+#endif
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            SafeRegistryHandle h;
+        }
+    }
+}");
+        }
+
+        [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void TestNestedNamespaceSimplified6()
+        {
+            Test(
+@"namespace Microsoft.MyApp
+{
+    using System;
+#if false
+    using Win32;
+#endif
+    using Win32;
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            [|SafeRegistryHandle|] h;
+        }
+    }
+}",
+@"namespace Microsoft.MyApp
+{
+    using System;
+#if false
+    using Win32;
+#endif
+    using Win32;
+    using Win32.SafeHandles;
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            SafeRegistryHandle h;
+        }
+    }
+}");
+        }
+
+
         public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -465,22 +465,27 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                     SyntaxNode newRoot = root.AddUsingDirective(
                                     fullyQualifiedUsingDirective, contextNode, placeSystemNamespaceFirst,
                                     Formatter.Annotation);
-                    var newDocument = document.WithSyntaxRoot(newRoot);
-                    var newSemanticModel = await newDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                    newRoot = await newDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                     var newUsing = newRoot
-                        .DescendantNodes().OfType<UsingDirectiveSyntax>().Where(uds => uds.IsEquivalentTo(fullyQualifiedUsingDirective, topLevel: true)).Single();
-                    var speculationAnalyzer = new SpeculationAnalyzer(newUsing.Name, simpleUsingDirective.Name, newSemanticModel, cancellationToken);
-                    if (speculationAnalyzer.ReplacementChangesSemantics())
+                        .DescendantNodes().OfType<UsingDirectiveSyntax>()
+                        .Where(uds => uds.IsEquivalentTo(fullyQualifiedUsingDirective, topLevel: true))
+                        .Single();
+                    newRoot = newRoot.TrackNodes(newUsing);
+                    var documentWithSyntaxRoot = document.WithSyntaxRoot(newRoot);
+                    var options = document.Project.Solution.Workspace.Options;
+                    var simplifiedDocument = await Simplifier.ReduceAsync(documentWithSyntaxRoot, newUsing.Span, options, cancellationToken).ConfigureAwait(false);
+
+                    newRoot = await simplifiedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                    var simplifiedUsing = newRoot.GetCurrentNode(newUsing);
+                    if (simplifiedUsing.Name.IsEquivalentTo(newUsing.Name, topLevel: true))
                     {
                         // Not fully qualifying the using causes to refer to a different namespace so we need to keep it as is.
-                        return newDocument;
+                        return documentWithSyntaxRoot;
                     }
                     else
                     {
                         // It does not matter if it is fully qualified or simple so lets return the simple name.
                         return document.WithSyntaxRoot(root.AddUsingDirective(
-                            simpleUsingDirective, contextNode, placeSystemNamespaceFirst,
+                            simplifiedUsing.WithoutTrivia().WithoutAnnotations(), contextNode, placeSystemNamespaceFirst,
                             Formatter.Annotation));
                     }
                 }


### PR DESCRIPTION
Previously if we added a using inside a namespace we would use a
speculative semantic model determine if we should use the fully qualified
name or not.  What this approach failed to account for was if the name
was going to be simplified further due to the containing namespace.  To
Fix this we run the simplifier over our document and check if there are
any changes made to the namespace.  If this is the case, then we re-sort
the usings according to the simplified name.  

This change also unified add import and sort using code paths.

Fixes #3080