### PR TITLE
Generate inaccessible getters and setters

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -372,5 +372,14 @@ abstract class A<T>
 }
 ", compareTokens: false);
         }
+
+        [WorkItem(2407, "https://github.com/dotnet/roslyn/issues/2407")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        public void ImplementClassWithInaccessibleMembers()
+        {
+            Test(
+@"using System ; using System . Globalization ; public class [|x|] : EastAsianLunisolarCalendar { } ",
+@"using System ; using System . Globalization ; public class x : EastAsianLunisolarCalendar { public override int [ ] Eras { get { throw new NotImplementedException ( ) ; } } internal override EraInfo [ ] CalEraInfo { get { throw new NotImplementedException ( ) ; } } internal override int MaxCalendarYear { get { throw new NotImplementedException ( ) ; } } internal override DateTime MaxDate { get { throw new NotImplementedException ( ) ; } } internal override int MinCalendarYear { get { throw new NotImplementedException ( ) ; } } internal override DateTime MinDate { get { throw new NotImplementedException ( ) ; } } public override int GetEra ( DateTime time ) { throw new NotImplementedException ( ) ; } internal override int GetGregorianYear ( int year , int era ) { throw new NotImplementedException ( ) ; } internal override int GetYear ( int year , DateTime time ) { throw new NotImplementedException ( ) ; } internal override int GetYearInfo ( int LunarYear , int Index ) { throw new NotImplementedException ( ) ; } } ");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.vb
@@ -197,5 +197,13 @@ End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
 compareTokens:=False)
         End Sub
+
+        <WorkItem(2407, "https://github.com/dotnet/roslyn/issues/2407")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        Public Sub ImplementClassWithInaccessibleMembers()
+            Test(
+NewLines("Imports System \n Imports System.Globalization \n Class [|x|] \n Inherits EastAsianLunisolarCalendar \n End Class"),
+NewLines("Imports System \n Imports System.Globalization \n Class x \n Inherits EastAsianLunisolarCalendar \n Public Overrides ReadOnly Property Eras As Integer() \n Get \n Throw New NotImplementedException() \n End Get \n End Property \n Friend Overrides ReadOnly Property CalEraInfo As EraInfo() \n Get \n Throw New NotImplementedException() \n End Get \n End Property \n Friend Overrides ReadOnly Property MaxCalendarYear As Integer \n Get \n Throw New NotImplementedException() \n End Get \n End Property \n Friend Overrides ReadOnly Property MaxDate As Date \n Get \n Throw New NotImplementedException() \n End Get \n End Property \n Friend Overrides ReadOnly Property MinCalendarYear As Integer \n Get \n Throw New NotImplementedException() \n End Get \n End Property \n Friend Overrides ReadOnly Property MinDate As Date \n Get \n Throw New NotImplementedException() \n End Get \n End Property \n Public Overrides Function GetEra(time As Date) As Integer \n Throw New NotImplementedException() \n End Function \n Friend Overrides Function GetGregorianYear(year As Integer, era As Integer) As Integer \n Throw New NotImplementedException() \n End Function \n Friend Overrides Function GetYear(year As Integer, time As Date) As Integer \n Throw New NotImplementedException() \n End Function \n Friend Overrides Function GetYearInfo(LunarYear As Integer, Index As Integer) As Integer \n Throw New NotImplementedException() \n End Function \n End Class"))
+        End Sub
     End Class
 End Namespace

--- a/src/Features/Core/Portable/ImplementAbstractClass/AbstractImplementAbstractClassService.Editor.cs
+++ b/src/Features/Core/Portable/ImplementAbstractClass/AbstractImplementAbstractClassService.Editor.cs
@@ -153,13 +153,7 @@ namespace Microsoft.CodeAnalysis.ImplementAbstractClass
                     setMethod: setMethod);
             }
 
-            private bool ShouldGenerateAccessor(IMethodSymbol method)
-            {
-                return
-                    method != null &&
-                    method.IsAccessibleWithin(_state.ClassType) &&
-                    _state.ClassType.FindImplementationForAbstractMember(method) == null;
-            }
+            private bool ShouldGenerateAccessor(IMethodSymbol method) => method != null && _state.ClassType.FindImplementationForAbstractMember(method) == null;
         }
     }
 }


### PR DESCRIPTION
The code generator no longer checks for accessibility when deciding if it
should generate a getter or a setter.  There are many cases where we
generate code that is inaccessible in the hope that the user can fix the
accessibility problem later.

Fixes #2407