### PR TITLE
Fix crash in VerifyForwardedTypes

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 }
 
                 // 3) If the symbols ARE equivalent ignoring assemblies, they may or may not be equivalent if containing assemblies are NOT ignored.
-                if (equivalentTypesWithDifferingAssemblies.Object.Any())
+                if (equivalentTypesWithDifferingAssemblies.Object.Count > 0)
                 {
                     // Step 3a) Ensure that all pairs of named types in equivalentTypesWithDifferingAssemblies are indeed equivalent types.
                     return VerifyForwardedTypes(equivalentTypesWithDifferingAssemblies.Object, searchSymbol, symbolToMatch,
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             CancellationToken cancellationToken)
         {
             var verifiedKeys = new HashSet<INamedTypeSymbol>();
-            var count = equivalentTypesWithDifferingAssemblies.Count();
+            var count = equivalentTypesWithDifferingAssemblies.Count;
             int verifiedCount = 0;
 
             // First check forwarded types in searchSymbolCompilation.

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -315,17 +315,23 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             searchSymbol = searchSymbol.GetOriginalUnreducedDefinition();
             symbolToMatch = symbolToMatch.GetOriginalUnreducedDefinition();
 
-            // We compare the given searchSymbol and symbolToMatch for equivalence using SymbolEquivalenceComparer as follows:
-            //  1)  We compare the given symbols using the SymbolEquivalenceComparer.IgnoreAssembliesInstance, which ignores the containing assemblies for named types equivalence checks.
-            //      This is required to handle equivalent named types which are forwarded to completely different assemblies.
+            // We compare the given searchSymbol and symbolToMatch for equivalence using SymbolEquivalenceComparer
+            // as follows:
+            //  1)  We compare the given symbols using the SymbolEquivalenceComparer.IgnoreAssembliesInstance,
+            //      which ignores the containing assemblies for named types equivalence checks. This is required
+            //      to handle equivalent named types which are forwarded to completely different assemblies.
             //  2)  If the symbols are NOT equivalent ignoring assemblies, then they cannot be equivalent.
-            //  3)  Otherwise, if the symbols ARE equivalent ignoring assemblies, they may or may not be equivalent if containing assemblies are NOT ignored.
-            //      We need to perform additional checks to ensure they are indeed equivalent:
-            //      (a) If IgnoreAssembliesInstance.Equals equivalence visitor encountered any pair of non-nested named types which were equivalent in all aspects,
-            //          except that they resided in different assemblies, we need to ensure that all such pairs are indeed equivalent types.
-            //          Such a pair of named types is equivalent if and only if one of them is a type defined in either searchSymbolCompilation(C1) or symbolToMatchCompilation(C2),
-            //          say defined in reference assembly A (version v1) in compilation C1, and the other type is a forwarded type, such that it is forwarded from
-            //          reference assembly A (version v2) to assembly B in compilation C2.
+            //  3)  Otherwise, if the symbols ARE equivalent ignoring assemblies, they may or may not be equivalent
+            //      if containing assemblies are NOT ignored. We need to perform additional checks to ensure they
+            //      are indeed equivalent:
+            //
+            //      (a) If IgnoreAssembliesInstance.Equals equivalence visitor encountered any pair of non-nested 
+            //          named types which were equivalent in all aspects, except that they resided in different 
+            //          assemblies, we need to ensure that all such pairs are indeed equivalent types. Such a pair
+            //          of named types is equivalent if and only if one of them is a type defined in either 
+            //          searchSymbolCompilation(C1) or symbolToMatchCompilation(C2), say defined in reference assembly
+            //          A (version v1) in compilation C1, and the other type is a forwarded type, such that it is 
+            //          forwarded from reference assembly A (version v2) to assembly B in compilation C2.
             //      (b) Otherwise, if no such named type pairs were encountered, symbols ARE equivalent.
 
             using (var equivalentTypesWithDifferingAssemblies = SharedPools.Default<Dictionary<INamedTypeSymbol, INamedTypeSymbol>>().GetPooledObject())

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             Contract.ThrowIfFalse(equivalentTypesWithDifferingAssemblies.All(kvp => kvp.Key.ContainingType == null));
             Contract.ThrowIfFalse(equivalentTypesWithDifferingAssemblies.All(kvp => kvp.Value.ContainingType == null));
 
-            var referencedAssemblies = new Dictionary<string, IAssemblySymbol>();
+            var referencedAssemblies = new MultiDictionary<string, IAssemblySymbol>();
             foreach (var reference in compilation.References)
             {
                 var referencedAssemblyOrModule = compilation.GetAssemblyOrModuleSymbol(reference);
@@ -430,13 +430,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                         expectedForwardedType = kvp.Value.OriginalDefinition;
                     }
 
-                    IAssemblySymbol referencedAssembly;
-                    if (referencedAssemblies.TryGetValue(originalType.ContainingAssembly.Name, out referencedAssembly))
+                    foreach (var referencedAssembly in referencedAssemblies[originalType.ContainingAssembly.Name])
                     {
                         var fullyQualifiedTypeName = originalType.MetadataName;
                         if (originalType.ContainingNamespace != null)
                         {
-                            fullyQualifiedTypeName = originalType.ContainingNamespace.ToDisplayString(SymbolDisplayFormats.SignatureFormat) + "." + fullyQualifiedTypeName;
+                            fullyQualifiedTypeName = originalType.ContainingNamespace.ToDisplayString(SymbolDisplayFormats.SignatureFormat) + 
+                                "." + fullyQualifiedTypeName;
                         }
 
                         // Resolve forwarded type and verify that the types from different assembly are indeed equivalent.


### PR DESCRIPTION
Test forthcoming.  It's somewhat complicated because you need to have forwarded types, and multiple assemblies/modules with the same assembly name.