### PR TITLE
Fix interactive window crash by resetting history navigation when hits...

### DIFF
--- a/src/InteractiveWindow/Editor/History.cs
+++ b/src/InteractiveWindow/Editor/History.cs
@@ -146,10 +146,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
             }
         }
-
         internal Entry GetNext(string pattern)
         {
-            return MoveNext(pattern);
+            Entry next = MoveNext(pattern);
+            if (next == null)
+            {
+                // if we hit the end of history list, reset _current to stop navigating history.
+                _current = -1;
+            }
+            return next;
         }
 
         internal Entry GetPrevious(string pattern)

--- a/src/InteractiveWindow/Editor/History.cs
+++ b/src/InteractiveWindow/Editor/History.cs
@@ -146,6 +146,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
             }
         }
+
         internal Entry GetNext(string pattern)
         {
             var next = MoveNext(pattern);

--- a/src/InteractiveWindow/Editor/History.cs
+++ b/src/InteractiveWindow/Editor/History.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         }
         internal Entry GetNext(string pattern)
         {
-            Entry next = MoveNext(pattern);
+            var next = MoveNext(pattern);
             if (next == null)
             {
                 // if we hit the end of history list, reset _current to stop navigating history.

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
@@ -161,6 +161,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             AssertCurrentSubmission(inputString1);
         }
 
+        [Fact]
         public void CheckHistoryNextNotCircular()
         {
             //submit, submit, down, up, down, down

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
@@ -187,6 +187,10 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             //Next should again do nothing as it is the last item, bufer should have the same value
             _operations.HistoryNext();
             AssertCurrentSubmission(inputString2);
+
+            //This is to make sure the window doesn't crash
+            ExecuteInput();
+            AssertCurrentSubmission(empty);
         }
 
         [Fact]


### PR DESCRIPTION
...the end of submission history

An `ArgumentOutOfRangeException` exception would be thrown when navigating past the end of submission history. Stop navigating when `History.GetNext()` hits the end of submission history list fixes this issue.

@cston @amcasey @tmat @KevinH-MS 