### PR TITLE
Automatic line ending for expression bodied members

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -102,11 +102,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
 
                 // currently, Parsing a field is not supported. as a workaround, wrap the field in a type and parse
                 var node = owningNode.TypeSwitch(
-                    (UsingDirectiveSyntax n) => (SyntaxNode)SyntaxFactory.ParseCompilationUnit(textToParse, options: (CSharpParseOptions)tree.Options),
                     (BaseFieldDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options),
-                    (StatementSyntax n) => SyntaxFactory.ParseStatement(textToParse, options: (CSharpParseOptions)tree.Options),
+                    (BaseMethodDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options),
                     (BasePropertyDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options),
-                    (BaseMethodDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options));
+                    (StatementSyntax n) => SyntaxFactory.ParseStatement(textToParse, options: (CSharpParseOptions)tree.Options),
+                    (UsingDirectiveSyntax n) => (SyntaxNode)SyntaxFactory.ParseCompilationUnit(textToParse, options: (CSharpParseOptions)tree.Options));
 
                 // Insert line ender if we didn't introduce any diagnostics, if not try the next owning node.
                 if (node != null && !node.ContainsDiagnostics)

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -76,6 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             var tree = document.GetSyntaxTreeAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var root = tree.GetRootAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var text = tree.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+            var semicolon = SyntaxFacts.GetText(SyntaxKind.SemicolonToken);
 
             // Go through the set of owning nodes in leaf to root chain.
             foreach (var owningNode in GetOwningNodes(root, position))
@@ -96,8 +97,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                 }
 
                 // so far so good. we only add semi-colon if it makes statement syntax error free
-                var semicolon = SyntaxFacts.GetText(SyntaxKind.SemicolonToken);
-
                 var textToParse = owningNode.NormalizeWhitespace().ToFullString() + semicolon;
 
                 // currently, Parsing a field is not supported. as a workaround, wrap the field in a type and parse

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
@@ -76,42 +77,45 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             var root = tree.GetRootAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var text = tree.GetTextAsync(cancellationToken).WaitAndGetResult(cancellationToken);
 
-            var owningNode = GetOwningNode(root, position);
-            if (owningNode == null)
+            // Go through the set of owning nodes in leaf to root chain.
+            foreach (var owningNode in GetOwningNodes(root, position))
             {
-                return null;
+                SyntaxToken lastToken;
+                if (!TryGetLastToken(text, position, owningNode, out lastToken))
+                {
+                    // If we can't get last token, there is nothing more to do, just skip
+                    // the other owning nodes and return.
+                    return null;
+                }
+
+                if (!CheckLocation(text, position, owningNode, lastToken))
+                {
+                    // If we failed this check, we indeed got the intended owner node and
+                    // inserting line ender here would introduce errors.
+                    return null;
+                }
+
+                // so far so good. we only add semi-colon if it makes statement syntax error free
+                var semicolon = SyntaxFacts.GetText(SyntaxKind.SemicolonToken);
+
+                var textToParse = owningNode.NormalizeWhitespace().ToFullString() + semicolon;
+
+                // currently, Parsing a field is not supported. as a workaround, wrap the field in a type and parse
+                var node = owningNode.TypeSwitch(
+                    (UsingDirectiveSyntax n) => (SyntaxNode)SyntaxFactory.ParseCompilationUnit(textToParse, options: (CSharpParseOptions)tree.Options),
+                    (BaseFieldDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options),
+                    (StatementSyntax n) => SyntaxFactory.ParseStatement(textToParse, options: (CSharpParseOptions)tree.Options),
+                    (BasePropertyDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options),
+                    (BaseMethodDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options));
+
+                // Insert line ender if we didn't introduce any diagnostics, if not try the next owning node.
+                if (node != null && !node.ContainsDiagnostics)
+                {
+                    return semicolon;
+                }
             }
 
-            SyntaxToken lastToken;
-            if (!TryGetLastToken(text, position, owningNode, out lastToken))
-            {
-                return null;
-            }
-
-            if (!CheckLocation(text, position, owningNode, lastToken))
-            {
-                return null;
-            }
-
-            // so far so good. we only add semi-colon if it makes statement syntax error free
-            var semicolon = SyntaxFacts.GetText(SyntaxKind.SemicolonToken);
-
-            var textToParse = owningNode.NormalizeWhitespace().ToFullString() + semicolon;
-
-            // currently, Parsing a field is not supported. as a workaround, wrap the field in a type and parse
-            var node = owningNode.TypeSwitch(
-                (UsingDirectiveSyntax n) => (SyntaxNode)SyntaxFactory.ParseCompilationUnit(textToParse, options: (CSharpParseOptions)tree.Options),
-                (BaseFieldDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options),
-                (StatementSyntax n) => SyntaxFactory.ParseStatement(textToParse, options: (CSharpParseOptions)tree.Options),
-                (BasePropertyDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options),
-                (BaseMethodDeclarationSyntax n) => SyntaxFactory.ParseCompilationUnit(WrapInType(textToParse), options: (CSharpParseOptions)tree.Options));
-
-            if (node == null)
-            {
-                return null;
-            }
-
-            return node.ContainsDiagnostics ? null : semicolon;
+            return null;
         }
 
         /// <summary>
@@ -180,18 +184,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
         }
 
         /// <summary>
-        /// get last token of the given using/field/statement if one exists
+        /// get last token of the given using/field/statement/expression bodied member if one exists
         /// </summary>
         private static bool TryGetLastToken(SourceText text, int position, SyntaxNode owningNode, out SyntaxToken lastToken)
         {
             lastToken = owningNode.GetLastToken(includeZeroWidth: true);
-
-            // regardless whether it is missing token or not, if last token is close brace
-            // don't do anything
-            if (lastToken.Kind() == SyntaxKind.CloseBraceToken)
-            {
-                return false;
-            }
 
             // last token must be on the same line as the caret
             var line = text.Lines.GetLineFromPosition(position);
@@ -221,19 +218,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
         /// <summary>
         /// find owning usings/field/statement/expression-bodied member of the given position
         /// </summary>
-        private static SyntaxNode GetOwningNode(SyntaxNode root, int position)
+        private static IEnumerable<SyntaxNode> GetOwningNodes(SyntaxNode root, int position)
         {
             // make sure caret position is somewhere we can find a token
             var token = root.FindTokenFromEnd(position);
             if (token.Kind() == SyntaxKind.None)
             {
-                return null;
+                return SpecializedCollections.EmptyEnumerable<SyntaxNode>();
             }
 
             return token.GetAncestors<SyntaxNode>()
                         .Where(AllowedConstructs)
-                        .Select(OwningNode)
-                        .FirstOrDefault();
+                        .Select(OwningNode);
         }
 
         private static bool AllowedConstructs(SyntaxNode n)

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -235,6 +235,204 @@ $$", "class {$$}");
 }");
         }
 
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedMethod()
+        {
+            Test(@"class T
+{
+    int M() => 1 + 2;
+    $$
+}", @"class T
+{
+    int M() => 1 + 2$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedOperator()
+        {
+            Test(@"class Complex
+{
+    int real; int imaginary;
+    public static Complex operator +(Complex a, Complex b) => a.Add(b.real + 1);
+    $$
+    private Complex Add(int b) => null;
+}", @"class Complex
+{
+    int real; int imaginary;
+    public static Complex operator +(Complex a, Complex b) => a.Add(b.real + 1)$$
+    private Complex Add(int b) => null;
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedConversionOperator()
+        {
+            Test(@"using System;
+public struct DBBool
+{
+    public static readonly DBBool dbFalse = new DBBool(-1);
+    int value;
+
+    DBBool(int value)
+    {
+        this.value = value;
+    }
+
+    public static implicit operator DBBool(bool x) => x ? new DBBool(1) : dbFalse;
+    $$
+}", @"using System;
+public struct DBBool
+{
+    public static readonly DBBool dbFalse = new DBBool(-1);
+    int value;
+
+    DBBool(int value)
+    {
+        this.value = value;
+    }
+
+    public static implicit operator DBBool(bool x) => x ? new DBBool(1) : dbFalse$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedProperty()
+        {
+            Test(@"class T
+{
+    int P1 => 1 + 2;
+    $$
+}", @"class T
+{
+    int P1 => 1 + 2$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedIndexer()
+        {
+            Test(@"using System;
+class SampleCollection<T>
+{
+    private T[] arr = new T[100];
+    public T this[int i] => i > 0 ? arr[i + 1] : arr[i + 2];
+    $$
+}", @"using System;
+class SampleCollection<T>
+{
+    private T[] arr = new T[100];
+    public T this[int i] => i > 0 ? arr[i + 1] : arr[i + 2]$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedMethodWithBlockBodiedAnonymousMethodExpression()
+        {
+            Test(@"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x)
+    {
+        return 9;
+    };
+    $$
+}", @"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x)
+    {
+        return 9;
+    }$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedMethodWithSingleLineBlockBodiedAnonymousMethodExpression()
+        {
+            Test(@"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x) { return 9; };
+    $$
+}", @"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x) { return 9; }$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedMethodWithBlockBodiedSimpleLambdaExpression()
+        {
+            Test(@"using System;
+class TestClass
+{
+    Func<int, int> Y() => f =>
+    {
+        return f * 9;
+    };
+    $$
+}", @"using System;
+class TestClass
+{
+    Func<int, int> Y() => f =>
+    {
+        return f * 9;
+    }$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedMethodWithExpressionBodiedSimpleLambdaExpression()
+        {
+            Test(@"using System;
+class TestClass
+{
+    Func<int, int> Y() => f => f * 9;
+    $$
+}", @"using System;
+class TestClass
+{
+    Func<int, int> Y() => f => f * 9$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void ExpressionBodiedMethodWithBlockBodiedAnonymousMethodExpressionInMethodArgs()
+        {
+            Test(@"using System;
+class TestClass
+{
+    public int Prop => Method1(delegate()
+    {
+        return 8;
+    });
+    $$
+
+    private int Method1(Func<int> p) => null;
+}", @"using System;
+class TestClass
+{
+    public int Prop => Method1(delegate()
+    {
+        return 8;
+    })$$
+
+    private int Method1(Func<int> p) => null;
+}");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void Format_Statement()
         {

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -433,6 +433,58 @@ class TestClass
 }");
         }
 
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void Format_SimpleExpressionBodiedMember()
+        {
+            Test(@"class T
+{
+    int M() => 1 + 2;
+    $$
+}", @"class T
+{
+         int   M()   =>    1       +     2$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void Format_ExpressionBodiedMemberWithSingleLineBlock()
+        {
+            Test(@"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x) { return 9; };
+    $$
+}", @"using System;
+class TestClass
+{
+                Func<int, int>  Y ()   =>   delegate(int x) { return     9  ; }$$
+}");
+        }
+
+        [WorkItem(3944, "https://github.com/dotnet/roslyn/issues/3944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void Format_ExpressionBodiedMemberWithMultiLineBlock()
+        {
+            Test(@"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate (int x)
+    {
+        return 9;
+    };
+    $$
+}", @"using System;
+class TestClass
+{
+    Func<int, int> Y() => delegate(int x)
+    {
+        return 9;
+        }$$
+}");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
         public void Format_Statement()
         {

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -632,6 +632,51 @@ $$
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotAfterExisitingSemicolon()
+        {
+            Test(@"class TestClass
+{
+    private int i;
+    $$
+}", @"class TestClass
+{
+    private int i;$$
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotAfterCloseBraceInMethod()
+        {
+            Test(@"class TestClass
+{
+    void Test() { }
+    $$
+}", @"class TestClass
+{
+    void Test() { }$$
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotAfterCloseBraceInStatement()
+        {
+            Test(@"class TestClass
+{
+    void Test()
+    {
+        if (true) { }
+        $$
+    }
+}", @"class TestClass
+{
+    void Test()
+    {
+        if (true) { }$$
+    }
+}");
+        }
+
         protected override TestWorkspace CreateWorkspace(string[] code)
         {
             return CSharpWorkspaceFactory.CreateWorkspaceFromLines(code);

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -414,7 +414,7 @@ class TestClass
             Test(@"using System;
 class TestClass
 {
-    public int Prop => Method1(delegate()
+    public int Prop => Method1(delegate ()
     {
         return 8;
     });

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -677,6 +677,32 @@ $$
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotAfterAutoPropertyAccessor()
+        {
+            Test(@"class TestClass
+{
+    public int A { get; set }
+    $$
+}", @"class TestClass
+{
+    public int A { get; set$$ }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotAfterAutoPropertyDeclaration()
+        {
+            Test(@"class TestClass
+{
+    public int A { get; set; }
+    $$
+}", @"class TestClass
+{
+    public int A { get; set; }$$
+}");
+        }
+
         protected override TestWorkspace CreateWorkspace(string[] code)
         {
             return CSharpWorkspaceFactory.CreateWorkspaceFromLines(code);


### PR DESCRIPTION
Add support for expression bodied member scenarios in automatic line ending in C#. 

Fixes #3944