### PR TITLE
Turn NuGet restore to quiet verbosity

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -15,8 +15,8 @@ call :Usage && exit /b 1
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
 
 REM Build the compiler so we can self host it for the full build
-nuget.exe restore %RoslynRoot%/build/ToolsetPackages/project.json
-nuget.exe restore %RoslynRoot%/build/Toolset.sln
+nuget.exe restore -verbosity quiet %RoslynRoot%/build/ToolsetPackages/project.json
+nuget.exe restore -verbosity quiet %RoslynRoot%/build/Toolset.sln
 msbuild /nologo /v:m /m %RoslynRoot%/build/Toolset.sln /p:Configuration=%BuildConfiguration%
 
 mkdir %RoslynRoot%\Binaries\Bootstrap
@@ -31,7 +31,7 @@ if ERRORLEVEL 1 (
     exit /b 1
 )
 
-nuget.exe restore src/Samples/Samples.sln
+nuget.exe restore -verbosity quiet src/Samples/Samples.sln
 msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%\Binaries\Bootstrap src/Samples/Samples.sln /p:Configuration=%BuildConfiguration%
 if ERRORLEVEL 1 (
     taskkill /F /IM vbcscompiler.exe


### PR DESCRIPTION
NuGet restore output is blowing up our log files, so this should output only errors.

@tannergooding 