### PR TITLE
Disable snippets in the Interactive window

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Projection;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
@@ -94,10 +95,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             CompletionItem updatedBuilder = builder;
             CompletionItem updatedDefaultBuilder = GetDefaultBuilder(defaultTrackingSpanInSubjectBuffer);
 
-            if (completionService != null && workspace != null && triggerInfo.TriggerReason != CompletionTriggerReason.Snippets)
+            if (completionService != null && 
+                workspace != null && 
+                workspace.Options.GetOption(InternalFeatureOnOffOptions.Snippets) && 
+                triggerInfo.TriggerReason != CompletionTriggerReason.Snippets)
             {
                 // In order to add snippet expansion notes to completion item descriptions, update
-                // all of the provided CompletionItems to DisplayCompletionItems which will proxy
+                // all of the provided CompletionItems to DescriptionModifyingCompletionItem which will proxy
                 // requests to the original completion items and add the snippet expansion note to
                 // the description if necessary. We won't do this if the list was triggered to show
                 // snippet shortcuts.

--- a/src/EditorFeatures/Test2/IntelliSense/TestState.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestState.vb
@@ -43,8 +43,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Private Sub New(workspaceElement As XElement,
                         extraCompletionProviders As IEnumerable(Of Lazy(Of CompletionListProvider, OrderableLanguageAndRoleMetadata)),
                         extraSignatureHelpProviders As IEnumerable(Of Lazy(Of ISignatureHelpProvider, OrderableLanguageMetadata)),
-                        Optional extraExportedTypes As List(Of Type) = Nothing)
-            MyBase.New(workspaceElement, CreatePartCatalog(extraExportedTypes))
+                        Optional extraExportedTypes As List(Of Type) = Nothing,
+                        Optional workspaceKind As String = Nothing)
+            MyBase.New(workspaceElement, CreatePartCatalog(extraExportedTypes), workspaceKind:=workspaceKind)
 
             Dim languageServices = Me.Workspace.CurrentSolution.Projects.First().LanguageServices
             Dim language = languageServices.Language
@@ -125,12 +126,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 workspaceElement As XElement,
                 Optional extraCompletionProviders As CompletionListProvider() = Nothing,
                 Optional extraSignatureHelpProviders As ISignatureHelpProvider() = Nothing,
-                Optional extraExportedTypes As List(Of Type) = Nothing) As TestState
+                Optional extraExportedTypes As List(Of Type) = Nothing,
+                Optional workspaceKind As String = Nothing) As TestState
             Return New TestState(
                 workspaceElement,
                 CreateLazyProviders(extraCompletionProviders, LanguageNames.VisualBasic, roles:=Nothing),
                 CreateLazyProviders(extraSignatureHelpProviders, LanguageNames.VisualBasic),
-                extraExportedTypes)
+                extraExportedTypes,
+                workspaceKind)
         End Function
 
 #Region "IntelliSense Operations"

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -43,9 +43,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             using (Logger.LogBlock(FunctionId.Completion_SnippetCompletionProvider_GetItemsWorker_CSharp, cancellationToken))
             {
+                // TODO (https://github.com/dotnet/roslyn/issues/5107): Enable in Interactive.
                 var workspace = document.Project.Solution.Workspace;
                 if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument) ||
-                     workspace.Kind == WorkspaceKind.Debugger)
+                     workspace.Kind == WorkspaceKind.Debugger ||
+                     workspace.Kind == WorkspaceKind.Interactive)
                 {
                     return SpecializedCollections.EmptyEnumerable<CompletionItem>();
                 }

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Editor.Interactive;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
@@ -24,6 +25,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             // register work coordinator for this workspace
             _registrationService = this.Services.GetService<ISolutionCrawlerRegistrationService>();
             _registrationService.Register(this);
+
+            // TODO (https://github.com/dotnet/roslyn/issues/5107): Enable in Interactive.
+            this.Options = this.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, false);
         }
 
         protected override void Dispose(bool finalize)

--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
@@ -49,6 +49,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
 
         public CommandState GetCommandState(SurroundWithCommandArgs args, Func<CommandState> nextHandler)
         {
+            AssertIsForeground();
+
+            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            {
+                return nextHandler();
+            }
+
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace))
             {

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
@@ -82,6 +82,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public CommandState GetCommandState(TabKeyCommandArgs args, Func<CommandState> nextHandler)
         {
             AssertIsForeground();
+            
+            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            {
+                return nextHandler();
+            }
+
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace))
             {
@@ -113,6 +119,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public CommandState GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler)
         {
             AssertIsForeground();
+
+            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            {
+                return nextHandler();
+            }
+
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace))
             {
@@ -144,6 +156,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public CommandState GetCommandState(EscapeKeyCommandArgs args, Func<CommandState> nextHandler)
         {
             AssertIsForeground();
+
+            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            {
+                return nextHandler();
+            }
+
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace))
             {
@@ -175,6 +193,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public CommandState GetCommandState(BackTabKeyCommandArgs args, Func<CommandState> nextHandler)
         {
             AssertIsForeground();
+
+            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            {
+                return nextHandler();
+            }
+
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace))
             {
@@ -199,6 +223,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
         public CommandState GetCommandState(InsertSnippetCommandArgs args, Func<CommandState> nextHandler)
         {
+            AssertIsForeground();
+
+            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            {
+                return nextHandler();
+            }
+
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace))
             {

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -2,6 +2,7 @@
 
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Editor.Shared.Options
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 Imports Microsoft.CodeAnalysis.Snippets
 Imports Microsoft.CodeAnalysis.Text
@@ -71,6 +72,33 @@ class C
                 state.SendTypeChars("DisplayTex")
                 state.AssertCompletionSession()
                 state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "InsertionText"))
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion), Trait(Traits.Feature, Traits.Features.Interactive)>
+        Public Sub SnippetExpansionNoteNotAddedToDescription_Interactive()
+            Dim workspaceXml =
+                <Workspace>
+                    <Submission Language="C#" CommonReferences="true">
+                        $$
+                    </Submission>
+                </Workspace>
+
+            Using state = TestState.CreateTestStateFromWorkspace(
+                workspaceXml,
+                New CompletionListProvider() {New MockCompletionProvider(New TextSpan(31, 10))},
+                Nothing,
+                New List(Of Type) From {GetType(TestCSharpSnippetInfoService)},
+                WorkspaceKind.Interactive)
+
+                Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService(Of ISnippetInfoService)(), TestCSharpSnippetInfoService)
+                testSnippetInfoService.SetSnippetShortcuts({"for"})
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, False)
+
+                state.SendTypeChars("for")
+                state.AssertCompletionSession()
+                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "for"))
             End Using
         End Sub
 

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetCommandHandlerTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetCommandHandlerTests.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.VisualStudio.Text
 Imports Roslyn.Test.Utilities
 
@@ -205,6 +206,77 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
                 testState.SendTab()
 
                 Assert.False(testState.SnippetExpansionClient.TryInsertExpansionCalled)
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Snippets), Trait(Traits.Feature, Traits.Features.Interactive)>
+        Public Sub SnippetCommandHandler_Interactive_Tab()
+            Dim markup = "for$$"
+            Dim testState = SnippetTestState.CreateSubmissionTestState(markup, LanguageNames.CSharp)
+            Using testState
+                testState.SnippetExpansionClient.TryInsertExpansionReturnValue = True
+                testState.SendTab()
+
+                Assert.False(testState.SnippetExpansionClient.TryInsertExpansionCalled)
+                Assert.Equal("for    ", testState.SubjectBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Snippets), Trait(Traits.Feature, Traits.Features.Interactive)>
+        Public Sub SnippetCommandHandler_Interactive_InsertSnippetCommand()
+            Dim markup = "for$$"
+
+            Dim testState = SnippetTestState.CreateSubmissionTestState(markup, LanguageNames.CSharp)
+            Using testState
+                Dim delegatedToNext = False
+                Dim nextHandler =
+                    Function()
+                        delegatedToNext = True
+                        Return CommandState.Unavailable
+                    End Function
+
+                Dim handler = testState.SnippetCommandHandler
+                Dim state = handler.GetCommandState(New Commands.InsertSnippetCommandArgs(testState.TextView, testState.SubjectBuffer), nextHandler)
+                Assert.True(delegatedToNext)
+                Assert.False(state.IsAvailable)
+
+                testState.SnippetExpansionClient.TryInsertExpansionReturnValue = True
+
+                delegatedToNext = False
+                testState.SendInsertSnippetCommand(AddressOf handler.ExecuteCommand, nextHandler)
+                Assert.True(delegatedToNext)
+
+                Assert.False(testState.SnippetExpansionClient.TryInsertExpansionCalled)
+                Assert.Equal("for", testState.SubjectBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Snippets), Trait(Traits.Feature, Traits.Features.Interactive)>
+        Public Sub SnippetCommandHandler_Interactive_SurroundWithCommand()
+            Dim markup = "for$$"
+
+            Dim testState = SnippetTestState.CreateSubmissionTestState(markup, LanguageNames.CSharp)
+            Using testState
+                Dim delegatedToNext = False
+                Dim nextHandler =
+                    Function()
+                        delegatedToNext = True
+                        Return CommandState.Unavailable
+                    End Function
+
+                Dim handler = CType(testState.SnippetCommandHandler, CSharp.Snippets.SnippetCommandHandler)
+                Dim state = handler.GetCommandState(New Commands.SurroundWithCommandArgs(testState.TextView, testState.SubjectBuffer), nextHandler)
+                Assert.True(delegatedToNext)
+                Assert.False(state.IsAvailable)
+
+                testState.SnippetExpansionClient.TryInsertExpansionReturnValue = True
+
+                delegatedToNext = False
+                testState.SendSurroundWithCommand(AddressOf handler.ExecuteCommand, nextHandler)
+                Assert.True(delegatedToNext)
+
+                Assert.False(testState.SnippetExpansionClient.TryInsertExpansionCalled)
+                Assert.Equal("for", testState.SubjectBuffer.CurrentSnapshot.GetText())
             End Using
         End Sub
     End Class


### PR DESCRIPTION
...for v1.  Filed #5107 to revive them.

(There are fewer VB tests since VB doesn't have SurroundWith and
Interactive window completion is NYI.)

Bonus: Improve consistency between ```ExecuteCommand``` and
```GetCommandState``` in snippet handler (part of #4993).