### PR TITLE
work around a bug when running an analyzer test in 64-bit

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -255,6 +255,13 @@ public class TestAnalyzer : DiagnosticAnalyzer
             var analyzer = dir.CopyFile(typeof(DiagnosticAnalyzer).Assembly.Location);
             var test = dir.CopyFile(typeof(FromFileLoader).Assembly.Location);
 
+            // The other app domain in 64-bit tries to load xunit.dll so to work around bug 4959
+            // (https://github.com/dotnet/roslyn/issues/4959) we are copying xunit to the test directory.
+            if (Environment.Is64BitProcess)
+            {
+                var xunit = dir.CopyFile(typeof(FactAttribute).Assembly.Location);
+            }
+
             var analyzerCompilation = CSharp.CSharpCompilation.Create(
                 "MyAnalyzer",
                 new SyntaxTree[] { CSharp.SyntaxFactory.ParseSyntaxTree(analyzerSource) },


### PR DESCRIPTION
This PR is to work around #4959 so we can have a passing 64-bit test run until the bug can be properly addressed.

FYI @amcasey @tannergooding