### PR TITLE
Start outlining span after all the whitespace on the target token.

### DIFF
--- a/src/EditorFeatures/CSharp/Outlining/CSharpOutliningHelpers.cs
+++ b/src/EditorFeatures/CSharp/Outlining/CSharpOutliningHelpers.cs
@@ -39,10 +39,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Outlining
 
             if (firstToken.HasTrailingTrivia)
             {
-                var lastTrailingCommentTrivia = firstToken.TrailingTrivia.GetLastComment();
-                if (lastTrailingCommentTrivia != null)
+                var lastTrailingCommentOrWhitespaceTrivia = firstToken.TrailingTrivia.GetLastCommentOrWhitespace();
+                if (lastTrailingCommentOrWhitespaceTrivia != null)
                 {
-                    start = lastTrailingCommentTrivia.Value.Span.End;
+                    start = lastTrailingCommentOrWhitespaceTrivia.Value.Span.End;
                 }
             }
 

--- a/src/EditorFeatures/CSharpTest/Outlining/AnonymousMethodExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/AnonymousMethodExpressionTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(44, 66),
+                TextSpan.FromBounds(45, 66),
                 TextSpan.FromBounds(36, 66),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(95, 131),
+                TextSpan.FromBounds(96, 131),
                 TextSpan.FromBounds(66, 131),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(95, 131),
+                TextSpan.FromBounds(96, 131),
                 TextSpan.FromBounds(66, 131),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);

--- a/src/EditorFeatures/CSharpTest/Outlining/MethodDeclarationOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/MethodDeclarationOutlinerTests.cs
@@ -46,6 +46,29 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public void TestMethodWithTrailingSpaces()
+        {
+            var tree = ParseLines("class C",
+                                        "{",
+                                        "  public string Foo()    ",
+                                        "  {",
+                                        "  }",
+                                        "}");
+
+            var typeDecl = tree.DigToFirstTypeDeclaration();
+            var methodDecl = typeDecl.DigToFirstNodeOfType<MethodDeclarationSyntax>();
+
+            var actualRegion = GetRegion(methodDecl);
+            var expectedRegion = new OutliningSpan(
+                TextSpan.FromBounds(37, 47),
+                TextSpan.FromBounds(14, 47),
+                CSharpOutliningHelpers.Ellipsis,
+                autoCollapse: true);
+
+            AssertRegion(expectedRegion, actualRegion);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public void TestMethodWithLeadingComments()
         {
             var tree = ParseLines("class C",

--- a/src/EditorFeatures/CSharpTest/Outlining/ParenthesizedLambdaOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/ParenthesizedLambdaOutlinerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(41, 63),
+                TextSpan.FromBounds(42, 63),
                 TextSpan.FromBounds(36, 63),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(78, 114),
+                TextSpan.FromBounds(79, 114),
                 TextSpan.FromBounds(66, 114),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(78, 114),
+                TextSpan.FromBounds(79, 114),
                 TextSpan.FromBounds(66, 114),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);

--- a/src/EditorFeatures/CSharpTest/Outlining/PropertyDeclarationOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/PropertyDeclarationOutlinerTests.cs
@@ -105,5 +105,30 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
 
             AssertRegion(expectedRegion, actualRegion);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public void TestPropertyWithSpaceAfterIdentifier()
+        {
+            var tree = ParseLines("class C",
+                                        "{",
+                                        "  public int Foo    ",
+                                        "  {",
+                                        "    get { }",
+                                        "    set { }",
+                                        "  }",
+                                        "}");
+
+            var typeDecl = tree.DigToFirstTypeDeclaration();
+            var propDecl = typeDecl.DigToFirstNodeOfType<PropertyDeclarationSyntax>();
+
+            var actualRegion = GetRegion(propDecl);
+            var expectedRegion = new OutliningSpan(
+                TextSpan.FromBounds(32, 68),
+                TextSpan.FromBounds(14, 68),
+                CSharpOutliningHelpers.Ellipsis,
+                autoCollapse: true);
+
+            AssertRegion(expectedRegion, actualRegion);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Outlining/SimpleLambdaExpressionOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/SimpleLambdaExpressionOutlinerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(40, 62),
+                TextSpan.FromBounds(41, 62),
                 TextSpan.FromBounds(36, 62),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(70, 98),
+                TextSpan.FromBounds(71, 98),
                 TextSpan.FromBounds(66, 98),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var actualRegion = GetRegion(lambdaExpression);
 
             var expectedRegion = new OutliningSpan(
-                TextSpan.FromBounds(70, 98),
+                TextSpan.FromBounds(71, 98),
                 TextSpan.FromBounds(66, 98),
                 CSharpOutliningHelpers.Ellipsis,
                 autoCollapse: false);

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
@@ -39,6 +39,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 .LastOrNullable();
         }
 
+        public static SyntaxTrivia? GetLastCommentOrWhitespace(this SyntaxTriviaList triviaList)
+        {
+            return triviaList
+                .Where(t => t.MatchesKind(SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia, SyntaxKind.WhitespaceTrivia))
+                .LastOrNullable();
+        }
+
         public static IEnumerable<SyntaxTrivia> SkipInitialWhitespace(this SyntaxTriviaList triviaList)
         {
             return triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);


### PR DESCRIPTION
This preserves behavior with VS2012, and provides a nicer looking set of outlining spans in certain user scenarios.

Fixes: https://github.com/dotnet/roslyn/issues/4353