### PR TITLE
Making stack scheduling optimizations more robust and fixing #4828

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -22,7 +22,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             //      stack scheduler must be the last one.
 
             var locals = PooledDictionary<LocalSymbol, LocalDefUseInfo>.GetInstance();
-            src = (BoundStatement)StackOptimizerPass1.Analyze(src, locals);
+            var evalStack = ArrayBuilder<ValueTuple<BoundExpression, ExprContext>>.GetInstance();
+            src = (BoundStatement)StackOptimizerPass1.Analyze(src, locals, evalStack);
+            evalStack.Free();
 
             FilterValidStackLocals(locals);
 
@@ -271,9 +273,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
     // context of expression evaluation. 
     // it will affect inference of stack behavior
-    // it will also affect when expressions can be dup-reused
+    // it will also affect when locals can be scheduled to the stack
     // Example:
-    //      Foo(x, ref x)     <-- x cannot be duped as it is used in different context  
+    //      Foo(x, ref x)     <-- x cannot be a stack local as it is used in different contexts.
     internal enum ExprContext
     {
         Sideeffects,
@@ -293,13 +295,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
     internal class StackOptimizerPass1 : BoundTreeRewriter
     {
         private int _counter;
-        private int _evalStack;
+        private readonly ArrayBuilder<ValueTuple<BoundExpression, ExprContext>> _evalStack;
+
         private ExprContext _context;
         private BoundLocal _assignmentLocal;
-
-        private BoundExpression _lastExpression;
-        private ExprContext _lastExprContext;
-        private int _lastExpressionCnt;
 
         private readonly Dictionary<LocalSymbol, LocalDefUseInfo> _locals =
             new Dictionary<LocalSymbol, LocalDefUseInfo>();
@@ -315,18 +314,23 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         // when we need to ensure that eval stack is not blocked by stack Locals, we record an access to empty.
         public static readonly DummyLocal empty = new DummyLocal();
 
-        private StackOptimizerPass1(Dictionary<LocalSymbol, LocalDefUseInfo> locals)
+        private StackOptimizerPass1(Dictionary<LocalSymbol, LocalDefUseInfo> locals,
+            ArrayBuilder<ValueTuple<BoundExpression, ExprContext>> evalStack)
         {
             _locals = locals;
+            _evalStack = evalStack;
 
             // this is the top of eval stack
             DeclareLocal(empty, 0);
             RecordVarWrite(empty);
         }
 
-        public static BoundNode Analyze(BoundNode node, Dictionary<LocalSymbol, LocalDefUseInfo> locals)
+        public static BoundNode Analyze(
+            BoundNode node, 
+            Dictionary<LocalSymbol, LocalDefUseInfo> locals,
+            ArrayBuilder<ValueTuple<BoundExpression, ExprContext>> evalStack)
         {
-            var analyzer = new StackOptimizerPass1(locals);
+            var analyzer = new StackOptimizerPass1(locals, evalStack);
             var rewritten = analyzer.Visit(node);
 
             return rewritten;
@@ -350,166 +354,98 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return result;
         }
 
-        private static bool CanDup(BoundExpression prevNode, BoundExpression curNode)
-        {
-            if (prevNode == null)
-            {
-                return false;
-            }
-
-            if (prevNode.Type != curNode.Type)
-            {
-                return false;
-            }
-
-            // TODO: constants
-            //      Codegen sometimes folds constants (conditional ops, anything else?) 
-            //      We cannot currently rely on constants being actually emitted so we cannot dup them.
-            //      It could be attractive to do that though for big constants like doubles.
-            var prevConst = prevNode.ConstantValue;
-            if (prevConst != null)
-            {
-                return false;
-            }
-
-            // locals
-            var prevAsLocal = prevNode as BoundLocal;
-            var curAsLocal = curNode as BoundLocal;
-
-            if (prevAsLocal != null && curAsLocal != null)
-            {
-                return prevAsLocal.LocalSymbol == curAsLocal.LocalSymbol;
-            }
-
-            // parameters
-            var prevAsParam = prevNode as BoundParameter;
-            var curAsParam = curNode as BoundParameter;
-
-            if (prevAsParam != null && curAsParam != null)
-            {
-                // TODO: it may be unnecessary to dup when it is ldloc[0-4]
-                //       just dup always for now for simplicity.
-                return prevAsParam.ParameterSymbol == curAsParam.ParameterSymbol;
-            }
-
-            //TODO: fields, constants, sequence points ...
-
-            return false;
-        }
-
-        /// <summary>
-        /// Recursively rewrites the node or simply replaces it with a dup node
-        /// if we have just seen exactly same node.
-        /// </summary>
-        private BoundExpression ReuseOrVisit(BoundExpression node, ExprContext context)
-        {
-            if (context == ExprContext.AssignmentTarget || context == ExprContext.Sideeffects)
-            {
-                return BaseVisitExpression(node);
-            }
-
-            // it must be most recent expression
-            // it can be a ref when we want a value, but cannot be the other way
-            // TODO: we could reuse boxed values, but we would need to make the Dup to know it was boxed
-            if (_counter == _lastExpressionCnt + 1 &&
-                _lastExprContext != ExprContext.Box &&
-                (_lastExprContext == context || _lastExprContext != ExprContext.Value) &&
-                CanDup(_lastExpression, node))
-            {
-                _lastExpressionCnt = _counter;
-
-                // when duping something not created in a Value context, we are actually duping a reference.
-                // record that so that codegen could know if it is a value or a reference.
-                RefKind dupRefKind = _lastExprContext == ExprContext.Value ?
-                                                    RefKind.None :
-                                                    RefKind.Ref;
-
-                // change the context to the most recently used. 
-                // Why? If we obtained a value from a duped reference, we now have a value on the stack.
-                _lastExprContext = context;
-
-                return new BoundDup(node.Syntax, dupRefKind, node.Type);
-            }
-            else
-            {
-                BoundExpression result = BaseVisitExpression(node);
-
-                _lastExpressionCnt = _counter;
-                _lastExprContext = context;
-                _lastExpression = result;
-
-                return result;
-            }
-        }
-
-        private BoundExpression BaseVisitExpression(BoundExpression node)
-        {
-            // Do not recurse into constant expressions. Their children do not push any locals.
-            // TODO: we may consider duping the constants though (see comments in CanDup)
-            if (node.ConstantValue == null)
-            {
-                node = (BoundExpression)base.Visit(node);
-            }
-
-            return node;
-        }
-
         public BoundExpression VisitExpression(BoundExpression node, ExprContext context)
         {
             var prevContext = _context;
-            int prevStack = _evalStack;
-
+            int prevStack = StackDepth();
             _context = context;
-            var result = ReuseOrVisit(node, context);
+
+            // Do not recurse into constant expressions. Their children do not push any values.
+            var result = node.ConstantValue == null ?
+                node = (BoundExpression)base.Visit(node) :
+                node;
+
+            _context = prevContext;
             _counter += 1;
 
             switch (context)
             {
                 case ExprContext.Sideeffects:
-                    _evalStack = prevStack;
+                    SetStackDepth(prevStack);
+                    break;
+
+                case ExprContext.AssignmentTarget:
                     break;
 
                 case ExprContext.Value:
                 case ExprContext.Address:
                 case ExprContext.Box:
-                    _evalStack = prevStack + 1;
-                    break;
-
-                case ExprContext.AssignmentTarget:
-                    _evalStack = prevStack;
-                    if (LhsUsesStackWhenAssignedTo(node, context))
-                    {
-                        _evalStack = prevStack + 1;
-                    }
+                    SetStackDepth(prevStack);
+                    PushEvalStack(node, context);
                     break;
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(context);
             }
 
-            _context = prevContext;
             return result;
+        }
+
+        private void PushEvalStack(BoundExpression result, ExprContext context)
+        {
+            _evalStack.Add(ValueTuple.Create(result, context));
+        }
+
+        private int StackDepth()
+        {
+            return _evalStack.Count;
+        }
+
+        private bool EvalStackIsEmpty()
+        {
+            return StackDepth() == 0;
+        }
+
+        private void SetStackDepth(int depth)
+        {
+            _evalStack.Clip(depth);
+        }
+
+        private void PopEvalStack()
+        {
+            SetStackDepth(_evalStack.Count - 1);
+        }
+
+        private void ClearEvalStack()
+        {
+            _evalStack.Clear();
         }
 
         public BoundNode VisitStatement(BoundNode node)
         {
+            Debug.Assert(node == null || EvalStackIsEmpty());
+
+            var origStack = StackDepth();
             var prevContext = _context;
-            int prevStack = _evalStack;
 
             var result = base.Visit(node);
 
-            ClearLastExpression();
-            _counter += 1;
-            _evalStack = prevStack;
             _context = prevContext;
+            SetStackDepth(origStack);
+            _counter += 1;
 
             return result;
         }
 
-        private void ClearLastExpression()
+        public override BoundNode VisitBlock(BoundBlock node)
         {
-            _lastExpressionCnt = 0;
-            _lastExpression = null;
+            Debug.Assert(EvalStackIsEmpty(), "entering blocks when evaluation stack is not empty?");
+
+            // normally we would not allow stack locals
+            // when evaluation stack is not empty.
+            DeclareLocals(node.Locals, 0);
+
+            return base.VisitBlock(node);
         }
 
         // here we have a case of indirect assignment:  *t1 = expr;
@@ -532,37 +468,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         //  We may consider detecting exactly these cases and pretend that we do not need 
         //  to push either t1 or t2 in this case.
         //
-        private bool LhsUsesStackWhenAssignedTo(BoundNode node, ExprContext context)
-        {
-            Debug.Assert(context == ExprContext.AssignmentTarget);
-
-            switch (node.Kind)
-            {
-                case BoundKind.Parameter:
-                case BoundKind.Local:
-                    return false;
-
-                case BoundKind.FieldAccess:
-                    return !((BoundFieldAccess)node).FieldSymbol.IsStatic;
-
-                case BoundKind.Sequence:
-                    return LhsUsesStackWhenAssignedTo(((BoundSequence)node).Value, context);
-            }
-
-            return true;
-        }
-
-        public override BoundNode VisitBlock(BoundBlock node)
-        {
-            Debug.Assert(_evalStack == 0, "entering blocks when evaluation stack is not empty?");
-
-            // normally we would not allow stack locals
-            // when evaluation stack is not empty.
-            DeclareLocals(node.Locals, 0);
-
-            return base.VisitBlock(node);
-        }
-
         public override BoundNode VisitSequence(BoundSequence node)
         {
             // Normally we can only use stack for local scheduling if stack is not used for evaluation.
@@ -603,7 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             //
             //  We will detect such case and indicate +1 as the desired stack depth at local accesses.
             //
-            var declarationStack = _evalStack;
+            var declarationStack = StackDepth();
 
             var locals = node.Locals;
             if (!locals.IsDefaultOrEmpty)
@@ -787,10 +692,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         // just remember what we are assigning to.
                         _assignmentLocal = node;
 
-                        // whatever is available as lastExpression is still available 
-                        // (adjust for visit of this node)
-                        _lastExpressionCnt++;
-
                         break;
 
                     case ExprContext.Sideeffects:
@@ -904,9 +805,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             if (rhsCookie != null)
             {
                 // we currently have the rhs on stack, adjust for that.
-                _evalStack--;
+                PopEvalStack();
                 this.EnsureStackState(rhsCookie);
-                _evalStack++;
             }
 
             return node.Update(left, right, node.RefKind, node.Type);
@@ -921,6 +821,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             var lhs = node.Left;
             switch (lhs.Kind)
             {
+                case BoundKind.ThisReference:
+                    Debug.Assert(lhs.Type.IsValueType && node.RefKind == RefKind.None);
+                    return true;
+
                 case BoundKind.Parameter:
                     if (((BoundParameter)lhs).ParameterSymbol.RefKind != RefKind.None)
                     {
@@ -1102,9 +1006,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         receiver = VisitExpression(receiver, ExprContext.Value);
                     }
                 }
-                // whatever is available as lastExpression is still available 
-                // (adjust for visit of this node)
-                _lastExpressionCnt++;
             }
             else
             {
@@ -1143,8 +1044,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public override BoundNode VisitConditionalGoto(BoundConditionalGoto node)
         {
             var result = base.VisitConditionalGoto(node);
-
-            _evalStack--;  // condition gets consumed.
+            PopEvalStack();  // condition gets consumed.
             RecordBranch(node.Label);
 
             return result;
@@ -1152,17 +1052,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)
         {
-            var origStack = _evalStack;
+            var origStack = StackDepth();
             BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
 
             var cookie = GetStackStateCookie();  // implicit goto here
 
-            _evalStack = origStack;  // consequence is evaluated with original stack
+            SetStackDepth(origStack);  // consequence is evaluated with original stack
             BoundExpression consequence = (BoundExpression)this.Visit(node.Consequence);
 
             EnsureStackState(cookie);   // implicit label here
 
-            _evalStack = origStack;  // alternative is evaluated with original stack
+            SetStackDepth(origStack);  // alternative is evaluated with original stack
             BoundExpression alternative = (BoundExpression)this.Visit(node.Alternative);
 
             EnsureStackState(cookie);   // implicit label here
@@ -1175,34 +1075,32 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             var isLogical = (node.OperatorKind & BinaryOperatorKind.Logical) != 0;
             if (isLogical)
             {
-                var origStack = _evalStack;
+                var origStack = StackDepth();
                 BoundExpression left = (BoundExpression)this.Visit(node.Left);
 
                 var cookie = GetStackStateCookie();     // implicit branch here
 
-                _evalStack = origStack;  // right is evaluated with original stack
+                SetStackDepth(origStack);  // right is evaluated with original stack
                 BoundExpression right = (BoundExpression)this.Visit(node.Right);
 
                 EnsureStackState(cookie);   // implicit label here
 
                 return node.Update(node.OperatorKind, left, right, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, node.Type);
             }
-            else
-            {
-                return base.VisitBinaryOperator(node);
-            }
+
+            return base.VisitBinaryOperator(node);
         }
 
         public override BoundNode VisitNullCoalescingOperator(BoundNullCoalescingOperator node)
         {
-            var origStack = _evalStack;
+            var origStack = StackDepth();
             BoundExpression left = (BoundExpression)this.Visit(node.LeftOperand);
 
             var cookie = GetStackStateCookie();     // implicit branch here
 
             // right is evaluated with original stack 
             // (this is not entirely true, codegen may keep left on the stack as an ephemeral temp, but that is irrelevant here)
-            _evalStack = origStack;
+            SetStackDepth(origStack);
             BoundExpression right = (BoundExpression)this.Visit(node.RightOperand);
 
             EnsureStackState(cookie);   // implicit label here
@@ -1212,14 +1110,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
         {
-            var origStack = _evalStack;
+            var origStack = StackDepth();
             BoundExpression receiver = VisitCallReceiver(node.Receiver);
 
             var cookie = GetStackStateCookie();     // implicit branch here
 
             // right is evaluated with original stack 
             // (this is not entirely true, codegen will keep receiver on the stack, but that is irrelevant here)
-            _evalStack = origStack;
+            SetStackDepth(origStack);
             BoundExpression whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
 
             EnsureStackState(cookie);   // implicit label here
@@ -1227,7 +1125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             var whenNull = node.WhenNullOpt;
             if (whenNull != null)
             {
-                _evalStack = origStack;  // whenNull is evaluated with original stack
+                SetStackDepth(origStack);  // whenNull is evaluated with original stack
                 whenNull = (BoundExpression)this.Visit(whenNull);
                 EnsureStackState(cookie);   // implicit label here
             }
@@ -1244,18 +1142,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             EnsureOnlyEvalStack();
 
-            var origStack = _evalStack;
+            var origStack = StackDepth();
 
-            _evalStack += 1;
+            PushEvalStack(null, ExprContext.Value);
 
             var cookie = GetStackStateCookie(); // implicit goto here 
 
-            _evalStack = origStack; // consequence is evaluated with original stack 
+            SetStackDepth(origStack); // consequence is evaluated with original stack 
             var valueTypeReceiver = (BoundExpression)this.Visit(node.ValueTypeReceiver);
 
             EnsureStackState(cookie); // implicit label here 
 
-            _evalStack = origStack; // alternative is evaluated with original stack 
+            SetStackDepth(origStack); // alternative is evaluated with original stack 
             var referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
 
             EnsureStackState(cookie); // implicit label here 
@@ -1268,11 +1166,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // checked(-x) is emitted as "0 - x"
             if (node.OperatorKind.IsChecked() && node.OperatorKind.Operator() == UnaryOperatorKind.UnaryMinus)
             {
-                var origStack = _evalStack;
-                _evalStack++;
-                CannotReusePreviousExpression(); // Loaded 0 on the stack.
+                var origStack = StackDepth();
+                PushEvalStack(new BoundDefaultOperator(node.Syntax, node.Operand.Type), ExprContext.Value);
                 BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
-                _evalStack = origStack;
                 return node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, node.Type);
             }
             else
@@ -1283,10 +1179,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
-            Debug.Assert(_evalStack == 0);
+            Debug.Assert(EvalStackIsEmpty());
             DeclareLocals(node.InnerLocals, 0);
-
-            var origStack = _evalStack;
 
             // switch needs a byval local or a parameter as a key.
             // if this is already a fitting local, let's keep it that way
@@ -1303,7 +1197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             boundExpression = (BoundExpression)this.Visit(boundExpression);
 
             // expression value is consumed by the switch
-            _evalStack = origStack;
+            PopEvalStack();
 
             // implicit control flow
             EnsureOnlyEvalStack();
@@ -1370,7 +1264,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             if (exceptionSourceOpt != null)
             {
                 // runtime pushes the exception object
-                _evalStack++;
+                PushEvalStack(null, ExprContext.Value);
                 _counter++;
 
                 // We consume it by writing into the exception source.
@@ -1380,13 +1274,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
                 else
                 {
-                    int prevStack = _evalStack;
+                    int prevStack = StackDepth();
                     exceptionSourceOpt = VisitExpression(exceptionSourceOpt, ExprContext.AssignmentTarget);
-                    Debug.Assert(_evalStack == prevStack + (LhsUsesStackWhenAssignedTo(exceptionSourceOpt, ExprContext.AssignmentTarget) ? 1 : 0));
-                    _evalStack = prevStack;
+                    SetStackDepth(prevStack);
                 }
 
-                _evalStack--;
+                PopEvalStack();
                 _counter++;
             }
 
@@ -1396,7 +1289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 boundFilter = (BoundExpression)this.Visit(node.ExceptionFilterOpt);
 
                 // the value of filter expression is consumed by the VM
-                _evalStack--;
+                PopEvalStack();
                 _counter++;
 
                 // variables allocated on stack in a filter can't be used in the catch handler 
@@ -1475,18 +1368,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         // It is done by accessing virtual "empty" local that is at the bottom of all stack locals.
         private void EnsureOnlyEvalStack()
         {
-            CannotReusePreviousExpression();
             RecordVarRead(empty);
         }
 
         private object GetStackStateCookie()
         {
-            CannotReusePreviousExpression();
-
             // create a dummy and start tracing it
             var dummy = new DummyLocal();
             _dummyVariables.Add(dummy, dummy);
-            _locals.Add(dummy, new LocalDefUseInfo(_evalStack));
+            _locals.Add(dummy, new LocalDefUseInfo(StackDepth()));
             RecordVarWrite(dummy);
 
             return dummy;
@@ -1494,16 +1384,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EnsureStackState(object cookie)
         {
-            CannotReusePreviousExpression();
-
             RecordVarRead(_dummyVariables[cookie]);
         }
 
         // called on branches and labels
         private void RecordBranch(LabelSymbol label)
         {
-            CannotReusePreviousExpression();
-
             DummyLocal dummy;
             if (_dummyVariables.TryGetValue(label, out dummy))
             {
@@ -1514,15 +1400,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // create a dummy and start tracing it
                 dummy = new DummyLocal();
                 _dummyVariables.Add(label, dummy);
-                _locals.Add(dummy, new LocalDefUseInfo(_evalStack));
+                _locals.Add(dummy, new LocalDefUseInfo(StackDepth()));
                 RecordVarWrite(dummy);
             }
         }
 
         private void RecordLabel(LabelSymbol label)
         {
-            CannotReusePreviousExpression();
-
             DummyLocal dummy;
             if (_dummyVariables.TryGetValue(label, out dummy))
             {
@@ -1536,12 +1420,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 _dummyVariables.Add(label, dummy);
                 RecordVarRead(dummy);
             }
-        }
-
-        private void CannotReusePreviousExpression()
-        {
-            _lastExpressionCnt = 0;
-            _lastExpression = null;
         }
 
         private void RecordVarRef(LocalSymbol local)
@@ -1581,7 +1459,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // if accessing real val, check stack
             if (local.SynthesizedKind != SynthesizedLocalKind.OptimizerTemp)
             {
-                if (locInfo.stackAtDeclaration != _evalStack)
+                if (locInfo.stackAtDeclaration != StackDepth() &&
+                    !EvalStackHasLocal(local))
                 {
                     //reading at different eval stack.
                     locInfo.ShouldNotSchedule();
@@ -1591,7 +1470,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             else
             {
                 // dummy must be accessed on same stack.
-                Debug.Assert(local == empty || locInfo.stackAtDeclaration == _evalStack);
+                Debug.Assert(local == empty || locInfo.stackAtDeclaration == StackDepth());
             }
 
             var definedAt = locInfo.LocalDefs.Last();
@@ -1599,6 +1478,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             var locDef = new LocalDefUseSpan(_counter);
             locInfo.LocalDefs.Add(locDef);
+        }
+
+        private bool EvalStackHasLocal(LocalSymbol local)
+        {
+            var top = _evalStack.Last();
+
+            return top.Item2 == (local.RefKind == RefKind.None? ExprContext.Value : ExprContext.Address) &&
+                   top.Item1.Kind == BoundKind.Local &&
+                   ((BoundLocal)top.Item1).LocalSymbol == local;
         }
 
         private void RecordVarWrite(LocalSymbol local)
@@ -1618,7 +1506,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             if (local.SynthesizedKind != SynthesizedLocalKind.OptimizerTemp)
             {
                 // -1 because real assignment "consumes, assigns, and then pushes back" the value.
-                var evalStack = _evalStack - 1;
+                var evalStack = StackDepth() - 1;
 
                 if (locInfo.stackAtDeclaration != evalStack)
                 {
@@ -1630,7 +1518,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             else
             {
                 // dummy must be accessed on same stack.
-                Debug.Assert(local == empty || locInfo.stackAtDeclaration == _evalStack);
+                Debug.Assert(local == empty || locInfo.stackAtDeclaration == StackDepth());
             }
 
             var locDef = new LocalDefUseSpan(_counter);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -1067,37 +1067,37 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
   // Code size      178 (0xb2)
   .maxstack  3
   .locals init (int V_0,
-  int V_1, 
-  int V_2, //x
-  int V_3,
-  System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-  System.Exception V_5)
+                int V_1,
+                int V_2, //x
+                int V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Test.<G>d__1.<>1__state""
   IL_0006:  stloc.0
   .try
-{
-  IL_0007:  ldloc.0
+  {
+    IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_0053
     IL_000a:  ldc.i4.0
     IL_000b:  stloc.2
     IL_000c:  ldc.i4.0
     IL_000d:  stloc.3
-  .try
-{
+    .try
+    {
       IL_000e:  ldloc.2
-      IL_000f:  dup
+      IL_000f:  ldloc.2
       IL_0010:  div
       IL_0011:  stloc.2
       IL_0012:  leave.s    IL_0019
-}
-  catch object
-{
+    }
+    catch object
+    {
       IL_0014:  pop
       IL_0015:  ldc.i4.1
       IL_0016:  stloc.3
       IL_0017:  leave.s    IL_0019
-}
+    }
     IL_0019:  ldloc.3
     IL_001a:  ldc.i4.1
     IL_001b:  bne.un.s   IL_0080
@@ -1140,9 +1140,9 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
     IL_0080:  ldloc.2
     IL_0081:  stloc.1
     IL_0082:  leave.s    IL_009d
-}
+  }
   catch System.Exception
-{
+  {
     IL_0084:  stloc.s    V_5
     IL_0086:  ldarg.0
     IL_0087:  ldc.i4.s   -2
@@ -1152,7 +1152,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
     IL_0094:  ldloc.s    V_5
     IL_0096:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
     IL_009b:  leave.s    IL_00b1
-}
+  }
   IL_009d:  ldarg.0
   IL_009e:  ldc.i4.s   -2
   IL_00a0:  stfld      ""int Test.<G>d__1.<>1__state""

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
@@ -4632,7 +4632,7 @@ class D
   IL_0018:  brtrue.s   IL_0030
   IL_001a:  pop
   IL_001b:  ldloc.0
-  IL_001c:  dup
+  IL_001c:  ldloc.0
   IL_001d:  ldftn      ""bool C.<>c__DisplayClass0_0<T>.<M>b__0(T)""
   IL_0023:  newobj     ""System.Func<T, bool>..ctor(object, System.IntPtr)""
   IL_0028:  dup
@@ -4730,7 +4730,7 @@ class D
   IL_0025:  brtrue.s   IL_003d
   IL_0027:  pop
   IL_0028:  ldloc.0
-  IL_0029:  dup
+  IL_0029:  ldloc.0
   IL_002a:  ldftn      ""int Program.<>c__DisplayClass3_0.<Test>b__0(int)""
   IL_0030:  newobj     ""System.Func<int, int>..ctor(object, System.IntPtr)""
   IL_0035:  dup
@@ -4757,7 +4757,7 @@ class D
   IL_005f:  ldc.i4.2
   IL_0060:  bge.s      IL_0084
   IL_0062:  ldloc.3
-  IL_0063:  dup
+  IL_0063:  ldloc.3
   IL_0064:  add
   IL_0065:  call       ""void System.Console.WriteLine(int)""
   IL_006a:  ldarg.0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -453,7 +453,7 @@ public class C : I
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
 }
@@ -2174,7 +2174,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
 }
@@ -2321,7 +2321,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
 }
@@ -2370,7 +2370,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
 }
@@ -2419,7 +2419,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
 }
@@ -2468,7 +2468,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
 }
@@ -2517,10 +2517,11 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -2565,7 +2566,7 @@ public class C
   IL_0041:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0046:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004b:  ldarg.1
-  IL_004c:  dup
+  IL_004c:  ldarg.1
   IL_004d:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0052:  ret
 }
@@ -2614,10 +2615,11 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -2662,10 +2664,11 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -4958,7 +4961,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  dup
   IL_0054:  starg.s    V_1
@@ -5009,7 +5012,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  dup
   IL_0054:  starg.s    V_1
@@ -5060,7 +5063,7 @@ public class C
   IL_0042:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004c:  ldarg.1
-  IL_004d:  dup
+  IL_004d:  ldarg.1
   IL_004e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0053:  starg.s    V_1
   IL_0055:  ret
@@ -7635,7 +7638,7 @@ public class C
   IL_0065:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_006a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_006f:  ldarg.1
-  IL_0070:  dup
+  IL_0070:  ldarg.1
   IL_0071:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0076:  ret
 }
@@ -7777,7 +7780,7 @@ public class C
   IL_0066:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object>>.Target""
   IL_006b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object>> C.<>o__0.<>p__0""
   IL_0070:  ldarg.1
-  IL_0071:  dup
+  IL_0071:  ldarg.1
   IL_0072:  ldarg.2
   IL_0073:  ldc.i4.s   123
   IL_0075:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object, int, int)""
@@ -8101,10 +8104,11 @@ public class C
   IL_010d:  initobj    ""System.DateTime""
   IL_0113:  ldloc.0
   IL_0114:  ldarg.1
-  IL_0115:  dup
+  IL_0115:  ldarg.1
   IL_0116:  callvirt   ""object <>F<System.Runtime.CompilerServices.CallSite, object, int, bool, double, char, string, byte, sbyte, uint, long, ulong, float, decimal, System.DateTime, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, int, bool, double, char, string, byte, sbyte, uint, long, ulong, float, decimal, System.DateTime, object, object)""
   IL_011b:  ret
-}"
+}
+"
                 );
         }
 
@@ -8410,7 +8414,7 @@ public class C
 }";
             CompileAndVerifyIL(source, "C.M", @"
 {
-  // Code size      102 (0x66)
+  // Code size      103 (0x67)
   .maxstack  9
   IL_0000:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>F{0000000c}<System.Runtime.CompilerServices.CallSite, object, object, object, object>> C.<>o__0.<>p__0""
   IL_0005:  brtrue.s   IL_004d
@@ -8447,9 +8451,9 @@ public class C
   IL_0057:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>F{0000000c}<System.Runtime.CompilerServices.CallSite, object, object, object, object>> C.<>o__0.<>p__0""
   IL_005c:  ldarg.1
   IL_005d:  ldarga.s   V_1
-  IL_005f:  dup
-  IL_0060:  callvirt   ""object <>F{0000000c}<System.Runtime.CompilerServices.CallSite, object, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, ref object, ref object)""
-  IL_0065:  ret
+  IL_005f:  ldarga.s   V_1
+  IL_0061:  callvirt   ""object <>F{0000000c}<System.Runtime.CompilerServices.CallSite, object, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, ref object, ref object)""
+  IL_0066:  ret
 }
 ");
         }
@@ -9786,7 +9790,7 @@ public class C
   IL_0060:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object>>.Target""
   IL_0065:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object>> C.<>o__0.<>p__0""
   IL_006a:  ldarg.1
-  IL_006b:  dup
+  IL_006b:  ldarg.1
   IL_006c:  ldarg.2
   IL_006d:  ldc.i4.s   123
   IL_006f:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, int, int, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object, int, int)""
@@ -9848,7 +9852,7 @@ public class C
   IL_0064:  ldfld      ""System.Action<System.Runtime.CompilerServices.CallSite, object, object, int, int> System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object, int, int>>.Target""
   IL_0069:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object, int, int>> C.<>o__0.<>p__0""
   IL_006e:  ldarg.1
-  IL_006f:  dup
+  IL_006f:  ldarg.1
   IL_0070:  ldarg.2
   IL_0071:  ldc.i4.s   123
   IL_0073:  callvirt   ""void System.Action<System.Runtime.CompilerServices.CallSite, object, object, int, int>.Invoke(System.Runtime.CompilerServices.CallSite, object, object, int, int)""
@@ -9964,11 +9968,12 @@ public class C
   IL_0059:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, F, object, object, object, object>> C.<>o__0.<>p__0""
   IL_005e:  ldarg.1
   IL_005f:  ldarg.2
-  IL_0060:  dup
-  IL_0061:  dup
+  IL_0060:  ldarg.2
+  IL_0061:  ldarg.2
   IL_0062:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, F, object, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, F, object, object, object)""
   IL_0067:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -11492,13 +11497,14 @@ public class C
   IL_009f:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object, object>>.Target""
   IL_00a4:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object, object>> C.<>o__0.<>p__0""
   IL_00a9:  ldarg.1
-  IL_00aa:  dup
-  IL_00ab:  dup
+  IL_00aa:  ldarg.1
+  IL_00ab:  ldarg.1
   IL_00ac:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object, object)""
   IL_00b1:  ldarg.1
   IL_00b2:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object, object)""
   IL_00b7:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -11566,7 +11572,7 @@ public class C
   IL_0079:  ldfld      ""<>F{00000020}<System.Runtime.CompilerServices.CallSite, object, object, int, object, object, object, object> System.Runtime.CompilerServices.CallSite<<>F{00000020}<System.Runtime.CompilerServices.CallSite, object, object, int, object, object, object, object>>.Target""
   IL_007e:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>F{00000020}<System.Runtime.CompilerServices.CallSite, object, object, int, object, object, object, object>> C.<>o__0.<>p__0""
   IL_0083:  ldarg.1
-  IL_0084:  dup
+  IL_0084:  ldarg.1
   IL_0085:  ldc.i4.0
   IL_0086:  ldnull
   IL_0087:  ldarga.s   V_1
@@ -11686,7 +11692,7 @@ public class C
   IL_0045:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_004a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_004f:  ldarg.1
-  IL_0050:  dup
+  IL_0050:  ldarg.1
   IL_0051:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_0056:  ret
 }
@@ -11761,7 +11767,7 @@ public class C
   IL_0094:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>>.Target""
   IL_0099:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>> C.<>o__0.<>p__0""
   IL_009e:  ldarg.1
-  IL_009f:  dup
+  IL_009f:  ldarg.1
   IL_00a0:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
   IL_00a5:  ldarg.1
   IL_00a6:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -3729,15 +3729,15 @@ public class Test
   // Code size       29 (0x1d)
   .maxstack  2
   .locals init (int[] V_0, //a
-  System.Collections.Generic.IEnumerable<int> V_1, //b
-  System.Collections.Generic.IEnumerable<int> V_2)
+                System.Collections.Generic.IEnumerable<int> V_1, //b
+                System.Collections.Generic.IEnumerable<int> V_2)
   IL_0000:  ldc.i4.0
   IL_0001:  newarr     ""int""
   IL_0006:  stloc.0
   IL_0007:  newobj     ""System.Collections.Generic.List<int>..ctor()""
   IL_000c:  stloc.1
   IL_000d:  ldloc.1
-  IL_000e:  dup
+  IL_000e:  ldloc.1
   IL_000f:  brtrue.s   IL_0016
   IL_0011:  ldloc.0
   IL_0012:  stloc.2
@@ -3746,7 +3746,8 @@ public class Test
   IL_0016:  ldloc.1
   IL_0017:  call       ""void Test.Foo<System.Collections.Generic.IEnumerable<int>, System.Collections.Generic.IEnumerable<int>>(System.Collections.Generic.IEnumerable<int>, System.Collections.Generic.IEnumerable<int>)""
   IL_001c:  ret
-}");
+}
+");
         }
 
 
@@ -4394,23 +4395,23 @@ class Program
   IL_002c:  call       ""bool decimal.op_Inequality(decimal, decimal)""
   IL_0031:  pop
   IL_0032:  ldloc.0
-  IL_0033:  dup
+  IL_0033:  ldloc.0
   IL_0034:  call       ""decimal decimal.op_Addition(decimal, decimal)""
   IL_0039:  pop
   IL_003a:  ldloc.0
-  IL_003b:  dup
+  IL_003b:  ldloc.0
   IL_003c:  call       ""decimal decimal.op_Subtraction(decimal, decimal)""
   IL_0041:  pop
   IL_0042:  ldloc.0
-  IL_0043:  dup
+  IL_0043:  ldloc.0
   IL_0044:  call       ""decimal decimal.op_Multiply(decimal, decimal)""
   IL_0049:  pop
   IL_004a:  ldloc.0
-  IL_004b:  dup
+  IL_004b:  ldloc.0
   IL_004c:  call       ""decimal decimal.op_Division(decimal, decimal)""
   IL_0051:  pop
   IL_0052:  ldloc.0
-  IL_0053:  dup
+  IL_0053:  ldloc.0
   IL_0054:  call       ""decimal decimal.op_Modulus(decimal, decimal)""
   IL_0059:  pop
   IL_005a:  ldloc.0
@@ -4579,6 +4580,36 @@ class test<T> where T : c0
   IL_002c:  ret
 }
 ");
+        }
+
+        [Fact()]
+        [WorkItem(4828, "https://github.com/dotnet/roslyn/issues/4828")]
+        public void OptimizeOutLocals_01()
+        {
+            const string source = @"
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            int a = 0;
+            int b = a + a / 1;
+        }
+    }";
+            var result = CompileAndVerify(source, options: TestOptions.ReleaseExe);
+
+            result.VerifyIL("Program.Main",
+@"
+{
+  // Code size        5 (0x5)
+  .maxstack  2
+  IL_0000:  ldc.i4.0
+  IL_0001:  ldc.i4.1
+  IL_0002:  div
+  IL_0003:  pop
+  IL_0004:  ret
+}
+");
+
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -83,7 +83,7 @@ False
   // Code size      189 (0xbd)
   .maxstack  2
   .locals init (bool V_0, //v1
-  bool V_1) //v2
+                bool V_1) //v2
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldc.i4.0
@@ -105,7 +105,7 @@ False
   IL_002e:  ldc.i4.0
   IL_002f:  call       ""void System.Console.WriteLine(bool)""
   IL_0034:  ldloc.0
-  IL_0035:  dup
+  IL_0035:  ldloc.0
   IL_0036:  and
   IL_0037:  call       ""void System.Console.WriteLine(bool)""
   IL_003c:  ldloc.0
@@ -117,7 +117,7 @@ False
   IL_0046:  and
   IL_0047:  call       ""void System.Console.WriteLine(bool)""
   IL_004c:  ldloc.1
-  IL_004d:  dup
+  IL_004d:  ldloc.1
   IL_004e:  and
   IL_004f:  call       ""void System.Console.WriteLine(bool)""
   IL_0054:  ldc.i4.s   76
@@ -235,7 +235,7 @@ False
   // Code size      189 (0xbd)
   .maxstack  2
   .locals init (bool V_0, //v1
-  bool V_1) //v2
+                bool V_1) //v2
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldc.i4.0
@@ -257,7 +257,7 @@ False
   IL_002e:  ldc.i4.0
   IL_002f:  call       ""void System.Console.WriteLine(bool)""
   IL_0034:  ldloc.0
-  IL_0035:  dup
+  IL_0035:  ldloc.0
   IL_0036:  or
   IL_0037:  call       ""void System.Console.WriteLine(bool)""
   IL_003c:  ldloc.0
@@ -269,7 +269,7 @@ False
   IL_0046:  or
   IL_0047:  call       ""void System.Console.WriteLine(bool)""
   IL_004c:  ldloc.1
-  IL_004d:  dup
+  IL_004d:  ldloc.1
   IL_004e:  or
   IL_004f:  call       ""void System.Console.WriteLine(bool)""
   IL_0054:  ldc.i4.s   76

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -2356,19 +2356,21 @@ class Program
             var compilation = CompileAndVerify(source);
 
             compilation.VerifyIL("Program.M",
-@"{
+@"
+{
   // Code size       25 (0x19)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  callvirt   ""int B.P.get""
   IL_0007:  callvirt   ""void A.Q.set""
   IL_000c:  ldarg.0
-  IL_000d:  dup
+  IL_000d:  ldarg.0
   IL_000e:  callvirt   ""int A.Q.get""
   IL_0013:  callvirt   ""void B.P.set""
   IL_0018:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -4012,56 +4014,57 @@ public class D
 ");
 
             compilation.VerifyIL("D.Main",
-@"{
+@"
+{
   // Code size      116 (0x74)
   .maxstack  5
   .locals init (D.C1 V_0, //c
-           int V_1,
-           int V_2)
+                int V_1,
+                int V_2)
   IL_0000:  newobj     ""D.C1..ctor()""
-  IL_0005:  stloc.0   
-  IL_0006:  ldloc.0   
-  IL_0007:  ldc.i4.2  
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.2
   IL_0008:  call       ""int D.GetInt(int)""
-  IL_000d:  stloc.1   
-  IL_000e:  ldc.i4.3  
+  IL_000d:  stloc.1
+  IL_000e:  ldc.i4.3
   IL_000f:  call       ""int D.GetInt(int)""
-  IL_0014:  ldloc.1   
+  IL_0014:  ldloc.1
   IL_0015:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_001a:  pop       
+  IL_001a:  pop
   IL_001b:  ldstr      "" ""
   IL_0020:  call       ""void System.Console.Write(string)""
-  IL_0025:  ldloc.0   
-  IL_0026:  ldc.i4.1  
+  IL_0025:  ldloc.0
+  IL_0026:  ldc.i4.1
   IL_0027:  call       ""int D.GetInt(int)""
-  IL_002c:  ldloc.0   
-  IL_002d:  ldc.i4.2  
+  IL_002c:  ldloc.0
+  IL_002d:  ldc.i4.2
   IL_002e:  call       ""int D.GetInt(int)""
-  IL_0033:  stloc.1   
-  IL_0034:  ldc.i4.3  
+  IL_0033:  stloc.1
+  IL_0034:  ldc.i4.3
   IL_0035:  call       ""int D.GetInt(int)""
-  IL_003a:  ldloc.1   
+  IL_003a:  ldloc.1
   IL_003b:  callvirt   ""int D.C1.Foo(int, int)""
   IL_0040:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_0045:  pop       
+  IL_0045:  pop
   IL_0046:  ldstr      "" ""
   IL_004b:  call       ""void System.Console.Write(string)""
-  IL_0050:  ldloc.0   
-  IL_0051:  ldc.i4.1  
+  IL_0050:  ldloc.0
+  IL_0051:  ldc.i4.1
   IL_0052:  call       ""int D.GetInt(int)""
-  IL_0057:  stloc.1   
-  IL_0058:  ldloc.0   
-  IL_0059:  ldc.i4.2  
+  IL_0057:  stloc.1
+  IL_0058:  ldloc.0
+  IL_0059:  ldc.i4.2
   IL_005a:  call       ""int D.GetInt(int)""
-  IL_005f:  stloc.2   
-  IL_0060:  ldc.i4.3  
+  IL_005f:  stloc.2
+  IL_0060:  ldc.i4.3
   IL_0061:  call       ""int D.GetInt(int)""
-  IL_0066:  ldloc.2   
+  IL_0066:  ldloc.2
   IL_0067:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_006c:  ldloc.1   
+  IL_006c:  ldloc.1
   IL_006d:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_0072:  pop       
-  IL_0073:  ret       
+  IL_0072:  pop
+  IL_0073:  ret
 }
 ");
         }
@@ -4116,45 +4119,41 @@ public class D
             compilation.VerifyIL("D.Main",
 @"
 {
-  // Code size       72 (0x48)
+  // Code size       68 (0x44)
   .maxstack  6
-  .locals init (D.C1 V_0, //c
-  int V_1,
-  int V_2,
-  int V_3,
-  int V_4)
+  .locals init (int V_0,
+                int V_1,
+                int V_2,
+                int V_3)
   IL_0000:  newobj     ""D.C1..ctor()""
-  IL_0005:  stloc.0
-  IL_0006:  ldloc.0
-  IL_0007:  ldc.i4.1
-  IL_0008:  call       ""int D.GetInt(int)""
-  IL_000d:  stloc.1
-  IL_000e:  ldloc.0
-  IL_000f:  dup
-  IL_0010:  ldc.i4.1
-  IL_0011:  call       ""int D.GetInt(int)""
-  IL_0016:  stloc.3
-  IL_0017:  ldloc.0
-  IL_0018:  ldc.i4.2
-  IL_0019:  call       ""int D.GetInt(int)""
-  IL_001e:  stloc.s    V_4
-  IL_0020:  ldc.i4.3
-  IL_0021:  call       ""int D.GetInt(int)""
-  IL_0026:  ldloc.s    V_4
-  IL_0028:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_002d:  ldloc.3
-  IL_002e:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_0033:  stloc.2
-  IL_0034:  ldc.i4.3
-  IL_0035:  call       ""int D.GetInt(int)""
-  IL_003a:  ldloc.2
-  IL_003b:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_0040:  ldloc.1
-  IL_0041:  callvirt   ""int D.C1.Foo(int, int)""
-  IL_0046:  pop
-  IL_0047:  ret
-}
-");
+  IL_0005:  dup
+  IL_0006:  ldc.i4.1
+  IL_0007:  call       ""int D.GetInt(int)""
+  IL_000c:  stloc.0
+  IL_000d:  dup
+  IL_000e:  dup
+  IL_000f:  ldc.i4.1
+  IL_0010:  call       ""int D.GetInt(int)""
+  IL_0015:  stloc.2
+  IL_0016:  ldc.i4.2
+  IL_0017:  call       ""int D.GetInt(int)""
+  IL_001c:  stloc.3
+  IL_001d:  ldc.i4.3
+  IL_001e:  call       ""int D.GetInt(int)""
+  IL_0023:  ldloc.3
+  IL_0024:  callvirt   ""int D.C1.Foo(int, int)""
+  IL_0029:  ldloc.2
+  IL_002a:  callvirt   ""int D.C1.Foo(int, int)""
+  IL_002f:  stloc.1
+  IL_0030:  ldc.i4.3
+  IL_0031:  call       ""int D.GetInt(int)""
+  IL_0036:  ldloc.1
+  IL_0037:  callvirt   ""int D.C1.Foo(int, int)""
+  IL_003c:  ldloc.0
+  IL_003d:  callvirt   ""int D.C1.Foo(int, int)""
+  IL_0042:  pop
+  IL_0043:  ret
+}");
         }
 
         //This is mostly to test array creation.
@@ -4753,14 +4752,15 @@ public class D
             var compilation = CompileAndVerify(source, expectedOutput: @"2 8 16 24 576 288");
 
             compilation.VerifyIL("D.Main",
-@"{
+@"
+{
   // Code size      119 (0x77)
   .maxstack  3
   .locals init (int V_0) //x
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  dup
+  IL_0003:  ldloc.0
   IL_0004:  add
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -4768,7 +4768,7 @@ public class D
   IL_000c:  ldstr      "" ""
   IL_0011:  call       ""void System.Console.Write(string)""
   IL_0016:  ldloc.0
-  IL_0017:  dup
+  IL_0017:  ldloc.0
   IL_0018:  ldc.i4.s   31
   IL_001a:  and
   IL_001b:  shl
@@ -4778,7 +4778,7 @@ public class D
   IL_0023:  ldstr      "" ""
   IL_0028:  call       ""void System.Console.Write(string)""
   IL_002d:  ldloc.0
-  IL_002e:  dup
+  IL_002e:  ldloc.0
   IL_002f:  add
   IL_0030:  conv.i8
   IL_0031:  dup
@@ -4904,7 +4904,8 @@ public class D
             var compilation = CompileAndVerify(source, expectedOutput: @"-25 4294967295 1073741823");
 
             compilation.VerifyIL("D.Main",
-@"{
+@"
+{
   // Code size       50 (0x32)
   .maxstack  2
   .locals init (uint V_0) //ux
@@ -4917,7 +4918,7 @@ public class D
   IL_0013:  ldc.i4.1
   IL_0014:  stloc.0
   IL_0015:  ldloc.0
-  IL_0016:  dup
+  IL_0016:  ldloc.0
   IL_0017:  sub
   IL_0018:  ldloc.0
   IL_0019:  sub
@@ -5779,7 +5780,7 @@ public class D
   // Code size        7 (0x7)
   .maxstack  3
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  ldind.i4
   IL_0003:  ldc.i4.1
   IL_0004:  add
@@ -5958,7 +5959,7 @@ public class D
   // Code size        7 (0x7)
   .maxstack  3
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  ldind.i4
   IL_0003:  ldc.i4.1
   IL_0004:  add
@@ -6776,11 +6777,12 @@ class Program
             var compilation = CompileAndVerify(source, expectedOutput: @"0");
 
             compilation.VerifyIL("Program.Main",
-@"{
+@"
+{
   // Code size       54 (0x36)
   .maxstack  2
   .locals init (bool V_0, //x
-  int V_1)
+                int V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
@@ -9424,7 +9426,7 @@ VerifyIL("MyClass.Main", @"
   IL_001e:  ldc.i4.0
   IL_001f:  stloc.3
   IL_0020:  ldloc.0
-  IL_0021:  dup
+  IL_0021:  ldloc.0
   IL_0022:  ldc.r8     1.00000000362749E-15
   IL_002b:  mul
   IL_002c:  add
@@ -9434,7 +9436,7 @@ VerifyIL("MyClass.Main", @"
   IL_0031:  ldc.i4.1
   IL_0032:  stloc.3
   IL_0033:  ldloc.0
-  IL_0034:  dup
+  IL_0034:  ldloc.0
   IL_0035:  neg
   IL_0036:  ldc.r8     1.00000000362749E-15
   IL_003f:  mul
@@ -12401,19 +12403,20 @@ Aggregate = 1,
 ";
             CompileAndVerify(source).VerifyIL("EdmFunction.SetFunctionAttribute", @"
 {
-  // Code size        9 (0x9)
+  // Code size       10 (0xa)
   .maxstack  4
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  ldind.u1
-  IL_0003:  dup
-  IL_0004:  ldarg.1
-  IL_0005:  and
-  IL_0006:  xor
-  IL_0007:  stind.i1
-  IL_0008:  ret
+  IL_0003:  ldarg.0
+  IL_0004:  ldind.u1
+  IL_0005:  ldarg.1
+  IL_0006:  and
+  IL_0007:  xor
+  IL_0008:  stind.i1
+  IL_0009:  ret
 }
-            ");
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
@@ -530,33 +530,33 @@ class Program
   .maxstack  2
   .locals init (System.Exception V_0) //ex
   .try
-{
-  IL_0000:  ldstr      ""bye""
-  IL_0005:  newobj     ""System.Exception..ctor(string)""
-  IL_000a:  throw
-}
+  {
+    IL_0000:  ldstr      ""bye""
+    IL_0005:  newobj     ""System.Exception..ctor(string)""
+    IL_000a:  throw
+  }
   filter
-{
-  IL_000b:  isinst     ""System.Exception""
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_0017
-  IL_0013:  pop
-  IL_0014:  ldc.i4.0
-  IL_0015:  br.s       IL_0022
-  IL_0017:  stloc.0
-  IL_0018:  ldloc.0
-  IL_0019:  dup
-  IL_001a:  call       ""bool Program.F(System.Exception, System.Exception)""
-  IL_001f:  ldc.i4.0
-  IL_0020:  cgt.un
-  IL_0022:  endfilter
-}  // end filter
-{  // handler
-  IL_0024:  pop
-  IL_0025:  ldloc.0
-  IL_0026:  call       ""void System.Console.WriteLine(object)""
-  IL_002b:  leave.s    IL_002d
-}
+  {
+    IL_000b:  isinst     ""System.Exception""
+    IL_0010:  dup
+    IL_0011:  brtrue.s   IL_0017
+    IL_0013:  pop
+    IL_0014:  ldc.i4.0
+    IL_0015:  br.s       IL_0022
+    IL_0017:  stloc.0
+    IL_0018:  ldloc.0
+    IL_0019:  ldloc.0
+    IL_001a:  call       ""bool Program.F(System.Exception, System.Exception)""
+    IL_001f:  ldc.i4.0
+    IL_0020:  cgt.un
+    IL_0022:  endfilter
+  }  // end filter
+  {  // handler
+    IL_0024:  pop
+    IL_0025:  ldloc.0
+    IL_0026:  call       ""void System.Console.WriteLine(object)""
+    IL_002b:  leave.s    IL_002d
+  }
   IL_002d:  ret
 }
 ");
@@ -661,35 +661,35 @@ class Program
   .maxstack  2
   .locals init (T V_0) //ex
   .try
-{
-  IL_0000:  ldstr      ""bye""
-  IL_0005:  newobj     ""System.Exception..ctor(string)""
-  IL_000a:  throw
-}
+  {
+    IL_0000:  ldstr      ""bye""
+    IL_0005:  newobj     ""System.Exception..ctor(string)""
+    IL_000a:  throw
+  }
   filter
-{
-  IL_000b:  isinst     ""T""
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_0017
-  IL_0013:  pop
-  IL_0014:  ldc.i4.0
-  IL_0015:  br.s       IL_0027
-  IL_0017:  unbox.any  ""T""
-  IL_001c:  stloc.0
-  IL_001d:  ldloc.0
-  IL_001e:  dup
-  IL_001f:  call       ""bool Program.F<T>(T, T)""
-  IL_0024:  ldc.i4.0
-  IL_0025:  cgt.un
-  IL_0027:  endfilter
-}  // end filter
-{  // handler
-  IL_0029:  pop
-  IL_002a:  ldloc.0
-  IL_002b:  box        ""T""
-  IL_0030:  call       ""void System.Console.WriteLine(object)""
-  IL_0035:  leave.s    IL_0037
-}
+  {
+    IL_000b:  isinst     ""T""
+    IL_0010:  dup
+    IL_0011:  brtrue.s   IL_0017
+    IL_0013:  pop
+    IL_0014:  ldc.i4.0
+    IL_0015:  br.s       IL_0027
+    IL_0017:  unbox.any  ""T""
+    IL_001c:  stloc.0
+    IL_001d:  ldloc.0
+    IL_001e:  ldloc.0
+    IL_001f:  call       ""bool Program.F<T>(T, T)""
+    IL_0024:  ldc.i4.0
+    IL_0025:  cgt.un
+    IL_0027:  endfilter
+  }  // end filter
+  {  // handler
+    IL_0029:  pop
+    IL_002a:  ldloc.0
+    IL_002b:  box        ""T""
+    IL_0030:  call       ""void System.Console.WriteLine(object)""
+    IL_0035:  leave.s    IL_0037
+  }
   IL_0037:  ret
 }
 ");
@@ -2197,7 +2197,7 @@ class C
       IL_0002:  ldstr      ""Try""
       IL_0007:  call       ""void System.Console.Write(string)""
       IL_000c:  ldloc.0
-      IL_000d:  dup
+      IL_000d:  ldloc.0
       IL_000e:  div
       IL_000f:  stloc.0
       IL_0010:  leave.s    IL_0035
@@ -2224,7 +2224,8 @@ class C
     IL_0034:  endfinally
   }
   IL_0035:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -2280,77 +2281,77 @@ class C
   // Code size      129 (0x81)
   .maxstack  2
   .locals init (int V_0, //x
-  System.DivideByZeroException V_1) //e
+                System.DivideByZeroException V_1) //e
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   .try
-{
-  .try
-{
-  IL_0002:  ldstr      ""Try""
-  IL_0007:  call       ""void System.Console.Write(string)""
-  IL_000c:  ldloc.0
-  IL_000d:  dup
-  IL_000e:  div
-  IL_000f:  stloc.0
-  IL_0010:  leave.s    IL_0080
-}
-  filter
-{
-  IL_0012:  isinst     ""System.DivideByZeroException""
-  IL_0017:  dup
-  IL_0018:  brtrue.s   IL_001e
-  IL_001a:  pop
-  IL_001b:  ldc.i4.0
-  IL_001c:  br.s       IL_0029
-  IL_001e:  callvirt   ""string System.Exception.Message.get""
-  IL_0023:  ldnull
-  IL_0024:  ceq
-  IL_0026:  ldc.i4.0
-  IL_0027:  cgt.un
-  IL_0029:  endfilter
-}  // end filter
-{  // handler
-  IL_002b:  pop
-  IL_002c:  ldstr      ""Catch1""
-  IL_0031:  call       ""void System.Console.Write(string)""
-  IL_0036:  leave.s    IL_0080
-}
-  filter
-{
-  IL_0038:  isinst     ""System.DivideByZeroException""
-  IL_003d:  dup
-  IL_003e:  brtrue.s   IL_0044
-  IL_0040:  pop
-  IL_0041:  ldc.i4.0
-  IL_0042:  br.s       IL_0051
-  IL_0044:  stloc.1
-  IL_0045:  ldloc.1
-  IL_0046:  callvirt   ""string System.Exception.Message.get""
-  IL_004b:  ldnull
-  IL_004c:  cgt.un
-  IL_004e:  ldc.i4.0
-  IL_004f:  cgt.un
-  IL_0051:  endfilter
-}  // end filter
-{  // handler
-  IL_0053:  pop
-  IL_0054:  ldstr      ""Catch2""
-  IL_0059:  ldloc.1
-  IL_005a:  callvirt   ""string System.Exception.Message.get""
-  IL_005f:  callvirt   ""int string.Length.get""
-  IL_0064:  box        ""int""
-  IL_0069:  call       ""string string.Concat(object, object)""
-  IL_006e:  call       ""void System.Console.Write(string)""
-  IL_0073:  leave.s    IL_0080
-}
-}
+  {
+    .try
+    {
+      IL_0002:  ldstr      ""Try""
+      IL_0007:  call       ""void System.Console.Write(string)""
+      IL_000c:  ldloc.0
+      IL_000d:  ldloc.0
+      IL_000e:  div
+      IL_000f:  stloc.0
+      IL_0010:  leave.s    IL_0080
+    }
+    filter
+    {
+      IL_0012:  isinst     ""System.DivideByZeroException""
+      IL_0017:  dup
+      IL_0018:  brtrue.s   IL_001e
+      IL_001a:  pop
+      IL_001b:  ldc.i4.0
+      IL_001c:  br.s       IL_0029
+      IL_001e:  callvirt   ""string System.Exception.Message.get""
+      IL_0023:  ldnull
+      IL_0024:  ceq
+      IL_0026:  ldc.i4.0
+      IL_0027:  cgt.un
+      IL_0029:  endfilter
+    }  // end filter
+    {  // handler
+      IL_002b:  pop
+      IL_002c:  ldstr      ""Catch1""
+      IL_0031:  call       ""void System.Console.Write(string)""
+      IL_0036:  leave.s    IL_0080
+    }
+    filter
+    {
+      IL_0038:  isinst     ""System.DivideByZeroException""
+      IL_003d:  dup
+      IL_003e:  brtrue.s   IL_0044
+      IL_0040:  pop
+      IL_0041:  ldc.i4.0
+      IL_0042:  br.s       IL_0051
+      IL_0044:  stloc.1
+      IL_0045:  ldloc.1
+      IL_0046:  callvirt   ""string System.Exception.Message.get""
+      IL_004b:  ldnull
+      IL_004c:  cgt.un
+      IL_004e:  ldc.i4.0
+      IL_004f:  cgt.un
+      IL_0051:  endfilter
+    }  // end filter
+    {  // handler
+      IL_0053:  pop
+      IL_0054:  ldstr      ""Catch2""
+      IL_0059:  ldloc.1
+      IL_005a:  callvirt   ""string System.Exception.Message.get""
+      IL_005f:  callvirt   ""int string.Length.get""
+      IL_0064:  box        ""int""
+      IL_0069:  call       ""string string.Concat(object, object)""
+      IL_006e:  call       ""void System.Console.Write(string)""
+      IL_0073:  leave.s    IL_0080
+    }
+  }
   finally
-{
-  IL_0075:  ldstr      ""Finally""
-  IL_007a:  call       ""void System.Console.Write(string)""
-  IL_007f:  endfinally
-}
+  {
+    IL_0075:  ldstr      ""Finally""
+    IL_007a:  call       ""void System.Console.Write(string)""
+    IL_007f:  endfinally
+  }
   IL_0080:  ret
 }
 ");
@@ -2399,7 +2400,7 @@ class C
       IL_0002:  ldstr      ""Try""
       IL_0007:  call       ""void System.Console.Write(string)""
       IL_000c:  ldloc.0
-      IL_000d:  dup
+      IL_000d:  ldloc.0
       IL_000e:  div
       IL_000f:  stloc.0
       IL_0010:  leave.s    IL_005e

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ForLoopsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ForLoopsTests.cs
@@ -1468,7 +1468,8 @@ public class Foo
     public string s;
 }
 ";
-            string expectedIL = @"{
+            string expectedIL = @"
+{
   // Code size       50 (0x32)
   .maxstack  3
   .locals init (Foo V_0) //f
@@ -1482,7 +1483,7 @@ public class Foo
   IL_0017:  stloc.0
   IL_0018:  br.s       IL_0028
   IL_001a:  ldloc.0
-  IL_001b:  dup
+  IL_001b:  ldloc.0
   IL_001c:  ldfld      ""int Foo.i""
   IL_0021:  ldc.i4.1
   IL_0022:  add

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -937,26 +937,27 @@ static class S2
 }";
             var compilation = CompileAndVerify(source);
             compilation.VerifyIL("N.C.M",
-@"{
+@"
+{
   // Code size       73 (0x49)
   .maxstack  3
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  ldftn      ""void N.S1.F1(object, object)""
   IL_0008:  newobj     ""System.Action<object>..ctor(object, System.IntPtr)""
   IL_000d:  call       ""void N.S1.M1(object, System.Action<object>)""
   IL_0012:  ldarg.0
-  IL_0013:  dup
+  IL_0013:  ldarg.0
   IL_0014:  ldftn      ""void S2.F2(object, object)""
   IL_001a:  newobj     ""System.Action<object>..ctor(object, System.IntPtr)""
   IL_001f:  call       ""void N.S1.M1(object, System.Action<object>)""
   IL_0024:  ldarg.0
-  IL_0025:  dup
+  IL_0025:  ldarg.0
   IL_0026:  ldftn      ""void N.S1.F3(object, object)""
   IL_002c:  newobj     ""System.Action<object>..ctor(object, System.IntPtr)""
   IL_0031:  call       ""void S2.M2(object, System.Action<object>)""
   IL_0036:  ldarg.0
-  IL_0037:  dup
+  IL_0037:  ldarg.0
   IL_0038:  ldftn      ""void S2.F4(object, object)""
   IL_003e:  newobj     ""System.Action<object>..ctor(object, System.IntPtr)""
   IL_0043:  call       ""void S2.M2(object, System.Action<object>)""

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -1463,45 +1463,45 @@ B.M");
             compilation.VerifyIL("C<T1, T2>.M<U1, U2>(T1, T2, U1, U2)",
 @"
 {
-  // Code size      143 (0x8f)
+  // Code size      145 (0x91)
   .maxstack  2
   IL_0000:  ldarga.s   V_0
-  IL_0002:  dup
-  IL_0003:  constrained. ""T1""
-  IL_0009:  callvirt   ""object I.P.get""
-  IL_000e:  constrained. ""T1""
-  IL_0014:  callvirt   ""void I.P.set""
-  IL_0019:  ldarga.s   V_0
-  IL_001b:  constrained. ""T1""
-  IL_0021:  callvirt   ""void I.M()""
-  IL_0026:  ldarg.1
-  IL_0027:  box        ""T2""
-  IL_002c:  ldarg.1
-  IL_002d:  box        ""T2""
-  IL_0032:  callvirt   ""object A.P.get""
-  IL_0037:  callvirt   ""void A.P.set""
-  IL_003c:  ldarg.1
-  IL_003d:  box        ""T2""
-  IL_0042:  callvirt   ""void A.M()""
-  IL_0047:  ldarga.s   V_2
-  IL_0049:  dup
-  IL_004a:  constrained. ""U1""
-  IL_0050:  callvirt   ""object I.P.get""
-  IL_0055:  constrained. ""U1""
-  IL_005b:  callvirt   ""void I.P.set""
-  IL_0060:  ldarga.s   V_2
-  IL_0062:  constrained. ""U1""
-  IL_0068:  callvirt   ""void I.M()""
-  IL_006d:  ldarg.3
-  IL_006e:  box        ""U2""
-  IL_0073:  ldarg.3
-  IL_0074:  box        ""U2""
-  IL_0079:  callvirt   ""object A.P.get""
-  IL_007e:  callvirt   ""void A.P.set""
-  IL_0083:  ldarg.3
-  IL_0084:  box        ""U2""
-  IL_0089:  callvirt   ""void A.M()""
-  IL_008e:  ret
+  IL_0002:  ldarga.s   V_0
+  IL_0004:  constrained. ""T1""
+  IL_000a:  callvirt   ""object I.P.get""
+  IL_000f:  constrained. ""T1""
+  IL_0015:  callvirt   ""void I.P.set""
+  IL_001a:  ldarga.s   V_0
+  IL_001c:  constrained. ""T1""
+  IL_0022:  callvirt   ""void I.M()""
+  IL_0027:  ldarg.1
+  IL_0028:  box        ""T2""
+  IL_002d:  ldarg.1
+  IL_002e:  box        ""T2""
+  IL_0033:  callvirt   ""object A.P.get""
+  IL_0038:  callvirt   ""void A.P.set""
+  IL_003d:  ldarg.1
+  IL_003e:  box        ""T2""
+  IL_0043:  callvirt   ""void A.M()""
+  IL_0048:  ldarga.s   V_2
+  IL_004a:  ldarga.s   V_2
+  IL_004c:  constrained. ""U1""
+  IL_0052:  callvirt   ""object I.P.get""
+  IL_0057:  constrained. ""U1""
+  IL_005d:  callvirt   ""void I.P.set""
+  IL_0062:  ldarga.s   V_2
+  IL_0064:  constrained. ""U1""
+  IL_006a:  callvirt   ""void I.M()""
+  IL_006f:  ldarg.3
+  IL_0070:  box        ""U2""
+  IL_0075:  ldarg.3
+  IL_0076:  box        ""U2""
+  IL_007b:  callvirt   ""object A.P.get""
+  IL_0080:  callvirt   ""void A.P.set""
+  IL_0085:  ldarg.3
+  IL_0086:  box        ""U2""
+  IL_008b:  callvirt   ""void A.M()""
+  IL_0090:  ret
 }");
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
@@ -148,16 +148,18 @@ internal class C : B
             context.CompileExpression("this.M(this.P)", out error, testData);
 
             testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"{
+@"
+{
   // Code size       13 (0xd)
   .maxstack  2
   .locals init (object V_0)
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  callvirt   ""object C.P.get""
   IL_0007:  callvirt   ""object B.M(object)""
   IL_000c:  ret
-}");
+}
+");
         }
 
         [Fact]


### PR DESCRIPTION
Stack scheduler performs two kinds of transformations -
1) it turns local slots into ephemeral locals that live on the evaluation stack.
2) It also tries to Dup previous expressions when the next one is exactly the same and other condittions allow.

The operation # 2 is basically a workaround for cases like

   temp = ...
   result = temp + temp;

Since ephemeral locals are modeled as occupying the space "below" the eval values, having temp on eval stack prevents that same temp from loading as a stack local.
The self-interference situations like above are fairly common, so the stack scheduler tries to reduce some of the cases by attempting a peephole optimization where value of previous expression could be Dup-ed if the following one is the same. (thus in our example it would look like the second load of the temp does not happen at all).

This # 2 optimization has numerous conditions where it is not applicable and as bug #4828 shows it is still fairly fragile. It relies on the presence of the value produced by the previous expression and that is not always guaranteed to be there if the expression has no sideeffects.

Instead of adding more conditions, I am removing the # 2 entirely.

It appears that it can be removed without any serious regression in # 1 as long as we track not only the depth of the eval stack but also what we have on it. That way we can detect self-interference cases by just examining our best knowledge of the stack and handle definite self-interference cases as not prohibiting.

The result of this change is that many dups have disappeared from the code, but in most cases they were dups of trivial local/parameter loads and as such are not a concern.
On the other hand most cases where local slots can be optimized away are still there and in some cases we actually are slightly better.

The most important part is that the whole scheduling got simpler and uses fewer assumptions about what emit might do.

Fixes #4828