### PR TITLE
properly classify shebang comments in the IDE

### DIFF
--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -13,7 +13,7 @@ Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax.WithIsActive(bool
 Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax.WithLoadKeyword(Microsoft.CodeAnalysis.SyntaxToken loadKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LoadDirectiveTrivia = 8923 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LoadKeyword = 8485 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
-Microsoft.CodeAnalysis.CSharp.SyntaxKind.ShebangCommentTrivia = 8922 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.ShebangTrivia = 8922 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 override Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.CommonWithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitLoadDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/Syntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/Syntax.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             else if (text.StartsWith("#", StringComparison.Ordinal))
             {
-                return SyntaxTrivia.Create(SyntaxKind.ShebangCommentTrivia, text);
+                return SyntaxTrivia.Create(SyntaxKind.ShebangTrivia, text);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxNode.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 using System.Diagnostics;
@@ -347,7 +345,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override bool IsTriviaWithEndOfLine()
         {
             return this.Kind == SyntaxKind.EndOfLineTrivia
-                || this.Kind == SyntaxKind.SingleLineCommentTrivia;
+                || this.Kind == SyntaxKind.SingleLineCommentTrivia
+                || this.Kind == SyntaxKind.ShebangCommentTrivia;
         }
 
         // Use conditional weak table so we always return same identity for structured trivia

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxNode.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             return this.Kind == SyntaxKind.EndOfLineTrivia
                 || this.Kind == SyntaxKind.SingleLineCommentTrivia
-                || this.Kind == SyntaxKind.ShebangCommentTrivia;
+                || this.Kind == SyntaxKind.ShebangTrivia;
         }
 
         // Use conditional weak table so we always return same identity for structured trivia

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <see cref="SyntaxKind.WhitespaceTrivia"/>, <see cref="SyntaxKind.EndOfLineTrivia"/>,
         /// <see cref="SyntaxKind.SingleLineCommentTrivia"/>, <see cref="SyntaxKind.MultiLineCommentTrivia"/>,
         /// <see cref="SyntaxKind.DocumentationCommentExteriorTrivia"/>, <see cref="SyntaxKind.DisabledTextTrivia"/>,
-        /// <see cref="SyntaxKind.ShebangCommentTrivia"/>
+        /// <see cref="SyntaxKind.ShebangTrivia"/>
         /// </param>
         /// <param name="text">
         /// The actual text of this token.
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.EndOfLineTrivia:
                 case SyntaxKind.MultiLineCommentTrivia:
                 case SyntaxKind.SingleLineCommentTrivia:
-                case SyntaxKind.ShebangCommentTrivia:
+                case SyntaxKind.ShebangTrivia:
                 case SyntaxKind.WhitespaceTrivia:
 
                     return new SyntaxTrivia(default(SyntaxToken), new Syntax.InternalSyntax.SyntaxTrivia(kind, text, null, null), 0, 0);

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -167,14 +167,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Trivia nodes represents parts of the program text that are not parts of the
-        /// syntactic grammar, such as spaces, newlines, comments, preprocessors
+        /// Trivia nodes represent parts of the program text that are not parts of the
+        /// syntactic grammar, such as spaces, newlines, comments, preprocessor
         /// directives, and disabled code.
         /// </summary>
         /// <param name="kind">
-        /// A <cref c="SyntaxKind"/> representing the specific kind of SyntaxTrivia. One of
-        /// WhitespaceTrivia, EndOfLineTrivia, CommentTrivia,
-        /// DocumentationCommentExteriorTrivia, DisabledTextTrivia.
+        /// A <see cref="SyntaxKind"/> representing the specific kind of <see cref="SyntaxTrivia"/>. One of
+        /// <see cref="SyntaxKind.WhitespaceTrivia"/>, <see cref="SyntaxKind.EndOfLineTrivia"/>,
+        /// <see cref="SyntaxKind.SingleLineCommentTrivia"/>, <see cref="SyntaxKind.MultiLineCommentTrivia"/>,
+        /// <see cref="SyntaxKind.DocumentationCommentExteriorTrivia"/>, <see cref="SyntaxKind.DisabledTextTrivia"/>,
+        /// <see cref="SyntaxKind.ShebangCommentTrivia"/>
         /// </param>
         /// <param name="text">
         /// The actual text of this token.

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using InternalSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -194,6 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.EndOfLineTrivia:
                 case SyntaxKind.MultiLineCommentTrivia:
                 case SyntaxKind.SingleLineCommentTrivia:
+                case SyntaxKind.ShebangCommentTrivia:
                 case SyntaxKind.WhitespaceTrivia:
 
                     return new SyntaxTrivia(default(SyntaxToken), new Syntax.InternalSyntax.SyntaxTrivia(kind, text, null, null), 0, 0);

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         InterpolationAlignmentClause = 8920,
         InterpolationFormatClause = 8921,
 
-        ShebangCommentTrivia = 8922,
+        ShebangTrivia = 8922,
         LoadDirectiveTrivia = 8923,
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -209,6 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.WhitespaceTrivia:
                 case SyntaxKind.SingleLineCommentTrivia:
                 case SyntaxKind.MultiLineCommentTrivia:
+                case SyntaxKind.ShebangCommentTrivia:
                 case SyntaxKind.SingleLineDocumentationCommentTrivia:
                 case SyntaxKind.MultiLineDocumentationCommentTrivia:
                 case SyntaxKind.DisabledTextTrivia:

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.WhitespaceTrivia:
                 case SyntaxKind.SingleLineCommentTrivia:
                 case SyntaxKind.MultiLineCommentTrivia:
-                case SyntaxKind.ShebangCommentTrivia:
+                case SyntaxKind.ShebangTrivia:
                 case SyntaxKind.SingleLineDocumentationCommentTrivia:
                 case SyntaxKind.MultiLineDocumentationCommentTrivia:
                 case SyntaxKind.DisabledTextTrivia:

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
@@ -113,13 +113,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             /// <summary>
             /// Returns whether the specified <see cref="SyntaxTrivia"/> token is also the end of the line.  This will
             /// be true for <see cref="SyntaxKind.EndOfLineTrivia"/>, <see cref="SyntaxKind.SingleLineCommentTrivia"/>,
-            /// <see cref="SyntaxKind.ShebangCommentTrivia"/>, and all preprocessor directives.
+            /// <see cref="SyntaxKind.ShebangTrivia"/>, and all preprocessor directives.
             /// </summary>
             private static bool IsEndOfLine(SyntaxTrivia trivia)
             {
                 return trivia.Kind() == SyntaxKind.EndOfLineTrivia
                     || trivia.Kind() == SyntaxKind.SingleLineCommentTrivia
-                    || trivia.Kind() == SyntaxKind.ShebangCommentTrivia
+                    || trivia.Kind() == SyntaxKind.ShebangTrivia
                     || trivia.IsDirective;
             }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
@@ -110,6 +110,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 }
             }
 
+            /// <summary>
+            /// Returns whether the specified <see cref="SyntaxTrivia"/> token is also the end of the line.  This will
+            /// be true for <see cref="SyntaxKind.EndOfLineTrivia"/>, <see cref="SyntaxKind.SingleLineCommentTrivia"/>,
+            /// <see cref="SyntaxKind.ShebangCommentTrivia"/>, and all preprocessor directives.
+            /// </summary>
             private static bool IsEndOfLine(SyntaxTrivia trivia)
             {
                 return trivia.Kind() == SyntaxKind.EndOfLineTrivia

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
@@ -114,6 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             {
                 return trivia.Kind() == SyntaxKind.EndOfLineTrivia
                     || trivia.Kind() == SyntaxKind.SingleLineCommentTrivia
+                    || trivia.Kind() == SyntaxKind.ShebangCommentTrivia
                     || trivia.IsDirective;
             }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -666,7 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             switch (kind)
             {
                 case SyntaxKind.SingleLineCommentTrivia:
-                case SyntaxKind.ShebangCommentTrivia:
+                case SyntaxKind.ShebangTrivia:
                     return true;
                 case SyntaxKind.MultiLineCommentTrivia:
                     return !isTrailingTrivia;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -666,6 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             switch (kind)
             {
                 case SyntaxKind.SingleLineCommentTrivia:
+                case SyntaxKind.ShebangCommentTrivia:
                     return true;
                 case SyntaxKind.MultiLineCommentTrivia:
                     return !isTrailingTrivia;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/InteractiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/InteractiveParsingTests.cs
@@ -8446,7 +8446,7 @@ p class A
             Assert.Empty(root.ChildNodes());
             var eof = root.EndOfFileToken;
             Assert.Equal(SyntaxKind.EndOfFileToken, eof.Kind());
-            Assert.Equal(SyntaxKind.ShebangCommentTrivia, eof.GetLeadingTrivia().Single().Kind());
+            Assert.Equal(SyntaxKind.ShebangTrivia, eof.GetLeadingTrivia().Single().Kind());
 
             tree = ParseAndValidate("#! /usr/bin/env scriptcs\r\n ", TestOptions.Script);
             root = tree.GetCompilationUnitRoot();
@@ -8456,7 +8456,7 @@ p class A
             Assert.Equal(SyntaxKind.EndOfFileToken, eof.Kind());
             var leading = eof.GetLeadingTrivia().ToArray();
             Assert.Equal(3, leading.Length);
-            Assert.Equal(SyntaxKind.ShebangCommentTrivia, leading[0].Kind());
+            Assert.Equal(SyntaxKind.ShebangTrivia, leading[0].Kind());
             Assert.Equal(SyntaxKind.EndOfLineTrivia, leading[1].Kind());
             Assert.Equal(SyntaxKind.WhitespaceTrivia, leading[2].Kind());
 
@@ -8469,7 +8469,7 @@ Console.WriteLine(""Hi!"");", TestOptions.Script);
             Assert.Equal(SyntaxKind.GlobalStatement, statement.Kind());
             leading = statement.GetLeadingTrivia().ToArray();
             Assert.Equal(2, leading.Length);
-            Assert.Equal(SyntaxKind.ShebangCommentTrivia, leading[0].Kind());
+            Assert.Equal(SyntaxKind.ShebangTrivia, leading[0].Kind());
             Assert.Equal(SyntaxKind.EndOfLineTrivia, leading[1].Kind());
         }
 

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -1000,6 +1000,68 @@ class Bar {
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public void ShebangAsFirstCommentInScript()
+        {
+            var code = @"#!/usr/bin/env scriptcs
+System.Console.WriteLine();";
+            var expected = new[]
+            {
+                Comment("#!/usr/bin/env scriptcs"),
+                Identifier("System"),
+                Operators.Dot,
+                Identifier("Console"),
+                Operators.Dot,
+                Identifier("WriteLine"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Punctuation.Semicolon
+            };
+            Test(code, code, expected, Options.Script);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public void ShebangAsFirstCommentInNonScript()
+        {
+            var code = @"#!/usr/bin/env scriptcs
+System.Console.WriteLine();";
+            var expected = new[]
+            {
+                PPKeyword("#"),
+                PPText("!/usr/bin/env scriptcs"),
+                Identifier("System"),
+                Operators.Dot,
+                Identifier("Console"),
+                Operators.Dot,
+                Identifier("WriteLine"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Punctuation.Semicolon
+            };
+            Test(code, code, expected, Options.Regular);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public void ShebangNotAsFirstCommentInScript()
+        {
+            var code = @" #!/usr/bin/env scriptcs
+System.Console.WriteLine();";
+            var expected = new[]
+            {
+                PPKeyword("#"),
+                PPText("!/usr/bin/env scriptcs"),
+                Identifier("System"),
+                Operators.Dot,
+                Identifier("Console"),
+                Operators.Dot,
+                Identifier("WriteLine"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Punctuation.Semicolon
+            };
+            Test(code, code, expected, Options.Script);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public void CommentAsMethodBodyContent()
         {
             var code = @"

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8367,5 +8367,12 @@ class Class2
 }";
             VerifyItemExists(markup, "Property1");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void NoCompletionInShebangComments()
+        {
+            VerifyNoItemsExist("#!$$", sourceCodeKind: SourceCodeKind.Script);
+            VerifyNoItemsExist("#! S$$", sourceCodeKind: SourceCodeKind.Script, usePreviousCharAsTrigger: true);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -318,10 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
 
         private static bool ShouldPreserve(SyntaxTriviaList trivia)
         {
-            return trivia.Any(
-                t => t.Kind() == SyntaxKind.SingleLineCommentTrivia ||
-                t.Kind() == SyntaxKind.MultiLineCommentTrivia ||
-                t.IsDirective);
+            return trivia.Any(t => t.IsRegularComment() || t.IsDirective);
         }
 
         private SyntaxNode RemoveDeclaratorFromVariableList(VariableDeclaratorSyntax variableDeclarator, VariableDeclarationSyntax variableDeclaration)

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -1180,8 +1180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             for (int i = triviaList.Count - 1; i >= 0; i--)
             {
                 var trivia = triviaList[i];
-                if (trivia.Kind() == SyntaxKind.SingleLineCommentTrivia ||
-                    trivia.Kind() == SyntaxKind.MultiLineCommentTrivia)
+                if (trivia.IsRegularComment())
                 {
                     commentList.Add(trivia);
                 }
@@ -1210,8 +1209,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             var textBuilder = new StringBuilder();
             foreach (var trivia in commentList)
             {
-                if (trivia.Kind() == SyntaxKind.SingleLineCommentTrivia ||
-                    trivia.Kind() == SyntaxKind.MultiLineCommentTrivia)
+                if (trivia.IsRegularComment())
                 {
                     textBuilder.AppendLine(trivia.GetCommentText());
                 }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -8,11 +8,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Implementation.F1Help;
 using Roslyn.Utilities;
@@ -77,7 +75,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return "#region";
             }
 
-            if (trivia.MatchesKind(SyntaxKind.MultiLineDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia, SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia))
+            if (trivia.IsRegularOrDocComment())
             {
                 // just find the first "word" that intersects with our position
                 var text = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -121,9 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
         private void ClassifyTrivia(SyntaxTrivia trivia)
         {
-            if (trivia.Kind() == SyntaxKind.SingleLineCommentTrivia ||
-                trivia.Kind() == SyntaxKind.MultiLineCommentTrivia ||
-                trivia.Kind() == SyntaxKind.ShebangCommentTrivia)
+            if (trivia.IsRegularComment())
             {
                 AddClassification(trivia, ClassificationTypeNames.Comment);
             }

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -121,7 +121,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
         private void ClassifyTrivia(SyntaxTrivia trivia)
         {
-            if (trivia.Kind() == SyntaxKind.SingleLineCommentTrivia || trivia.Kind() == SyntaxKind.MultiLineCommentTrivia)
+            if (trivia.Kind() == SyntaxKind.SingleLineCommentTrivia ||
+                trivia.Kind() == SyntaxKind.MultiLineCommentTrivia ||
+                trivia.Kind() == SyntaxKind.ShebangCommentTrivia)
             {
                 AddClassification(trivia, ClassificationTypeNames.Comment);
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -175,9 +175,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var endOfLine = Match(SyntaxKind.EndOfLineTrivia, "\\n");
             var singleBlankLine = Matcher.Sequence(whitespace, endOfLine);
 
+            var shebangComment = Match(SyntaxKind.ShebangCommentTrivia, "#!");
             var singleLineComment = Match(SyntaxKind.SingleLineCommentTrivia, "//");
             var multiLineComment = Match(SyntaxKind.MultiLineCommentTrivia, "/**/");
-            var anyCommentMatcher = Matcher.Choice(singleLineComment, multiLineComment);
+            var anyCommentMatcher = Matcher.Choice(shebangComment, singleLineComment, multiLineComment);
 
             var commentLine = Matcher.Sequence(whitespace, anyCommentMatcher, whitespace, endOfLine);
 

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var endOfLine = Match(SyntaxKind.EndOfLineTrivia, "\\n");
             var singleBlankLine = Matcher.Sequence(whitespace, endOfLine);
 
-            var shebangComment = Match(SyntaxKind.ShebangCommentTrivia, "#!");
+            var shebangComment = Match(SyntaxKind.ShebangTrivia, "#!");
             var singleLineComment = Match(SyntaxKind.SingleLineCommentTrivia, "//");
             var multiLineComment = Match(SyntaxKind.MultiLineCommentTrivia, "/**/");
             var anyCommentMatcher = Matcher.Choice(shebangComment, singleLineComment, multiLineComment);

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTreeExtensions.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 trivia = trivia.GetPreviousTrivia(syntaxTree, cancellationToken);
             }
 
-            if (trivia.IsSingleLineComment())
+            if (trivia.IsSingleLineComment() || trivia.IsShebangComment())
             {
                 var span = trivia.FullSpan;
 

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTreeExtensions.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 trivia = trivia.GetPreviousTrivia(syntaxTree, cancellationToken);
             }
 
-            if (trivia.IsSingleLineComment() || trivia.IsShebangComment())
+            if (trivia.IsSingleLineComment() || trivia.IsShebang())
             {
                 var span = trivia.FullSpan;
 

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         public static bool IsRegularComment(this SyntaxTrivia trivia)
         {
-            return trivia.IsSingleLineComment() || trivia.IsMultiLineComment() || trivia.IsShebangComment();
+            return trivia.IsSingleLineComment() || trivia.IsMultiLineComment() || trivia.IsShebang();
         }
 
         public static bool IsRegularOrDocComment(this SyntaxTrivia trivia)
@@ -50,9 +50,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return trivia.Kind() == SyntaxKind.MultiLineCommentTrivia;
         }
 
-        public static bool IsShebangComment(this SyntaxTrivia trivia)
+        public static bool IsShebang(this SyntaxTrivia trivia)
         {
-            return trivia.Kind() == SyntaxKind.ShebangCommentTrivia;
+            return trivia.Kind() == SyntaxKind.ShebangTrivia;
         }
 
         public static bool IsCompleteMultiLineComment(this SyntaxTrivia trivia)

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaExtensions.cs
@@ -32,12 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         public static bool IsRegularComment(this SyntaxTrivia trivia)
         {
-            return trivia.IsSingleLineComment() || trivia.IsMultiLineComment();
+            return trivia.IsSingleLineComment() || trivia.IsMultiLineComment() || trivia.IsShebangComment();
         }
 
         public static bool IsRegularOrDocComment(this SyntaxTrivia trivia)
         {
-            return trivia.IsSingleLineComment() || trivia.IsMultiLineComment() || trivia.IsDocComment();
+            return trivia.IsRegularComment() || trivia.IsDocComment();
         }
 
         public static bool IsSingleLineComment(this SyntaxTrivia trivia)
@@ -48,6 +48,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static bool IsMultiLineComment(this SyntaxTrivia trivia)
         {
             return trivia.Kind() == SyntaxKind.MultiLineCommentTrivia;
+        }
+
+        public static bool IsShebangComment(this SyntaxTrivia trivia)
+        {
+            return trivia.Kind() == SyntaxKind.ShebangCommentTrivia;
         }
 
         public static bool IsCompleteMultiLineComment(this SyntaxTrivia trivia)

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
@@ -2,10 +2,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
@@ -35,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static SyntaxTrivia? GetLastComment(this SyntaxTriviaList triviaList)
         {
             return triviaList
-                .Where(t => t.MatchesKind(SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia))
+                .Where(t => t.IsRegularComment())
                 .LastOrNullable();
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Utilities/Matcher.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/Matcher.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
@@ -24,11 +23,11 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         }
 
         /// <summary>
-        /// Matcher equivalent to (m_1|m_2)
+        /// Matcher equivalent to (m_1|m_2|...|m_n)
         /// </summary>
-        public static Matcher<T> Choice<T>(Matcher<T> matcher1, Matcher<T> matcher2)
+        public static Matcher<T> Choice<T>(params Matcher<T>[] matchers)
         {
-            return Matcher<T>.Choice(matcher1, matcher2);
+            return Matcher<T>.Choice(matchers);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Shared/Utilities/Matcher`1.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/Matcher`1.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
@@ -29,9 +28,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return Sequence(matcher, Repeat(matcher));
         }
 
-        internal static Matcher<T> Choice(Matcher<T> matcher1, Matcher<T> matcher2)
+        internal static Matcher<T> Choice(params Matcher<T>[] matchers)
         {
-            return new ChoiceMatcher(matcher1, matcher2);
+            return new ChoiceMatcher(matchers);
         }
 
         internal static Matcher<T> Sequence(params Matcher<T>[] matchers)


### PR DESCRIPTION
Building off of PR #4470, this ensures the file-leading shebang comment is classified as trivia so it gets colorized in the IDE.

Tagging @Pilchie @dpoeschl @jasonmalinowski @rchande @balajikris @CyrusNajmabadi @jmarolf @davkean @KevinH-MS for review.