### PR TITLE
always show signature help when explicitly invoked

### DIFF
--- a/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
@@ -59,7 +59,8 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         {
             AssertIsForeground();
 
-            // check whether this feature is on, but only if `args` was not InvokeSignatureHelpCommandArgs; in that case always invoke
+            // If args is `InvokeSignatureHelpCommandArgs` then sig help was explicitly invoked by the user and should
+            // be shown whether or not the option is set.
             if (!(args is InvokeSignatureHelpCommandArgs) && !args.SubjectBuffer.GetOption(SignatureHelpOptions.ShowSignatureHelp))
             {
                 controller = null;

--- a/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
@@ -59,8 +59,8 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         {
             AssertIsForeground();
 
-            // check whether this feature is on.
-            if (!args.SubjectBuffer.GetOption(SignatureHelpOptions.ShowSignatureHelp))
+            // check whether this feature is on, but only if `args` was not InvokeSignatureHelpCommandArgs; in that case always invoke
+            if (!(args is InvokeSignatureHelpCommandArgs) && !args.SubjectBuffer.GetOption(SignatureHelpOptions.ShowSignatureHelp))
             {
                 controller = null;
                 return false;

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
@@ -1,7 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CSharp
-Imports Microsoft.CodeAnalysis.Editor.CSharp
+Imports Microsoft.CodeAnalysis.Editor.Options
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
     Public Class CSharpSignatureHelpCommandHandlerTests
@@ -449,6 +449,31 @@ class C
 
                 state.SendTypeChars("<")
                 state.AssertSelectedSignatureHelpItem($"({CSharpFeaturesResources.Extension}) IEnumerable<TResult> IEnumerable.OfType<TResult>()")
+            End Using
+        End Sub
+
+        <WorkItem(5174, "https://github.com/dotnet/roslyn/issues/5174")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
+        Public Sub DontShowSignatureHelpIfOptionIsTurnedOffUnlessExplicitlyInvoked()
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void M(int i)
+    {
+        M$$
+    }
+}
+                              </Document>)
+
+                ' disable implicit sig help then type a trigger character -> no session should be available
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(SignatureHelpOptions.ShowSignatureHelp, "C#", False)
+                state.SendTypeChars("(")
+                state.AssertNoSignatureHelpSession()
+
+                ' force-invoke -> session should be available
+                state.SendInvokeSignatureHelp()
+                state.AssertSignatureHelpSession()
             End Using
         End Sub
     End Class


### PR DESCRIPTION
Signature help was only being shown when the option `Edit.ParameterInfo` was turned on.  This fix causes signature help to display when explicitly invoked (default keyboard shortcut: `Ctrl+Shift+Space`), even if the implicit option is turned off.

Fixes #5174.