### PR TITLE
Calculate snippet $end$ location based on column, not line length

### DIFF
--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
@@ -4,6 +4,8 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.VisualStudio.LanguageServices
 Imports Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
 Imports Microsoft.VisualStudio.Text.Projection
@@ -163,7 +165,7 @@ using G=   H.I;
         } 
 &lt;/div&gt;</SurfaceBuffer>
 
-            Test(workspaceXmlWithSubjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
+            TestProjectionFormatting(workspaceXmlWithSubjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Snippets)>
@@ -193,7 +195,7 @@ using G=   H.I;
 }
 &lt;/div&gt;</SurfaceBuffer>
 
-            Test(workspaceXmlWithSubjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
+            TestProjectionFormatting(workspaceXmlWithSubjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Snippets)>
@@ -223,10 +225,74 @@ using G=   H.I;
 }
 &lt;/div&gt;</SurfaceBuffer>
 
-            Test(workspaceXmlWithSubjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
+            TestProjectionFormatting(workspaceXmlWithSubjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
         End Sub
 
-        Public Sub Test(workspaceXmlWithSubjectBufferDocument As XElement, surfaceBufferDocumentXml As XElement, expectedSurfaceBuffer As XElement)
+        <Fact, WorkItem(4652, "https://github.com/dotnet/roslyn/issues/4652")>
+        <Trait(Traits.Feature, Traits.Features.Snippets)>
+        Public Sub SnippetFormatting_TabSize_3()
+            TestFormattingWithTabSize(3)
+        End Sub
+
+        <Fact, WorkItem(4652, "https://github.com/dotnet/roslyn/issues/4652")>
+        <Trait(Traits.Feature, Traits.Features.Snippets)>
+        Public Sub SnippetFormatting_TabSize_4()
+            TestFormattingWithTabSize(4)
+        End Sub
+
+        <Fact, WorkItem(4652, "https://github.com/dotnet/roslyn/issues/4652")>
+        <Trait(Traits.Feature, Traits.Features.Snippets)>
+        Public Sub SnippetFormatting_TabSize_5()
+            TestFormattingWithTabSize(5)
+        End Sub
+
+        Public Sub TestFormattingWithTabSize(tabSize As Integer)
+            Dim workspaceXml =
+<Workspace>
+    <Project Language=<%= LanguageNames.CSharp %> CommonReferences="true">
+        <Document>class C {
+	void M()
+	{
+		[|for (int x = 0; x &lt; length; x++)
+{
+    $$
+}|]
+	}
+}</Document>
+    </Project>
+</Workspace>
+
+            Dim expectedResult = <Test>class C {
+	void M()
+	{
+		for (int x = 0; x &lt; length; x++)
+		{
+
+		}
+	}
+}</Test>
+
+            Using testWorkspace = TestWorkspaceFactory.CreateWorkspace(workspaceXml)
+                Dim document = testWorkspace.Documents.Single()
+
+                Dim optionService = testWorkspace.Services.GetService(Of IOptionService)()
+                Dim optionSet = optionService.GetOptions()
+                optionSet = optionSet.WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True)
+                optionSet = optionSet.WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize)
+                optionSet = optionSet.WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)
+                optionService.SetOptions(optionSet)
+
+                Dim snippetExpansionClient = New SnippetExpansionClient(
+                    Guids.CSharpLanguageServiceId,
+                    document.GetTextView(),
+                    document.TextBuffer,
+                    Nothing)
+
+                SnippetExpansionClientTestsHelper.TestFormattingAndCaretPosition(snippetExpansionClient, document, expectedResult, tabSize * 3)
+            End Using
+        End Sub
+
+        Public Sub TestProjectionFormatting(workspaceXmlWithSubjectBufferDocument As XElement, surfaceBufferDocumentXml As XElement, expectedSurfaceBuffer As XElement)
             Using testWorkspace = TestWorkspaceFactory.CreateWorkspace(workspaceXmlWithSubjectBufferDocument)
                 Dim subjectBufferDocument = testWorkspace.Documents.Single()
 
@@ -242,7 +308,7 @@ using G=   H.I;
                     subjectBufferDocument.TextBuffer,
                     Nothing)
 
-                SnippetExpansionClientTestsHelper.Test(snippetExpansionClient, subjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
+                SnippetExpansionClientTestsHelper.TestProjectionBuffer(snippetExpansionClient, subjectBufferDocument, surfaceBufferDocument, expectedSurfaceBuffer)
             End Using
         End Sub
 

--- a/src/VisualStudio/Core/Test/Snippets/SnippetExpansionClientTestsHelper.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetExpansionClientTestsHelper.vb
@@ -7,7 +7,7 @@ Imports Microsoft.VisualStudio.TextManager.Interop
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
     Friend Class SnippetExpansionClientTestsHelper
-        Public Shared Sub Test(snippetExpansionClient As AbstractSnippetExpansionClient,
+        Public Shared Sub TestProjectionBuffer(snippetExpansionClient As AbstractSnippetExpansionClient,
                  subjectBufferDocument As TestHostDocument,
                  surfaceBufferDocument As TestHostDocument,
                  expectedSurfaceBuffer As XElement)
@@ -43,6 +43,64 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
             snippetExpansionClient.FormatSpan(Nothing, {snippetTextSpanInSurfaceBuffer})
 
             Assert.Equal(expectedSurfaceBuffer.NormalizedValue, surfaceBufferDocument.TextBuffer.CurrentSnapshot.GetText)
+        End Sub
+
+        Friend Shared Sub TestFormattingAndCaretPosition(
+                 snippetExpansionClient As AbstractSnippetExpansionClient,
+                 document As TestHostDocument,
+                 expectedResult As XElement,
+                 expectedVirtualSpacing As Integer)
+
+            Dim mockExpansionSession = New TestExpansionSession()
+
+            Dim cursorPosition = document.CursorPosition.Value
+            Dim cursorLine = document.TextBuffer.CurrentSnapshot.GetLineFromPosition(cursorPosition)
+
+            mockExpansionSession.SetEndSpan(New TextSpan() With
+                    {
+                        .iStartLine = cursorLine.LineNumber,
+                        .iStartIndex = cursorPosition - cursorLine.Start.Position,
+                        .iEndLine = cursorLine.LineNumber,
+                        .iEndIndex = cursorPosition - cursorLine.Start.Position
+                    })
+
+            snippetExpansionClient.OnBeforeInsertion(mockExpansionSession)
+
+            Dim snippetSpan = document.SelectedSpans(0)
+            Dim snippetStartLine = document.TextBuffer.CurrentSnapshot.GetLineFromPosition(snippetSpan.Start)
+            Dim snippetEndLine = document.TextBuffer.CurrentSnapshot.GetLineFromPosition(snippetSpan.End)
+            Dim snippetTextSpan = New TextSpan() With
+                    {
+                        .iStartLine = snippetStartLine.LineNumber,
+                        .iStartIndex = snippetSpan.Start - snippetStartLine.Start.Position,
+                        .iEndLine = snippetEndLine.LineNumber,
+                        .iEndIndex = snippetSpan.End - snippetEndLine.Start.Position
+                    }
+
+            mockExpansionSession.snippetSpanInSurfaceBuffer = snippetTextSpan
+
+            Dim endPosition = document.CursorPosition.Value
+            Dim endPositionLine = document.TextBuffer.CurrentSnapshot.GetLineFromPosition(endPosition)
+            Dim endPositionIndex = endPosition - endPositionLine.Start.Position
+
+            mockExpansionSession.endSpanInSurfaceBuffer = New TextSpan() With
+                    {
+                        .iStartLine = endPositionLine.LineNumber,
+                        .iStartIndex = endPositionIndex,
+                        .iEndLine = endPositionLine.LineNumber,
+                        .iEndIndex = endPositionIndex
+                    }
+
+            snippetExpansionClient.FormatSpan(Nothing, {snippetTextSpan})
+
+            Dim finalEndSpan(1) As TextSpan
+            mockExpansionSession.GetEndSpan(finalEndSpan)
+            Dim formattedEndPositionLine = document.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(finalEndSpan(0).iStartLine)
+
+            snippetExpansionClient.PositionCaretForEditingInternal(formattedEndPositionLine.GetText(), formattedEndPositionLine.Start.Position)
+
+            Assert.Equal(expectedVirtualSpacing, document.GetTextView().Caret.Position.VirtualSpaces)
+            Assert.Equal(expectedResult.NormalizedValue, document.TextBuffer.CurrentSnapshot.GetText)
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #4652

When an expanded snippet's $end$ position ends up on its own line after formatting (potentially with leading whitespace), we calculate & store its indentation level and then remove any leading whitespace. Then when the snippet is completed (either automatically or after field editing is complete), we position the caret in virtual space at this stored indentation level. The bug here was one of mismatched units. Specifying the position in virtual space is done in columns, but the indentation was being stored as a count of characters. When the "Keep Tabs" option is enabled, an intended indentation of 3 tabs (12 spaces if the tab size is 4) would result in the caret being positioned at column 3 in virtual space instead of column 12.