### PR TITLE
Add handling for initialization of multiple properties with [As New ...] initializer.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
@@ -118,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     '  get property symbol
                     Dim propertySymbol = DirectCast(Me.MemberSymbol, SourcePropertySymbol)
                     Dim boundInitializers = ArrayBuilder(Of boundInitializer).GetInstance
-                    binder.BindPropertyInitializer(propertySymbol, initializer, boundInitializers, diagnostics)
+                    binder.BindPropertyInitializer(ImmutableArray.Create(Of Symbol)(propertySymbol), initializer, boundInitializers, diagnostics)
                     boundInitializer = boundInitializers.First
                     boundInitializers.Free()
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -425,7 +425,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each initializerGroup In initializers
                     If Not initializerGroup.IsEmpty Then
                         For Each initializer In initializerGroup
-                            For Each fieldOrProperty In initializer.FieldsOrProperty
+                            For Each fieldOrProperty In initializer.FieldsOrProperties
                                 Debug.Assert(fieldOrProperty.Kind = SymbolKind.Field)
                                 Debug.Assert(DirectCast(fieldOrProperty, FieldSymbol).IsConst)
                             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldOrPropertyInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldOrPropertyInitializer.vb
@@ -10,9 +10,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' </summary>
     Friend Structure FieldOrPropertyInitializer
         ''' <summary>
-        ''' The fields or a property being initialized, or Nothing if this represents an executable statement in script code.
+        ''' The fields or properties being initialized, or Nothing if this represents an executable statement in script code.
+        ''' We can get into a multiple properties case when multiple WithEvents fields are initialized with As New ...
         ''' </summary>
-        Public ReadOnly FieldsOrProperty As ImmutableArray(Of Symbol)
+        Public ReadOnly FieldsOrProperties As ImmutableArray(Of Symbol)
 
         ''' <summary>
         ''' A reference to 
@@ -53,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                          syntax.GetSyntax().IsKind(SyntaxKind.EqualsValue) OrElse
                          syntax.GetSyntax().IsKind(SyntaxKind.ModifiedIdentifier))
 
-            Me.FieldsOrProperty = ImmutableArray.Create(Of Symbol)(field)
+            Me.FieldsOrProperties = ImmutableArray.Create(Of Symbol)(field)
             Me.Syntax = syntax
             Me.IsMetadataConstant = field.IsMetadataConstant
             Me.PrecedingInitializersLength = precedingInitializersLength
@@ -65,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Sub New(fieldsOrProperties As ImmutableArray(Of Symbol), syntax As SyntaxReference, precedingInitializersLength As Integer)
             Debug.Assert(Not fieldsOrProperties.IsEmpty)
             Debug.Assert(syntax.GetSyntax().IsKind(SyntaxKind.AsNewClause) OrElse syntax.GetSyntax().IsKind(SyntaxKind.EqualsValue))
-            Me.FieldsOrProperty = fieldsOrProperties
+            Me.FieldsOrProperties = fieldsOrProperties
             Me.Syntax = syntax
             Me.IsMetadataConstant = False
             Me.PrecedingInitializersLength = precedingInitializersLength
@@ -81,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(syntax IsNot Nothing)
             Debug.Assert(syntax.GetSyntax().IsKind(SyntaxKind.AsNewClause) OrElse syntax.GetSyntax().IsKind(SyntaxKind.EqualsValue))
 
-            Me.FieldsOrProperty = ImmutableArray.Create(Of Symbol)([property])
+            Me.FieldsOrProperties = ImmutableArray.Create(Of Symbol)([property])
             Me.Syntax = syntax
             Me.IsMetadataConstant = False
             Me.PrecedingInitializersLength = precedingInitializersLength

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -2356,7 +2356,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If initializerSet IsNot Nothing Then
                 For Each initializers In initializerSet
                     For Each initializer In initializers
-                        Dim fieldOrPropertyArray As ImmutableArray(Of Symbol) = initializer.FieldsOrProperty
+                        Dim fieldOrPropertyArray As ImmutableArray(Of Symbol) = initializer.FieldsOrProperties
 
                         If Not fieldOrPropertyArray.IsDefault Then
                             Debug.Assert(fieldOrPropertyArray.Length > 0)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWithEvents.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWithEvents.vb
@@ -1998,5 +1998,126 @@ End Class
 
             CompileAndVerify(source)
         End Sub
+
+        <Fact, WorkItem(4544, "https://github.com/dotnet/roslyn/issues/4544")>
+        Public Sub MultipleInitializationsWithAsNew_01()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+Class C1
+    Shared WithEvents a1, b1, c1 As New C2()
+    WithEvents a2, b2, c2 As New C2()
+    Shared a3, b3, c3 As New C2()
+    Dim a4, b4, c4 As New C2()
+
+    Shared Sub Main()
+        Check(a1, b1, c1)
+        Check(a3, b3, c3)
+        
+        Dim c as New C1()
+        Check(c.a2, c.b2, c.c2)
+        Check(c.a4, c.b4, c.c4)
+    End Sub
+
+    Private Shared Sub Check(a As Object, b As Object, c As Object)
+        System.Console.WriteLine(a Is Nothing)
+        System.Console.WriteLine(b Is Nothing)
+        System.Console.WriteLine(c Is Nothing)
+        System.Console.WriteLine(a Is b)
+        System.Console.WriteLine(a Is c)
+        System.Console.WriteLine(b Is c)
+    End Sub
+End Class
+
+Class C2
+End Class
+    </file>
+</compilation>
+
+            CompileAndVerify(source, expectedOutput:=
+            <![CDATA[
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+False
+]]>)
+        End Sub
+
+        <Fact, WorkItem(4544, "https://github.com/dotnet/roslyn/issues/4544")>
+        Public Sub MultipleInitializationsWithAsNew_02()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+Class C1
+    Shared WithEvents a, b, c As New C1() With {.P1 = 2}
+
+    Shared Sub Main()
+        System.Console.WriteLine(a.P1)
+        System.Console.WriteLine(b.P1)
+        System.Console.WriteLine(c.P1)
+        System.Console.WriteLine(a Is b)
+        System.Console.WriteLine(a Is c)
+        System.Console.WriteLine(b Is c)
+    End Sub
+
+    Public P1 As Integer
+End Class
+    </file>
+</compilation>
+
+            CompileAndVerify(source, expectedOutput:=
+            <![CDATA[
+2
+2
+2
+False
+False
+False
+]]>).
+            VerifyIL("C1..cctor",
+            <![CDATA[
+{
+  // Code size       52 (0x34)
+  .maxstack  3
+  IL_0000:  newobj     "Sub C1..ctor()"
+  IL_0005:  dup
+  IL_0006:  ldc.i4.2
+  IL_0007:  stfld      "C1.P1 As Integer"
+  IL_000c:  call       "Sub C1.set_a(C1)"
+  IL_0011:  newobj     "Sub C1..ctor()"
+  IL_0016:  dup
+  IL_0017:  ldc.i4.2
+  IL_0018:  stfld      "C1.P1 As Integer"
+  IL_001d:  call       "Sub C1.set_b(C1)"
+  IL_0022:  newobj     "Sub C1..ctor()"
+  IL_0027:  dup
+  IL_0028:  ldc.i4.2
+  IL_0029:  stfld      "C1.P1 As Integer"
+  IL_002e:  call       "Sub C1.set_c(C1)"
+  IL_0033:  ret
+}
+]]>)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #4544.

There was an assumption that properties cannot share initializer, but this can happen when multiple WithEvents fields are sharing [As New …] initializer. Binder.BindPropertyInitializer is adjusted to handle the case.

@gafter, @VSadov, @jaredpar, @agocke Please review.    