### PR TITLE
Fix Visual Basic Workflow v1 projects when events are hooked up

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
         private const string NameRefElementName = "NameRef";
         private const string NewArrayElementName = "NewArray";
         private const string NewClassElementName = "NewClass";
+        private const string NewDelegateElementName = "NewDelegate";
         private const string NullElementName = "Null";
         private const string NumberElementName = "Number";
         private const string ParenthesesElementName = "Parentheses";
@@ -42,7 +43,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
         private const string TypeElementName = "Type";
 
         private const string BinaryOperatorAttributeName = "binaryoperator";
+        private const string FullNameAttributeName = "fullname";
+        private const string ImplicitAttributeName = "implicit";
         private const string LineAttributeName = "line";
+        private const string NameAttributeName = "name";
         private const string RankAttributeName = "rank";
         private const string TypeAttributeName = "type";
         private const string VariableKindAttributeName = "variablekind";
@@ -182,9 +186,39 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
             return new AttributeInfo(BinaryOperatorAttributeName, GetBinaryOperatorKindText(kind));
         }
 
+        private AttributeInfo FullNameAttribute(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return AttributeInfo.Empty;
+            }
+
+            return new AttributeInfo(FullNameAttributeName, name);
+        }
+
+        private AttributeInfo ImplicitAttribute(bool? @implicit)
+        {
+            if (@implicit == null)
+            {
+                return AttributeInfo.Empty;
+            }
+
+            return new AttributeInfo(ImplicitAttributeName, @implicit.Value ? "yes" : "no");
+        }
+
         private AttributeInfo LineNumberAttribute(int lineNumber)
         {
             return new AttributeInfo(LineAttributeName, lineNumber.ToString());
+        }
+
+        private AttributeInfo NameAttribute(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return AttributeInfo.Empty;
+            }
+
+            return new AttributeInfo(NameAttributeName, name);
         }
 
         private AttributeInfo RankAttribute(int rank)
@@ -307,9 +341,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
             return Tag(NameElementName);
         }
 
-        protected IDisposable NameRefTag(VariableKind kind)
+        protected IDisposable NameRefTag(VariableKind kind, string name = null, string fullName = null)
         {
-            return Tag(NameRefElementName, VariableKindAttribute(kind));
+            return Tag(NameRefElementName, VariableKindAttribute(kind), NameAttribute(name), FullNameAttribute(fullName));
         }
 
         protected IDisposable NewArrayTag()
@@ -320,6 +354,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
         protected IDisposable NewClassTag()
         {
             return Tag(NewClassElementName);
+        }
+
+        protected IDisposable NewDelegateTag(string name)
+        {
+            return Tag(NewDelegateElementName, NameAttribute(name));
         }
 
         protected void NullTag()
@@ -352,9 +391,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
             AppendLeafTag(ThisReferenceElementName);
         }
 
-        protected IDisposable TypeTag()
+        protected IDisposable TypeTag(bool? @implicit = null)
         {
-            return Tag(TypeElementName);
+            return Tag(TypeElementName, ImplicitAttribute(@implicit));
         }
 
         protected void LineBreak()
@@ -427,21 +466,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
             }
         }
 
-        protected void GenerateType(ITypeSymbol type)
+        protected void GenerateType(ITypeSymbol type, bool? @implicit = null, bool fullyQualify = false)
         {
             if (type.TypeKind == TypeKind.Array)
             {
                 var arrayType = (IArrayTypeSymbol)type;
                 using (var tag = ArrayTypeTag(arrayType.Rank))
                 {
-                    GenerateType(arrayType.ElementType);
+                    GenerateType(arrayType.ElementType, @implicit, fullyQualify);
                 }
             }
             else
             {
-                using (TypeTag())
+                using (TypeTag(@implicit))
                 {
-                    EncodedText(GetTypeName(type));
+                    var typeName = fullyQualify
+                        ? GetTypeName(type) + ", " + type.ContainingAssembly.ToDisplayString()
+                        : GetTypeName(type);
+
+                    EncodedText(typeName);
                 }
             }
         }

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBLocalDeclarations.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBLocalDeclarations.vb
@@ -1,7 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Roslyn.Test.Utilities
-Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.MethodXML
     Partial Public Class MethodXMLTests

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBStatements.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBStatements.vb
@@ -340,5 +340,340 @@ End Class
             Test(definition, expected)
         End Sub
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_RemoveHandler1()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class C
+    Event E As EventHandler
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+
+    $$Sub M()
+        RemoveHandler E, AddressOf Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="10">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="remove_E">
+                        <Expression>
+                            <ThisReference/>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.C, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <ThisReference/>
+                            </Expression>
+                            <Type implicit="yes">N.C, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_RemoveHandler2()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class B
+    Event E As EventHandler
+End Class
+
+Class C
+    Dim b As New B
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+
+    $$Sub M()
+        RemoveHandler b.E, AddressOf Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="14">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="remove_E">
+                        <Expression>
+                            <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                <Expression>
+                                    <ThisReference/>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <ThisReference/>
+                            </Expression>
+                            <Type implicit="yes">N.C, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_RemoveHandler3()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class B
+    Event E As EventHandler
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+End Class
+
+Class C
+    Dim b As New B
+
+    $$Sub M()
+        RemoveHandler b.E, AddressOf b.Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="14">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="remove_E">
+                        <Expression>
+                            <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                <Expression>
+                                    <ThisReference/>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                    <Expression>
+                                        <ThisReference/>
+                                    </Expression>
+                                </NameRef>
+                            </Expression>
+                            <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_RemoveHandler4()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class A
+    Event E As EventHandler
+End Class
+
+Class B
+    Property A As New A
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+End Class
+
+Class C
+    Dim b As New B
+
+    $$Sub M()
+        RemoveHandler b.A.E, AddressOf b.Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="18">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="remove_E">
+                        <Expression>
+                            <NameRef variablekind="property" name="A" fullname="N.B.A">
+                                <Expression>
+                                    <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                        <Expression>
+                                            <ThisReference/>
+                                        </Expression>
+                                    </NameRef>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.A, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                    <Expression>
+                                        <ThisReference/>
+                                    </Expression>
+                                </NameRef>
+                            </Expression>
+                            <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_RemoveHandler5()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class A
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+End Class
+
+Class B
+    Property A As New A
+
+    Event E As EventHandler
+End Class
+
+Class C
+    Dim b As New B
+
+    $$Sub M()
+        RemoveHandler b.E, AddressOf b.A.Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="18">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="remove_E">
+                        <Expression>
+                            <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                <Expression>
+                                    <ThisReference/>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <NameRef variablekind="property" name="A" fullname="N.B.A">
+                                    <Expression>
+                                        <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                            <Expression>
+                                                <ThisReference/>
+                                            </Expression>
+                                        </NameRef>
+                                    </Expression>
+                                </NameRef>
+                            </Expression>
+                            <Type implicit="yes">N.A, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBStatements.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBStatements.vb
@@ -1,0 +1,194 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.MethodXML
+    Partial Public Class MethodXMLTests
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_AddHandler1()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class C
+    Event E As EventHandler
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+
+    $$Sub M()
+        AddHandler E, AddressOf Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="10">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="add_E">
+                        <Expression>
+                            <ThisReference/>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.C, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <ThisReference/>
+                            </Expression>
+                            <Type implicit="yes">N.C, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_AddHandler2()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class B
+    Event E As EventHandler
+End Class
+
+Class C
+    Dim b As New B
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+
+    $$Sub M()
+        AddHandler b.E, AddressOf Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="14">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="add_E">
+                        <Expression>
+                            <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                <Expression>
+                                    <ThisReference/>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <ThisReference/>
+                            </Expression>
+                            <Type implicit="yes">N.C, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_AddHandler3()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class B
+    Event E As EventHandler
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+End Class
+
+Class C
+    Dim b As New B
+
+    $$Sub M()
+        AddHandler b.E, AddressOf b.Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="14">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="add_E">
+                        <Expression>
+                            <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                <Expression>
+                                    <ThisReference/>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                    <Expression>
+                                        <ThisReference/>
+                                    </Expression>
+                                </NameRef>
+                            </Expression>
+                            <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBStatements.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBStatements.vb
@@ -190,5 +190,155 @@ End Class
             Test(definition, expected)
         End Sub
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_AddHandler4()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class A
+    Event E As EventHandler
+End Class
+
+Class B
+    Property A As New A
+
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+End Class
+
+Class C
+    Dim b As New B
+
+    $$Sub M()
+        AddHandler b.A.E, AddressOf b.Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="18">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="add_E">
+                        <Expression>
+                            <NameRef variablekind="property" name="A" fullname="N.B.A">
+                                <Expression>
+                                    <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                        <Expression>
+                                            <ThisReference/>
+                                        </Expression>
+                                    </NameRef>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.A, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                    <Expression>
+                                        <ThisReference/>
+                                    </Expression>
+                                </NameRef>
+                            </Expression>
+                            <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
+        Public Sub VBStatements_AddHandler5()
+            Dim definition =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="Test">
+        <CompilationOptions RootNamespace="N"/>
+        <Document>
+Imports System
+
+Class A
+    Sub Handler(sender As Object, e As EventArgs)
+    End Sub
+End Class
+
+Class B
+    Property A As New A
+
+    Event E As EventHandler
+End Class
+
+Class C
+    Dim b As New B
+
+    $$Sub M()
+        AddHandler b.E, AddressOf b.A.Handler
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<Block>
+    <ExpressionStatement line="18">
+        <Expression>
+            <MethodCall>
+                <Expression>
+                    <NameRef variablekind="method" name="add_E">
+                        <Expression>
+                            <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                <Expression>
+                                    <ThisReference/>
+                                </Expression>
+                            </NameRef>
+                        </Expression>
+                    </NameRef>
+                </Expression>
+                <Type implicit="yes">N.B, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                <Argument>
+                    <Expression>
+                        <NewDelegate name="Handler">
+                            <Type implicit="yes">System.EventHandler, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</Type>
+                            <Expression>
+                                <NameRef variablekind="property" name="A" fullname="N.B.A">
+                                    <Expression>
+                                        <NameRef variablekind="field" name="b" fullname="N.C.b">
+                                            <Expression>
+                                                <ThisReference/>
+                                            </Expression>
+                                        </NameRef>
+                                    </Expression>
+                                </NameRef>
+                            </Expression>
+                            <Type implicit="yes">N.A, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Type>
+                        </NewDelegate>
+                    </Expression>
+                </Argument>
+            </MethodCall>
+        </Expression>
+    </ExpressionStatement>
+</Block>
+
+            Test(definition, expected)
+        End Sub
+
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -325,6 +325,7 @@
     <Compile Include="CodeModel\MethodXML\MethodXMLTests_VBInitializeComponent_TestContent.vb" />
     <Compile Include="CodeModel\MethodXML\MethodXMLTests_VBInvocations.vb" />
     <Compile Include="CodeModel\MethodXML\MethodXMLTests_VBLocalDeclarations.vb" />
+    <Compile Include="CodeModel\MethodXML\MethodXMLTests_VBStatements.vb" />
     <Compile Include="CodeModel\Mocks\MockTextManagerAdapter.vb" />
     <Compile Include="CodeModel\Mocks\MockTextPoint.vb" />
     <Compile Include="CodeModel\VisualBasic\CodeAccessorFunctionTests.vb" />


### PR DESCRIPTION
Fixes #4339

Most VS designers hook up events with Handles clauses in VB. However, the version 1 Workflow designer is an exception. Workflow inserts AddHandler statements in the InitializeComponent method. Unfortunately, our rewritten IMethodXML generation did not support AddHandler statements, which caused the designer to fail spectacularly. This change addresses that.

Note that there's additional code in this change to try to replicate the VB IMethodXML for AddHandler statements precisely as VS 2013. In general, we've tried to unify the shape of the XML between C# and VB. However, in this specific case, Workflow deeply depends on the XML elements and attributes to be correct for VB.