### PR TITLE
Add System.IO.FileSystem to Microsoft.DiaSymReader.PortablePdb packages.config

### DIFF
--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/packages.config
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DiaSymReader" version="1.0.5" targetFramework="net45" />
+  <package id="System.IO.FileSystem" version="4.0.0" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0" />
 </packages>


### PR DESCRIPTION
This will allow us to avoid shims in PortablePdb.