### PR TITLE
Fix space formatting of exception filter.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentKind == SyntaxKind.OpenParenToken &&
                 (previousKind == SyntaxKind.IfKeyword || previousKind == SyntaxKind.WhileKeyword || previousKind == SyntaxKind.SwitchKeyword ||
                 previousKind == SyntaxKind.ForKeyword || previousKind == SyntaxKind.ForEachKeyword || previousKind == SyntaxKind.CatchKeyword ||
-                previousKind == SyntaxKind.UsingKeyword))
+                previousKind == SyntaxKind.UsingKeyword || previousKind == SyntaxKind.WhenKeyword))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword);
             }
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return (syntaxKind == SyntaxKind.IfStatement || syntaxKind == SyntaxKind.WhileStatement || syntaxKind == SyntaxKind.SwitchStatement ||
                 syntaxKind == SyntaxKind.ForStatement || syntaxKind == SyntaxKind.ForEachStatement || syntaxKind == SyntaxKind.DoStatement ||
                 syntaxKind == SyntaxKind.CatchDeclaration || syntaxKind == SyntaxKind.UsingStatement || syntaxKind == SyntaxKind.LockStatement ||
-                syntaxKind == SyntaxKind.FixedStatement);
+                syntaxKind == SyntaxKind.FixedStatement || syntaxKind == SyntaxKind.CatchFilterClause);
         }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4819,7 +4819,7 @@ class Program
         { }
         catch (System.Exception)
         { }
-        catch (System.Exception e)
+        catch (System.Exception e) when (true)
         { }
 
         using(somevar)
@@ -4861,7 +4861,7 @@ class Program
         { }
         catch ( System.Exception )
         { }
-        catch ( System.Exception e )
+        catch ( System.Exception e ) when ( true )
         { }
 
         using ( somevar )
@@ -4908,7 +4908,7 @@ class Program
 
         try
         { }
-        catch (System.Exception e)
+        catch (System.Exception e) when (true)
         { }
 
         using (somevar)
@@ -4942,7 +4942,7 @@ class Program
 
         try
         { }
-        catch(System.Exception e)
+        catch(System.Exception e) when(true)
         { }
 
         using(somevar)


### PR DESCRIPTION
Fixes #5099 and another related bug: the spacing option after the `when` keyword.