### PR TITLE
Don't throw if we're called on a background thread.  

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -687,7 +687,10 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// </summary>
             public TagSpanIntervalTree<TTag> GetTagIntervalTreeForBuffer(ITextBuffer buffer)
             {
-                this._workQueue.AssertIsForeground();
+                if (!this._workQueue.IsForeground())
+                {
+                    return null;
+                }
 
                 // If we're currently pausing updates to the UI, then just use the tags we had before we
                 // were paused so that nothing changes.  
@@ -702,7 +705,10 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
             public TagSpanIntervalTree<TTag> GetAccurateTagIntervalTreeForBuffer(ITextBuffer buffer, CancellationToken cancellationToken)
             {
-                this._workQueue.AssertIsForeground();
+                if (!this._workQueue.IsForeground())
+                {
+                    return null;
+                }
 
                 if (!this.UpToDate)
                 {

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -52,24 +52,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
     }
 }"))
             {
-                Callback tagProducer = (span, cancellationToken) =>
-                    {
-                        return new List<ITagSpan<TestTag>>() { new TagSpan<TestTag>(span, new TestTag()) };
-                    };
                 var asyncListener = new TaggerOperationListener();
-
-                var notificationService = workspace.GetService<IForegroundNotificationService>();
 
                 var eventSource = CreateEventSource();
                 var taggerProvider = new TestTaggerProvider(
-                    tagProducer,
-                    eventSource,
-                    workspace,
-                    asyncListener,
-                    notificationService);
+                    (span, _) => new List<ITagSpan<TestTag>> { new TagSpan<TestTag>(span, new TestTag()) },
+                    eventSource, workspace, asyncListener, workspace.GetService<IForegroundNotificationService>());
 
-                var document = workspace.Documents.First();
-                var textBuffer = document.TextBuffer;
+                var textBuffer = workspace.Documents.First().TextBuffer;
                 var snapshot = textBuffer.CurrentSnapshot;
                 var tagger = taggerProvider.CreateTagger<TestTag>(textBuffer);
 
@@ -79,7 +69,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
                     var snapshotSpans = new NormalizedSnapshotSpanCollection(snapshot, spans);
 
                     eventSource.SendUpdateEvent();
-
                     asyncListener.CreateWaitTask().PumpingWait();
 
                     var tags = tagger.GetTags(snapshotSpans);
@@ -94,30 +83,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
         {
             using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(@"class C {}"))
             {
-                Callback tagProducer = (span, cancellationToken) =>
-                {
-                    return new List<ITagSpan<TestTag>>() { new TagSpan<TestTag>(span, new TestTag()) };
-                };
                 var asyncListener = new TaggerOperationListener();
-
-                var notificationService = workspace.GetService<IForegroundNotificationService>();
 
                 var eventSource = CreateEventSource();
                 var taggerProvider = new TestTaggerProvider(
-                    tagProducer,
-                    eventSource,
-                    workspace,
-                    asyncListener,
-                    notificationService);
+                    (span, _) => new List<ITagSpan<TestTag>> { new TagSpan<TestTag>(span, new TestTag()) },
+                    eventSource, workspace, asyncListener, workspace.GetService<IForegroundNotificationService>());
 
-                var document = workspace.Documents.First();
-                var textBuffer = document.TextBuffer;
-                var snapshot = textBuffer.CurrentSnapshot;
+                var textBuffer = workspace.Documents.First().TextBuffer;
                 var tagger = taggerProvider.CreateTagger<TestTag>(textBuffer);
 
                 using (IDisposable disposable = (IDisposable)tagger)
                 {
-                    var snapshotSpans = snapshot.GetSnapshotSpanCollection();
+                    var snapshotSpans = textBuffer.CurrentSnapshot.GetSnapshotSpanCollection();
 
                     eventSource.SendUpdateEvent();
                     asyncListener.CreateWaitTask().PumpingWait();


### PR DESCRIPTION
Just return an empty set of tags.