### PR TITLE
Correctly Generate Interface in Generic Class

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -2686,5 +2686,15 @@ public class Holder
     }
 }");
         }
+
+        [WorkItem(2785, "https://github.com/dotnet/roslyn/issues/2785")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public void TestImplementInterfaceThroughStaticMemberInGenericClass()
+        {
+            Test(
+@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Issue2785 < T > : [|IList < object >|] { private static List < object > innerList = new List < object > ( ) ; } ",
+@"using System ; using System . Collections ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Issue2785 < T > : IList < object > { private static List < object > innerList = new List < object > ( ) ; public object this [ int index ] { get { return ( ( IList < object > ) innerList ) [ index ] ; } set { ( ( IList < object > ) innerList ) [ index ] = value ; } } public int Count { get { return ( ( IList < object > ) innerList ) . Count ; } } public bool IsReadOnly { get { return ( ( IList < object > ) innerList ) . IsReadOnly ; } } public void Add ( object item ) { ( ( IList < object > ) innerList ) . Add ( item ) ; } public void Clear ( ) { ( ( IList < object > ) innerList ) . Clear ( ) ; } public bool Contains ( object item ) { return ( ( IList < object > ) innerList ) . Contains ( item ) ; } public void CopyTo ( object [ ] array , int arrayIndex ) { ( ( IList < object > ) innerList ) . CopyTo ( array , arrayIndex ) ; } public IEnumerator < object > GetEnumerator ( ) { return ( ( IList < object > ) innerList ) . GetEnumerator ( ) ; } public int IndexOf ( object item ) { return ( ( IList < object > ) innerList ) . IndexOf ( item ) ; } public void Insert ( int index , object item ) { ( ( IList < object > ) innerList ) . Insert ( index , item ) ; } public bool Remove ( object item ) { return ( ( IList < object > ) innerList ) . Remove ( item ) ; } public void RemoveAt ( int index ) { ( ( IList < object > ) innerList ) . RemoveAt ( index ) ; } IEnumerator IEnumerable . GetEnumerator ( ) { return ( ( IList < object > ) innerList ) . GetEnumerator ( ) ; } } ",
+index: 1);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
@@ -2167,5 +2167,15 @@ Public Class Holder
 	End Class
 End Class", compareTokens:=False)
         End Sub
+
+
+        <WorkItem(2785, "https://github.com/dotnet/roslyn/issues/2785")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        Public Sub TestImplementInterfaceThroughStaticMemberInGenericClass()
+            Test(
+NewLines("Imports System \n Imports System.Collections.Generic \n Class Program(Of T) \n Implements [|IList(Of Object)|] \n Private Shared innerList As List(Of Object) = New List(Of Object) \n End Class"),
+NewLines("Imports System \n Imports System.Collections \n Imports System.Collections.Generic \n Class Program(Of T) \n Implements IList(Of Object) \n Private Shared innerList As List(Of Object) = New List(Of Object) \n Public ReadOnly Property Count As Integer Implements ICollection(Of Object).Count \n Get \n Return DirectCast(innerList, IList(Of Object)).Count \n End Get \n End Property \n Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Object).IsReadOnly \n Get \n Return DirectCast(innerList, IList(Of Object)).IsReadOnly \n End Get \n End Property \n Default Public Property Item(index As Integer) As Object Implements IList(Of Object).Item \n Get \n Return DirectCast(innerList, IList(Of Object))(index) \n End Get \n Set(value As Object) \n DirectCast(innerList, IList(Of Object))(index) = value \n End Set \n End Property \n Public Sub Add(item As Object) Implements ICollection(Of Object).Add \n DirectCast(innerList, IList(Of Object)).Add(item) \n End Sub \n Public Sub Clear() Implements ICollection(Of Object).Clear \n DirectCast(innerList, IList(Of Object)).Clear() \n End Sub \n Public Sub CopyTo(array() As Object, arrayIndex As Integer) Implements ICollection(Of Object).CopyTo \n DirectCast(innerList, IList(Of Object)).CopyTo(array, arrayIndex) \n End Sub \n Public Sub Insert(index As Integer, item As Object) Implements IList(Of Object).Insert \n DirectCast(innerList, IList(Of Object)).Insert(index, item) \n End Sub \n Public Sub RemoveAt(index As Integer) Implements IList(Of Object).RemoveAt \n DirectCast(innerList, IList(Of Object)).RemoveAt(index) \n End Sub \n Public Function Contains(item As Object) As Boolean Implements ICollection(Of Object).Contains \n Return DirectCast(innerList, IList(Of Object)).Contains(item) \n End Function \n Public Function GetEnumerator() As IEnumerator(Of Object) Implements IEnumerable(Of Object).GetEnumerator \n Return DirectCast(innerList, IList(Of Object)).GetEnumerator() \n End Function \n Public Function IndexOf(item As Object) As Integer Implements IList(Of Object).IndexOf \n Return DirectCast(innerList, IList(Of Object)).IndexOf(item) \n End Function \n Public Function Remove(item As Object) As Boolean Implements ICollection(Of Object).Remove \n Return DirectCast(innerList, IList(Of Object)).Remove(item) \n End Function \n Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Return DirectCast(innerList, IList(Of Object)).GetEnumerator() \n End Function \n End Class"),
+index:=1)
+        End Sub
     End Class
 End Namespace

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -407,9 +407,20 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
 
             private SyntaxNode CreateThroughExpression(SyntaxGenerator factory)
             {
-                var through = ThroughMember.IsStatic
-                    ? factory.IdentifierName(State.ClassOrStructType.Name)
-                    : factory.ThisExpression();
+                SyntaxNode through;
+                if (State.ClassOrStructType.IsGenericType)
+                {
+                    through = ThroughMember.IsStatic
+                        ? factory.GenericName(State.ClassOrStructType.Name, State.ClassOrStructType.TypeArguments)
+                        : factory.ThisExpression();
+                }
+                else
+                {
+                    through = ThroughMember.IsStatic
+                        ? factory.IdentifierName(State.ClassOrStructType.Name)
+                        : factory.ThisExpression();
+                }
+
 
                 through = factory.MemberAccessExpression(
                     through, factory.IdentifierName(ThroughMember.Name));

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -407,20 +407,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
 
             private SyntaxNode CreateThroughExpression(SyntaxGenerator factory)
             {
-                SyntaxNode through;
-                if (State.ClassOrStructType.IsGenericType)
-                {
-                    through = ThroughMember.IsStatic
-                        ? factory.GenericName(State.ClassOrStructType.Name, State.ClassOrStructType.TypeArguments)
+                var through = ThroughMember.IsStatic
+                        ? GenerateName(factory, State.ClassOrStructType.IsGenericType)
                         : factory.ThisExpression();
-                }
-                else
-                {
-                    through = ThroughMember.IsStatic
-                        ? factory.IdentifierName(State.ClassOrStructType.Name)
-                        : factory.ThisExpression();
-                }
-
 
                 through = factory.MemberAccessExpression(
                     through, factory.IdentifierName(ThroughMember.Name));
@@ -462,6 +451,13 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 }
 
                 return through.WithAdditionalAnnotations(Simplifier.Annotation);
+            }
+
+            private SyntaxNode GenerateName(SyntaxGenerator factory, bool isGenericType)
+            {
+                return isGenericType 
+                    ? factory.GenericName(State.ClassOrStructType.Name, State.ClassOrStructType.TypeArguments) 
+                    : factory.IdentifierName(State.ClassOrStructType.Name);
             }
 
             private bool HasNameConflict(


### PR DESCRIPTION
Use generic name if class we are generating into is generic.

Fixes #2785