### PR TITLE
Async loading with property pages

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProjectContainer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioHostProjectContainer.cs
@@ -11,5 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     internal interface IVisualStudioHostProjectContainer
     {
         IEnumerable<IVisualStudioHostProject> GetProjects();
+
+        void NotifyNonDocumentOpenedForProject(IVisualStudioHostProject project);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -350,6 +350,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return _hostProjects.Values;
         }
 
+        void IVisualStudioHostProjectContainer.NotifyNonDocumentOpenedForProject(IVisualStudioHostProject project)
+        {
+            // Since the MiscellaneousFilesWorkspace doesn't do anything lazily, this is a no-op
+        }
+
         private class LanguageInformation
         {
             public LanguageInformation(string languageName, string scriptExtension, ParseOptions parseOptions)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -57,6 +57,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return this.Projects;
         }
 
+        void IVisualStudioHostProjectContainer.NotifyNonDocumentOpenedForProject(IVisualStudioHostProject project)
+        {
+            var abstractProject = (AbstractProject)project;
+            StartPushingToWorkspaceAndNotifyOfOpenDocuments(SpecializedCollections.SingletonEnumerable(abstractProject));
+        }
+
         private uint? _solutionEventsCookie;
 
         public VisualStudioProjectTracker(IServiceProvider serviceProvider)


### PR DESCRIPTION
When non-text files are opened for a project, push the project to the workspace. This is needed for property pages, which we want to ensure have the project in the workspace or else they might not be able to query stuff, such as the property page code I'm changing as a part of #4183.

*Note:* this is branched from my other branch that contains the fixes I needed to actually validate this. That PR will go in first and I'll then refresh the diff to this.

Reviewers: @balajikris, @basoundr, @brettfo, @davkean, @DustinCampbell, @dpoeschl, @Pilchie