### PR TITLE
Fixes a subtle bug in branch optimizer.

### DIFF
--- a/src/Compilers/Core/Portable/CodeGen/BasicBlock.cs
+++ b/src/Compilers/Core/Portable/CodeGen/BasicBlock.cs
@@ -408,6 +408,26 @@ namespace Microsoft.CodeAnalysis.CodeGen
                         var diff = this.BranchCode.Size() + this.BranchCode.BranchOperandSize();
                         delta -= diff;
                         this.SetBranch(null, ILOpCode.Nop);
+
+                        // If current block has no regular instructions the resulting block is a trivial noop
+                        // TryOptimizeBranchOverUncondBranch relies on an invariant that 
+                        // trivial blocks are not targeted by branches,
+                        // make sure we are not breaking this condition.
+                        if (this.HasNoRegularInstructions)
+                        {
+                            var labelInfos = builder._labelInfos;
+                            var labels = labelInfos.Keys;
+                            foreach (var label in labels)
+                            {
+                                var info = labelInfos[label];
+                                if (info.bb == this)
+                                {
+                                    // move the label from "this" to "next"
+                                    labelInfos[label] = info.WithNewTarget(next);
+                                }
+                            }
+                        }
+
                         return true;
                     }
                 }
@@ -427,19 +447,18 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                     if (revBrOp != ILOpCode.Nop)
                     {
-                        // we are effectively removing "next" from the block chain.
-                        // that is ok, since branch-to-branch should already eliminate any possible branches to "next"
-                        // and it was only reachable from current via NextBlock which we are re-directing.
-                        // Also, if there are any blocks between "next" and BranchBlock, they are all empty
-                        // so we do not even care if they are reachable or not.
-                        Debug.Assert(!builder._labelInfos.Values.Any(li => li.bb == next), "nothing should branch to a branch at this point");
-
-                        var intermediateNext = this.NextBlock;
-                        while (intermediateNext != next)
+                        // we are effectively removing blocks between this and the BranchBlock (including next) from the block chain.
+                        // that is ok, since branch-to-branch should already eliminate any possible branches to these blocks
+                        // and they were only reachable from current via NextBlock which we are re-directing.
+                        var toRemove = this.NextBlock;
+                        var branchBlock = this.BranchBlock;
+                        while (toRemove != branchBlock)
                         {
-                            Debug.Assert(intermediateNext.TotalSize == 0);
-                            intermediateNext.Reachability = ILBuilder.Reachability.NotReachable;
-                            intermediateNext = intermediateNext.NextBlock;
+                            Debug.Assert(toRemove == next || toRemove.TotalSize == 0);
+                            Debug.Assert(!builder._labelInfos.Values.Any(li => li.bb == toRemove), 
+                                "nothing should branch to a trivial block at this point");
+                            toRemove.Reachability = ILBuilder.Reachability.NotReachable;
+                            toRemove = toRemove.NextBlock;
                         }
 
                         next.Reachability = Reachability.NotReachable;

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -814,7 +814,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                     if (_optimizations == OptimizationLevel.Release)
                     {
-                        branchesOptimized |= current.OptimizeBranches(ref delta);
+                       branchesOptimized |= current.OptimizeBranches(ref delta);
                     }
 
                     current.ShortenBranches(ref delta);

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -814,7 +814,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                     if (_optimizations == OptimizationLevel.Release)
                     {
-                       branchesOptimized |= current.OptimizeBranches(ref delta);
+                        branchesOptimized |= current.OptimizeBranches(ref delta);
                     }
 
                     current.ShortenBranches(ref delta);


### PR DESCRIPTION
"branch over branch" optimization eliminates chains of trivial basic blocks from the graph, which is correct as long as trivial blocks are not reachable individually from outside via branches.
The "same as next" optimization can make a block trivial and if it was targeted by a branch, break the assumption, leading to a rare situation of some branches having stale offsets.

The fix makes sure if a block becomes trivial, its labels are moved to the next nontrivial block.

Fixes #4838
Fixes #4839