### PR TITLE
Fix options serialization issue causing the VB language settings to deserialize within a C# project

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -7,14 +7,15 @@ namespace Microsoft.CodeAnalysis.Completion
     internal static class CompletionOptions
     {
         public const string FeatureName = "Completion";
+        public const string ControllerFeatureName = "CompletionController";
 
         public static readonly PerLanguageOption<bool> HideAdvancedMembers = new PerLanguageOption<bool>(FeatureName, "HideAdvancedMembers", defaultValue: false);
         public static readonly PerLanguageOption<bool> IncludeKeywords = new PerLanguageOption<bool>(FeatureName, "IncludeKeywords", defaultValue: true);
         public static readonly PerLanguageOption<bool> TriggerOnTyping = new PerLanguageOption<bool>(FeatureName, "TriggerOnTyping", defaultValue: true);
         public static readonly PerLanguageOption<bool> TriggerOnTypingLetters = new PerLanguageOption<bool>(FeatureName, "TriggerOnTypingLetters", defaultValue: true);
 
-        public static readonly Option<bool> AlwaysShowBuilder = new Option<bool>(FeatureName, "AlwaysShowBuilder", defaultValue: false);
-        public static readonly Option<bool> FilterOutOfScopeLocals = new Option<bool>(FeatureName, "FilterOutOfScopeLocals", defaultValue: true);
-        public static readonly Option<bool> ShowXmlDocCommentCompletion = new Option<bool>(FeatureName, "ShowXmlDocCommentCompletion", defaultValue: true);
+        public static readonly Option<bool> AlwaysShowBuilder = new Option<bool>(ControllerFeatureName, "AlwaysShowBuilder", defaultValue: false);
+        public static readonly Option<bool> FilterOutOfScopeLocals = new Option<bool>(ControllerFeatureName, "FilterOutOfScopeLocals", defaultValue: true);
+        public static readonly Option<bool> ShowXmlDocCommentCompletion = new Option<bool>(ControllerFeatureName, "ShowXmlDocCommentCompletion", defaultValue: true);
     }
 }


### PR DESCRIPTION
Note that this only occurs within Visual Studio.

Essentially, ```PerLanguageOptions``` and ```Options``` can't really exist under the same feature name, as the feature is strongly tied to the serializer. In this case, I'd added options that were not per language but had the same feature name as some per language options. This caused the VB language settings to try and serialize when attempting to display C# completion. This was easily spotted because completion is computed on a background thread and the VB language settings assert that they must be deserialized on the UI thread.