### PR TITLE
Fix syntax associated with bound implicit return statement

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    block = FlowAnalysisPass.AppendImplicitReturn(block, lambdaSymbol, _unboundLambda.Syntax);
+                    block = FlowAnalysisPass.AppendImplicitReturn(block, lambdaSymbol);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -634,7 +634,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private bool CanHandleReturnLabel(BoundReturnStatement boundReturnStatement)
         {
             return boundReturnStatement.WasCompilerGenerated &&
-                    (boundReturnStatement.Syntax.Kind() == SyntaxKind.Block || (((object)_method != null) && _method.IsImplicitConstructor)) &&
+                    (boundReturnStatement.Syntax.IsKind(SyntaxKind.Block) || _method?.IsImplicitConstructor == true) &&
                     !_builder.InExceptionHandler;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -312,8 +312,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(this.ContainingType, frame);
                 CompilationState.AddSynthesizedMethod(
                     frame.Constructor,
-                    FlowAnalysisPass.AppendImplicitReturn(MethodCompiler.BindMethodBody(frame.Constructor, CompilationState, null),
-                    frame.Constructor));
+                    FlowAnalysisPass.AppendImplicitReturn(
+                        MethodCompiler.BindMethodBody(frame.Constructor, CompilationState, null),
+                        frame.Constructor));
             }
 
             return frame;
@@ -358,8 +359,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // add its ctor
                     CompilationState.AddSynthesizedMethod(
                         frame.Constructor,
-                        FlowAnalysisPass.AppendImplicitReturn(MethodCompiler.BindMethodBody(frame.Constructor, CompilationState, null),
-                        frame.Constructor));
+                        FlowAnalysisPass.AppendImplicitReturn(
+                            MethodCompiler.BindMethodBody(frame.Constructor, CompilationState, null),
+                            frame.Constructor));
 
                     // associate the frame with the first lambda that caused it to exist. 
                     // we need to associate this with some syntax.

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -1289,14 +1289,13 @@ class C
             // lambda body unchanged:
             diff1.VerifyIL("C.<>c.<F>b__2_0", @"
 {
-  // Code size       11 (0xb)
+  // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  nop
   IL_0001:  ldc.i4.1
   IL_0002:  call       ""void System.Console.WriteLine(int)""
   IL_0007:  nop
-  IL_0008:  br.s       IL_000a
-  IL_000a:  ret
+  IL_0008:  ret
 }");
 
             var diff2 = compilation2.EmitDifference(
@@ -1311,7 +1310,7 @@ class C
             // lambda body updated:
             diff2.VerifyIL("C.<>c.<F>b__2_0", @"
 {
-  // Code size       18 (0x12)
+  // Code size       16 (0x10)
   .maxstack  1
   IL_0000:  nop
   IL_0001:  ldc.i4.1
@@ -1320,8 +1319,7 @@ class C
   IL_0008:  ldc.i4.2
   IL_0009:  call       ""void System.Console.WriteLine(int)""
   IL_000e:  nop
-  IL_000f:  br.s       IL_0011
-  IL_0011:  ret
+  IL_000f:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2722,7 +2722,7 @@ class C
             var v0 = CompileAndVerify(compilation0);
             v0.VerifyIL("C.<>c.<M>b__1_0()", @"
 {
-  // Code size       36 (0x24)
+  // Code size       34 (0x22)
   .maxstack  2
   .locals init (object V_0,
                 bool V_1)
@@ -2750,8 +2750,7 @@ class C
     IL_001f:  nop
     IL_0020:  endfinally
   }
-  IL_0021:  br.s       IL_0023
-  IL_0023:  ret
+  IL_0021:  ret
 }");
 
 #if TODO // identify the lambda in a semantic edit

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -107,9 +107,9 @@ class C
         <entry offset=""0x0"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
         <entry offset=""0x1"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""14"" />
         <entry offset=""0x2"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""14"" />
-        <entry offset=""0x5"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
+        <entry offset=""0x3"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x6"">
+      <scope startOffset=""0x0"" endOffset=""0x4"">
         <constant name=""y"" value=""2"" type=""Int32"" />
         <scope startOffset=""0x1"" endOffset=""0x3"">
           <constant name=""z"" value=""3"" type=""Int32"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
@@ -994,10 +994,10 @@ class Test
       <sequencePoints>
         <entry offset=""0x0"" startLine=""10"" startColumn=""32"" endLine=""10"" endColumn=""33"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""46"" endLine=""10"" endColumn=""54"" />
-        <entry offset=""0x5"" startLine=""10"" startColumn=""55"" endLine=""10"" endColumn=""56"" />
+        <entry offset=""0x3"" startLine=""10"" startColumn=""55"" endLine=""10"" endColumn=""56"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x6"">
-        <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x6"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x4"">
+        <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
       </scope>
     </method>
     <method containingType=""Test+&lt;&gt;c"" name=""&lt;Main&gt;b__2_2"" parameterNames=""d6"">

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -1330,5 +1330,89 @@ class C
 </symbols>
 ");
         }
+
+        [Fact]
+        public void IfStatement1()
+        {
+            string source = @"
+class C
+{
+    static void F()
+    {
+        new System.Action(() =>
+        {
+            bool result = false;
+            if (result)
+                System.Console.WriteLine(1);
+        })();
+    }
+}
+";
+            var v = CompileAndVerify(source, options: TestOptions.DebugDll);
+
+            v.VerifyIL("C.<>c.<F>b__0_0", @"
+{
+  // Code size       16 (0x10)
+  .maxstack  1
+  .locals init (bool V_0, //result
+                bool V_1)
+ -IL_0000:  nop
+ -IL_0001:  ldc.i4.0
+  IL_0002:  stloc.0
+ -IL_0003:  ldloc.0
+  IL_0004:  stloc.1
+ ~IL_0005:  ldloc.1
+  IL_0006:  brfalse.s  IL_000f
+ -IL_0008:  ldc.i4.1
+  IL_0009:  call       ""void System.Console.WriteLine(int)""
+  IL_000e:  nop
+ -IL_000f:  ret
+}
+", sequencePoints: "C+<>c.<F>b__0_0");
+        }
+
+        [Fact]
+        public void IfStatement2()
+        {
+            string source = @"
+class C
+{
+    static void F()
+    {
+        new System.Action(() =>
+        {
+            {
+                bool result = false;
+                if (result)
+                    System.Console.WriteLine(1);
+            }
+        })();
+    }
+}
+";
+            var v = CompileAndVerify(source, options: TestOptions.DebugDll);
+
+            v.VerifyIL("C.<>c.<F>b__0_0", @"
+{
+  // Code size       18 (0x12)
+  .maxstack  1
+  .locals init (bool V_0, //result
+                bool V_1)
+ -IL_0000:  nop
+ -IL_0001:  nop
+ -IL_0002:  ldc.i4.0
+  IL_0003:  stloc.0
+ -IL_0004:  ldloc.0
+  IL_0005:  stloc.1
+ ~IL_0006:  ldloc.1
+  IL_0007:  brfalse.s  IL_0010
+ -IL_0009:  ldc.i4.1
+  IL_000a:  call       ""void System.Console.WriteLine(int)""
+  IL_000f:  nop
+ -IL_0010:  nop
+ -IL_0011:  ret
+}
+", sequencePoints: "C+<>c.<F>b__0_0");
+        }
     }
 }


### PR DESCRIPTION
The compiler didn't eliminate br instruction for block lambda bodies and it didn't place sequence point on them, which resulted in incorrect stepping. Branch elimination depends on syntax node associated with the implicit return statement. Flow analysis associated the lambda node instead of its body.

Fixes internal bug 1206595.

Repro -- run the following program till the breakpoint is hit and then step. Console.WriteLine(1) should not be stepped on but it is.

```C#
using System;

class Program
{
    static void Main(string[] args)
    {
        new Action(() =>
        {
            bool result = false;
            if (result) // breakpoint here
                Console.WriteLine(1);
        })();
    }
}
```