### PR TITLE
when generating sig help, use SymbolInfo if TypeInfo resolution fails

### DIFF
--- a/src/EditorFeatures/CSharp/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -208,7 +208,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
 
             if (expressionType is IErrorTypeSymbol)
             {
-                expressionType = (expressionType as IErrorTypeSymbol).CandidateSymbols.FirstOrDefault().GetSymbolType();
+                // If `expression` is a QualifiedNameSyntax then GetTypeInfo().Type won't have any CandidateSymbols, so
+                // we should then fall back to getting the actual symbol for the expression.
+                expressionType = (expressionType as IErrorTypeSymbol).CandidateSymbols.FirstOrDefault().GetSymbolType()
+                    ?? semanticModel.GetSymbolInfo(expression).GetAnySymbol().GetSymbolType();
             }
 
             indexers = semanticModel.LookupSymbols(position, expressionType, WellKnownMemberNames.Indexer).OfType<IPropertySymbol>();

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
@@ -833,6 +833,30 @@ public class P
 
                 Test(markup);
             }
+
+            [WorkItem(2482, "https://github.com/dotnet/roslyn/issues/2482")]
+            [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+            public void WhereExpressionLooksLikeArrayTypeSyntaxOfQualifiedName()
+            {
+                var markup = @"
+class WithIndexer
+{
+    public int this[int index] { get { return 0; } }
+}
+
+class TestClass
+{
+    public WithIndexer Item { get; set; }
+
+    public void Method(TestClass tc)
+    {
+        // `tc.Item[]` parses as ArrayTypeSyntax with an ElementType of QualifiedNameSyntax
+        tc.Item[$$]
+    }
+}
+";
+                Test(markup, new[] { new SignatureHelpTestItem("int WithIndexer[int index]") }, usePreviousCharAsTrigger: true);
+            }
         }
     }
 }


### PR DESCRIPTION
For indexer (ElementAccessExpression) signature help in C# to work correctly, the signature help provider has to handle broken code as the user hasn't finished typing and that's accomplished by accepting the parser's output of an `ArrayTypeSyntax` and peeling off the `ElementType` property which is then mapped to a local variable.  If the user's code is

``` C#
localVariable[$$]
```

then the `ElementType` of the parsed `ArrayTypeSyntax` is an `IdentifierName` of "localVariable".  This parse error is then handled by calling `GetTypeInfo()` on "localVariable" which correctly identifies the variable's type causing the rest of the signature help provider to function properly.

This PR considers the case where the user's code instead looks like this:

``` C#
localVariable.SomeProperty[$$]
```

and in this case, the `ArrayTypeSyntax`'s `ElementType` is a `QualifiedNameSyntax` of "localVariable.SomeProperty" which `GetTypeInfo()` can't resolve.  The fix is to then fall back to calling `GetSymbolInfo()` on "localVariable.Property" which *does* give us the correct symbol to use.

VB doesn't have this issue.

Tagging  @Pilchie @DustinCampbell @dpoeschl @jasonmalinowski @rchande @balajikris @CyrusNajmabadi @jmarolf @davkean for review.

Fixes #2482.