### PR TITLE
Change unzip to use the -u option instead of the -f option

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -72,13 +72,11 @@ restore_nuget()
 
     rm $package_name 2>/dev/null
     curl -O https://dotnetci.blob.core.windows.net/roslyn/$package_name
-    unzip -foq $package_name -d ~/
+    unzip -uoq $package_name -d ~/
     if [ $? -ne 0 ]; then
         echo "Unable to download NuGet packages"
         exit 1
     fi
-
-    rm $package_name 2>/dev/null
 
     popd
 }


### PR DESCRIPTION
The -f option doesn't include files that don't exist, while -u extracts 
new and missing files.

Also, we were deleting the zip file after unzipping, leading the caching
to always fail and download new zip files every time, so this should
allow caching to work again.