### PR TITLE
Share doc comment finding code

### DIFF
--- a/src/Scripting/Core/MetadataShadowCopyProvider.cs
+++ b/src/Scripting/Core/MetadataShadowCopyProvider.cs
@@ -450,7 +450,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
                     ShadowCopy documentationFileCopy = null;
                     string xmlOriginalPath;
-                    if (TryFindXmlDocumentationFile(originalPath, out xmlOriginalPath))
+                    if (ReferencePathUtilities.TryFindXmlDocumentationFile(originalPath, out xmlOriginalPath))
                     {
                         // TODO (tomat): how do doc comments work for multi-module assembly?
                         var xmlCopyPath = Path.ChangeExtension(shadowCopyPath, ".xml");
@@ -492,45 +492,6 @@ namespace Microsoft.CodeAnalysis.Scripting
                     throw;
                 }
             }
-        }
-
-        private bool TryFindXmlDocumentationFile(string assemblyFilePath, out string xmlDocumentationFilePath)
-        {
-            xmlDocumentationFilePath = null;
-
-            // Look for the documentation xml in subdirectories based on the current 
-            // culture
-            // TODO: This logic is somewhat duplicated between here and 
-            // Roslyn.Utilities.FilePathUtilities.TryFindXmlDocumentationFile
-
-            string candidateFilePath = string.Empty;
-            string xmlFileName = Path.ChangeExtension(Path.GetFileName(assemblyFilePath), ".xml");
-            string originalDirectory = Path.GetDirectoryName(assemblyFilePath);
-
-            var culture = CultureInfo.CurrentCulture;
-            while (culture != CultureInfo.InvariantCulture)
-            {
-                candidateFilePath = Path.Combine(originalDirectory, culture.Name, xmlFileName);
-                if (File.Exists(candidateFilePath))
-                {
-                    xmlDocumentationFilePath = candidateFilePath;
-                    return true;
-                }
-
-                culture = culture.Parent;
-            }
-
-            // The documentation xml was not found in a subdirectory for the current culture, so 
-            // check the directory containing the assembly itself
-            candidateFilePath = Path.ChangeExtension(assemblyFilePath, ".xml");
-
-            if (File.Exists(candidateFilePath))
-            {
-                xmlDocumentationFilePath = candidateFilePath;
-                return true;
-            }
-
-            return false;
         }
 
         private AssemblyMetadata CreateAssemblyMetadata(FileStream manifestModuleCopyStream, string originalPath, string shadowCopyPath)

--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -64,6 +64,9 @@
     <Compile Include="..\..\Compilers\Helpers\GlobalAssemblyCacheHelpers\GlobalAssemblyCache.cs">
       <Link>GlobalAssemblyCache.cs</Link>
     </Compile>
+    <Compile Include="..\..\Workspaces\Core\Desktop\Utilities\ReferencePathUtilities.cs">
+      <Link>ReferencePathUtilities.cs</Link>
+    </Compile>
     <Compile Include="AssemblyLoadResult.cs" />
     <Compile Include="DesktopMetadataReferenceResolver.cs" />
     <Compile Include="InteractiveAssemblyLoader.cs" />

--- a/src/Workspaces/Core/Desktop/Utilities/ReferencePathUtilities.cs
+++ b/src/Workspaces/Core/Desktop/Utilities/ReferencePathUtilities.cs
@@ -1,48 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
-    internal static class ReferencePathUtilities
+    internal static partial class ReferencePathUtilities
     {
-        public static bool TryGetReferenceFilePath(string filePath, out string referenceFilePath)
-        {
-            // TODO(DustinCa): This is a workaround and we'll need to update this to handle getting the
-            // correct reference assembly for different framework versions and profiles. We can use
-            // the handy ToolLocationHelper from Microsoft.Build.Utilities.v4.5.dll
-
-            var assemblyName = Path.GetFileName(filePath);
-
-            // NOTE: Don't use the Path.HasExtension() and Path.ChangeExtension() helpers because
-            // an assembly might have a dotted name like 'System.Core'.
-            var extension = Path.GetExtension(assemblyName);
-            if (!string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase) &&
-                !string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase))
-            {
-                assemblyName += ".dll";
-            }
-
-            foreach (var referenceAssemblyPath in GetReferencePaths())
-            {
-                var referenceAssembly = Path.Combine(referenceAssemblyPath, assemblyName);
-                if (File.Exists(referenceAssembly))
-                {
-                    referenceFilePath = referenceAssembly;
-                    return true;
-                }
-            }
-
-            referenceFilePath = null;
-            return false;
-        }
-
         public static bool TryFindXmlDocumentationFile(string assemblyFilePath, out string xmlDocumentationFilePath)
         {
             // TODO(DustinCa): This is a workaround  and we'll need to update this to handle getting the correct
@@ -93,6 +58,7 @@ namespace Roslyn.Utilities
                 return true;
             }
 
+#if !SCRIPTING
             // 3. Look for reference assemblies
 
             string referenceAssemblyFilePath;
@@ -109,36 +75,10 @@ namespace Roslyn.Utilities
                 xmlDocumentationFilePath = xmlFilePath;
                 return true;
             }
+#endif
 
             xmlDocumentationFilePath = null;
             return false;
-        }
-
-        private static IEnumerable<string> GetFrameworkPaths()
-        {
-            ////            Concat(Path.GetDirectoryName(typeof(Microsoft.CSharp.RuntimeHelpers.SessionHelpers).Assembly.Location)).
-            return GlobalAssemblyCache.RootLocations.Concat(RuntimeEnvironment.GetRuntimeDirectory());
-        }
-
-        public static IEnumerable<string> GetReferencePaths()
-        {
-            // TODO:
-            // WORKAROUND: properly enumerate them
-            yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5");
-            yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0");
-        }
-
-        public static bool PartOfFrameworkOrReferencePaths(string filePath)
-        {
-            if (!PathUtilities.IsAbsolute(filePath))
-            {
-                return false;
-            }
-
-            var directory = Path.GetDirectoryName(filePath);
-
-            var frameworkOrReferencePaths = GetReferencePaths().Concat(GetFrameworkPaths()).Select(FileUtilities.NormalizeDirectoryPath);
-            return frameworkOrReferencePaths.Any(dir => directory.StartsWith(dir, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Utilities/ReferencePathUtilities_Desktop.cs
+++ b/src/Workspaces/Core/Desktop/Utilities/ReferencePathUtilities_Desktop.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.Utilities
+{
+    internal static partial class ReferencePathUtilities
+    {
+        public static bool TryGetReferenceFilePath(string filePath, out string referenceFilePath)
+        {
+            // TODO(DustinCa): This is a workaround and we'll need to update this to handle getting the
+            // correct reference assembly for different framework versions and profiles. We can use
+            // the handy ToolLocationHelper from Microsoft.Build.Utilities.v4.5.dll
+
+            var assemblyName = Path.GetFileName(filePath);
+
+            // NOTE: Don't use the Path.HasExtension() and Path.ChangeExtension() helpers because
+            // an assembly might have a dotted name like 'System.Core'.
+            var extension = Path.GetExtension(assemblyName);
+            if (!string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                assemblyName += ".dll";
+            }
+
+            foreach (var referenceAssemblyPath in GetReferencePaths())
+            {
+                var referenceAssembly = Path.Combine(referenceAssemblyPath, assemblyName);
+                if (File.Exists(referenceAssembly))
+                {
+                    referenceFilePath = referenceAssembly;
+                    return true;
+                }
+            }
+
+            referenceFilePath = null;
+            return false;
+        }
+
+        private static IEnumerable<string> GetFrameworkPaths()
+        {
+            ////            Concat(Path.GetDirectoryName(typeof(Microsoft.CSharp.RuntimeHelpers.SessionHelpers).Assembly.Location)).
+            return GlobalAssemblyCache.RootLocations.Concat(RuntimeEnvironment.GetRuntimeDirectory());
+        }
+
+        public static IEnumerable<string> GetReferencePaths()
+        {
+            // TODO:
+            // WORKAROUND: properly enumerate them
+            yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5");
+            yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0");
+        }
+
+        public static bool PartOfFrameworkOrReferencePaths(string filePath)
+        {
+            if (!PathUtilities.IsAbsolute(filePath))
+            {
+                return false;
+            }
+
+            var directory = Path.GetDirectoryName(filePath);
+
+            var frameworkOrReferencePaths = GetReferencePaths().Concat(GetFrameworkPaths()).Select(FileUtilities.NormalizeDirectoryPath);
+            return frameworkOrReferencePaths.Any(dir => directory.StartsWith(dir, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Log\RoslynEventSource.cs" />
     <Compile Include="Options\Providers\ExportedOptionKeyOptionProvider.cs" />
     <Compile Include="Utilities\Documentation\FileBasedXmlDocumentationProvider.cs" />
+    <Compile Include="Utilities\ReferencePathUtilities_Desktop.cs" />
     <Compile Include="Utilities\ReferencePathUtilities.cs" />
     <Compile Include="WorkspaceDesktopResources.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
The code was duplicated between scripting and workspaces because it is
partially non-portable.  Share the files by linking (and, unfortunately,
ifdef'ing) instead.

Replaces https://github.com/dotnet/roslyn/pull/4963