### PR TITLE
Removing erroneous spaces that were added to cibuild.cmd

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -5,14 +5,19 @@ REM Parse Arguments.
 set RoslynRoot=%~dp0
 set BuildConfiguration=Debug
 :ParseArguments
+echo [%1]
+echo [%BuildConfiguration%]
+echo [%Test64%]
 if "%1" == "" goto :DoneParsing
 if /I "%1" == "/?" call :Usage && exit /b 1
-if /I "%1" == "/debug" set BuildConfiguration=Debug && shift && goto :ParseArguments
-if /I "%1" == "/release" set BuildConfiguration=Release && shift && goto :ParseArguments
-if /I "%1" == "/test32" set Test64=false && shift && goto :ParseArguments
-if /I "%1" == "/test64" set Test64=true && shift && goto :ParseArguments
+if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
+if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
+if /I "%1" == "/test32" set Test64=false&&shift&& goto :ParseArguments
+if /I "%1" == "/test64" set Test64=true&&shift&& goto :ParseArguments
 call :Usage && exit /b 1
 :DoneParsing
+
+pause
 
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
 


### PR DESCRIPTION
FYI. @agocke, @VSadov, @ManishJayaswal 

Apparently this works on Win10, but not on Server 2012 R2.