### PR TITLE
Minor SourceFileResolver fixups...

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5588,7 +5588,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Metadata references not supported..
+        ///   Looks up a localized string similar to Metadata references are not supported..
         /// </summary>
         internal static string ERR_MetadataReferencesNotSupported {
             get {
@@ -7762,6 +7762,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_SizeofUnsafe {
             get {
                 return ResourceManager.GetString("ERR_SizeofUnsafe", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source file references are not supported..
+        /// </summary>
+        internal static string ERR_SourceFileReferencesNotSupported {
+            get {
+                return ResourceManager.GetString("ERR_SourceFileReferencesNotSupported", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -373,7 +373,7 @@
     <value>Metadata file '{0}' could not be found</value>
   </data>
   <data name="ERR_MetadataReferencesNotSupported" xml:space="preserve">
-    <value>Metadata references not supported.</value>
+    <value>Metadata references are not supported.</value>
   </data>
   <data name="FTL_MetadataCantOpenFile" xml:space="preserve">
     <value>Metadata file '{0}' could not be opened -- {1}</value>
@@ -4650,5 +4650,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="SyntaxTreeFromLoadNoRemoveReplace" xml:space="preserve">
     <value>SyntaxTree '{0}' resulted from a #load directive and cannot be removed or replaced directly.</value>
+  </data>
+  <data name="ERR_SourceFileReferencesNotSupported" xml:space="preserve">
+    <value>Source file references are not supported.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1314,5 +1314,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DebugEntryPointNotSourceMethodDefinition = 8096,
         ERR_LoadDirectiveOnlyAllowedInScripts = 8097,
         ERR_PPLoadFollowsToken = 8098,
+        ERR_SourceFileReferencesNotSupported = 8099,
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -62,6 +62,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "asdf").WithArguments("asdf").WithLocation(3, 21));
         }
 
+        [Fact]
+        void NoSourceReferenceResolver()
+        {
+            var code = "#load \"test\"";
+            var compilation = CreateCompilationWithMscorlib(code, parseOptions: TestOptions.Script);
+
+            Assert.Single(compilation.SyntaxTrees);
+            compilation.GetDiagnostics().Verify(
+                // (1,1): error CS8099: Source file references not supported
+                // #load "test"
+                Diagnostic(ErrorCode.ERR_SourceFileReferencesNotSupported, @"#load ""test""").WithLocation(1, 1));
+        }
+
         private static CSharpCompilation CreateCompilation(string code, SourceReferenceResolver sourceReferenceResolver = null)
         {
             var options = new CSharpCompilationOptions(

--- a/src/Compilers/Core/Portable/Compilation/CommonSyntaxAndDeclarationManager.cs
+++ b/src/Compilers/Core/Portable/Compilation/CommonSyntaxAndDeclarationManager.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
         {
             this.ExternalSyntaxTrees = externalSyntaxTrees;
             this.ScriptClassName = scriptClassName ?? "";
-            this.Resolver = resolver; // TODO: What if SourceReferenceResolver is null?
+            this.Resolver = resolver;
             this.MessageProvider = messageProvider;
             this.IsSubmission = isSubmission;
         }

--- a/src/Compilers/Core/Portable/Compilation/SourceReferenceResolver.cs
+++ b/src/Compilers/Core/Portable/Compilation/SourceReferenceResolver.cs
@@ -62,7 +62,10 @@ namespace Microsoft.CodeAnalysis
         /// <param name="resolvedPath">Path returned by <see cref="ResolveReference(string, string)"/>.</param>
         public virtual SourceText ReadText(string resolvedPath)
         {
-            return SourceText.From(OpenRead(resolvedPath));
+            using (var stream = OpenRead(resolvedPath))
+            {
+                return EncodedStringText.Create(stream);
+            }
         }
     }
 }

--- a/src/Scripting/CSharp/CSharpScriptCompiler.cs
+++ b/src/Scripting/CSharp/CSharpScriptCompiler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp
                     platform: Platform.AnyCpu,
                     warningLevel: 4,
                     xmlReferenceResolver: null, // don't support XML file references in interactive (permissions & doc comment includes)
-                    sourceReferenceResolver: LoadDirectiveResolver.Default,
+                    sourceReferenceResolver: null,
                     metadataReferenceResolver: script.Options.ReferenceResolver,
                     assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default
                 ),
@@ -61,26 +61,6 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp
             );
 
             return compilation;
-        }
-
-        private class LoadDirectiveResolver : SourceFileResolver
-        {
-            public static new LoadDirectiveResolver Default { get; } = new LoadDirectiveResolver();
-
-            private LoadDirectiveResolver()
-                : base(ImmutableArray<string>.Empty, baseDirectory: null)
-            {
-            }
-
-            public override SourceText ReadText(string resolvedPath)
-            {
-                string unused;
-                return CommonCompiler.ReadFileContentHelper(
-                    resolvedPath,
-                    encoding: null,
-                    checksumAlgorithm: SourceHashAlgorithm.Sha1, // TODO: Should we be fetching the checksum algorithm from somewhere?
-                    normalizedFilePath: out unused);
-            }
         }
     }
 }


### PR DESCRIPTION
- Undo some refactoring of CommonCompiler.ReadFileContent
- Remove LoadDirectiveResolver
- Make SourceReferenceResolver.ReadText detect encoding
- Make SourceReferenceResolver.ReadText Dispose its Stream
- Make SyntaxAndDeclarationManager use SourceFileResolver.Default if no resolver is specified