### PR TITLE
Add an (internal) overload to Rename to allow features to rename a subset of locations.

### DIFF
--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -232,9 +232,6 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 return solution;
             }
 
-            var locationsToIgnore = SpecializedCollections.EmptySet<TextSpan>();
-            var optionSet = document.Project.Solution.Workspace.Options;
-
             if (field.IsReadOnly)
             {
                 // Inside the constructor we want to rename references the field to the final field name.
@@ -251,9 +248,8 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 }
 
                 // Outside the constructor we want to rename references to the field to final property name.
-                solution = await Renamer.RenameSymbolAsync(solution, field, generatedPropertyName, solution.Workspace.Options,
+                return await Renamer.RenameSymbolAsync(solution, field, generatedPropertyName, solution.Workspace.Options,
                     location => !constructorSyntaxes.Any(c => c.Span.IntersectsWith(location.SourceSpan)), cancellationToken).ConfigureAwait(false);
-                return solution;
             }
             else
             {


### PR DESCRIPTION
Previously EncapsulateField was using internal implementation details of the rename API.  It did this so it could effectively perform two renames, one for one set of locations, and one for another.

I've augmented hte internal rename API to just allow features to filter what locations they want to update.

This cleanup was done because i also intend to use this API for the "Use auto property" feature.