### PR TITLE
Make NuGet sources more deterministic

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -9,6 +9,7 @@
     <add key="repositoryPath" value="../packages" />
   </config>
   <packageSources>
+    <clear />
     <add key="myget.org buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
     <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
Added a clear entry to our package sources to ensure builds on developer machines weren't inadvertently affected by local settings.