### PR TITLE
Make ReadStandardInput thread-safe

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindowResources.Designer.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindowResources.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The interactive window has not yet been initialized..
+        /// </summary>
+        internal static string NotInitialized {
+            get {
+                return ResourceManager.GetString("NotInitialized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This method may not be called on the UI thread (to avoid hangs)..
         /// </summary>
         internal static string RequireNonUIThread {

--- a/src/InteractiveWindow/Editor/InteractiveWindowResources.resx
+++ b/src/InteractiveWindow/Editor/InteractiveWindowResources.resx
@@ -129,6 +129,9 @@
   <data name="MissingCommandName" xml:space="preserve">
     <value>The command of type '{0}' has no command names.</value>
   </data>
+  <data name="NotInitialized" xml:space="preserve">
+    <value>The interactive window has not yet been initialized.</value>
+  </data>
   <data name="RequireNonUIThread" xml:space="preserve">
     <value>This method may not be called on the UI thread (to avoid hangs).</value>
   </data>

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -247,7 +247,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         [Fact]
         public void CallInsertCodeOnNonUIThread()
         {
-            // TODO (https://github.com/dotnet/roslyn/issues/3984): InsertCode is a no-op unless standard input is being collected.
             Task.Run(() => Window.InsertCode("1")).PumpingWait();
         }
 


### PR DESCRIPTION
```ReadStandardInput``` was one of the thorniest areas of the interactive
window because it not only could but needed to be called on a non-UI
thread (so it could block waiting for user input).  (In hindsight, it
should probably have been task-returning, but the interface is frozen now.
I hope to introduce an async version in a subsequent change.)

The biggest change was moving the cleanup code - which tried to guess
what had happened to the standard input session - to the individual
methods that terminate the session - clear, reset, and submit.  Now we
don't have to guess about what state the UI thread will be in when we
regain access.

Based on a suggestion from @tmat, I also eliminated the previous-state
mechanism in favor of encoding the information in the state itself.  The
complexity is basically the same, but this way we can have an explicit
state machine (i.e. we don't have to consider the previous-state variable
before making a state transition).

There are still a few rough edges:
https://github.com/dotnet/roslyn/issues/4879
https://github.com/dotnet/roslyn/issues/4878

Since our host doesn't currently support reading standard input, I tested
the code manually using PTVS.