### PR TITLE
Simplify the smart tag text we show for 'Fully Qualify' and 'Add Imports'

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
@@ -50,6 +50,14 @@ index: 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        public void TestSmartTagDisplayText()
+        {
+            TestSmartTagText(
+@"class Class { [|List<int>|] Method() { Foo(); } }",
+"System.Collections.Generic.List");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericWithWrongArgs()
         {
             TestMissing(

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -32,6 +32,13 @@ NewLines("Imports System.Threading \n Class Class1 \n Dim v As Thread \n End Cla
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        Public Sub TestSmartTagDisplay()
+            TestSmartTagText(
+NewLines("Class Class1 \n Dim v As [|Thread|] \n End Class"),
+"Imports System.Threading")
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericClassDefinitionAsClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class Base \n End Class \n End Namespace \n Class SomeClass(Of x As [|Base|]) \n End Class"),

--- a/src/Features/Core/Portable/CodeFixes/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -84,18 +84,20 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
                             }
 
                             var codeAction = new MyCodeAction(
-                                string.Format(FeaturesResources.ChangeTo, name, containerName, memberName),
-                                (c) =>
-                                {
-                                    var newRoot = this.ReplaceNode(node, containerName, c);
-                                    return Task.FromResult(document.WithSyntaxRoot(newRoot));
-                                });
+                                $"{containerName}.{memberName}",
+                                c => ProcessNode(document, node, containerName, c));
 
                             context.RegisterCodeFix(codeAction, diagnostic);
                         }
                     }
                 }
             }
+        }
+
+        private Task<Document> ProcessNode(Document document, SyntaxNode node, string containerName, CancellationToken cancellationToken)
+        {
+            var newRoot = this.ReplaceNode(node, containerName, cancellationToken);
+            return Task.FromResult(document.WithSyntaxRoot(newRoot));
         }
 
         internal async Task<IEnumerable<ISymbol>> GetMatchingTypesAsync(

--- a/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -231,7 +231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
         End Function
 
         Protected Overrides Function GetDescription(namespaceSymbol As INamespaceOrTypeSymbol, semanticModel As SemanticModel, root As SyntaxNode) As String
-            Return String.Format(VBFeaturesResources.Import, namespaceSymbol.ToDisplayString())
+            Return $"Imports {namespaceSymbol.ToDisplayString()}"
         End Function
 
         Protected Overrides Function GetNamespacesInScope(semanticModel As SemanticModel, node As SyntaxNode, cancellationToken As CancellationToken) As ISet(Of INamespaceSymbol)

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
@@ -1363,15 +1363,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Import &apos;{0}&apos;..
-        '''</summary>
-        Friend ReadOnly Property Import() As String
-            Get
-                Return ResourceManager.GetString("Import", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Imports all or specified elements of a namespace into a file..
         '''</summary>
         Friend ReadOnly Property ImportsKeywordToolTip() As String

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Import" xml:space="preserve">
-    <value>Import '{0}'.</value>
-  </data>
   <data name="Insert" xml:space="preserve">
     <value>Insert '{0}'.</value>
   </data>


### PR DESCRIPTION
Part of the overall fix for: https://github.com/dotnet/roslyn/issues/5139