### PR TITLE
Prioritize uncommenting single line comments over multi-line comments.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
@@ -58,6 +58,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CommentSelection
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        public void UncommentSingleLineCommentInPseudoBlockComment()
+        {
+            var code = @"
+class C
+{
+    /// <include file='doc\Control.uex' path='docs/doc[@for=""Control.RtlTranslateAlignment1""]/*' />
+    protected void RtlTranslateAlignment2()
+    {
+        //[|int x = 0;|]
+    }
+    /* Hello world */
+}";
+
+            var expected = @"
+class C
+{
+    /// <include file='doc\Control.uex' path='docs/doc[@for=""Control.RtlTranslateAlignment1""]/*' />
+    protected void RtlTranslateAlignment2()
+    {
+        int x = 0;
+    }
+    /* Hello world */
+}";
+
+            UncommentSelection(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
         public void UncommentAndFormat3()
         {
             var code = @"class A

--- a/src/EditorFeatures/Core/Implementation/CommentSelection/CommentUncommentSelectionCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/CommentUncommentSelectionCommandHandler.cs
@@ -239,52 +239,74 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
         /// </summary>
         private void UncommentSpan(ICommentUncommentService service, SnapshotSpan span, List<TextChange> textChanges, List<ITrackingSpan> spansToSelect)
         {
-            if (service.SupportsBlockComment)
+            if (TryUncommentSingleLineComments(service, span, textChanges, spansToSelect))
             {
-                var positionOfStart = -1;
-                var positionOfEnd = -1;
-                var spanText = span.GetText();
-                var trimmedSpanText = spanText.Trim();
+                return;
+            }
 
-                // See if the selection includes just a block comment (plus whitespace)
-                if (trimmedSpanText.StartsWith(service.BlockCommentStartString, StringComparison.Ordinal) && trimmedSpanText.EndsWith(service.BlockCommentEndString, StringComparison.Ordinal))
-                {
-                    positionOfStart = span.Start + spanText.IndexOf(service.BlockCommentStartString, StringComparison.Ordinal);
-                    positionOfEnd = span.Start + spanText.LastIndexOf(service.BlockCommentEndString, StringComparison.Ordinal);
-                }
-                else
-                {
-                    // See if we are (textually) contained in a block comment.
-                    // This could allow a selection that spans multiple block comments to uncomment the beginning of
-                    // the first and end of the last.  Oh well.
-                    var text = span.Snapshot.AsText();
-                    positionOfStart = text.LastIndexOf(service.BlockCommentStartString, span.Start, caseSensitive: true);
+            TryUncommentContainingBlockComment(service, span, textChanges, spansToSelect);
+        }
 
-                    // If we found a start comment marker, make sure there isn't an end comment marker after it but before our span.
-                    if (positionOfStart >= 0)
+        private bool TryUncommentContainingBlockComment(ICommentUncommentService service, SnapshotSpan span, List<TextChange> textChanges, List<ITrackingSpan> spansToSelect)
+        {
+            // We didn't make any single line changes.  If the language supports block comments, see 
+            // if we're inside a containing block comment and uncomment that.
+
+            if (!service.SupportsBlockComment)
+            {
+                return false;
+            }
+
+            var positionOfStart = -1;
+            var positionOfEnd = -1;
+            var spanText = span.GetText();
+            var trimmedSpanText = spanText.Trim();
+
+            // See if the selection includes just a block comment (plus whitespace)
+            if (trimmedSpanText.StartsWith(service.BlockCommentStartString, StringComparison.Ordinal) && trimmedSpanText.EndsWith(service.BlockCommentEndString, StringComparison.Ordinal))
+            {
+                positionOfStart = span.Start + spanText.IndexOf(service.BlockCommentStartString, StringComparison.Ordinal);
+                positionOfEnd = span.Start + spanText.LastIndexOf(service.BlockCommentEndString, StringComparison.Ordinal);
+            }
+            else
+            {
+                // See if we are (textually) contained in a block comment.
+                // This could allow a selection that spans multiple block comments to uncomment the beginning of
+                // the first and end of the last.  Oh well.
+                var text = span.Snapshot.AsText();
+                positionOfStart = text.LastIndexOf(service.BlockCommentStartString, span.Start, caseSensitive: true);
+
+                // If we found a start comment marker, make sure there isn't an end comment marker after it but before our span.
+                if (positionOfStart >= 0)
+                {
+                    var lastEnd = text.LastIndexOf(service.BlockCommentEndString, span.Start, caseSensitive: true);
+                    if (lastEnd < positionOfStart)
                     {
-                        var lastEnd = text.LastIndexOf(service.BlockCommentEndString, span.Start, caseSensitive: true);
-                        if (lastEnd < positionOfStart)
-                        {
-                            positionOfEnd = text.IndexOf(service.BlockCommentEndString, span.End, caseSensitive: true);
-                        }
-                        else if (lastEnd + service.BlockCommentEndString.Length > span.End)
-                        {
-                            // The end of the span is *inside* the end marker, so searching backwards found it.
-                            positionOfEnd = lastEnd;
-                        }
+                        positionOfEnd = text.IndexOf(service.BlockCommentEndString, span.End, caseSensitive: true);
                     }
-                }
-
-                if (positionOfStart >= 0 && positionOfEnd >= 0)
-                {
-                    spansToSelect.Add(span.Snapshot.CreateTrackingSpan(Span.FromBounds(positionOfStart, positionOfEnd + service.BlockCommentEndString.Length), SpanTrackingMode.EdgeExclusive));
-                    DeleteText(textChanges, new TextSpan(positionOfStart, service.BlockCommentStartString.Length));
-                    DeleteText(textChanges, new TextSpan(positionOfEnd, service.BlockCommentEndString.Length));
-                    return;
+                    else if (lastEnd + service.BlockCommentEndString.Length > span.End)
+                    {
+                        // The end of the span is *inside* the end marker, so searching backwards found it.
+                        positionOfEnd = lastEnd;
+                    }
                 }
             }
 
+            if (positionOfStart < 0 || positionOfEnd < 0)
+            {
+                return false;
+            }
+
+            spansToSelect.Add(span.Snapshot.CreateTrackingSpan(Span.FromBounds(positionOfStart, positionOfEnd + service.BlockCommentEndString.Length), SpanTrackingMode.EdgeExclusive));
+            DeleteText(textChanges, new TextSpan(positionOfStart, service.BlockCommentStartString.Length));
+            DeleteText(textChanges, new TextSpan(positionOfEnd, service.BlockCommentEndString.Length));
+            return true;
+        }
+
+        private bool TryUncommentSingleLineComments(ICommentUncommentService service, SnapshotSpan span, List<TextChange> textChanges, List<ITrackingSpan> spansToSelect)
+        {
+            // First see if we're selecting any lines that have the single-line comment prefix.
+            // If so, then we'll just remove the single-line comment prefix from those lines.
             var firstAndLastLine = DetermineFirstAndLastLine(span);
             for (int lineNumber = firstAndLastLine.Item1.LineNumber; lineNumber <= firstAndLastLine.Item2.LineNumber; ++lineNumber)
             {
@@ -298,12 +320,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
 
             // If we made any changes, select the entirety of the lines we change, so that subsequent invocations will
             // affect the same lines.
-            if (textChanges.Any())
+            if (!textChanges.Any())
             {
-                spansToSelect.Add(span.Snapshot.CreateTrackingSpan(Span.FromBounds(firstAndLastLine.Item1.Start.Position,
-                                                                                   firstAndLastLine.Item2.End.Position),
-                                                                   SpanTrackingMode.EdgeExclusive));
+                return false;
             }
+
+            spansToSelect.Add(span.Snapshot.CreateTrackingSpan(Span.FromBounds(firstAndLastLine.Item1.Start.Position,
+                                                                               firstAndLastLine.Item2.End.Position),
+                                                               SpanTrackingMode.EdgeExclusive));
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/548

Technically this means that if you have:

```C#
/*
// foo
*/
```

And you try to just uncomment the 'foo' line, then we'll remove the ```//``` instead of the ```/*``` and ```*/```.  

However, this only happens if you're on the ```// foo``` line.  If you're on any other in the commented out section that doesn't look like a single-line comment, then you're ok.

This is preferable over the current situation, where the incorrect belief that we're in a multi-line block comment means we'll uncomment the wrong thing.  In this case, there's nothing you can do to uncomment the desired line of code.

--

I considered actually going and trying to get the syntax tree to make a completely accurate judgement.  But i'm concerned about going that route for such a corner case, esp when it can impact perf here for every other case.