### PR TITLE
Fix Add using under chained conditional access expressions.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_ExtensionMethods.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_ExtensionMethods.cs
@@ -186,5 +186,99 @@ null, 0, true, true, null, false, null);
 @"using System ; using System . Collections ; using Ext2 ; class X : IEnumerable { public IEnumerator GetEnumerator ( ) { new X { { 1 , 2 , 3 } , { ""Four"" , ""Five"" , ""Six"" } , { '7' , '8' , '9' } } ; return null ; } } namespace Ext { static class Extensions { public static void Add ( this X x , int i ) { } } } namespace Ext2 { static class Extensions { public static void Add ( this X x , object [ ] i ) { } } } ",
 null, 1, true, true, null, false, null);
         }
+
+        [WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void InExtensionMethodUnderConditionalAccessExpression()
+        {
+            var initialText =
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+        <Document FilePath = ""Program"">
+namespace Sample
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string myString = ""Sample"";
+            var other = myString?[|.StringExtension()|].Substring(0);
+        }
+    }
+}
+       </Document>
+       <Document FilePath = ""Extensions"">
+namespace Sample.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string StringExtension(this string s)
+        {
+            return ""Ok"";
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expectedText =
+@"using Sample.Extensions;
+namespace Sample
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string myString = ""Sample"";
+            var other = myString?.StringExtension().Substring(0);
+        }
+    }
+}";
+            Test(initialText, expectedText, isLine: false);
+        }
+
+        [WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void InExtensionMethodUnderMultipleConditionalAccessExpressions()
+        {
+            var initialText =
+  @"<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+        <Document FilePath = ""Program"">
+public class C
+{
+    public T F&lt;T&gt;(T x)
+    {
+        return F(new C())?.F(new C())?[|.Extn()|];
+    }
+}
+       </Document>
+       <Document FilePath = ""Extensions"">
+namespace Sample.Extensions
+{
+    public static class Extensions
+    {
+        public static C Extn(this C obj)
+        {
+            return obj.F(new C());
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expectedText =
+@"using Sample.Extensions;
+public class C
+{
+    public T F<T>(T x)
+    {
+        return F(new C())?.F(new C())?.Extn();
+    }
+}";
+            Test(initialText, expectedText, isLine: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_ExtensionMethods.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_ExtensionMethods.cs
@@ -280,5 +280,48 @@ public class C
 }";
             Test(initialText, expectedText, isLine: false);
         }
+
+        [WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public void InExtensionMethodUnderMultipleConditionalAccessExpressions2()
+        {
+            var initialText =
+  @"<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+        <Document FilePath = ""Program"">
+public class C
+{
+    public T F&lt;T&gt;(T x)
+    {
+        return F(new C())?.F(new C())[|.Extn()|]?.F(newC());
+    }
+}
+       </Document>
+       <Document FilePath = ""Extensions"">
+namespace Sample.Extensions
+{
+    public static class Extensions
+    {
+        public static C Extn(this C obj)
+        {
+            return obj.F(new C());
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expectedText =
+@"using Sample.Extensions;
+public class C
+{
+    public T F<T>(T x)
+    {
+        return F(new C())?.F(new C()).Extn()?.F(newC());
+    }
+}";
+            Test(initialText, expectedText, isLine: false);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -648,7 +648,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
         protected override bool IsViableExtensionMethod(IMethodSymbol method, SyntaxNode expression, SemanticModel semanticModel, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken)
         {
-            var leftExpression = syntaxFacts.GetExpressionOfMemberAccessExpression(expression) ?? syntaxFacts.GetExpressionOfConditionalMemberAccessExpression(expression);
+            var leftExpression = syntaxFacts.GetExpressionOfMemberAccessExpression(expression);
             if (leftExpression == null)
             {
                 if (expression.IsKind(SyntaxKind.CollectionInitializerExpression))

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -555,9 +555,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public SyntaxNode GetExpressionOfMemberAccessExpression(SyntaxNode node)
         {
-            return node.IsKind(SyntaxKind.MemberBindingExpression) ?
-                GetExpressionOfConditionalMemberAccessExpression(node.GetParentConditionalAccessExpression()) :
-                (node as MemberAccessExpressionSyntax)?.Expression;
+            return node.IsKind(SyntaxKind.MemberBindingExpression)
+                ? GetExpressionOfConditionalMemberAccessExpression(node.GetParentConditionalAccessExpression()) 
+                : (node as MemberAccessExpressionSyntax)?.Expression;
         }
 
         public SyntaxNode GetExpressionOfConditionalMemberAccessExpression(SyntaxNode node)

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -555,20 +555,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public SyntaxNode GetExpressionOfMemberAccessExpression(SyntaxNode node)
         {
-            if (node.IsKind(SyntaxKind.MemberBindingExpression))
-            {
-                if (node.IsParentKind(SyntaxKind.ConditionalAccessExpression))
-                {
-                    return GetExpressionOfConditionalMemberAccessExpression(node.Parent);
-                }
-                if (node.IsParentKind(SyntaxKind.InvocationExpression) &&
-                    node.Parent.IsParentKind(SyntaxKind.ConditionalAccessExpression))
-                {
-                    return GetExpressionOfConditionalMemberAccessExpression(node.Parent.Parent);
-                }
-            }
-
-            return (node as MemberAccessExpressionSyntax)?.Expression;
+            return node.IsKind(SyntaxKind.MemberBindingExpression) ?
+                GetExpressionOfConditionalMemberAccessExpression(node.GetParentConditionalAccessExpression()) :
+                (node as MemberAccessExpressionSyntax)?.Expression;
         }
 
         public SyntaxNode GetExpressionOfConditionalMemberAccessExpression(SyntaxNode node)


### PR DESCRIPTION
Handle ConditionalAccessExpression cases properly in `GetExpressionOfMemberAccessExpression` by using `GetParentCondtionalAccessExpression` helper to find a ConditionalAccessExpression if one exists in a parent hierarchy. This change is C# only. The VB implementation of this method
correctly uses `GetCorrespondingConditionalAccessExpression` in this case.

Fixes #3818.