### PR TITLE
Don't offer 'Generate Type' on lowercase names in VB

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
@@ -49,6 +49,12 @@ NewLines("Class C \n dim f as Foo \n End Class \n Friend Class Foo \n End Class"
 index:=1)
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestMissingOnLowercaseName()
+            TestMissing(
+NewLines("Class C \n dim f as [|foo|] \n End Class"))
+        End Sub
+
         <WorkItem(539716)>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassFromFullyQualifiedFieldIntoSameNamespace()

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -111,6 +111,16 @@ namespace Microsoft.CodeAnalysis.GenerateType
                     return false;
                 }
 
+                if (char.IsLower(name[0]) && !document.SemanticModel.Compilation.IsCaseSensitive)
+                {
+                    // It's near universal in .Net that types start with a capital letter.  As such,
+                    // if this name starts with a lowercase letter, don't even bother to offer 
+                    // "generate type".  The user most likely wants to run 'Add Import' (which will
+                    // then fix up a case where they typed an existing type name in lowercase, 
+                    // intending the fix to case correct it).
+                    return false;
+                }
+
                 this.NameOrMemberAccessExpression = generateTypeServiceStateOptions.NameOrMemberAccessExpression;
                 this.ObjectCreationExpressionOpt = generateTypeServiceStateOptions.ObjectCreationExpressionOpt;
 


### PR DESCRIPTION
This just leads to a ton of clutter in code-actions when the user most likely wanted to run 'add import' instead to resolve and case-correct the name. 

As lower-cast type names are practically non-existent in .Net, this seems like a very reasonably restriction that cleans things up quite a bit.  

This is part of the fix for: https://github.com/dotnet/roslyn/pull/5192