### PR TITLE
Implement missing LangVersion checks for new features/relaxations introduced in VB14.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -781,6 +781,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)
                                 Else
+                                    If node.Syntax.Kind = SyntaxKind.PredefinedCastExpression Then
+                                        Dim cast = DirectCast(node.Syntax, PredefinedCastExpressionSyntax)
+
+                                        If cast.Keyword.Kind = SyntaxKind.CObjKeyword Then
+                                            InternalSyntax.Parser.CheckFeatureAvailability(diagBag,
+                                                                                           cast.Keyword.GetLocation(),
+                                                                                           DirectCast(cast.SyntaxTree, VisualBasicSyntaxTree).Options.LanguageVersion,
+                                                                                           InternalSyntax.Feature.CObjInAttributeArguments)
+                                        End If
+                                    End If
                                     node = conv.Operand
                                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1936,5 +1936,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         FEATURE_GlobalNamespace
         FEATURE_NullPropagatingOperator
         FEATURE_NameOfExpressions
+        FEATURE_ReadonlyAutoProperties
+        FEATURE_RegionsEverywhere
+        FEATURE_MultilineStringLiterals
+        FEATURE_CObjInAttributeArguments
+        FEATURE_LineContinuationComments
+        FEATURE_TypeOfIsNot
+        FEATURE_YearFirstDateLiterals
+        FEATURE_WarningDirectives
+        FEATURE_PartialModules
+        FEATURE_PartialInterfaces
+        FEATURE_ImplementingReadonlyOrWriteonlyPropertyWithReadwrite
     End Enum
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Parser/BlockContexts/CompilationUnitContext.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/BlockContexts/CompilationUnitContext.vb
@@ -87,6 +87,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Friend Function CreateCompilationUnit(optionalTerminator As PunctuationSyntax,
                                               notClosedIfDirectives As ArrayBuilder(Of IfDirectiveTriviaSyntax),
                                               notClosedRegionDirectives As ArrayBuilder(Of RegionDirectiveTriviaSyntax),
+                                              haveRegionDirectives As Boolean,
                                               notClosedExternalSourceDirective As ExternalSourceDirectiveTriviaSyntax) As CompilationUnitSyntax
 
             Debug.Assert(optionalTerminator Is Nothing OrElse optionalTerminator.Kind = SyntaxKind.EndOfFileToken)
@@ -113,8 +114,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                                        declarations,
                                                        optionalTerminator)
 
-            If notClosedIfDirectives IsNot Nothing OrElse notClosedRegionDirectives IsNot Nothing OrElse notClosedExternalSourceDirective IsNot Nothing Then
-                result = DiagnosticRewriter.Rewrite(result, notClosedIfDirectives, notClosedRegionDirectives, notClosedExternalSourceDirective)
+            Dim regionsAreAllowedEverywhere = Not haveRegionDirectives OrElse Parser.CheckFeatureAvailability(Feature.RegionsEverywhere)
+
+            If notClosedIfDirectives IsNot Nothing OrElse notClosedRegionDirectives IsNot Nothing OrElse notClosedExternalSourceDirective IsNot Nothing OrElse
+               Not regionsAreAllowedEverywhere Then
+                result = DiagnosticRewriter.Rewrite(result, notClosedIfDirectives, notClosedRegionDirectives, regionsAreAllowedEverywhere, notClosedExternalSourceDirective, Parser)
 
                 If notClosedIfDirectives IsNot Nothing Then
                     notClosedIfDirectives.Free()
@@ -134,6 +138,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Private _notClosedIfDirectives As HashSet(Of IfDirectiveTriviaSyntax) = Nothing
             Private _notClosedRegionDirectives As HashSet(Of RegionDirectiveTriviaSyntax) = Nothing
             Private _notClosedExternalSourceDirective As ExternalSourceDirectiveTriviaSyntax = Nothing
+            Private _regionsAreAllowedEverywhere As Boolean
+
+            Private _parser As Parser
+            Private _declarationBlocksBeingVisited As ArrayBuilder(Of VisualBasicSyntaxNode) ' CompilationUnitSyntax is treated as a declaration block for our purposes
+            Private _parentsOfRegionDirectivesAwaitingClosure As ArrayBuilder(Of VisualBasicSyntaxNode) ' Nodes are coming from _declrationBlocksBeingVisited
+            Private _tokenWithDirectivesBeingVisited As SyntaxToken
 
             Private Sub New()
                 MyBase.New()
@@ -142,7 +152,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Public Shared Function Rewrite(compilationUnit As CompilationUnitSyntax,
                                            notClosedIfDirectives As ArrayBuilder(Of IfDirectiveTriviaSyntax),
                                            notClosedRegionDirectives As ArrayBuilder(Of RegionDirectiveTriviaSyntax),
-                                           notClosedExternalSourceDirective As ExternalSourceDirectiveTriviaSyntax) As CompilationUnitSyntax
+                                           regionsAreAllowedEverywhere As Boolean,
+                                           notClosedExternalSourceDirective As ExternalSourceDirectiveTriviaSyntax,
+                                           parser As Parser) As CompilationUnitSyntax
 
                 Dim rewriter As New DiagnosticRewriter()
 
@@ -164,9 +176,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Next
                 End If
 
+                rewriter._parser = parser
+                rewriter._regionsAreAllowedEverywhere = regionsAreAllowedEverywhere
+
+                If Not regionsAreAllowedEverywhere Then
+                    rewriter._declarationBlocksBeingVisited = ArrayBuilder(Of VisualBasicSyntaxNode).GetInstance()
+                    rewriter._parentsOfRegionDirectivesAwaitingClosure = ArrayBuilder(Of VisualBasicSyntaxNode).GetInstance()
+                End If
+
                 rewriter._notClosedExternalSourceDirective = notClosedExternalSourceDirective
 
-                Return DirectCast(rewriter.Visit(compilationUnit), CompilationUnitSyntax)
+                Dim result = DirectCast(rewriter.Visit(compilationUnit), CompilationUnitSyntax)
+
+                If Not regionsAreAllowedEverywhere Then
+                    Debug.Assert(rewriter._declarationBlocksBeingVisited.Count = 0)
+                    Debug.Assert(rewriter._parentsOfRegionDirectivesAwaitingClosure.Count = 0) ' We never add parents of not closed #Region directives into this stack.
+                    rewriter._declarationBlocksBeingVisited.Free()
+                    rewriter._parentsOfRegionDirectivesAwaitingClosure.Free()
+                End If
+
+                Return result
             End Function
 
 #If DEBUG Then
@@ -174,6 +203,201 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' NOTE: one single tree are not reused, the following code assert this
             Private ReadOnly _processedNodesWithoutDuplication As HashSet(Of VisualBasicSyntaxNode) = New HashSet(Of VisualBasicSyntaxNode)(ReferenceEqualityComparer.Instance)
 #End If
+
+            Public Overrides Function VisitCompilationUnit(node As CompilationUnitSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitCompilationUnit(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitMethodBlock(node As MethodBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitMethodBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitConstructorBlock(node As ConstructorBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitConstructorBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitOperatorBlock(node As OperatorBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitOperatorBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitAccessorBlock(node As AccessorBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitAccessorBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitNamespaceBlock(node As NamespaceBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitNamespaceBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitClassBlock(node As ClassBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitClassBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitStructureBlock(node As StructureBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitStructureBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitModuleBlock(node As ModuleBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitModuleBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitInterfaceBlock(node As InterfaceBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitInterfaceBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitEnumBlock(node As EnumBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitEnumBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitPropertyBlock(node As PropertyBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitPropertyBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
+
+            Public Overrides Function VisitEventBlock(node As EventBlockSyntax) As VisualBasicSyntaxNode
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    _declarationBlocksBeingVisited.Push(node)
+                End If
+
+                Dim result = MyBase.VisitEventBlock(node)
+
+                If _declarationBlocksBeingVisited IsNot Nothing Then
+                    Dim n = _declarationBlocksBeingVisited.Pop()
+                    Debug.Assert(n Is node)
+                End If
+
+                Return result
+            End Function
 
             Public Overrides Function VisitIfDirectiveTrivia(node As IfDirectiveTriviaSyntax) As VisualBasicSyntaxNode
 #If DEBUG Then
@@ -183,6 +407,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 If Me._notClosedIfDirectives IsNot Nothing AndAlso Me._notClosedIfDirectives.Contains(node) Then
                     rewritten = Parser.ReportSyntaxError(rewritten, ERRID.ERR_LbExpectedEndIf)
                 End If
+
                 Return rewritten
             End Function
 
@@ -193,7 +418,90 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Dim rewritten = MyBase.VisitRegionDirectiveTrivia(node)
                 If Me._notClosedRegionDirectives IsNot Nothing AndAlso Me._notClosedRegionDirectives.Contains(node) Then
                     rewritten = Parser.ReportSyntaxError(rewritten, ERRID.ERR_ExpectedEndRegion)
+
+                ElseIf Not _regionsAreAllowedEverywhere
+                    rewritten = VerifyRegionPlacement(node, rewritten)
                 End If
+
+                Return rewritten
+            End Function
+
+
+            Private Function VerifyRegionPlacement(original As VisualBasicSyntaxNode, rewritten As VisualBasicSyntaxNode) As VisualBasicSyntaxNode
+                Dim containingBlock = _declarationBlocksBeingVisited.Peek()
+
+                ' Ensure that the directive is inside the block, rather than is attached to it as a leading/trailing trivia 
+                Debug.Assert(_declarationBlocksBeingVisited.Count > 1 OrElse containingBlock.Kind = SyntaxKind.CompilationUnit)
+
+                If _declarationBlocksBeingVisited.Count > 1 Then
+
+                    If _tokenWithDirectivesBeingVisited Is containingBlock.GetFirstToken() Then
+                        Dim leadingTrivia = _tokenWithDirectivesBeingVisited.GetLeadingTrivia()
+
+                        If leadingTrivia IsNot Nothing AndAlso New SyntaxList(Of VisualBasicSyntaxNode)(leadingTrivia).Nodes.Contains(original) Then
+                            containingBlock = _declarationBlocksBeingVisited(_declarationBlocksBeingVisited.Count - 2)
+                        End If
+
+                    ElseIf _tokenWithDirectivesBeingVisited Is containingBlock.GetLastToken() Then
+                        Dim trailingTrivia = _tokenWithDirectivesBeingVisited.GetTrailingTrivia()
+
+                        If trailingTrivia IsNot Nothing AndAlso New SyntaxList(Of VisualBasicSyntaxNode)(trailingTrivia).Nodes.Contains(original) Then
+                            containingBlock = _declarationBlocksBeingVisited(_declarationBlocksBeingVisited.Count - 2)
+                        End If
+                    End If
+                End If
+
+                Dim reportAnError = Not IsValidContainingBlockForRegionInVB12(containingBlock)
+
+                If original.Kind = SyntaxKind.RegionDirectiveTrivia Then
+                    _parentsOfRegionDirectivesAwaitingClosure.Push(containingBlock)
+                Else
+                    Debug.Assert(original.Kind = SyntaxKind.EndRegionDirectiveTrivia)
+
+                    If _parentsOfRegionDirectivesAwaitingClosure.Count > 0 Then
+                        Dim regionBeginContainingBlock = _parentsOfRegionDirectivesAwaitingClosure.Pop()
+
+                        If regionBeginContainingBlock IsNot containingBlock AndAlso IsValidContainingBlockForRegionInVB12(regionBeginContainingBlock) Then
+                            reportAnError = True
+                        End If
+                    End If
+                End If
+
+                If reportAnError Then
+                    rewritten = _parser.ReportFeatureUnavailable(Feature.RegionsEverywhere, rewritten)
+                End If
+
+                Return rewritten
+            End Function
+
+            Private Shared Function IsValidContainingBlockForRegionInVB12(containingBlock As VisualBasicSyntaxNode) As Boolean
+                Select Case containingBlock.Kind
+                    Case SyntaxKind.FunctionBlock,
+                         SyntaxKind.SubBlock,
+                         SyntaxKind.ConstructorBlock,
+                         SyntaxKind.OperatorBlock,
+                         SyntaxKind.SetAccessorBlock,
+                         SyntaxKind.GetAccessorBlock,
+                         SyntaxKind.AddHandlerAccessorBlock,
+                         SyntaxKind.RemoveHandlerAccessorBlock,
+                         SyntaxKind.RaiseEventAccessorBlock
+
+                        Return False
+                End Select
+
+                Return True
+            End Function
+
+            Public Overrides Function VisitEndRegionDirectiveTrivia(node As EndRegionDirectiveTriviaSyntax) As VisualBasicSyntaxNode
+#If DEBUG Then
+                Debug.Assert(_processedNodesWithoutDuplication.Add(node))
+#End If
+                Dim rewritten = MyBase.VisitEndRegionDirectiveTrivia(node)
+
+                If Not _regionsAreAllowedEverywhere Then
+                    rewritten = VerifyRegionPlacement(node, rewritten)
+                End If
+
                 Return rewritten
             End Function
 
@@ -221,6 +529,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return token
                 End If
 
+                Debug.Assert(_tokenWithDirectivesBeingVisited Is Nothing)
+                _tokenWithDirectivesBeingVisited = token
+
                 Dim leadingTrivia = token.GetLeadingTrivia()
                 Dim trailingTrivia = token.GetTrailingTrivia()
 
@@ -238,6 +549,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
                 End If
 
+                _tokenWithDirectivesBeingVisited = Nothing
                 Return token
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseConditional.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseConditional.vb
@@ -257,13 +257,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             VerifyExpectedToken(SyntaxKind.StringLiteralToken, title)
 
             Dim statement = SyntaxFactory.RegionDirectiveTrivia(hashToken, regionKeyword, title)
-
-            'TODO - There isn't a context anymore for directives.  So this check can't be done here.  Is it really necessary to restrict
-            ' regions to be outside of method bodies? Commenting out the check for now.
-            'If Context.IsWithin(AddressOf SyntaxFacts.IsMethodBlockStatement) Then
-            '    statement = ReportSyntaxError(statement, ERRID.ERR_RegionWithinMethod)
-            'End If
-
             Return statement
         End Function
 
@@ -436,6 +429,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ElseIf enableOrDisableKeyword.Kind = SyntaxKind.DisableKeyword Then
                 statement = SyntaxFactory.DisableWarningDirectiveTrivia(
                     hashToken, enableOrDisableKeyword, warningKeyword, errorCodes.ToList)
+            End If
+
+            If statement IsNot Nothing Then
+                statement = CheckFeatureAvailability(Feature.WarningDirectives, statement)
             End If
 
             Me._pool.Free(errorCodes)

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -944,6 +944,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 operatorToken = DirectCast(current, KeywordSyntax)
 
+                If operatorToken.Kind = SyntaxKind.IsNotKeyword Then
+                    operatorToken = CheckFeatureAvailability(Feature.TypeOfIsNot, operatorToken)
+                End If
+
                 GetNextToken()
 
                 TryEatNewLine(ScannerState.VB)

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseScan.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseScan.vb
@@ -346,6 +346,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 If Not NextLineStartsWithStatementTerminator() Then
                     _hadImplicitLineContinuation = True
 
+                    If PrevToken.GetTrailingTrivia().ContainsCommentTrivia() Then
+                        _hadLineContinuationComment = True
+                    End If
+
                     GetNextToken(state)
                     Return True
                 End If

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -25,6 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private _allowLeadingMultilineTrivia As Boolean = True
         Private _hadImplicitLineContinuation As Boolean = False
+        Private _hadLineContinuationComment As Boolean = False
         Private _possibleFirstStatementOnLine As PossibleFirstStatementKind = PossibleFirstStatementKind.Yes
         Private _recursionDepth As Integer
         Private _evaluatingConditionCompilationExpression As Boolean
@@ -501,9 +502,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Dim notClosedIfDirectives As ArrayBuilder(Of IfDirectiveTriviaSyntax) = Nothing
             Dim notClosedRegionDirectives As ArrayBuilder(Of RegionDirectiveTriviaSyntax) = Nothing
+            Dim haveRegionDirectives As Boolean = False
             Dim notClosedExternalSourceDirective As ExternalSourceDirectiveTriviaSyntax = Nothing
-            terminator = _scanner.RecoverFromMissingConditionalEnds(terminator, notClosedIfDirectives, notClosedRegionDirectives, notClosedExternalSourceDirective)
-            Return programContext.CreateCompilationUnit(terminator, notClosedIfDirectives, notClosedRegionDirectives, notClosedExternalSourceDirective)
+            terminator = _scanner.RecoverFromMissingConditionalEnds(terminator, notClosedIfDirectives, notClosedRegionDirectives, haveRegionDirectives, notClosedExternalSourceDirective)
+            Return programContext.CreateCompilationUnit(terminator, notClosedIfDirectives, notClosedRegionDirectives, haveRegionDirectives, notClosedExternalSourceDirective)
         End Function
 
         Private Function ParseWithStackGuard(Of TNode As VisualBasicSyntaxNode)(parseFunc As Func(Of TNode), defaultFunc As Func(Of TNode)) As TNode
@@ -636,6 +638,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' *
         ' **********************************************************************/
         Friend Function ParseDeclarationStatement() As StatementSyntax
+            Dim oldHadImplicitLineContinuation = _hadImplicitLineContinuation
+            Dim oldHadLineContinuationComment = _hadLineContinuationComment
+
+            Try
+                _hadImplicitLineContinuation = False
+                _hadLineContinuationComment = False
+
+                Dim statementSyntax = ParseDeclarationStatementInternal()
+
+                Debug.Assert(Not _hadLineContinuationComment OrElse _hadImplicitLineContinuation)
+                If _hadImplicitLineContinuation Then
+                    Dim original = statementSyntax
+                    statementSyntax = CheckFeatureAvailability(Feature.LineContinuation, statementSyntax)
+
+                    If original Is statementSyntax AndAlso _hadLineContinuationComment Then
+                        statementSyntax = CheckFeatureAvailability(Feature.LineContinuationComments, statementSyntax)
+                    End If
+                End If
+
+                Return statementSyntax
+            Finally
+                _hadImplicitLineContinuation = oldHadImplicitLineContinuation
+                _hadLineContinuationComment = oldHadLineContinuationComment
+            End Try
+        End Function
+
+        Friend Function ParseDeclarationStatementInternal() As StatementSyntax
             _cancellationToken.ThrowIfCancellationRequested()
 
             ' ParseEnumMember is now handled below with case NodeKind.Identifier
@@ -746,7 +775,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case SyntaxKind.ColonToken,
                     SyntaxKind.StatementTerminatorToken
                     Debug.Assert(False, "Unexpected terminator: " & CurrentToken.Kind.ToString())
-                    Return ParseStatementInMethodBody()
+                    Return ParseStatementInMethodBodyInternal()
 
                 Case SyntaxKind.IntegerLiteralToken
                     If IsFirstStatementOnLine(CurrentToken) Then
@@ -781,7 +810,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     End If
 
                     If Context.BlockKind = SyntaxKind.CompilationUnit Then
-                        Return ParseStatementInMethodBody()
+                        Return ParseStatementInMethodBodyInternal()
                     End If
 
                     If ShouldParseAsLabel() Then
@@ -820,11 +849,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     If statement IsNot Nothing Then
                         Return statement
                     End If
-                    Return ParseStatementInMethodBody()
+                    Return ParseStatementInMethodBodyInternal()
 
                 Case Else
                     ' misplaced statement errors are reported by the context
-                    Return ParseStatementInMethodBody()
+                    Return ParseStatementInMethodBodyInternal()
             End Select
 
         End Function
@@ -857,6 +886,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' .Parser::ParseStatementInMethodBody( [ _Inout_ bool& ErrorInConstruct ] )
         Friend Function ParseStatementInMethodBody() As StatementSyntax
             Dim oldHadImplicitLineContinuation = _hadImplicitLineContinuation
+            Dim oldHadLineContinuationComment = _hadLineContinuationComment
+
+            Try
+                _hadImplicitLineContinuation = False
+                _hadLineContinuationComment = False
+
+                Dim statementSyntax = ParseStatementInMethodBodyInternal()
+
+                Debug.Assert(Not _hadLineContinuationComment OrElse _hadImplicitLineContinuation)
+                If _hadImplicitLineContinuation Then
+                    Dim original = statementSyntax
+                    statementSyntax = CheckFeatureAvailability(Feature.LineContinuation, statementSyntax)
+
+                    If original Is statementSyntax AndAlso _hadLineContinuationComment Then
+                        statementSyntax = CheckFeatureAvailability(Feature.LineContinuationComments, statementSyntax)
+                    End If
+                End If
+
+                Return statementSyntax
+            Finally
+                _hadImplicitLineContinuation = oldHadImplicitLineContinuation
+                _hadLineContinuationComment = oldHadLineContinuationComment
+            End Try
+        End Function
+
+        Friend Function ParseStatementInMethodBodyInternal() As StatementSyntax
 
             Try
                 _recursionDepth += 1
@@ -864,20 +919,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
                 End If
 
-                _hadImplicitLineContinuation = False
-                Dim statementSyntax = ParseStatementInMethodBodyCore()
-                If _hadImplicitLineContinuation Then
-                    statementSyntax = CheckFeatureAvailability(Feature.LineContinuation, statementSyntax)
-                End If
-
-                Return statementSyntax
+                Return ParseStatementInMethodBodyCore()
             Finally
                 _recursionDepth -= 1
-                _hadImplicitLineContinuation = oldHadImplicitLineContinuation
             End Try
         End Function
 
-        Friend Function ParseStatementInMethodBodyCore() As StatementSyntax
+        Private Function ParseStatementInMethodBodyCore() As StatementSyntax
             _cancellationToken.ThrowIfCancellationRequested()
 
             Select Case CurrentToken.Kind
@@ -1188,7 +1236,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         SyntaxKind.ModuleKeyword
                     ' This used to return a BadStatement with ERRID_InvInsideEndsProc.
                     ' Just delegate to ParseDeclarationStatement and let the context add the error
-                    Return ParseDeclarationStatement()
+                    Return ParseDeclarationStatementInternal()
 
                 Case SyntaxKind.QuestionToken
 
@@ -1569,6 +1617,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End If
 
             Dim statement As TypeStatementSyntax = InternalSyntaxFactory.TypeStatement(kind, attributes, modifiers, typeKeyword, ident, optionalTypeParameters)
+
+            If (kind = SyntaxKind.ModuleStatement OrElse kind = SyntaxKind.InterfaceStatement) AndAlso statement.Modifiers.Any(SyntaxKind.PartialKeyword) Then
+                statement = CheckFeatureAvailability(If(kind = SyntaxKind.ModuleStatement, Feature.PartialModules, Feature.PartialInterfaces), statement)
+            End If
 
             Return statement
         End Function
@@ -4072,7 +4124,14 @@ checkNullable:
             If CurrentToken.Kind <> SyntaxKind.EndOfFileToken Then
                 Dim peek = PeekToken(1)
                 If peek.Kind <> SyntaxKind.GetKeyword AndAlso peek.Kind <> SyntaxKind.SetKeyword Then
-                    propertyStatement = CheckFeatureAvailability(Feature.AutoProperties, propertyStatement)
+                    If Context.BlockKind <> SyntaxKind.InterfaceBlock AndAlso Not propertyStatement.Modifiers.Any(SyntaxKind.MustOverrideKeyword) Then
+                        Dim originalStatement = propertyStatement
+                        propertyStatement = CheckFeatureAvailability(Feature.AutoProperties, propertyStatement)
+
+                        If propertyStatement Is originalStatement AndAlso propertyStatement.Modifiers.Any(SyntaxKind.ReadOnlyKeyword) Then
+                            propertyStatement = CheckFeatureAvailability(Feature.ReadonlyAutoProperties, propertyStatement)
+                        End If
+                    End If
                 End If
             End If
 
@@ -5998,7 +6057,10 @@ checkNullable:
         ''' of the parser.  If it is not available a diagnostic will be added to the returned value.
         ''' </summary>
         Private Function CheckFeatureAvailability(Of TNode As VisualBasicSyntaxNode)(feature As Feature, node As TNode) As TNode
-            Dim languageVersion = _scanner.Options.LanguageVersion
+            Return CheckFeatureAvailability(feature, node, _scanner.Options.LanguageVersion)
+        End Function
+
+        Friend Shared Function CheckFeatureAvailability(Of TNode As VisualBasicSyntaxNode)(feature As Feature, node As TNode, languageVersion As LanguageVersion) As TNode
             If CheckFeatureAvailability(languageVersion, feature) Then
                 Return node
             End If
@@ -6008,16 +6070,24 @@ checkNullable:
                 ' an unlocalized string and fix this to be localized in the next release.
                 Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), "interpolated strings")
             Else
-                Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
-                Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), featureName)
+                Return ReportFeatureUnavailable(feature, node, languageVersion)
             End If
         End Function
 
-        Private Function CheckFeatureAvailability(feature As Feature) As Boolean
+        Private Shared Function ReportFeatureUnavailable(Of TNode As VisualBasicSyntaxNode)(feature As Feature, node As TNode, languageVersion As LanguageVersion) As TNode
+            Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
+            Return ReportSyntaxError(node, ERRID.ERR_LanguageVersion, languageVersion.GetErrorName(), featureName)
+        End Function
+
+        Friend Function ReportFeatureUnavailable(Of TNode As VisualBasicSyntaxNode)(feature As Feature, node As TNode) As TNode
+            Return ReportFeatureUnavailable(feature, node, _scanner.Options.LanguageVersion)
+        End Function
+
+        Friend Function CheckFeatureAvailability(feature As Feature) As Boolean
             Return CheckFeatureAvailability(_scanner.Options.LanguageVersion, feature)
         End Function
 
-        Private Shared Function CheckFeatureAvailability(languageVersion As LanguageVersion, feature As Feature) As Boolean
+        Friend Shared Function CheckFeatureAvailability(languageVersion As LanguageVersion, feature As Feature) As Boolean
             Dim required = feature.GetLanguageVersion()
             Return CInt(required) <= CInt(languageVersion)
         End Function

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
@@ -18,6 +18,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         NullPropagatingOperator
         NameOfExpressions
         InterpolatedStrings
+        ReadonlyAutoProperties
+        RegionsEverywhere
+        MultilineStringLiterals
+        CObjInAttributeArguments
+        LineContinuationComments
+        TypeOfIsNot
+        YearFirstDateLiterals
+        WarningDirectives
+        PartialModules
+        PartialInterfaces
+        ImplementingReadonlyOrWriteonlyPropertyWithReadwrite
     End Enum
 
     Friend Module FeatureExtensions
@@ -50,7 +61,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 Case Feature.NullPropagatingOperator,
                      Feature.NameOfExpressions,
-                     Feature.InterpolatedStrings
+                     Feature.InterpolatedStrings,
+                     Feature.ReadonlyAutoProperties,
+                     Feature.RegionsEverywhere,
+                     Feature.MultilineStringLiterals,
+                     Feature.CObjInAttributeArguments,
+                     Feature.LineContinuationComments,
+                     Feature.TypeOfIsNot,
+                     Feature.YearFirstDateLiterals,
+                     Feature.WarningDirectives,
+                     Feature.PartialModules,
+                     Feature.PartialInterfaces,
+                     Feature.ImplementingReadonlyOrWriteonlyPropertyWithReadwrite
                     Return LanguageVersion.VisualBasic14
 
                 Case Else
@@ -64,6 +86,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Select Case feature
                 Case Feature.AutoProperties
                     Return ERRID.FEATURE_AutoProperties
+                Case Feature.ReadonlyAutoProperties
+                    Return ERRID.FEATURE_ReadonlyAutoProperties
                 Case Feature.LineContinuation
                     Return ERRID.FEATURE_LineContinuation
                 Case Feature.StatementLambdas
@@ -86,6 +110,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return ERRID.FEATURE_NullPropagatingOperator
                 Case Feature.NameOfExpressions
                     Return ERRID.FEATURE_NameOfExpressions
+                Case Feature.RegionsEverywhere
+                    Return ERRID.FEATURE_RegionsEverywhere
+                Case Feature.MultilineStringLiterals
+                    Return ERRID.FEATURE_MultilineStringLiterals
+                Case Feature.CObjInAttributeArguments
+                    Return ERRID.FEATURE_CObjInAttributeArguments
+                Case Feature.LineContinuationComments
+                    Return ERRID.FEATURE_LineContinuationComments
+                Case Feature.TypeOfIsNot
+                    Return ERRID.FEATURE_TypeOfIsNot
+                Case Feature.YearFirstDateLiterals
+                    Return ERRID.FEATURE_YearFirstDateLiterals
+                Case Feature.WarningDirectives
+                    Return ERRID.FEATURE_WarningDirectives
+                Case Feature.PartialModules
+                    Return ERRID.FEATURE_PartialModules
+                Case Feature.PartialInterfaces
+                    Return ERRID.FEATURE_PartialInterfaces
+                Case Feature.ImplementingReadonlyOrWriteonlyPropertyWithReadwrite
+                    Return ERRID.FEATURE_ImplementingReadonlyOrWriteonlyPropertyWithReadwrite
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(feature)
             End Select

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -1999,6 +1999,7 @@ FullWidthRepeat2:
             Dim DateIsInvalid As Boolean = False
             Dim YearIsTwoDigits As Boolean = False
             Dim DaysToMonth As Integer() = Nothing
+            Dim yearIsFirst As Boolean = False
 
             ' // Unfortunately, we can't fall back on OLE Automation's date parsing because
             ' // they don't have the same range as the URT's DateTime class
@@ -2028,6 +2029,7 @@ FullWidthRepeat2:
                 ' Condition below uses 5 because we already skipped the separator.
                 If Here - FirstValueStart = 5 Then
                     HaveYearValue = True
+                    yearIsFirst = True
                     YearValue = FirstValue
 
                     ' // We have to have a month value
@@ -2264,7 +2266,13 @@ FullWidthRepeat2:
 
             If Not DateIsInvalid Then
                 Dim DateTimeValue As New DateTime(YearValue, MonthValue, DayValue, HourValue, MinuteValue, SecondValue)
-                Return MakeDateLiteralToken(precedingTrivia, DateTimeValue, Here)
+                Dim result = MakeDateLiteralToken(precedingTrivia, DateTimeValue, Here)
+
+                If yearIsFirst Then
+                    result = Parser.CheckFeatureAvailability(Feature.YearFirstDateLiterals, result, Options.LanguageVersion)
+                End If
+
+                Return result
             Else
                 Return MakeBadToken(precedingTrivia, Here, ERRID.ERR_InvalidDate)
             End If
@@ -2326,6 +2334,8 @@ baddate:
                 Return MakeBadToken(precedingTrivia, 3, ERRID.ERR_IllegalCharConstant)
             End If
 
+            Dim haveNewLine As Boolean = False
+
             Dim scratch = GetScratch()
             While CanGet(length)
                 ch = Peek(length)
@@ -2357,10 +2367,20 @@ baddate:
                     followingTrivia = ScanSingleLineTrivia()
 
                     ' NATURAL TEXT, NO INTERNING
-                    Return SyntaxFactory.StringLiteralToken(spelling, GetScratchText(scratch), precedingTrivia.Node, followingTrivia.Node)
+                    Dim result As SyntaxToken = SyntaxFactory.StringLiteralToken(spelling, GetScratchText(scratch), precedingTrivia.Node, followingTrivia.Node)
 
-                ElseIf Me._isScanningDirective AndAlso IsNewLine(ch) Then
-                    Exit While
+                    If haveNewLine Then
+                        result = Parser.CheckFeatureAvailability(Feature.MultilineStringLiterals, result, Options.LanguageVersion)
+                    End If
+
+                    Return result
+
+                ElseIf IsNewLine(ch) Then
+                    If Me._isScanningDirective Then
+                        Exit While
+                    End If
+
+                    haveNewLine = True
                 End If
 
                 scratch.Append(ch)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -443,6 +443,12 @@ DoneWithErrorReporting:
                     Binder.ReportDiagnostic(diagBag, implementedMemberSyntax, ERRID.ERR_PropertyDoesntImplementAllAccessors,
                                             implementedProperty,
                                             implementingProperty.GetPropertyKindText())
+
+                ElseIf ((implementedProperty.GetMethod Is Nothing) Xor (implementedProperty.SetMethod Is Nothing)) AndAlso
+                       implementingProperty.GetMethod IsNot Nothing AndAlso implementingProperty.SetMethod IsNot Nothing
+                    InternalSyntax.Parser.CheckFeatureAvailability(diagBag, implementedMemberSyntax.GetLocation(),
+                                                                   DirectCast(implementedMemberSyntax.SyntaxTree, VisualBasicSyntaxTree).Options.LanguageVersion,
+                                                                   InternalSyntax.Feature.ImplementingReadonlyOrWriteonlyPropertyWithReadwrite)
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeExtensions.vb
@@ -616,6 +616,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 #End Region
 
+        <Extension()>
+        Friend Function ContainsCommentTrivia(this As VisualBasicSyntaxNode) As Boolean
+            If this Is Nothing Then
+                Return False
+            End If
+
+            Dim trivia = New SyntaxList(Of VisualBasicSyntaxNode)(this)
+
+            For i = 0 To trivia.Count - 1
+                Dim kind = trivia.ItemUntyped(i).RawKind
+                If kind = SyntaxKind.CommentTrivia Then
+                    Return True
+                End If
+            Next
+
+            Return False
+        End Function
+
         ' This was Semantics::ExtractAnonTypeMemberName in Dev 10
         <Extension()>
         Friend Function ExtractAnonymousTypeMemberName(input As ExpressionSyntax,

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -2703,7 +2703,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Debug entry point must be a definition of a source method..
+        '''  Looks up a localized string similar to Debug entry point must be a definition of a method declared in the current compilation..
         '''</summary>
         Friend ReadOnly Property ERR_DebugEntryPointNotSourceMethodDefinition() As String
             Get
@@ -11614,6 +11614,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to CObj in attribute arguments.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_CObjInAttributeArguments() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_CObjInAttributeArguments", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to variance.
         '''</summary>
         Friend ReadOnly Property FEATURE_CoContraVariance() As String
@@ -11641,6 +11650,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to implementing read-only or write-only property with read-write property.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_ImplementingReadonlyOrWriteonlyPropertyWithReadwrite() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_ImplementingReadonlyOrWriteonlyPropertyWithReadwrite", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to iterators.
         '''</summary>
         Friend ReadOnly Property FEATURE_Iterators() As String
@@ -11655,6 +11673,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property FEATURE_LineContinuation() As String
             Get
                 Return ResourceManager.GetString("FEATURE_LineContinuation", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to line continuation comments.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_LineContinuationComments() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_LineContinuationComments", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to multiline string literals.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_MultilineStringLiterals() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_MultilineStringLiterals", resourceCulture)
             End Get
         End Property
         
@@ -11677,6 +11713,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to partial interafces.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_PartialInterfaces() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_PartialInterfaces", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to partial modules.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_PartialModules() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_PartialModules", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to readonly auto-implemented properties.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_ReadonlyAutoProperties() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_ReadonlyAutoProperties", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to region directives within method bodies or regions crossing boundaries of declaration blocks.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_RegionsEverywhere() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_RegionsEverywhere", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to multi-line lambda expressions.
         '''</summary>
         Friend ReadOnly Property FEATURE_StatementLambdas() As String
@@ -11691,6 +11763,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property FEATURE_SubLambdas() As String
             Get
                 Return ResourceManager.GetString("FEATURE_SubLambdas", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to TypeOf IsNot expression.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_TypeOfIsNot() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_TypeOfIsNot", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to warning directives.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_WarningDirectives() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_WarningDirectives", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to year-first date literals.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_YearFirstDateLiterals() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_YearFirstDateLiterals", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5268,6 +5268,9 @@
   <data name="FEATURE_AutoProperties" xml:space="preserve">
     <value>auto-implemented properties</value>
   </data>
+  <data name="FEATURE_ReadonlyAutoProperties" xml:space="preserve">
+    <value>readonly auto-implemented properties</value>
+  </data>
   <data name="FEATURE_CoContraVariance" xml:space="preserve">
     <value>variance</value>
   </data>
@@ -5294,6 +5297,36 @@
   </data>
   <data name="FEATURE_NameOfExpressions" xml:space="preserve">
     <value>'nameof' expressions</value>
+  </data>
+  <data name="FEATURE_RegionsEverywhere" xml:space="preserve">
+    <value>region directives within method bodies or regions crossing boundaries of declaration blocks</value>
+  </data>
+  <data name="FEATURE_MultilineStringLiterals" xml:space="preserve">
+    <value>multiline string literals</value>
+  </data>
+  <data name="FEATURE_CObjInAttributeArguments" xml:space="preserve">
+    <value>CObj in attribute arguments</value>
+  </data>
+  <data name="FEATURE_LineContinuationComments" xml:space="preserve">
+    <value>line continuation comments</value>
+  </data>
+  <data name="FEATURE_TypeOfIsNot" xml:space="preserve">
+    <value>TypeOf IsNot expression</value>
+  </data>
+  <data name="FEATURE_YearFirstDateLiterals" xml:space="preserve">
+    <value>year-first date literals</value>
+  </data>
+  <data name="FEATURE_WarningDirectives" xml:space="preserve">
+    <value>warning directives</value>
+  </data>
+  <data name="FEATURE_PartialModules" xml:space="preserve">
+    <value>partial modules</value>
+  </data>
+  <data name="FEATURE_PartialInterfaces" xml:space="preserve">
+    <value>partial interafces</value>
+  </data>
+  <data name="FEATURE_ImplementingReadonlyOrWriteonlyPropertyWithReadwrite" xml:space="preserve">
+    <value>implementing read-only or write-only property with read-write property</value>
   </data>
   <data name="ERR_DebugEntryPointNotSourceMethodDefinition" xml:space="preserve">
     <value>Debug entry point must be a definition of a method declared in the current compilation.</value>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -24476,5 +24476,1474 @@ BC42004: Expression recursively calls the containing Operator 'Public Shared Wid
 
         End Sub
 
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_ReadonlyAutoProperties()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+
+    Public Sub New()
+        'Check assignment of readonly auto property
+        Test = "Test"
+    End Sub
+
+    'Check readonly auto-properties
+    Public ReadOnly Property Test As String
+End Class
+
+Interface I1
+    ReadOnly Property Test1 As String
+    WriteOnly Property Test2 As String
+    Property Test3 As String
+End Interface
+
+MustInherit Class C1
+    MustOverride ReadOnly Property Test1 As String
+    MustOverride WriteOnly Property Test2 As String
+    MustOverride Property Test3 As String
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support readonly auto-implemented properties.
+    Public ReadOnly Property Test As String
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+
+            compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic9))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 9.0 does not support auto-implemented properties.
+    Public ReadOnly Property Test As String
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere01()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+
+    Sub New()
+#Region "Region in .ctor"
+#End Region ' "Region in .ctor"
+    End Sub
+
+    Shared Sub New()
+#Region "Region in .cctor"
+#End Region ' "Region in .cctor"
+    End Sub
+
+    Public Sub ASub()
+#Region "Region in a Sub"
+#End Region ' "Region in a Sub"
+    End Sub
+
+    Public Function AFunc()
+#Region "Region in a Func"
+#End Region ' "Region in a Func"
+    End Function
+
+    Shared Operator +(x As TestClass, y As TestClass) As TestClass
+#Region "Region in an operator"
+#End Region ' "Region in an operator"
+    End Operator
+
+    Property P As Integer
+        Get
+#Region "Region in a get"
+#End Region ' "Region in a get"
+        End Get
+        Set(value As Integer)
+#Region "Region in a set"
+#End Region ' "Region in a set"
+        End Set
+    End Property
+
+    Custom Event E As System.Action
+        AddHandler(value As Action)
+#Region "Region in an add"
+#End Region ' "Region in an add"
+        End AddHandler
+        RemoveHandler(value As Action)
+#Region "Region in a remove"
+#End Region ' "Region in a remove"
+        End RemoveHandler
+        RaiseEvent()
+#Region "Region in a raise"
+#End Region ' "Region in a raise"
+        End RaiseEvent
+    End Event
+
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in .ctor"
+~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in .ctor"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in .cctor"
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in .cctor"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in a Sub"
+~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in a Sub"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in a Func"
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in a Func"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in an operator"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in an operator"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in a get"
+~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in a get"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in a set"
+~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in a set"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in an add"
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in an add"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in a remove"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in a remove"
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region in a raise"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' "Region in a raise"
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere02()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+#Region "Region"
+#End Region 
+    Sub New()
+    End Sub
+#Region "Region"
+#End Region 
+    Shared Sub New()
+    End Sub
+#Region "Region"
+#End Region 
+    Public Sub ASub()
+    End Sub
+#Region "Region"
+#End Region 
+    Public Function AFunc()
+    End Function
+#Region "Region"
+#End Region 
+    Shared Operator +(x As TestClass, y As TestClass) As TestClass
+    End Operator
+#Region "Region"
+#End Region 
+    Property P As Integer
+#Region "Region"
+#End Region 
+        Get
+        End Get
+#Region "Region"
+#End Region 
+        Set(value As Integer)
+        End Set
+#Region "Region"
+#End Region 
+    End Property
+#Region "Region"
+#End Region 
+    Custom Event E As System.Action
+#Region "Region"
+#End Region 
+        AddHandler(value As Action)
+        End AddHandler
+#Region "Region"
+#End Region 
+        RemoveHandler(value As Action)
+        End RemoveHandler
+#Region "Region"
+#End Region 
+        RaiseEvent()
+        End RaiseEvent
+#Region "Region"
+#End Region 
+    End Event
+#Region "Region"
+#End Region 
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere03()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+    Sub New()
+    End Sub
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+    Shared Sub New()
+    End Sub
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+    Public Sub ASub()
+    End Sub
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+    Public Function AFunc()
+    End Function
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+    Shared Operator +(x As TestClass, y As TestClass) As TestClass
+    End Operator
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+    Property P As Integer
+#Region "Region"
+#End Region 
+        Get
+        End Get
+#Region "Region"
+#End Region 
+        Set(value As Integer)
+        End Set
+#Region "Region"
+#End Region 
+    End Property
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+    Custom Event E As System.Action
+#Region "Region"
+#End Region 
+        AddHandler(value As Action)
+        End AddHandler
+#Region "Region"
+#End Region 
+        RemoveHandler(value As Action)
+        End RemoveHandler
+#Region "Region"
+#End Region 
+        RaiseEvent()
+        End RaiseEvent
+#Region "Region"
+#End Region 
+    End Event
+#Region "Region"
+    Private f1 as Integer
+#End Region 
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere04()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+#Region "Region"
+    Sub New()
+    End Sub
+#End Region 
+#Region "Region"
+    Shared Sub New()
+    End Sub
+#End Region 
+#Region "Region"
+    Public Sub ASub()
+    End Sub
+#End Region 
+#Region "Region"
+    Public Function AFunc()
+    End Function
+#End Region 
+#Region "Region"
+    Shared Operator +(x As TestClass, y As TestClass) As TestClass
+    End Operator
+#End Region 
+#Region "Region"
+    Property P As Integer
+#Region "Region"
+        Get
+        End Get
+#End Region 
+#Region "Region"
+        Set(value As Integer)
+        End Set
+#End Region 
+    End Property
+#End Region 
+#Region "Region"
+    Custom Event E As System.Action
+#Region "Region"
+        AddHandler(value As Action)
+        End AddHandler
+#End Region 
+#Region "Region"
+        RemoveHandler(value As Action)
+        End RemoveHandler
+#End Region 
+#Region "Region"
+        RaiseEvent()
+        End RaiseEvent
+#End Region 
+    End Event
+#End Region 
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere05()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+    Property P As Integer
+        Get
+#Region "Region"
+#End Region 
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC30481: 'Class' statement must end with a matching 'End Class'.
+Class TestClass
+~~~~~~~~~~~~~~~
+BC30025: Property missing 'End Property'.
+    Property P As Integer
+    ~~~~~~~~~~~~~~~~~~~~~
+BC30631: 'Get' statement must end with a matching 'End Get'.
+        Get
+        ~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere06()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+    Property P As Integer
+        Get
+        End Get
+#Region "Region"
+#End Region</file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC30481: 'Class' statement must end with a matching 'End Class'.
+Class TestClass
+~~~~~~~~~~~~~~~
+BC30025: Property missing 'End Property'.
+    Property P As Integer
+    ~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere07()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+    Property P As Integer
+        Get
+#Region "Region"
+#End Region 
+    End Property
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC30631: 'Get' statement must end with a matching 'End Get'.
+        Get
+        ~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere08()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class TestClass
+    Sub Test()
+#if False
+#Region "Region"
+#End Region 
+#End if
+    End Sub
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere09()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+#Region "Region 1"
+#End Region ' 1 
+        </file>
+        <file name="b.vb">
+#Region "Region 2"
+        </file>
+        <file name="c.vb">
+#End Region ' 3 
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region 2"
+~~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 3
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere10()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Namespace NS1
+#Region "Region1"
+#End Region ' 1
+End Namespace
+
+#Region "Region2"
+Namespace NS2
+#End Region ' 2
+End Namespace
+
+Namespace NS3
+#Region "Region3"
+End Namespace
+#End Region ' 3
+
+Namespace NS4
+#Region "Region4"
+
+End Namespace
+Namespace NS5
+
+#End Region ' 4
+
+End Namespace
+
+#Region "Region5"
+Namespace NS6
+End Namespace
+#End Region ' 5
+        </file>
+        <file name="b.vb">
+Namespace NS7
+#Region "Region6"
+End Namespace
+        </file>
+        <file name="c.vb">
+Namespace NS8
+#End Region ' 7
+End Namespace
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere11()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Module NS1
+#Region "Region1"
+#End Region ' 1
+End Module
+
+#Region "Region2"
+Module NS2
+#End Region ' 2
+End Module
+
+Module NS3
+#Region "Region3"
+End Module
+#End Region ' 3
+
+Module NS4
+#Region "Region4"
+
+End Module
+Module NS5
+
+#End Region ' 4
+
+End Module
+
+#Region "Region5"
+Module NS6
+End Module
+#End Region ' 5
+        </file>
+        <file name="b.vb">
+Module NS7
+#Region "Region6"
+End Module
+        </file>
+        <file name="c.vb">
+Module NS8
+#End Region ' 7
+End Module
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere12()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class NS1
+#Region "Region1"
+#End Region ' 1
+End Class
+
+#Region "Region2"
+Class NS2
+#End Region ' 2
+End Class
+
+Class NS3
+#Region "Region3"
+End Class
+#End Region ' 3
+
+Class NS4
+#Region "Region4"
+
+End Class
+Class NS5
+
+#End Region ' 4
+
+End Class
+
+#Region "Region5"
+Class NS6
+End Class
+#End Region ' 5
+        </file>
+        <file name="b.vb">
+Class NS7
+#Region "Region6"
+End Class
+        </file>
+        <file name="c.vb">
+Class NS8
+#End Region ' 7
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere13()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Structure NS1
+#Region "Region1"
+#End Region ' 1
+End Structure
+
+#Region "Region2"
+Structure NS2
+#End Region ' 2
+End Structure
+
+Structure NS3
+#Region "Region3"
+End Structure
+#End Region ' 3
+
+Structure NS4
+#Region "Region4"
+
+End Structure
+Structure NS5
+
+#End Region ' 4
+
+End Structure
+
+#Region "Region5"
+Structure NS6
+End Structure
+#End Region ' 5
+        </file>
+        <file name="b.vb">
+Structure NS7
+#Region "Region6"
+End Structure
+        </file>
+        <file name="c.vb">
+Structure NS8
+#End Region ' 7
+End Structure
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere14()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Interface NS1
+#Region "Region1"
+#End Region ' 1
+End Interface
+
+#Region "Region2"
+Interface NS2
+#End Region ' 2
+End Interface
+
+Interface NS3
+#Region "Region3"
+End Interface
+#End Region ' 3
+
+Interface NS4
+#Region "Region4"
+
+End Interface
+Interface NS5
+
+#End Region ' 4
+
+End Interface
+
+#Region "Region5"
+Interface NS6
+End Interface
+#End Region ' 5
+        </file>
+        <file name="b.vb">
+Interface NS7
+#Region "Region6"
+End Interface
+        </file>
+        <file name="c.vb">
+Interface NS8
+#End Region ' 7
+End Interface
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere15()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Enum NS1
+#Region "Region1"
+#End Region ' 1
+End Enum
+
+#Region "Region2"
+Enum NS2
+#End Region ' 2
+End Enum
+
+Enum NS3
+#Region "Region3"
+End Enum
+#End Region ' 3
+
+Enum NS4
+#Region "Region4"
+
+End Enum
+Enum NS5
+
+#End Region ' 4
+
+End Enum
+
+#Region "Region5"
+Enum NS6
+End Enum
+#End Region ' 5
+        </file>
+        <file name="b.vb">
+Enum NS7
+#Region "Region6"
+End Enum
+        </file>
+        <file name="c.vb">
+Enum NS8
+#End Region ' 7
+End Enum
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere16()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class NS1
+    Property P1 As Integer
+#Region "Region1"
+#End Region ' 1
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+
+Class NS2
+#Region "Region2"
+    Property P1 As Integer
+#End Region ' 2
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+
+Class NS3
+    Property P1 As Integer
+#Region "Region3"
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+#End Region ' 3
+End Class
+
+Class NS4
+    Property P1 As Integer
+#Region "Region4"
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+
+    Property P2 As Integer
+
+#End Region ' 4
+
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+
+Class NS6
+#Region "Region5"
+    Property P1 As Integer
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+#End Region ' 5
+End Class
+        </file>
+        <file name="b.vb">
+Class NS7
+    Property P1 As Integer
+#Region "Region6"
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+        </file>
+        <file name="c.vb">
+Class NS8
+    Property P1 As Integer
+#End Region ' 7
+        Get
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere17()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+Class NS1
+    Custom Event E1 As System.Action
+#Region "Region1"
+#End Region ' 1
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+
+Class NS2
+#Region "Region2"
+    Custom Event E1 As System.Action
+#End Region ' 2
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+
+Class NS3
+    Custom Event E1 As System.Action
+#Region "Region3"
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+#End Region ' 3
+End Class
+
+Class NS4
+    Custom Event E1 As System.Action
+#Region "Region4"
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+
+    Custom Event E2 As System.Action
+
+#End Region ' 4
+
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+
+Class NS6
+#Region "Region5"
+    Custom Event E1 As System.Action
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+#End Region ' 5
+End Class
+        </file>
+        <file name="b.vb">
+Class NS7
+    Custom Event E1 As System.Action
+#Region "Region6"
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+        </file>
+        <file name="c.vb">
+Class NS8
+    Custom Event E1 As System.Action
+#End Region ' 7
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 3
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 4
+~~~~~~~~~~~
+BC30681: '#Region' statement must end with a matching '#End Region'.
+#Region "Region6"
+~~~~~~~~~~~~~~~~~
+BC30680: '#End Region' must be preceded by a matching '#Region'.
+#End Region ' 7
+~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_RegionEveryWhere18()
+            Dim source =
+    <compilation>
+        <file name="a.vb">
+#Region "Region1"
+Class NS1
+#Region "Region2"
+        Sub Test1()
+#End Region ' 2
+        End Sub
+End Class
+#End Region ' 1
+        </file>
+        <file name="b.vb">
+#Region "Region3"
+Class NS2
+        Sub Test1()
+#Region "Region4"
+        End Sub
+#End Region ' 4
+End Class
+#End Region ' 3
+        </file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#End Region ' 2
+~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support region directives within method bodies or regions crossing boundaries of declaration blocks.
+#Region "Region4"
+~~~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_CObjInAttributes()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class TestClass1
+
+    <System.ComponentModel.DefaultValue(CObj("Test"))>
+    Public Property Test2 As String
+
+    '<System.ComponentModel.DefaultValue(CType("Test", Object))>
+    'Public Property Test3 As String
+
+    '<System.ComponentModel.DefaultValue(DirectCast("Test", Object))>
+    'Public Property Test4 As String
+
+    '<System.ComponentModel.DefaultValue(TryCast("Test", Object))>
+    'Public Property Test5 As String
+End Class
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndReferences(source, {SystemRef}, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC36716: Visual Basic 12.0 does not support CObj in attribute arguments.
+    <System.ComponentModel.DefaultValue(CObj("Test"))>
+                                        ~~~~
+]]></expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_MultilineStrings()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class TestClass
+
+    Dim test4 = "
+    This is
+    a muiltiline
+    string"
+
+End Class
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support multiline string literals.
+    Dim test4 = "
+                ~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_LineContinuationComments()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class TestClass
+
+    Dim test5 As String = ""
+    Dim chars = From c In test5 'This is a test of comments in a linq statement
+                Let asc = Asc(c) 'VS2015 can handle this
+                Select asc
+
+    Sub Test()
+        Dim chars2 = From c In test5 'This is a test of comments in a linq statement
+                     Let asc = Asc(c) 'VS2015 can handle this
+                     Select asc
+    End Sub
+End Class
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support line continuation comments.
+    Dim chars = From c In test5 'This is a test of comments in a linq statement
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support line continuation comments.
+        Dim chars2 = From c In test5 'This is a test of comments in a linq statement
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+
+            compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic9))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 9.0 does not support implicit line continuation.
+    Dim chars = From c In test5 'This is a test of comments in a linq statement
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 9.0 does not support implicit line continuation.
+        Dim chars2 = From c In test5 'This is a test of comments in a linq statement
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_TypeOfIsNot()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class TestClass
+
+        Sub Test()
+            Dim test6 As String = ""
+            If TypeOf test6 IsNot System.String Then Console.WriteLine("That string isn't a string")
+        End Sub
+
+End Class
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support TypeOf IsNot expression.
+            If TypeOf test6 IsNot System.String Then Console.WriteLine("That string isn't a string")
+                            ~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_YearFirstDateLiterals()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class TestClass
+
+        Sub Test()
+            Dim d = #2015-08-23#
+        End Sub
+
+End Class
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support year-first date literals.
+            Dim d = #2015-08-23#
+                    ~~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_Pragma()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class TestClass
+
+        Sub Test()
+#Disable Warning BC42024
+            Dim test7 As String 'Should have no "unused variable" warning
+#Enable Warning BC42024
+        End Sub
+
+End Class
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support warning directives.
+#Disable Warning BC42024
+~~~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support warning directives.
+#Enable Warning BC42024
+~~~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_PartialModulesAndInterfaces()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Partial Module Module1
+End Module
+
+Partial Interface IFace
+End Interface
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(source, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseParseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support partial modules.
+Partial Module Module1
+~~~~~~~~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support partial interafces.
+Partial Interface IFace
+~~~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact(), WorkItem(5072, "https://github.com/dotnet/roslyn/issues/5072")>
+        Public Sub LangVersion_ImplementReadonlyWithReadwrite()
+            Dim source =
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Interface IReadOnly
+    ReadOnly Property Test1 As String
+    WriteOnly Property Test2 As String
+End Interface
+
+Class ReadWrite
+    Implements IReadOnly
+
+    Public Property Test1 As String Implements IReadOnly.Test1
+
+    Public Property Test2 As String Implements IReadOnly.Test2
+End Class
+        ]]></file>
+    </compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndReferences(source, {SystemRef}, parseOptions:=VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.VisualBasic12))
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected>
+BC36716: Visual Basic 12.0 does not support implementing read-only or write-only property with read-write property.
+    Public Property Test1 As String Implements IReadOnly.Test1
+                                               ~~~~~~~~~~~~~~~
+BC36716: Visual Basic 12.0 does not support implementing read-only or write-only property with read-write property.
+    Public Property Test2 As String Implements IReadOnly.Test2
+                                               ~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #5072.
Also fixed some issues around LangVersion handling, which were found along the way.

@gafter, @VSadov, @jaredpar, @agocke Please review. 