### PR TITLE
Pay attention to sizes and lower bounds specified for multi-dimensional arrays in metadata signatures.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2266,7 +2266,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var delegateParameterType = delegateParameters[i].Type;
                     var delegateRefKind = delegateParameters[i].RefKind;
 
-                    if (!lambdaParameterType.Equals(delegateParameterType, ignoreCustomModifiers: true, ignoreDynamic: true))
+                    if (!lambdaParameterType.Equals(delegateParameterType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
                     {
                         SymbolDistinguisher distinguisher = new SymbolDistinguisher(this.Compilation, lambdaParameterType, delegateParameterType);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     for (int p = 0; p < delegateParameters.Length; ++p)
                     {
                         if (delegateParameters[p].RefKind != anonymousFunction.RefKind(p) ||
-                            !delegateParameters[p].Type.Equals(anonymousFunction.ParameterType(p), ignoreCustomModifiers: true, ignoreDynamic: true))
+                            !delegateParameters[p].Type.Equals(anonymousFunction.ParameterType(p), ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
                         {
                             return LambdaConversionResult.MismatchedParameterType;
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)type1 != null);
             Debug.Assert((object)type2 != null);
 
-            return type1.Equals(type2, ignoreCustomModifiers: true, ignoreDynamic: true);
+            return type1.Equals(type2, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true);
         }
 
         public static bool HasIdentityConversionToAny<T>(T type, ArrayBuilder<T> targetTypes)

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -879,7 +879,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // - i.e assigns int value to a short local.
                 // in that case we should force lhs to be a real local.
                 Debug.Assert(
-                    node.Left.Type.Equals(node.Right.Type, ignoreCustomModifiers: true, ignoreDynamic: true),
+                    node.Left.Type.Equals(node.Right.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true),
                     @"type of the assignment value is not the same as the type of assignment target. 
                 This is not expected by the optimizer and is typically a result of a bug somewhere else.");
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     return ArrayTypeSymbol.CreateSZArray(_otherAssembly, otherElementType, otherModifiers);
                 }
 
-                return ArrayTypeSymbol.CreateMDArray(_otherAssembly, otherElementType, symbol.Rank, otherModifiers);
+                return ArrayTypeSymbol.CreateMDArray(_otherAssembly, otherElementType, symbol.Rank, symbol.Sizes, symbol.LowerBounds, otherModifiers);
             }
 
             public override Symbol VisitEvent(EventSymbol symbol)
@@ -829,7 +829,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     return ArrayTypeSymbol.CreateSZArray(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, translatedElementType, translatedModifiers);
                 }
 
-                return ArrayTypeSymbol.CreateMDArray(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, translatedElementType, symbol.Rank, translatedModifiers);
+                return ArrayTypeSymbol.CreateMDArray(symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly, translatedElementType, symbol.Rank, symbol.Sizes, symbol.LowerBounds, translatedModifiers);
             }
 
             public override Symbol VisitDynamicType(DynamicTypeSymbol symbol)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/ArrayTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ArrayTypeSymbolAdapter.cs
@@ -39,9 +39,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                for (int i = 0; i < this.Rank; ++i)
-                    yield return 0;
+                var lowerBounds = this.LowerBounds;
+
+                if (lowerBounds.IsDefault)
+                {
+                    return DefaultLowerBounds(this.Rank);
+                }
+                else
+                {
+                    return lowerBounds;
+                }
             }
+        }
+
+        private static IEnumerable<int> DefaultLowerBounds(int rank)
+        {
+            for (int i = 0; i < rank; ++i)
+                yield return 0;
         }
 
         uint Cci.IArrayTypeReference.Rank
@@ -56,7 +70,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return SpecializedCollections.EmptyEnumerable<ulong>();
+                if (this.Sizes.IsEmpty)
+                {
+                    return SpecializedCollections.EmptyEnumerable<ulong>();
+                }
+
+                return GetSizes();
+            }
+        }
+
+        private IEnumerable<ulong> GetSizes()
+        {
+            foreach (var size in this.Sizes)
+            {
+                yield return (ulong)size;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // but we need to change the Type property on the resulting BoundExpression to match the rewrittenType.
                     // This is necessary so that subsequent lowering transformations see that the expression is dynamic.
 
-                    if (_inExpressionLambda || !rewrittenOperand.Type.Equals(rewrittenType, ignoreCustomModifiers: false, ignoreDynamic: false))
+                    if (_inExpressionLambda || !rewrittenOperand.Type.Equals(rewrittenType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false))
                     {
                         break;
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -607,7 +607,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundExpression Coalesce(BoundExpression left, BoundExpression right)
         {
-            Debug.Assert(left.Type.Equals(right.Type, ignoreCustomModifiers: true));
+            Debug.Assert(left.Type.Equals(right.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
             Debug.Assert(left.Type.IsReferenceType);
 
             return new BoundNullCoalescingOperator(Syntax, left, right, Conversion.Identity, left.Type) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -197,6 +197,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ArrayTypeSymbol.CreateMDArray(
                 element.Type,
                 t.Rank,
+                t.Sizes,
+                t.LowerBounds,
                 t.BaseTypeNoUseSiteDiagnostics,
                 element.CustomModifiers);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
@@ -59,13 +59,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public bool Equals(AnonymousTypeDescriptor desc)
         {
-            return this.Equals(desc, ignoreCustomModifiers: false, ignoreDynamic: false);
+            return this.Equals(desc, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false);
         }
 
         /// <summary>
         /// Compares two anonymous type descriptors, takes into account fields names and types, not locations.
         /// </summary>
-        internal bool Equals(AnonymousTypeDescriptor other, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal bool Equals(AnonymousTypeDescriptor other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             // Comparing keys ensures field count and field names are the same
             if (this.Key != other.Key)
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<AnonymousTypeField> otherFields = other.Fields;
             for (int i = 0; i < count; i++)
             {
-                if (!myFields[i].Type.Equals(otherFields[i].Type, ignoreCustomModifiers, ignoreDynamic))
+                if (!myFields[i].Type.Equals(otherFields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
                 {
                     return false;
                 }
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public override bool Equals(object obj)
         {
-            return obj is AnonymousTypeDescriptor && this.Equals((AnonymousTypeDescriptor)obj, ignoreCustomModifiers: false, ignoreDynamic: false);
+            return obj is AnonymousTypeDescriptor && this.Equals((AnonymousTypeDescriptor)obj, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
@@ -76,12 +76,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Logical equality on anonymous types that ignores custom modifiers and/or the object/dynamic distinction.
         /// Differs from IsSameType for arrays, pointers, and generic instantiations.
         /// </summary>
-        internal static bool IsSameType(TypeSymbol type1, TypeSymbol type2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal static bool IsSameType(TypeSymbol type1, TypeSymbol type2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             Debug.Assert(type1.IsAnonymousType);
             Debug.Assert(type2.IsAnonymousType);
 
-            if (ignoreCustomModifiers || ignoreDynamic)
+            if (ignoreCustomModifiersAndArraySizesAndLowerBounds || ignoreDynamic)
             {
                 AnonymousTypeDescriptor left = ((AnonymousTypePublicSymbol)type1).TypeDescriptor;
                 AnonymousTypeDescriptor right = ((AnonymousTypePublicSymbol)type2).TypeDescriptor;
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(right.Fields.Length == count);
                 for (int i = 0; i < count; i++)
                 {
-                    if (!left.Fields[i].Type.Equals(right.Fields[i].Type, ignoreCustomModifiers, ignoreDynamic))
+                    if (!left.Fields[i].Type.Equals(right.Fields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
                     {
                         return false;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ImmutableArray<NamedTypeSymbol>.Empty;
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var other = t2 as AnonymousTypePublicSymbol;
-                return (object)other != null && this.TypeDescriptor.Equals(other.TypeDescriptor, ignoreCustomModifiers, ignoreDynamic);
+                return (object)other != null && this.TypeDescriptor.Equals(other.TypeDescriptor, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
             }
 
             public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                              substitutedReferencedType.CustomModifiers);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             if ((object)this == (object)t2)
             {
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             ByRefReturnErrorTypeSymbol other = t2 as ByRefReturnErrorTypeSymbol;
-            return (object)other != null && _referencedType.Equals(other._referencedType, ignoreCustomModifiers, ignoreDynamic) &&
-                   (ignoreCustomModifiers || _countOfCustomModifiersPrecedingByRef == other._countOfCustomModifiersPrecedingByRef);
+            return (object)other != null && _referencedType.Equals(other._referencedType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic) &&
+                   (ignoreCustomModifiersAndArraySizesAndLowerBounds || _countOfCustomModifiersPrecedingByRef == other._countOfCustomModifiersPrecedingByRef);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (int)Microsoft.CodeAnalysis.SpecialType.System_Object;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             if ((object)t2 == null)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(_container.GetHashCode(), _ordinal);
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var other = t2 as ErrorTypeParameterSymbol;
                 return (object)other != null &&
                     other._ordinal == _ordinal &&
-                    other.ContainingType.Equals(this.ContainingType, ignoreCustomModifiers, ignoreDynamic);
+                    other.ContainingType.Equals(this.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return commonTypeKind;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             if (ReferenceEquals(this, t2))
             {
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return
-                ((object)this.ContainingType != null ? this.ContainingType.Equals(other.ContainingType, ignoreCustomModifiers, ignoreDynamic) :
+                ((object)this.ContainingType != null ? this.ContainingType.Equals(other.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic) :
                  (object)this.ContainingSymbol == null ? (object)other.ContainingSymbol == null : this.ContainingSymbol.Equals(other.ContainingSymbol)) &&
                 this.Name == other.Name && this.Arity == other.Arity;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -464,7 +464,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // the runtime compares custom modifiers using (effectively) SequenceEqual
             return considerCustomModifiers ?
                 returnType1.Equals(returnType2, ignoreDynamic: true) :
-                returnType1.Type.Equals(returnType2.Type, ignoreCustomModifiers: true, ignoreDynamic: true);
+                returnType1.Type.Equals(returnType2.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true);
         }
 
         private static TypeMap GetTypeMap(Symbol member)
@@ -610,7 +610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         return false;
                     }
                 }
-                else if (!type1.Type.Equals(type2.Type, ignoreCustomModifiers: true, ignoreDynamic: true))
+                else if (!type1.Type.Equals(type2.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -226,30 +226,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return count;
         }
 
-        /// <summary>
-        /// Count the number of custom modifiers in/on the return type
-        /// and parameters of the specified method.
-        /// </summary>
-        public static bool HasCustomModifiers(this MethodSymbol method)
-        {
-            if (method.ReturnTypeCustomModifiers.Any() || method.ReturnType.HasCustomModifiers())
-            {
-                return true;
-            }
-
-            foreach (ParameterSymbol param in method.Parameters)
-            {
-                if (param.CustomModifiers.Any() || param.Type.HasCustomModifiers())
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        //UNDONE: HasCustomModifiers(PropertySymbol), HasCustomModifiers(FieldSymbol)
-
         internal static Symbol SymbolAsMember(this Symbol s, NamedTypeSymbol newOwner)
         {
             switch (s.Kind)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 arrayType :
                 arrayType.IsSZArray ?
                     ArrayTypeSymbol.CreateSZArray(_containingAssembly, transformedElementType, arrayType.CustomModifiers) :
-                    ArrayTypeSymbol.CreateMDArray(_containingAssembly, transformedElementType, arrayType.Rank, arrayType.CustomModifiers);
+                    ArrayTypeSymbol.CreateMDArray(_containingAssembly, transformedElementType, arrayType.Rank, arrayType.Sizes, arrayType.LowerBounds, arrayType.CustomModifiers);
         }
 
         private PointerTypeSymbol TransformPointerType(PointerTypeSymbol pointerType)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -11,14 +11,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
     {
         internal static readonly SymbolFactory Instance = new SymbolFactory();
 
-        internal override TypeSymbol GetMDArrayTypeSymbol(PEModuleSymbol moduleSymbol, int rank, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers)
+        internal override TypeSymbol GetMDArrayTypeSymbol(PEModuleSymbol moduleSymbol, int rank, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers,
+                                                          ImmutableArray<int> sizes, ImmutableArray<int> lowerBounds)
         {
             if (elementType is UnsupportedMetadataTypeSymbol)
             {
                 return elementType;
             }
 
-            return ArrayTypeSymbol.CreateMDArray(moduleSymbol.ContainingAssembly, elementType, rank, CSharpCustomModifier.Convert(customModifiers));
+            return ArrayTypeSymbol.CreateMDArray(moduleSymbol.ContainingAssembly, elementType, rank, sizes, lowerBounds, CSharpCustomModifier.Convert(customModifiers));
         }
 
         internal override TypeSymbol GetByRefReturnTypeSymbol(PEModuleSymbol moduleSymbol, TypeSymbol referencedType, ushort countOfCustomModifiersPrecedingByRef)

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(MetadataName, Hash.Combine(_containingModule, Hash.Combine(_namespaceName, arity)));
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(_containingType, Hash.Combine(MetadataName, arity));
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var other = t2 as Nested;
                 return (object)other != null && string.Equals(MetadataName, other.MetadataName, StringComparison.Ordinal) &&
                     arity == other.arity &&
-                    _containingType.Equals(other._containingType, ignoreCustomModifiers, ignoreDynamic);
+                    _containingType.Equals(other._containingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -632,7 +632,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Compares this type to another type.
         /// </summary>
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers = false, bool ignoreDynamic = false)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds = false, bool ignoreDynamic = false)
         {
             if (ReferenceEquals(this, t2)) return true;
             if ((object)t2 == null) return false;
@@ -665,15 +665,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // The checks above are supposed to handle the vast majority of cases.
             // More complicated cases are handled in a special helper to make the common case scenario simple/fast
-            return EqualsComplicatedCases(other, ignoreCustomModifiers, ignoreDynamic);
+            return EqualsComplicatedCases(other, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
         }
 
         /// <summary>
         /// Helper for more complicated cases of Equals like when we have generic instantiations or types nested within them.
         /// </summary>
-        private bool EqualsComplicatedCases(NamedTypeSymbol other, bool ignoreCustomModifiers, bool ignoreDynamic)
+        private bool EqualsComplicatedCases(NamedTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
-            if ((object)this.ContainingType != null && !this.ContainingType.Equals(other.ContainingType, ignoreCustomModifiers, ignoreDynamic))
+            if ((object)this.ContainingType != null && !this.ContainingType.Equals(other.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
             {
                 return false;
             }
@@ -698,7 +698,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             bool hasTypeArgumentsCustomModifiers = this.HasTypeArgumentsCustomModifiers;
 
-            if (!ignoreCustomModifiers && hasTypeArgumentsCustomModifiers != other.HasTypeArgumentsCustomModifiers)
+            if (!ignoreCustomModifiersAndArraySizesAndLowerBounds && hasTypeArgumentsCustomModifiers != other.HasTypeArgumentsCustomModifiers)
             {
                 return false;
             }
@@ -712,10 +712,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int i = 0; i < count; i++)
             {
-                if (!typeArguments[i].Equals(otherTypeArguments[i], ignoreCustomModifiers, ignoreDynamic)) return false;
+                if (!typeArguments[i].Equals(otherTypeArguments[i], ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic)) return false;
             }
 
-            if (!ignoreCustomModifiers && hasTypeArgumentsCustomModifiers)
+            if (!ignoreCustomModifiersAndArraySizesAndLowerBounds && hasTypeArgumentsCustomModifiers)
             {
                 Debug.Assert(other.HasTypeArgumentsCustomModifiers);
                 var modifiers = this.TypeArgumentsCustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -571,7 +571,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 foreach (ParameterSymbol param in currTypeBestMatch.GetParameters())
                 {
                     Debug.Assert(!param.CustomModifiers.Any());
-                    Debug.Assert(!param.Type.HasCustomModifiers());
+                    Debug.Assert(!param.Type.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds:false));
                 }
 #endif
 
@@ -823,13 +823,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case SymbolKind.Method:
                     MethodSymbol method = (MethodSymbol)member;
-                    return method.ReturnTypeCustomModifiers.Any() || method.ReturnType.HasCustomModifiers();
+                    return method.ReturnTypeCustomModifiers.Any() || method.ReturnType.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds:false);
                 case SymbolKind.Property:
                     PropertySymbol property = (PropertySymbol)member;
-                    return property.TypeCustomModifiers.Any() || property.Type.HasCustomModifiers();
+                    return property.TypeCustomModifiers.Any() || property.Type.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds:false);
                 case SymbolKind.Event:
                     EventSymbol @event = (EventSymbol)member;
-                    return @event.Type.HasCustomModifiers(); //can't have custom modifiers on (vs in) type
+                    return @event.Type.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds:false); //can't have custom modifiers on (vs in) type
                 default:
                     throw ExceptionUtilities.UnexpectedValue(member.Kind);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -229,9 +229,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Hash.Combine(current, indirections);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
-            return this.Equals(t2 as PointerTypeSymbol, ignoreCustomModifiers, ignoreDynamic);
+            return this.Equals(t2 as PointerTypeSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
         }
 
         internal bool Equals(PointerTypeSymbol other)
@@ -239,19 +239,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return this.Equals(other, false, false);
         }
 
-        private bool Equals(PointerTypeSymbol other, bool ignoreCustomModifiers, bool ignoreDynamic)
+        private bool Equals(PointerTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            if ((object)other == null || !other._pointedAtType.Equals(_pointedAtType, ignoreCustomModifiers, ignoreDynamic))
+            if ((object)other == null || !other._pointedAtType.Equals(_pointedAtType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
             {
                 return false;
             }
 
-            if (!ignoreCustomModifiers)
+            if (!ignoreCustomModifiersAndArraySizesAndLowerBounds)
             {
                 // Make sure custom modifiers are the same.
                 var mod = this.CustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -681,7 +681,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                     return ArrayTypeSymbol.CreateSZArray(this.RetargetingAssembly, newElement, newModifiers);
                 }
 
-                return ArrayTypeSymbol.CreateMDArray(this.RetargetingAssembly, newElement, type.Rank, newModifiers);
+                return ArrayTypeSymbol.CreateMDArray(this.RetargetingAssembly, newElement, type.Rank, type.Sizes, type.LowerBounds, newModifiers);
             }
 
             internal ImmutableArray<CustomModifier> RetargetModifiers(ImmutableArray<CustomModifier> oldModifiers, out bool modifiersHaveChanged)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _ordinal; }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             if (ReferenceEquals(this, t2))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // we want to retain the original (incorrect) return type to avoid hiding the return type
             // given in source.
             TypeSymbol returnTypeWithCustomModifiers = constructedSourceMethod.ReturnType;
-            if (returnType.Equals(returnTypeWithCustomModifiers, ignoreCustomModifiers: true, ignoreDynamic: true))
+            if (returnType.Equals(returnTypeWithCustomModifiers, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
             {
                 returnType = CopyTypeCustomModifiers(returnTypeWithCustomModifiers, returnType, RefKind.None, destinationMethod.ContainingAssembly);
             }
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <returns><paramref name="destinationType"/> with custom modifiers copied from <paramref name="sourceType"/>.</returns>
         internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, RefKind refKind, AssemblySymbol containingAssembly)
         {
-            Debug.Assert(sourceType.Equals(destinationType, ignoreCustomModifiers: true, ignoreDynamic: true));
+            Debug.Assert(sourceType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
 
             // NOTE: overrides can differ by object/dynamic.  If they do, we'll need to tweak newType before
             // we can use it in place of this.Type.  We do so by computing the dynamic transform flags that
@@ -69,8 +69,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.Encode(destinationType, customModifierCount, refKind);
             TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 
-            Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiers: false, ignoreDynamic: true)); // Same custom modifiers as source type.
-            Debug.Assert(resultType.Equals(destinationType, ignoreCustomModifiers: true, ignoreDynamic: false)); // Same object/dynamic as destination type.
+            Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true)); // Same custom modifiers as source type.
+            Debug.Assert(resultType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false)); // Same object/dynamic as destination type.
 
             return resultType;
         }
@@ -91,8 +91,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SourceParameterSymbolBase destinationParameter = (SourceParameterSymbolBase)destinationParameters[i];
                 ParameterSymbol sourceParameter = sourceParameters[i];
 
-                if (sourceParameter.CustomModifiers.Any() || sourceParameter.Type.HasCustomModifiers() ||
-                    destinationParameter.CustomModifiers.Any() || destinationParameter.Type.HasCustomModifiers() || // Could happen if the associated property has custom modifiers.
+                if (sourceParameter.CustomModifiers.Any() || sourceParameter.Type.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds:true) ||
+                    destinationParameter.CustomModifiers.Any() || destinationParameter.Type.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds:true) || // Could happen if the associated property has custom modifiers.
                     (alsoCopyParamsModifier && (sourceParameter.IsParams != destinationParameter.IsParams)))
                 {
                     if (builder == null)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         // These object are unique (per index).
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We do an extra check before copying the type to handle the case where the overriding
             // event (incorrectly) has a different type than the overridden event.  In such cases,
             // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-            if (type.Equals(overriddenEventType, ignoreCustomModifiers: true, ignoreDynamic: false))
+            if (type.Equals(overriddenEventType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false))
             {
                 type = overriddenEventType;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1894,13 +1894,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int p = 0; p < op1.ParameterCount; ++p)
             {
-                if (!op1.ParameterTypes[p].Equals(op2.ParameterTypes[p], ignoreCustomModifiers: true, ignoreDynamic: true))
+                if (!op1.ParameterTypes[p].Equals(op2.ParameterTypes[p], ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
                 {
                     return false;
                 }
             }
 
-            if (!op1.ReturnType.Equals(op2.ReturnType, ignoreCustomModifiers: true, ignoreDynamic: true))
+            if (!op1.ReturnType.Equals(op2.ReturnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
             {
                 return false;
             }
@@ -2563,7 +2563,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var propertyParamType = ((i == numParams - 1) && !getNotSet) ? propertySymbol.Type : propertyParams[i].Type;
-                if (!propertyParamType.Equals(methodParam.Type, ignoreCustomModifiers: true, ignoreDynamic: true))
+                if (!propertyParamType.Equals(methodParam.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
                 {
                     return false;
                 }
@@ -2581,7 +2581,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return
                 methodParams.Length == 1 &&
                 methodParams[0].RefKind == RefKind.None &&
-                eventSymbol.Type.Equals(methodParams[0].Type, ignoreCustomModifiers: true, ignoreDynamic: true);
+                eventSymbol.Type.Equals(methodParams[0].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true);
         }
 
         private void AddEnumMembers(MembersAndInitializersBuilder result, EnumDeclarationSyntax syntax, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -699,7 +699,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             TypeSymbol overriddenMemberType = overriddenProperty.Type;
 
                             // Ignore custom modifiers because this diagnostic is based on the C# semantics.
-                            if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiers: true, ignoreDynamic: true))
+                            if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
                             {
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType);
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
@@ -736,7 +736,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             TypeSymbol overriddenMemberType = overriddenEvent.Type;
 
                             // Ignore custom modifiers because this diagnostic is based on the C# semantics.
-                            if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiers: true, ignoreDynamic: true))
+                            if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
                             {
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType);
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // We do an extra check before copying the type to handle the case where the overriding
                     // property (incorrectly) has a different type than the overridden property.  In such cases,
                     // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-                    if (_lazyType.Equals(overriddenPropertyType, ignoreCustomModifiers: true, ignoreDynamic: false))
+                    if (_lazyType.Equals(overriddenPropertyType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false))
                     {
                         _lazyType = overriddenPropertyType;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -21,17 +21,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public SynthesizedIntrinsicOperatorSymbol(TypeSymbol leftType, string name, TypeSymbol rightType, TypeSymbol returnType, bool isCheckedBuiltin)
         {
-            if (leftType.Equals(rightType, ignoreCustomModifiers: true))
+            if (leftType.Equals(rightType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true))
             {
                 _containingType = leftType;
             }
-            else if (rightType.Equals(returnType, ignoreCustomModifiers: true))
+            else if (rightType.Equals(returnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true))
             {
                 _containingType = rightType;
             }
             else
             {
-                Debug.Assert(leftType.Equals(returnType, ignoreCustomModifiers: true));
+                Debug.Assert(leftType.Equals(returnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
                 _containingType = leftType;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -493,9 +493,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
-            return this.Equals(t2 as TypeParameterSymbol, ignoreCustomModifiers, ignoreDynamic);
+            return this.Equals(t2 as TypeParameterSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
         }
 
         internal bool Equals(TypeParameterSymbol other)
@@ -503,7 +503,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Equals(other, false, false);
         }
 
-        private bool Equals(TypeParameterSymbol other, bool ignoreCustomModifiers, bool ignoreDynamic)
+        private bool Equals(TypeParameterSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             if (ReferenceEquals(this, other))
             {
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Type parameters may be equal but not reference equal due to independent alpha renamings.
-            return other.ContainingSymbol.ContainingType.Equals(this.ContainingSymbol.ContainingType, ignoreCustomModifiers, ignoreDynamic);
+            return other.ContainingSymbol.ContainingType.Equals(this.ContainingSymbol.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// A comparator that treats dynamic and object as "the same" types.
         /// </summary>
-        internal static readonly EqualityComparer<TypeSymbol> EqualsIgnoringDynamicComparer = new EqualsIgnoringComparer(ignoreDynamic: true, ignoreCustomModifiers: false);
+        internal static readonly EqualityComparer<TypeSymbol> EqualsIgnoringDynamicComparer = new EqualsIgnoringComparer(ignoreDynamic: true, ignoreCustomModifiersAndArraySizesAndLowerBounds: false);
 
         /// <summary>
         /// The original definition of this symbol. If this symbol is constructed from another
@@ -296,10 +296,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// semantics.
         /// </summary>
         /// <param name="t2">The other type.</param>
-        /// <param name="ignoreCustomModifiers">True to compare without regard to custom modifiers, false by default.</param>
+        /// <param name="ignoreCustomModifiersAndArraySizesAndLowerBounds">True to compare without regard to custom modifiers, false by default.</param>
         /// <param name="ignoreDynamic">True to ignore the distinction between object and dynamic, false by default.</param>
         /// <returns>True if the types are equivalent.</returns>
-        internal virtual bool Equals(TypeSymbol t2, bool ignoreCustomModifiers = false, bool ignoreDynamic = false)
+        internal virtual bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds = false, bool ignoreDynamic = false)
         {
             return ReferenceEquals(this, t2);
         }
@@ -322,12 +322,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private sealed class EqualsIgnoringComparer : EqualityComparer<TypeSymbol>
         {
-            private readonly bool _ignoreDynamic, _ignoreCustomModifiers;
+            private readonly bool _ignoreDynamic, _ignoreCustomModifiersAndArraySizesAndLowerBounds;
 
-            public EqualsIgnoringComparer(bool ignoreDynamic, bool ignoreCustomModifiers)
+            public EqualsIgnoringComparer(bool ignoreDynamic, bool ignoreCustomModifiersAndArraySizesAndLowerBounds)
             {
                 _ignoreDynamic = ignoreDynamic;
-                _ignoreCustomModifiers = ignoreCustomModifiers;
+                _ignoreCustomModifiersAndArraySizesAndLowerBounds = ignoreCustomModifiersAndArraySizesAndLowerBounds;
             }
 
             public override int GetHashCode(TypeSymbol obj)
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return
                     (object)x == null ? (object)y == null :
-                    x.Equals(y, ignoreCustomModifiers: _ignoreCustomModifiers, ignoreDynamic: _ignoreDynamic);
+                    x.Equals(y, ignoreCustomModifiersAndArraySizesAndLowerBounds: _ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic: _ignoreDynamic);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
         {
             if ((object)t2 == (object)this)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// A much less efficient implementation would be CustomModifierCount() == 0.
         /// CONSIDER: Could share a backing method with CustomModifierCount.
         /// </remarks>
-        public static bool HasCustomModifiers(this TypeSymbol type)
+        public static bool HasCustomModifiers(this TypeSymbol type, bool flagNonDefaultArraySizesOrLowerBounds)
         {
             if ((object)type == null)
             {
@@ -98,12 +98,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.ArrayType:
                     {
                         var array = (ArrayTypeSymbol)type;
-                        return array.CustomModifiers.Any() || array.ElementType.HasCustomModifiers();
+                        return array.CustomModifiers.Any() || array.ElementType.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds) || 
+                               (flagNonDefaultArraySizesOrLowerBounds && !array.HasDefaultSizesAndLowerBounds);
                     }
                 case SymbolKind.PointerType:
                     {
                         var pointer = (PointerTypeSymbol)type;
-                        return pointer.CustomModifiers.Any() || pointer.PointedAtType.HasCustomModifiers();
+                        return pointer.CustomModifiers.Any() || pointer.PointedAtType.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds);
                     }
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
@@ -124,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                                 foreach (TypeSymbol typeArg in typeArgs)
                                 {
-                                    if (typeArg.HasCustomModifiers())
+                                    if (typeArg.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds))
                                     {
                                         return true;
                                     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MultiDimensionalArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MultiDimensionalArrayTests.cs
@@ -734,5 +734,691 @@ System.Double
                 );
         }
 
+        [WorkItem(4954, "https://github.com/dotnet/roslyn/issues/4954")]
+        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        public void SizesAndLowerBounds_01()
+        {
+            var ilSource = @"
+.class public auto ansi beforefieldinit Test
+       extends [mscorlib]System.Object
+{
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method Test1::.ctor
+
+    .method public hidebysig newslot virtual 
+            instance float64[,] Test1() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test1""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[...,] Test2() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test2""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[...,...] Test3() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test3""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,] Test4() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test4""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,...] Test5() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test5""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,5] Test6() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test6""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,2...] Test7() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test7""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,2...8] Test8() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test8""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,] Test9() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test9""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,...] Test10() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test10""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,5] Test11() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test11""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,2...] Test12() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test12""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,2...8] Test13() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test13""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...,] Test14() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test14""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...,...] Test15() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test15""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...,2...] Test16() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test16""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+} // end of class Test
+";
+
+            var source =
+@"class C : Test
+{
+    static void Main()
+    {
+        double[,] a;
+
+        var t = new Test();
+        a = t.Test1();
+        a = t.Test2();
+        a = t.Test3();
+        a = t.Test4();
+        a = t.Test5();
+        a = t.Test6();
+        a = t.Test7();
+        a = t.Test8();
+        a = t.Test9();
+        a = t.Test10();
+        a = t.Test11();
+        a = t.Test12();
+        a = t.Test13();
+        a = t.Test14();
+        a = t.Test15();
+        a = t.Test16();
+
+        t = new C();
+        a = t.Test1();
+        a = t.Test2();
+        a = t.Test3();
+        a = t.Test4();
+        a = t.Test5();
+        a = t.Test6();
+        a = t.Test7();
+        a = t.Test8();
+        a = t.Test9();
+        a = t.Test10();
+        a = t.Test11();
+        a = t.Test12();
+        a = t.Test13();
+        a = t.Test14();
+        a = t.Test15();
+        a = t.Test16();
+    }
+
+    public override double[,] Test1()
+    {
+        System.Console.WriteLine(""Overriden 1"");
+        return null;
+    }
+    public override double[,] Test2()
+    {
+        System.Console.WriteLine(""Overriden 2"");
+        return null;
+    }
+    public override double[,] Test3()
+    {
+        System.Console.WriteLine(""Overriden 3"");
+        return null;
+    }
+    public override double[,] Test4()
+    {
+        System.Console.WriteLine(""Overriden 4"");
+        return null;
+    }
+    public override double[,] Test5()
+    {
+        System.Console.WriteLine(""Overriden 5"");
+        return null;
+    }
+    public override double[,] Test6()
+    {
+        System.Console.WriteLine(""Overriden 6"");
+        return null;
+    }
+    public override double[,] Test7()
+    {
+        System.Console.WriteLine(""Overriden 7"");
+        return null;
+    }
+    public override double[,] Test8()
+    {
+        System.Console.WriteLine(""Overriden 8"");
+        return null;
+    }
+    public override double[,] Test9()
+    {
+        System.Console.WriteLine(""Overriden 9"");
+        return null;
+    }
+    public override double[,] Test10()
+    {
+        System.Console.WriteLine(""Overriden 10"");
+        return null;
+    }
+    public override double[,] Test11()
+    {
+        System.Console.WriteLine(""Overriden 11"");
+        return null;
+    }
+    public override double[,] Test12()
+    {
+        System.Console.WriteLine(""Overriden 12"");
+        return null;
+    }
+    public override double[,] Test13()
+    {
+        System.Console.WriteLine(""Overriden 13"");
+        return null;
+    }
+    public override double[,] Test14()
+    {
+        System.Console.WriteLine(""Overriden 14"");
+        return null;
+    }
+    public override double[,] Test15()
+    {
+        System.Console.WriteLine(""Overriden 15"");
+        return null;
+    }
+    public override double[,] Test16()
+    {
+        System.Console.WriteLine(""Overriden 16"");
+        return null;
+    }
+}
+";
+            var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput:
+@"Test1
+Test2
+Test3
+Test4
+Test5
+Test6
+Test7
+Test8
+Test9
+Test10
+Test11
+Test12
+Test13
+Test14
+Test15
+Test16
+Overriden 1
+Overriden 2
+Overriden 3
+Overriden 4
+Overriden 5
+Overriden 6
+Overriden 7
+Overriden 8
+Overriden 9
+Overriden 10
+Overriden 11
+Overriden 12
+Overriden 13
+Overriden 14
+Overriden 15
+Overriden 16
+");
+        }
+
+        [WorkItem(4954, "https://github.com/dotnet/roslyn/issues/4954")]
+        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        public void SizesAndLowerBounds_02()
+        {
+            var ilSource = @"
+.class public auto ansi beforefieldinit Test
+       extends [mscorlib]System.Object
+{
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method Test1::.ctor
+
+    .method public hidebysig newslot virtual 
+            instance void Test1(float64[,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test1""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test2(float64[...,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test2""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test3(float64[...,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test3""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test4(float64[5,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test4""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test5(float64[5,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test5""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test6(float64[5,5] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test6""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test7(float64[5,2...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test7""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test8(float64[5,2...8] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test8""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test9(float64[1...5,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test9""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test10(float64[1...5,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test10""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test11(float64[1...5,5] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test11""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test12(float64[1...5,2...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test12""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test13(float64[1...5,2...8] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test13""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test14(float64[1...,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test14""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test15(float64[1...,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test15""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test16(float64[1...,2...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      ""Test16""
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+} // end of class Test
+";
+
+            var source =
+@"class C : Test
+{
+    static void Main()
+    {
+        double[,] a = new double [,] {};
+
+        var t = new Test();
+        t.Test1(a);
+        t.Test2(a);
+        t.Test3(a);
+        t.Test4(a);
+        t.Test5(a);
+        t.Test6(a);
+        t.Test7(a);
+        t.Test8(a);
+        t.Test9(a);
+        t.Test10(a);
+        t.Test11(a);
+        t.Test12(a);
+        t.Test13(a);
+        t.Test14(a);
+        t.Test15(a);
+        t.Test16(a);
+
+        t = new C();
+        t.Test1(a);
+        t.Test2(a);
+        t.Test3(a);
+        t.Test4(a);
+        t.Test5(a);
+        t.Test6(a);
+        t.Test7(a);
+        t.Test8(a);
+        t.Test9(a);
+        t.Test10(a);
+        t.Test11(a);
+        t.Test12(a);
+        t.Test13(a);
+        t.Test14(a);
+        t.Test15(a);
+        t.Test16(a);
+    }
+
+    public override void Test1(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 1"");
+    }
+    public override void Test2(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 2"");
+    }
+    public override void Test3(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 3"");
+    }
+    public override void Test4(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 4"");
+    }
+    public override void Test5(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 5"");
+    }
+    public override void Test6(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 6"");
+    }
+    public override void Test7(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 7"");
+    }
+    public override void Test8(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 8"");
+    }
+    public override void Test9(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 9"");
+    }
+    public override void Test10(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 10"");
+    }
+    public override void Test11(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 11"");
+    }
+    public override void Test12(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 12"");
+    }
+    public override void Test13(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 13"");
+    }
+    public override void Test14(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 14"");
+    }
+    public override void Test15(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 15"");
+    }
+    public override void Test16(double[,] x)
+    {
+        System.Console.WriteLine(""Overriden 16"");
+    }
+}
+";
+            var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput:
+@"Test1
+Test2
+Test3
+Test4
+Test5
+Test6
+Test7
+Test8
+Test9
+Test10
+Test11
+Test12
+Test13
+Test14
+Test15
+Test16
+Overriden 1
+Overriden 2
+Overriden 3
+Overriden 4
+Overriden 5
+Overriden 6
+Overriden 7
+Overriden 8
+Overriden 9
+Overriden 10
+Overriden 11
+Overriden 12
+Overriden 13
+Overriden 14
+Overriden 15
+Overriden 16
+");
+        }
+
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -240,41 +240,41 @@ class X {
             string s = f7Type.ToTestDisplayString();
 
             Assert.False(f1Type.Equals(f2Type));
-            Assert.True(f1Type.Equals(f2Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f2Type.Equals(f1Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f1Type.Equals(f1Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f2Type.Equals(f2Type, ignoreCustomModifiers: true, ignoreDynamic: true));
+            Assert.True(f1Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f2Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f1Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f2Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
 
             Assert.False(f3Type.Equals(f4Type));
-            Assert.True(f3Type.Equals(f4Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f4Type.Equals(f3Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.False(f4Type.Equals(f5Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.False(f5Type.Equals(f4Type, ignoreCustomModifiers: true, ignoreDynamic: true));
+            Assert.True(f3Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f4Type.Equals(f3Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.False(f4Type.Equals(f5Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.False(f5Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
 
             Assert.False(f6Type.Equals(f7Type));
             Assert.False(f6Type.Equals(f8Type));
             Assert.False(f7Type.Equals(f8Type));
-            Assert.True(f6Type.Equals(f7Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f6Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f7Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f8Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f6Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f6Type.Equals(f8Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiers: true, ignoreDynamic: true));
+            Assert.True(f6Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f7Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f8Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f7Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f8Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f6Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
 
-            Assert.False(f9Type.Equals(f10Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.False(f10Type.Equals(f9Type, ignoreCustomModifiers: true, ignoreDynamic: true));
+            Assert.False(f9Type.Equals(f10Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.False(f10Type.Equals(f9Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
 
             Assert.False(g1Type.Equals(g2Type));
-            Assert.True(g1Type.Equals(g2Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(g2Type.Equals(g1Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(g1Type.Equals(g1Type, ignoreCustomModifiers: true, ignoreDynamic: true));
-            Assert.True(g2Type.Equals(g2Type, ignoreCustomModifiers: true, ignoreDynamic: true));
+            Assert.True(g1Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(g2Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(g1Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(g2Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
         }
 
         /// <summary>
@@ -306,7 +306,7 @@ class C
             var interfaceI3 = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("I3");
             var typeIntArrayWithCustomModifiers = interfaceI3.GetMember<MethodSymbol>("M1").Parameters.Single().Type;
 
-            Assert.True(typeIntArrayWithCustomModifiers.HasCustomModifiers());
+            Assert.True(typeIntArrayWithCustomModifiers.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds:false));
 
             var conv = new BuckStopsHereBinder(compilation).Conversions;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -187,7 +187,7 @@ class CL3
             var withoutModifiers = withModifiers.OriginalDefinition.Construct(withModifiers.TypeArguments);
             Assert.True(withModifiers.HasTypeArgumentsCustomModifiers);
             Assert.False(withoutModifiers.HasTypeArgumentsCustomModifiers);
-            Assert.True(withoutModifiers.Equals(withModifiers, ignoreCustomModifiers:true));
+            Assert.True(withoutModifiers.Equals(withModifiers, ignoreCustomModifiersAndArraySizesAndLowerBounds:true));
             Assert.NotEqual(withoutModifiers, withModifiers);
 
             CompileAndVerify(compilation, expectedOutput: "Overriden");
@@ -799,11 +799,11 @@ class Module1
 
             Assert.True(base1.HasTypeArgumentsCustomModifiers);
             Assert.True(base2.HasTypeArgumentsCustomModifiers);
-            Assert.True(base1.Equals(base2, ignoreCustomModifiers:true));
+            Assert.True(base1.Equals(base2, ignoreCustomModifiersAndArraySizesAndLowerBounds:true));
             Assert.NotEqual(base1, base2);
 
             Assert.True(base3.HasTypeArgumentsCustomModifiers);
-            Assert.True(base1.Equals(base3, ignoreCustomModifiers: true));
+            Assert.True(base1.Equals(base3, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
             Assert.Equal(base1, base3);
             Assert.NotSame(base1, base3);
         }

--- a/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
@@ -17,7 +17,8 @@ namespace Microsoft.CodeAnalysis
         internal abstract TypeSymbol MakeUnboundIfGeneric(ModuleSymbol moduleSymbol, TypeSymbol type);
 
         internal abstract TypeSymbol GetSZArrayTypeSymbol(ModuleSymbol moduleSymbol, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers);
-        internal abstract TypeSymbol GetMDArrayTypeSymbol(ModuleSymbol moduleSymbol, int rank, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers);
+        internal abstract TypeSymbol GetMDArrayTypeSymbol(ModuleSymbol moduleSymbol, int rank, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers,
+                                                          ImmutableArray<int> sizes, ImmutableArray<int> lowerBounds);
 
         /// <summary>
         /// Produce constructed type symbol.

--- a/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
@@ -62,9 +62,9 @@ namespace Microsoft.CodeAnalysis
             return _factory.GetSZArrayTypeSymbol(this.moduleSymbol, elementType, customModifiers);
         }
 
-        protected TypeSymbol GetMDArrayTypeSymbol(int rank, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers)
+        protected TypeSymbol GetMDArrayTypeSymbol(int rank, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers, ImmutableArray<int> sizes, ImmutableArray<int> lowerBounds)
         {
-            return _factory.GetMDArrayTypeSymbol(this.moduleSymbol, rank, elementType, customModifiers);
+            return _factory.GetMDArrayTypeSymbol(this.moduleSymbol, rank, elementType, customModifiers, sizes, lowerBounds);
         }
 
         protected TypeSymbol GetByRefReturnTypeSymbol(TypeSymbol referencedType, ushort countOfCustomModifiersPrecedingByRef)
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis
                     Debug.Assert(rank > 0);
                     container = rank == 1 ? 
                                 GetSZArrayTypeSymbol(container, default(ImmutableArray<ModifierInfo<TypeSymbol>>)) : 
-                                GetMDArrayTypeSymbol(rank, container, default(ImmutableArray<ModifierInfo<TypeSymbol>>));
+                                GetMDArrayTypeSymbol(rank, container, default(ImmutableArray<ModifierInfo<TypeSymbol>>), ImmutableArray<int>.Empty, default(ImmutableArray<int>));
                 }
             }
 

--- a/src/Compilers/VisualBasic/Portable/Emit/ArrayTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ArrayTypeSymbolAdapter.vb
@@ -29,7 +29,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IArrayTypeReferenceLowerBounds As IEnumerable(Of Integer) Implements Cci.IArrayTypeReference.LowerBounds
             Get
-                Return Linq.Enumerable.Repeat(0, Me.Rank)
+                Dim lowerBounds = Me.LowerBounds
+
+                If lowerBounds.IsDefault Then
+                    Return Linq.Enumerable.Repeat(0, Me.Rank)
+                End If
+
+                Return lowerBounds
             End Get
         End Property
 
@@ -41,9 +47,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IArrayTypeReferenceSizes As IEnumerable(Of ULong) Implements Cci.IArrayTypeReference.Sizes
             Get
-                Return SpecializedCollections.EmptyEnumerable(Of ULong)()
+                If Me.Sizes.IsEmpty Then
+                    Return SpecializedCollections.EmptyEnumerable(Of ULong)()
+                End If
+
+                Return GetSizes()
             End Get
         End Property
+
+        Private Iterator Function GetSizes() As IEnumerable(Of ULong)
+            For Each size In Me.Sizes
+                Yield CType(size, ULong)
+            Next
+        End Function
 
         Private ReadOnly Property ITypeReferenceIsEnum As Boolean Implements Cci.ITypeReference.IsEnum
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -295,7 +295,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                     Return ArrayTypeSymbol.CreateSZArray(otherElementType, otherModifiers, Me._otherAssembly)
                 End If
 
-                Return ArrayTypeSymbol.CreateMDArray(otherElementType, otherModifiers, symbol.Rank, Me._otherAssembly)
+                Return ArrayTypeSymbol.CreateMDArray(otherElementType, otherModifiers, symbol.Rank, symbol.Sizes, symbol.LowerBounds, Me._otherAssembly)
             End Function
 
             Public Overrides Function VisitEvent(symbol As EventSymbol) As Symbol
@@ -641,7 +641,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                     Return ArrayTypeSymbol.CreateSZArray(translatedElementType, translatedModifiers, symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly)
                 End If
 
-                Return ArrayTypeSymbol.CreateMDArray(translatedElementType, translatedModifiers, symbol.Rank, symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly)
+                Return ArrayTypeSymbol.CreateMDArray(translatedElementType, translatedModifiers, symbol.Rank, symbol.Sizes, symbol.LowerBounds, symbol.BaseTypeNoUseSiteDiagnostics.ContainingAssembly)
             End Function
 
             Public Overrides Function VisitNamedType(type As NamedTypeSymbol) As Symbol

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -4338,6 +4338,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Friend Overrides ReadOnly Property HasDefaultSizesAndLowerBounds As Boolean
+            Get
+                Return _arrayLiteral.InferredType.HasDefaultSizesAndLowerBounds
+            End Get
+        End Property
+
         Friend Overrides ReadOnly Property InterfacesNoUseSiteDiagnostics As ImmutableArray(Of NamedTypeSymbol)
             Get
                 Return _arrayLiteral.InferredType.InterfacesNoUseSiteDiagnostics

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
@@ -10,7 +10,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Friend Shared ReadOnly Instance As New SymbolFactory()
 
-        Friend Overrides Function GetMDArrayTypeSymbol(moduleSymbol As PEModuleSymbol, rank As Integer, elementType As TypeSymbol, customModifiers As ImmutableArray(Of ModifierInfo(Of TypeSymbol))) As TypeSymbol
+        Friend Overrides Function GetMDArrayTypeSymbol(
+            moduleSymbol As PEModuleSymbol,
+            rank As Integer,
+            elementType As TypeSymbol,
+            customModifiers As ImmutableArray(Of ModifierInfo(Of TypeSymbol)),
+            sizes As ImmutableArray(Of Integer),
+            lowerBounds As ImmutableArray(Of Integer)
+        ) As TypeSymbol
             If TypeOf elementType Is UnsupportedMetadataTypeSymbol Then
                 Return elementType
             End If
@@ -18,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return ArrayTypeSymbol.CreateMDArray(
                             elementType,
                             VisualBasicCustomModifier.Convert(customModifiers),
-                            rank, moduleSymbol.ContainingAssembly)
+                            rank, sizes, lowerBounds, moduleSymbol.ContainingAssembly)
         End Function
 
         Friend Overrides Function GetByRefReturnTypeSymbol(moduleSymbol As PEModuleSymbol, referencedType As TypeSymbol, countOfCustomModifiersPrecedingByRef As UShort) As TypeSymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -583,7 +583,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                     Return ArrayTypeSymbol.CreateSZArray(newElement, newModifiers, RetargetingAssembly)
                 End If
 
-                Return ArrayTypeSymbol.CreateMDArray(newElement, newModifiers, type.Rank, RetargetingAssembly)
+                Return ArrayTypeSymbol.CreateMDArray(newElement, newModifiers, type.Rank, type.Sizes, type.LowerBounds, RetargetingAssembly)
             End Function
 
             Friend Function RetargetModifiers(oldModifiers As ImmutableArray(Of CustomModifier), ByRef modifiersHaveChanged As Boolean) As ImmutableArray(Of CustomModifier)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/MultiDimensionalTest.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/MultiDimensionalTest.vb
@@ -1781,5 +1781,670 @@ System.Int32
 ]]>)
         End Sub
 
+        <WorkItem(4954, "https://github.com/dotnet/roslyn/issues/4954")>
+        <ClrOnlyFact(ClrOnlyReason.Ilasm)>
+        Public Sub SizesAndLowerBounds_01()
+
+            Dim ilSource As String =
+            <![CDATA[
+.class public auto ansi beforefieldinit Test
+       extends [mscorlib]System.Object
+{
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method Test1::.ctor
+
+    .method public hidebysig newslot virtual 
+            instance float64[,] Test1() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test1"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[...,] Test2() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test2"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[...,...] Test3() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test3"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,] Test4() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test4"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,...] Test5() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test5"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,5] Test6() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test6"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,2...] Test7() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test7"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[5,2...8] Test8() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test8"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,] Test9() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test9"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,...] Test10() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test10"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,5] Test11() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test11"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,2...] Test12() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test12"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...5,2...8] Test13() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test13"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...,] Test14() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test14"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...,...] Test15() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test15"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance float64[1...,2...] Test16() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test16"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_0007:  ldnull
+      IL_000a:  ret
+    } 
+} // end of class Test
+]]>.Value
+
+            Dim source =
+<compilation>
+    <file name="a.vb">
+class C 
+    Inherits Test
+
+    Shared Sub Main()
+        Dim a As double(,)
+
+        Dim t = new Test()
+        a = t.Test1()
+        a = t.Test2()
+        a = t.Test3()
+        a = t.Test4()
+        a = t.Test5()
+        a = t.Test6()
+        a = t.Test7()
+        a = t.Test8()
+        a = t.Test9()
+        a = t.Test10()
+        a = t.Test11()
+        a = t.Test12()
+        a = t.Test13()
+        a = t.Test14()
+        a = t.Test15()
+        a = t.Test16()
+
+        t = new C()
+        a = t.Test1()
+        a = t.Test2()
+        a = t.Test3()
+        a = t.Test4()
+        a = t.Test5()
+        a = t.Test6()
+        a = t.Test7()
+        a = t.Test8()
+        a = t.Test9()
+        a = t.Test10()
+        a = t.Test11()
+        a = t.Test12()
+        a = t.Test13()
+        a = t.Test14()
+        a = t.Test15()
+        a = t.Test16()
+    End Sub
+
+    public overrides Function Test1() As Double(,)
+        System.Console.WriteLine("Overriden 1")
+        return Nothing
+    End Function
+    public overrides Function Test2() As Double(,)
+        System.Console.WriteLine("Overriden 2")
+        return Nothing
+    End Function
+    public overrides Function Test3() As Double(,)
+        System.Console.WriteLine("Overriden 3")
+        return Nothing
+    End Function
+    public overrides Function Test4() As Double(,)
+        System.Console.WriteLine("Overriden 4")
+        return Nothing
+    End Function
+    public overrides Function Test5() As Double(,)
+        System.Console.WriteLine("Overriden 5")
+        return Nothing
+    End Function
+    public overrides Function Test6() As Double(,)
+        System.Console.WriteLine("Overriden 6")
+        return Nothing
+    End Function
+    public overrides Function Test7() As Double(,)
+        System.Console.WriteLine("Overriden 7")
+        return Nothing
+    End Function
+    public overrides Function Test8() As Double(,)
+        System.Console.WriteLine("Overriden 8")
+        return Nothing
+    End Function
+    public overrides Function Test9() As Double(,)
+        System.Console.WriteLine("Overriden 9")
+        return Nothing
+    End Function
+    public overrides Function Test10() As Double(,)
+        System.Console.WriteLine("Overriden 10")
+        return Nothing
+    End Function
+    public overrides Function Test11() As Double(,)
+        System.Console.WriteLine("Overriden 11")
+        return Nothing
+    End Function
+    public overrides Function Test12() As Double(,)
+        System.Console.WriteLine("Overriden 12")
+        return Nothing
+    End Function
+    public overrides Function Test13() As Double(,)
+        System.Console.WriteLine("Overriden 13")
+        return Nothing
+    End Function
+    public overrides Function Test14() As Double(,)
+        System.Console.WriteLine("Overriden 14")
+        return Nothing
+    End Function
+    public overrides Function Test15() As Double(,)
+        System.Console.WriteLine("Overriden 15")
+        return Nothing
+    End Function
+    public overrides Function Test16() As Double(,)
+        System.Console.WriteLine("Overriden 16")
+        return Nothing
+    End Function
+End Class
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilationWithCustomILSource(source, ilSource, options:=TestOptions.ReleaseExe)
+            Dim verifier = CompileAndVerify(compilation, expectedOutput:=
+            <![CDATA[Test1
+Test2
+Test3
+Test4
+Test5
+Test6
+Test7
+Test8
+Test9
+Test10
+Test11
+Test12
+Test13
+Test14
+Test15
+Test16
+Overriden 1
+Overriden 2
+Overriden 3
+Overriden 4
+Overriden 5
+Overriden 6
+Overriden 7
+Overriden 8
+Overriden 9
+Overriden 10
+Overriden 11
+Overriden 12
+Overriden 13
+Overriden 14
+Overriden 15
+Overriden 16
+]]>)
+        End Sub
+
+        <WorkItem(4954, "https://github.com/dotnet/roslyn/issues/4954")>
+        <ClrOnlyFact(ClrOnlyReason.Ilasm)>
+        Public Sub SizesAndLowerBounds_02()
+
+            Dim ilSource As String =
+            <![CDATA[
+.class public auto ansi beforefieldinit Test
+       extends [mscorlib]System.Object
+{
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method Test1::.ctor
+
+    .method public hidebysig newslot virtual 
+            instance void Test1(float64[,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test1"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test2(float64[...,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test2"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test3(float64[...,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test3"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test4(float64[5,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test4"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test5(float64[5,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test5"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test6(float64[5,5] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test6"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test7(float64[5,2...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test7"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test8(float64[5,2...8] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test8"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test9(float64[1...5,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test9"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test10(float64[1...5,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test10"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test11(float64[1...5,5] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test11"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test12(float64[1...5,2...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test12"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test13(float64[1...5,2...8] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test13"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test14(float64[1...,] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test14"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test15(float64[1...,...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test15"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+
+    .method public hidebysig newslot virtual 
+            instance void Test16(float64[1...,2...] x) cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  4
+      IL_0000:  ldstr      "Test16"
+      IL_0005:  call       void [mscorlib]System.Console::WriteLine(string)
+      IL_000a:  ret
+    } 
+} // end of class Test
+]]>.Value
+
+            Dim source =
+<compilation>
+    <file name="a.vb">
+Class C 
+    Inherits Test
+
+    Shared Sub Main()
+    
+        Dim a As double(,) = New Double(,) {}
+
+        Dim t = new Test()
+        t.Test1(a)
+        t.Test2(a)
+        t.Test3(a)
+        t.Test4(a)
+        t.Test5(a)
+        t.Test6(a)
+        t.Test7(a)
+        t.Test8(a)
+        t.Test9(a)
+        t.Test10(a)
+        t.Test11(a)
+        t.Test12(a)
+        t.Test13(a)
+        t.Test14(a)
+        t.Test15(a)
+        t.Test16(a)
+
+        t = new C()
+        t.Test1(a)
+        t.Test2(a)
+        t.Test3(a)
+        t.Test4(a)
+        t.Test5(a)
+        t.Test6(a)
+        t.Test7(a)
+        t.Test8(a)
+        t.Test9(a)
+        t.Test10(a)
+        t.Test11(a)
+        t.Test12(a)
+        t.Test13(a)
+        t.Test14(a)
+        t.Test15(a)
+        t.Test16(a)
+    End Sub
+
+    public overrides Sub Test1(x As double(,))
+        System.Console.WriteLine("Overriden 1")
+    End Sub
+    public overrides Sub Test2(x As double(,))
+        System.Console.WriteLine("Overriden 2")
+    End Sub
+    public overrides Sub Test3(x As double(,))
+        System.Console.WriteLine("Overriden 3")
+    End Sub
+    public overrides Sub Test4(x As double(,))
+        System.Console.WriteLine("Overriden 4")
+    End Sub
+    public overrides Sub Test5(x As double(,))
+        System.Console.WriteLine("Overriden 5")
+    End Sub
+    public overrides Sub Test6(x As double(,))
+        System.Console.WriteLine("Overriden 6")
+    End Sub
+    public overrides Sub Test7(x As double(,))
+        System.Console.WriteLine("Overriden 7")
+    End Sub
+    public overrides Sub Test8(x As double(,))
+        System.Console.WriteLine("Overriden 8")
+    End Sub
+    public overrides Sub Test9(x As double(,))
+        System.Console.WriteLine("Overriden 9")
+    End Sub
+    public overrides Sub Test10(x As double(,))
+        System.Console.WriteLine("Overriden 10")
+    End Sub
+    public overrides Sub Test11(x As double(,))
+        System.Console.WriteLine("Overriden 11")
+    End Sub
+    public overrides Sub Test12(x As double(,))
+        System.Console.WriteLine("Overriden 12")
+    End Sub
+    public overrides Sub Test13(x As double(,))
+        System.Console.WriteLine("Overriden 13")
+    End Sub
+    public overrides Sub Test14(x As double(,))
+        System.Console.WriteLine("Overriden 14")
+    End Sub
+    public overrides Sub Test15(x As double(,))
+        System.Console.WriteLine("Overriden 15")
+    End Sub
+    public overrides Sub Test16(x As double(,))
+        System.Console.WriteLine("Overriden 16")
+    End Sub
+End Class
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilationWithCustomILSource(source, ilSource, options:=TestOptions.ReleaseExe)
+            Dim verifier = CompileAndVerify(compilation, expectedOutput:=
+            <![CDATA[Test1
+Test2
+Test3
+Test4
+Test5
+Test6
+Test7
+Test8
+Test9
+Test10
+Test11
+Test12
+Test13
+Test14
+Test15
+Test16
+Overriden 1
+Overriden 2
+Overriden 3
+Overriden 4
+Overriden 5
+Overriden 6
+Overriden 7
+Overriden 8
+Overriden 9
+Overriden 10
+Overriden 11
+Overriden 12
+Overriden 13
+Overriden 14
+Overriden 15
+Overriden 16
+]]>)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #4954.

We will treat Sizes and LowerBounds similar to custom modifiers. They should match for the purpose
of signature comparison (overriding/implementing, etc), but shouldn't affect conversions.

@gafter, @VSadov, @jaredpar, @agocke Please review. Many files for C# compiler were modified due to simple parameter rename.   