### PR TITLE
Respect noconfig in InteractiveEvaluator

### DIFF
--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -171,11 +171,11 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         /// <summary>
         /// Invoked by <see cref="InteractiveHost"/> when a new process is being started.
         /// </summary>
-        private void ProcessStarting(InteractiveHostOptions options)
+        private void ProcessStarting(bool initialize)
         {
             if (!Dispatcher.CheckAccess())
             {
-                Dispatcher.BeginInvoke(new Action(() => ProcessStarting(options)));
+                Dispatcher.BeginInvoke(new Action(() => ProcessStarting(initialize)));
                 return;
             }
 
@@ -192,8 +192,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             var metadataService = _workspace.CurrentSolution.Services.MetadataService;
             ImmutableArray<string> referencePaths;
 
-            // reset configuration (null initialization file indicates "noconfig"):
-            if (options.InitializationFile != null && File.Exists(_responseFilePath))
+            if (initialize && File.Exists(_responseFilePath))
             {
                 // The base directory for relative paths is the directory that contains the .rsp file.
                 // Note that .rsp files included by this .rsp file will share the base directory (Dev10 behavior of csc/vbc).

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -192,8 +192,8 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             var metadataService = _workspace.CurrentSolution.Services.MetadataService;
             ImmutableArray<string> referencePaths;
 
-            // reset configuration:
-            if (File.Exists(_responseFilePath))
+            // reset configuration (null initialization file indicates "noconfig"):
+            if (options.InitializationFile != null && File.Exists(_responseFilePath))
             {
                 // The base directory for relative paths is the directory that contains the .rsp file.
                 // Note that .rsp files included by this .rsp file will share the base directory (Dev10 behavior of csc/vbc).

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     var notification = Host.ProcessStarting;
                     if (notification != null)
                     {
-                        notification(this.Options);
+                        notification(this.Options.InitializationFile != null);
                     }
 
                     var remoteService = await TryStartProcessAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         private TextWriter _output;
         private TextWriter _errorOutput;
 
-        internal event Action<InteractiveHostOptions> ProcessStarting;
+        internal event Action<bool> ProcessStarting;
 
         public InteractiveHost(
             Type replServiceProviderType,


### PR DESCRIPTION
Don't consume the response file when re-initializing after ```#reset
noconfig```.  The host already handles this correctly.

Fixes #4397.

Integration test to follow.