### PR TITLE
Adjusting uses of %RoslynRoot% in cibuild.cmd to no longer specify two consecutive path separator characters.

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -17,16 +17,16 @@ call :Usage && exit /b 1
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
 
 REM Build the compiler so we can self host it for the full build
-nuget.exe restore -verbosity quiet %RoslynRoot%/build/ToolsetPackages/project.json
-nuget.exe restore -verbosity quiet %RoslynRoot%/build/Toolset.sln
-msbuild /nologo /v:m /m %RoslynRoot%/build/Toolset.sln /p:Configuration=%BuildConfiguration%
+nuget.exe restore -verbosity quiet %RoslynRoot%build/ToolsetPackages/project.json
+nuget.exe restore -verbosity quiet %RoslynRoot%build/Toolset.sln
+msbuild /nologo /v:m /m %RoslynRoot%build/Toolset.sln /p:Configuration=%BuildConfiguration%
 
-mkdir %RoslynRoot%\Binaries\Bootstrap
-move Binaries\%BuildConfiguration%\* %RoslynRoot%\Binaries\Bootstrap
+mkdir %RoslynRoot%Binaries\Bootstrap
+move Binaries\%BuildConfiguration%\* %RoslynRoot%Binaries\Bootstrap
 msbuild /v:m /t:Clean build/Toolset.sln /p:Configuration=%BuildConfiguration%
 taskkill /F /IM vbcscompiler.exe
 
-msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%\Binaries\Bootstrap BuildAndTest.proj /p:Configuration=%BuildConfiguration% /p:Test64=%Test64%
+msbuild /v:m /m /p:BootstrapBuildPath=%RoslynRoot%Binaries\Bootstrap BuildAndTest.proj /p:Configuration=%BuildConfiguration% /p:Test64=%Test64%
 if ERRORLEVEL 1 (
     taskkill /F /IM vbcscompiler.exe
     echo Build failed


### PR DESCRIPTION
FYI. @agocke, @VSadov, @ManishJayaswal 

Apparently the 'move' command breaks if you have a number and then two consecutive path separator characters (such as ...dbg_32\\).