### PR TITLE
Fix finding xml help files for winmds in Visual Studio.

### DIFF
--- a/src/Scripting/Core/AssemblyLoader/MetadataShadowCopyProvider.cs
+++ b/src/Scripting/Core/AssemblyLoader/MetadataShadowCopyProvider.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using Roslyn.Utilities;
@@ -450,7 +449,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
 
                     ShadowCopy documentationFileCopy = null;
                     string xmlOriginalPath;
-                    if (ReferencePathUtilities.TryFindXmlDocumentationFile(originalPath, out xmlOriginalPath))
+                    if (XmlFileResolverForAssemblies.TryFindXmlDocumentationFile(originalPath, out xmlOriginalPath))
                     {
                         // TODO (tomat): how do doc comments work for multi-module assembly?
                         var xmlCopyPath = Path.ChangeExtension(shadowCopyPath, ".xml");

--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -58,9 +58,6 @@
     <Compile Include="..\..\Compilers\Helpers\GlobalAssemblyCacheHelpers\GlobalAssemblyCache.cs">
       <Link>Resolvers\GlobalAssemblyCache.cs</Link>
     </Compile>
-    <Compile Include="..\..\Workspaces\Core\Desktop\Utilities\ReferencePathUtilities.cs">
-      <Link>ReferencePathUtilities.cs</Link>
-    </Compile>
     <Compile Include="AssemblyLoader\AssemblyLoadResult.cs" />
     <Compile Include="CommandLine\CommandLineHostObject.cs" />
     <Compile Include="CommandLine\CommandLineRunner.cs" />
@@ -76,6 +73,7 @@
     <Compile Include="ScriptRunner.cs" />
     <Compile Include="ObjectFormatter.cs" />
     <Compile Include="ObjectFormatter.Formatter.cs" />
+    <Compile Include="XmlFileResolverForAssemblies.cs" />
     <Compile Include="Script.cs" />
     <Compile Include="ScriptBuilder.cs" />
     <Compile Include="CompilationErrorException.cs" />

--- a/src/Scripting/Core/XmlFileResolverForAssemblies.cs
+++ b/src/Scripting/Core/XmlFileResolverForAssemblies.cs
@@ -4,9 +4,9 @@ using System;
 using System.Globalization;
 using System.IO;
 
-namespace Roslyn.Utilities
+namespace Microsoft.CodeAnalysis.Scripting.Hosting
 {
-    internal static partial class ReferencePathUtilities
+    internal static class XmlFileResolverForAssemblies
     {
         public static bool TryFindXmlDocumentationFile(string assemblyFilePath, out string xmlDocumentationFilePath)
         {
@@ -16,8 +16,6 @@ namespace Roslyn.Utilities
             string xmlFilePath = string.Empty;
 
             // 1. Look in subdirectories based on the current culture
-            // TODO: This logic is somewhat duplicated between here and 
-            // Microsoft.CodeAnalysis.Scripting.MetadataShadowCopyProvider
             string xmlFileName = Path.ChangeExtension(Path.GetFileName(assemblyFilePath), ".xml");
             string originalDirectory = Path.GetDirectoryName(assemblyFilePath);
 
@@ -40,10 +38,10 @@ namespace Roslyn.Utilities
             }
 
             // 2. Look in the same directory as the assembly itself
-
             var extension = Path.GetExtension(assemblyFilePath);
             if (string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase))
+                string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(extension, ".winmd", StringComparison.OrdinalIgnoreCase))
             {
                 xmlFilePath = Path.ChangeExtension(assemblyFilePath, ".xml");
             }
@@ -62,7 +60,7 @@ namespace Roslyn.Utilities
             // 3. Look for reference assemblies
 
             string referenceAssemblyFilePath;
-            if (!TryGetReferenceFilePath(assemblyFilePath, out referenceAssemblyFilePath))
+            if (!Roslyn.Utilities.ReferencePathUtilities.TryGetReferenceFilePath(assemblyFilePath, out referenceAssemblyFilePath))
             {
                 xmlDocumentationFilePath = null;
                 return false;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
@@ -82,15 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             protected override DocumentationProvider CreateDocumentationProvider()
             {
-                string xmlDocumentPath;
-                if (ReferencePathUtilities.TryFindXmlDocumentationFile(FilePath, out xmlDocumentPath))
-                {
-                    return new VisualStudioDocumentationProvider(xmlDocumentPath, _provider.XmlMemberIndexService);
-                }
-                else
-                {
-                    return DocumentationProvider.Default;
-                }
+                return new VisualStudioDocumentationProvider(this.FilePath, _provider.XmlMemberIndexService);
             }
 
             protected override PortableExecutableReference WithPropertiesImpl(MetadataReferenceProperties properties)

--- a/src/Workspaces/Core/Desktop/Utilities/ReferencePathUtilities_Desktop.cs
+++ b/src/Workspaces/Core/Desktop/Utilities/ReferencePathUtilities_Desktop.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
-    internal static partial class ReferencePathUtilities
+    internal static class ReferencePathUtilities
     {
         public static bool TryGetReferenceFilePath(string filePath, out string referenceFilePath)
         {

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -80,7 +80,6 @@
     <Compile Include="Options\Providers\ExportedOptionKeyOptionProvider.cs" />
     <Compile Include="Utilities\Documentation\FileBasedXmlDocumentationProvider.cs" />
     <Compile Include="Utilities\ReferencePathUtilities_Desktop.cs" />
-    <Compile Include="Utilities\ReferencePathUtilities.cs" />
     <Compile Include="WorkspaceDesktopResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
We should pass the location of the metadata file to the
IVsXmlMemberIndexService than passing the location of the xml help file.
IVsXmlMemberIndexService locates the help file by looking at
appropriate locations such as localized directories or the root
directory where the metadata file is present. This change removes
calling our utility to locate the help file in the VS provider (the helper
is probably meant for internal test applications and such). This fixes a
bug where we were unable to find xml help files for WinMds in the fall
back case where people place help file next to winmds for cultures that
help file wasn't translated for. In such cases, the user should get the
english documentation.

**Fixes internal bug #105440**: XML doc-comment file not being picked up for WinRT components

**Tested scenarios**:
* xml documentation works in the fallback case for dlls and winmds (both Win81 and Windows UWP apps).
* xml documentation works in the localized case (help file within en folder) for dlls and winmds (both Win81 and Windows UWP apps).
* Internal test app and hosted interactive window inside of it work as expected.
* Interactive window in VS *will regress* because it does not work off of reference assemblies, it is tracked by #5013. 