### PR TITLE
Support Open-Generic-Types in 'nameof' expressions.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -847,6 +847,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument))
             {
+                if (typeSyntax.Kind() == SyntaxKind.GenericName)
+                {
+                    var genericName = (GenericNameSyntax)typeSyntax;
+                    if (genericName.IsUnboundGenericName && IsUnboundTypeAllowed(genericName))
+                    {
+                        return type;
+                    }
+                }
+
                 // Note: lookup won't have reported this, since the arity was correct.
                 // CONSIDER: the text of this error message makes sense, but we might want to add a separate code.
                 Error(diagnostics, ErrorCode.ERR_BadArity, typeSyntax, type, MessageID.IDS_SK_TYPE.Localize(), typeArgumentsSyntax.Count);

--- a/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
@@ -10,11 +10,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal class NameofBinder : Binder
+    internal class NameofBinder : TypeofOrNameofBinder
     {
         private readonly SyntaxNode _nameofArgument;
 
-        public NameofBinder(SyntaxNode nameofArgument, Binder next) : base(next)
+        public NameofBinder(ExpressionSyntax nameofArgument, Binder next) : base(nameofArgument, next, next.Flags)
         {
             _nameofArgument = nameofArgument;
         }

--- a/src/Compilers/CSharp/Portable/Binder/TypeofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/TypeofBinder.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </return>
             public static Dictionary<GenericNameSyntax, bool> Create(ExpressionSyntax typeSyntax)
             {
-                OpenTypeVisitor visitor = new OpenTypeVisitor();
-                ((CSharpSyntaxVisitor)visitor).Visit(typeSyntax);
+                var visitor = new OpenTypeVisitor();
+                visitor.Visit(typeSyntax);
                 return visitor._allowedMap;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/TypeofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/TypeofBinder.cs
@@ -8,77 +8,24 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
-    /// This binder is for binding the argument to typeof.  It traverses
-    /// the syntax marking each open type ("unbound generic type" in the
-    /// C# spec) as either allowed or not allowed, so that BindType can 
-    /// appropriately return either the corresponding type symbol or an 
-    /// error type.  It also indicates whether the argument as a whole 
-    /// should be considered open so that the flag can be set 
-    /// appropriately in BoundTypeOfOperator.
+    /// Base type for nameof and typeof expression arguments.  Properly handles binding open types
+    /// in the argument.
     /// </summary>
-    internal sealed class TypeofBinder : Binder
+    internal abstract class TypeofOrNameofBinder : Binder
     {
         private readonly Dictionary<GenericNameSyntax, bool> _allowedMap;
-        private readonly bool _isTypeExpressionOpen;
 
-        internal TypeofBinder(ExpressionSyntax typeExpression, Binder next)
-            // Unsafe types are not unsafe in typeof, so it is effectively an unsafe region.
-            // Since we only depend on existence of nameable members and nameof(x) produces a constant
-            // string expression usable in an early attribute, we use early attribute binding.
-            : base(next, next.Flags | BinderFlags.UnsafeRegion | BinderFlags.EarlyAttributeBinding)
+        protected TypeofOrNameofBinder(ExpressionSyntax typeExpression, Binder next, BinderFlags flags)
+            : base(next, flags)
         {
-            OpenTypeVisitor.Visit(typeExpression, out _allowedMap, out _isTypeExpressionOpen);
+            _allowedMap = OpenTypeVisitor.Create(typeExpression);
         }
-
-        internal bool IsTypeExpressionOpen { get { return _isTypeExpressionOpen; } }
 
         protected override bool IsUnboundTypeAllowed(GenericNameSyntax syntax)
         {
             bool allowed;
             return _allowedMap != null && _allowedMap.TryGetValue(syntax, out allowed) && allowed;
         }
-
-        /////// <summary>
-        /////// Returns the list of the symbols which represent the argument of the nameof operator. Ambiguities are not an error for the nameof.
-        /////// </summary>
-        ////internal ImmutableArray<Symbol> LookupForNameofArgument(ExpressionSyntax left, IdentifierNameSyntax right, string name, DiagnosticBag diagnostics, bool isAliasQualified, out bool hasErrors)
-        ////{
-        ////    ArrayBuilder<Symbol> symbols = ArrayBuilder<Symbol>.GetInstance();
-        ////    Symbol container = null;
-        ////    hasErrors = false;
-
-        ////    // We treat the AliasQualified syntax different than the rest. We bind the whole part for the alias.
-        ////    if (isAliasQualified)
-        ////    {
-        ////        container = BindNamespaceAliasSymbol((IdentifierNameSyntax)left, diagnostics);
-        ////        var aliasSymbol = container as AliasSymbol;
-        ////        if (aliasSymbol != null) container = aliasSymbol.Target;
-        ////        if (container.Kind == SymbolKind.NamedType)
-        ////        {
-        ////            diagnostics.Add(ErrorCode.ERR_ColColWithTypeAlias, left.Location, left);
-        ////            hasErrors = true;
-        ////            return symbols.ToImmutableAndFree();
-        ////        }
-        ////    }
-        ////    // If it isn't AliasQualified, we first bind the left part, and then bind the right part as a simple name.
-        ////    else if (left != null)
-        ////    {
-        ////        // We use OriginalDefinition because of the unbound generic names such as List<>, Dictionary<,>.
-        ////        container = BindNamespaceOrTypeSymbol(left, diagnostics, null, false).OriginalDefinition;
-        ////    }
-
-        ////    this.BindNonGenericSimpleName(right, diagnostics, null, false, (NamespaceOrTypeSymbol)container, isNameofArgument: true, symbols: symbols);
-        ////    if (CheckUsedBeforeDeclarationIfLocal(symbols, right))
-        ////    {
-        ////        Error(diagnostics, ErrorCode.ERR_VariableUsedBeforeDeclaration, right, right);
-        ////        hasErrors = true;
-        ////    }
-        ////    else if (symbols.Count == 0)
-        ////    {
-        ////        hasErrors = true;
-        ////    }
-        ////    return symbols.ToImmutableAndFree();
-        ////}
 
         /// <summary>
         /// This visitor walks over a type expression looking for open types.
@@ -91,26 +38,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             private Dictionary<GenericNameSyntax, bool> _allowedMap;
             private bool _seenConstructed;
-            private bool _seenGeneric;
 
             /// <param name="typeSyntax">The argument to typeof.</param>
-            /// <param name="allowedMap">
+            /// <return>
             /// Keys are GenericNameSyntax nodes representing unbound generic types.
             /// Values are false if the node should result in an error and true otherwise.
-            /// </param>
-            /// <param name="isUnboundGenericType">True if no constructed generic type was encountered.</param>
-            public static void Visit(ExpressionSyntax typeSyntax, out Dictionary<GenericNameSyntax, bool> allowedMap, out bool isUnboundGenericType)
+            /// </return>
+            public static Dictionary<GenericNameSyntax, bool> Create(ExpressionSyntax typeSyntax)
             {
                 OpenTypeVisitor visitor = new OpenTypeVisitor();
-                visitor.Visit(typeSyntax);
-                allowedMap = visitor._allowedMap;
-                isUnboundGenericType = visitor._seenGeneric && !visitor._seenConstructed;
+                ((CSharpSyntaxVisitor)visitor).Visit(typeSyntax);
+                return visitor._allowedMap;
             }
 
             public override void VisitGenericName(GenericNameSyntax node)
             {
-                _seenGeneric = true;
-
                 SeparatedSyntaxList<TypeSyntax> typeArguments = node.TypeArgumentList.Arguments;
                 if (node.IsUnboundGenericName)
                 {
@@ -130,21 +72,37 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+            {
+                if (node.Kind() == SyntaxKind.SimpleMemberAccessExpression)
+                {
+                    VisitDottedExpression(node.Expression, node.Name);
+                    return;
+                }
+
+                base.VisitMemberAccessExpression(node);
+            }
+
             public override void VisitQualifiedName(QualifiedNameSyntax node)
+            {
+                VisitDottedExpression(node.Left, node.Right);
+            }
+
+            private void VisitDottedExpression(ExpressionSyntax left, SimpleNameSyntax right)
             {
                 bool seenConstructedBeforeRight = _seenConstructed;
 
                 // Visit Right first because it's smaller (to make backtracking cheaper).
-                Visit(node.Right);
+                Visit(right);
 
                 bool seenConstructedBeforeLeft = _seenConstructed;
 
-                Visit(node.Left);
+                Visit(left);
 
                 // If the first time we saw a constructed type was in Left, then we need to re-visit Right
                 if (!seenConstructedBeforeRight && !seenConstructedBeforeLeft && _seenConstructed)
                 {
-                    Visit(node.Right);
+                    Visit(right);
                 }
             }
 
@@ -170,6 +128,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _seenConstructed = true;
                 Visit(node.ElementType);
             }
+        }
+    }
+
+    /// <summary>
+    /// This binder is for binding the argument to typeof.  It traverses
+    /// the syntax marking each open type ("unbound generic type" in the
+    /// C# spec) as either allowed or not allowed, so that BindType can 
+    /// appropriately return either the corresponding type symbol or an 
+    /// error type.  It also indicates whether the argument as a whole 
+    /// should be considered open so that the flag can be set 
+    /// appropriately in BoundTypeOfOperator.
+    /// </summary>
+    internal sealed class TypeofBinder : TypeofOrNameofBinder
+    {
+        internal TypeofBinder(ExpressionSyntax typeExpression, Binder next)
+            // Unsafe types are not unsafe in typeof, so it is effectively an unsafe region.
+            // Since we only depend on existence of nameable members and nameof(x) produces a constant
+            // string expression usable in an early attribute, we use early attribute binding.
+            : base(typeExpression, next, next.Flags | BinderFlags.UnsafeRegion | BinderFlags.EarlyAttributeBinding)
+        {
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -5468,16 +5468,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         return result;
                     }
 
-                    switch (this.ScanType(out lastTokenOfList))
+                    if (this.CurrentToken.Kind != SyntaxKind.CommaToken)
                     {
-                        case ScanTypeFlags.NotType:
-                            lastTokenOfList = null;
-                            return ScanTypeFlags.NotType;
+                        switch (this.ScanType(out lastTokenOfList))
+                        {
+                            case ScanTypeFlags.NotType:
+                                lastTokenOfList = null;
+                                return ScanTypeFlags.NotType;
 
-                        case ScanTypeFlags.MustBeType:
-                        case ScanTypeFlags.GenericTypeOrMethod:
-                            result = ScanTypeFlags.GenericTypeOrMethod;
-                            break;
+                            case ScanTypeFlags.MustBeType:
+                            case ScanTypeFlags.GenericTypeOrMethod:
+                                result = ScanTypeFlags.GenericTypeOrMethod;
+                                break;
+                        }
                     }
                 }
                 while (this.CurrentToken.Kind == SyntaxKind.CommaToken);

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -857,9 +857,17 @@ class Program
     }
 }";
             var comp = CreateCompilationWithMscorlib(program);
-            var parseErrors = comp.SyntaxTrees[0].GetDiagnostics();
-            var errors = comp.GetDiagnostics();
-            Assert.Equal(parseErrors.Count(), errors.Count());
+            comp.SyntaxTrees[0].GetDiagnostics().Verify(
+                // (6,21): error CS1031: Type expected
+                //         var s = foo<,int>(123);
+                Diagnostic(ErrorCode.ERR_TypeExpected, ",").WithLocation(6, 21));
+            comp.VerifyDiagnostics(
+                // (6,21): error CS1031: Type expected
+                //         var s = foo<,int>(123);
+                Diagnostic(ErrorCode.ERR_TypeExpected, ",").WithLocation(6, 21),
+                // (6,17): error CS0305: Using the generic method 'Program.foo<T>(int)' requires 1 type arguments
+                //         var s = foo<,int>(123);
+                Diagnostic(ErrorCode.ERR_BadArity, "foo<,int>").WithArguments("Program.foo<T>(int)", "method", "1").WithLocation(6, 17));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
@@ -1260,6 +1260,36 @@ class Test {
         }
 
         [Fact, WorkItem(4827, "https://github.com/dotnet/roslyn/issues/4827")]
+        public void NameofOpenGenericType8()
+        {
+            var source =
+@"class B<X,Y> { }
+class Test {
+  void M(string v = nameof(B<int,>)) {
+  }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+                // (3,34): error CS1031: Type expected
+                //   void M(string v = nameof(B<int,>)) {
+                Diagnostic(ErrorCode.ERR_TypeExpected, ">").WithLocation(3, 34));
+        }
+
+        [Fact, WorkItem(4827, "https://github.com/dotnet/roslyn/issues/4827")]
+        public void NameofOpenGenericType9()
+        {
+            var source =
+@"class B<X,Y> { }
+class Test {
+  void M(string v = nameof(B<,int>)) {
+  }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+                // (3,30): error CS1031: Type expected
+                //   void M(string v = nameof(B<,int>)) {
+                Diagnostic(ErrorCode.ERR_TypeExpected, ",").WithLocation(3, 30));
+        }
+
+        [Fact, WorkItem(4827, "https://github.com/dotnet/roslyn/issues/4827")]
         public void NameofOpenGenericType_OpenNameOnRight()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -21181,6 +21181,37 @@ public class Test
         }
 
         [Fact]
+        public void CS7003ERR_UnexpectedUnboundGenericName1()
+        {
+            var text = @"
+using System.Collections.Generic;
+class C
+{
+    void Main()
+    {
+        object v = new List<>();
+        v = new Dictionary<,>();
+        v = new Dictionary<int,>();
+        v = new Dictionary<,int>();
+    }
+}
+";
+            CreateCompilationWithMscorlibAndSystemCore(text).VerifyDiagnostics(
+                // (9,32): error CS1031: Type expected
+                //         v = new Dictionary<int,>();
+                Diagnostic(ErrorCode.ERR_TypeExpected, ">").WithLocation(9, 32),
+                // (10,28): error CS1031: Type expected
+                //         v = new Dictionary<,int>();
+                Diagnostic(ErrorCode.ERR_TypeExpected, ",").WithLocation(10, 28),
+                // (7,24): error CS7003: Unexpected use of an unbound generic name
+                //         object v = new List<>();
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "List<>").WithLocation(7, 24),
+                // (8,17): error CS7003: Unexpected use of an unbound generic name
+                //         v = new Dictionary<,>();
+                Diagnostic(ErrorCode.ERR_UnexpectedUnboundGenericName, "Dictionary<,>").WithLocation(8, 17));
+        }
+
+        [Fact]
         public void CS7013WRN_MetadataNameTooLong()
         {
             var text = @"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/4827

I've run this by @MadsTorgersen and he also think this is something that we should probably support.

Note: this PR is out in order for me to find out if i've missed anything.  This will not be merged in until it has both PR signoff and has signoff from the language design team.  