### PR TITLE
Check SupportsCompilation before retrieving compilation

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.FieldSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.FieldSymbols.vb
@@ -351,6 +351,24 @@ class Program
             Test(input)
         End Sub
 
+        <WorkItem(4952, "https://github.com/dotnet/roslyn/pull/4952")>
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub Field_AcrossSubmission_Command()
+            Dim input =
+<Workspace>
+    <Submission Language="C#" CommonReferences="true">
+        object {|Definition:$$foo|};
+    </Submission>
+    <Submission Language="NoCompilation" CommonReferences="false">
+        #help
+    </Submission>
+    <Submission Language="C#" CommonReferences="true">
+        [|foo|]
+    </Submission>
+</Workspace>
+            Test(input)
+        End Sub
+
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Sub TestCrefField()
             Dim input =

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             foreach (var projectId in solution.ProjectIds)
             {
                 var project = solution.GetProject(projectId);
-                if (project.IsSubmission)
+                if (project.IsSubmission && project.SupportsCompilation)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Command submissions (e.g. ```#reset```) don't have compilations.

Replaces https://github.com/dotnet/roslyn/pull/4952

@jasonmalinowski I added a unit test.