### PR TITLE
Don't classify 'var' in 'out var' as a keyword.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -3507,5 +3507,19 @@ catch (System.Exception) when (true)
                 Punctuation.OpenCurly,
                 Punctuation.CloseCurly);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public void OutVar()
+        {
+            var code = @"
+F(out var);";
+            TestInMethod(code,
+                Identifier("F"),
+                Punctuation.OpenParen,
+                Keyword("out"),
+                Identifier("var"),
+                Punctuation.CloseParen,
+                Punctuation.Semicolon);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -283,23 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             {
                 // cases:
                 //   var
-                //   out var
-                if (token.Parent is IdentifierNameSyntax)
-                {
-                    if (token.Parent.Parent is ExpressionStatementSyntax)
-                    {
-                        return true;
-                    }
-
-                    if (token.Parent.Parent is ArgumentSyntax)
-                    {
-                        var argument = (ArgumentSyntax)token.Parent.Parent;
-                        if (argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword))
-                        {
-                            return true;
-                        }
-                    }
-                }
+                return token.Parent is IdentifierNameSyntax && token.Parent.Parent is ExpressionStatementSyntax;
             }
 
             return false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/4190