### PR TITLE
Handle CodeFix with bad ImmutableArray

### DIFF
--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -78,6 +78,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
         }
 
         [Fact]
+        public void TestGetCodeFixWithExceptionInFixableDiagnosticIds2()
+        {
+            GetDefaultFixes(new ErrorCases.ExceptionInFixableDiagnosticIds2());
+            GetAddedFixes(new ErrorCases.ExceptionInFixableDiagnosticIds2());
+        }
+
+        [Fact]
         public void TestGetCodeFixWithExceptionInGetFixAllProvider()
         {
             GetAddedFixes(new ErrorCases.ExceptionInGetFixAllProvider());

--- a/src/EditorFeatures/Test/CodeFixes/ErrorCases/CodeFixExceptionInFixableDiagnosticIds2.cs
+++ b/src/EditorFeatures/Test/CodeFixes/ErrorCases/CodeFixExceptionInFixableDiagnosticIds2.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes.ErrorCases
+{
+    public class ExceptionInFixableDiagnosticIds2 : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => new ImmutableArray<string>();
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -193,6 +193,7 @@
     <Compile Include="CodeAnalysisResources.cs" />
     <Compile Include="CodeFixes\CodeFixServiceTests.cs" />
     <Compile Include="CodeFixes\ErrorCases\CodeFixExceptionInFixableDiagnosticIds.cs" />
+    <Compile Include="CodeFixes\ErrorCases\CodeFixExceptionInFixableDiagnosticIds2.cs" />
     <Compile Include="CodeFixes\ErrorCases\CodeFixExceptionInGetFixAllProvider.cs" />
     <Compile Include="CodeFixes\ErrorCases\CodeFixExceptionInRegisterMethod.cs" />
     <Compile Include="CodeFixes\ErrorCases\CodeFixExceptionInRegisterMethodAsync.cs" />

--- a/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
@@ -408,13 +408,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             {
                 return extensionManager.PerformFunction(
                     fixer,
-                    () => ImmutableInterlocked.GetOrAdd(ref _fixerToFixableIdsMap, fixer, f => f.FixableDiagnosticIds),
+                    () => ImmutableInterlocked.GetOrAdd(ref _fixerToFixableIdsMap, fixer, f => GetAndTestFixableDiagnosticIds(f)),
                     defaultValue: ImmutableArray<DiagnosticId>.Empty);
             }
 
             try
             {
-                return ImmutableInterlocked.GetOrAdd(ref _fixerToFixableIdsMap, fixer, f => f.FixableDiagnosticIds);
+                return ImmutableInterlocked.GetOrAdd(ref _fixerToFixableIdsMap, fixer, f => GetAndTestFixableDiagnosticIds(f));
             }
             catch (OperationCanceledException)
             {
@@ -428,6 +428,20 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 }
                 return ImmutableArray<DiagnosticId>.Empty;
             }
+        }
+
+        private static ImmutableArray<string> GetAndTestFixableDiagnosticIds(CodeFixProvider codeFixProvider)
+        {
+            var ids = codeFixProvider.FixableDiagnosticIds;
+            if (ids.IsDefault)
+            {
+                throw new InvalidOperationException(
+                    string.Format(
+                        WorkspacesResources.FixableDiagnosticIdsIncorrectlyInitialized, 
+                        codeFixProvider.GetType().Name+ "."+ nameof(CodeFixProvider.FixableDiagnosticIds)));
+            }
+
+            return ids;
         }
 
         private ImmutableDictionary<LanguageKind, Lazy<ImmutableDictionary<DiagnosticId, ImmutableArray<CodeFixProvider>>>> GetFixerPerLanguageMap(

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -440,6 +440,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; returned an uninitialized ImmutableArray.
+        /// </summary>
+        internal static string FixableDiagnosticIdsIncorrectlyInitialized {
+            get {
+                return ResourceManager.GetString("FixableDiagnosticIdsIncorrectlyInitialized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix all &apos;{0}&apos;.
         /// </summary>
         internal static string FixAllOccurrencesOfDiagnostic {

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -456,4 +456,7 @@
   <data name="Exceptions" xml:space="preserve">
     <value>Exceptions:</value>
   </data>
+  <data name="FixableDiagnosticIdsIncorrectlyInitialized" xml:space="preserve">
+    <value>'{0}' returned an uninitialized ImmutableArray</value>
+  </data>
 </root>


### PR DESCRIPTION
Check IsDefaultOrEmpty of any ImmutableArray given for FixableDiagnosticIds, to ensure that it has been properly initialized.
Throw and ArgumentException to let the user know to fix their CodeFixer.
Fixes #2002