### PR TITLE
Allow instance member accesses in top-level field initializers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8304,11 +8304,58 @@ class A {
         {
             var markup = @"
 class A {
-    static int s_abc;
-    int B { get; } = $$
+    static Action s_abc;
+    event Action B = $$
 }
 ";
             VerifyItemExists(markup, "s_abc");
+        }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void NoInstanceMembersInFieldLikeEventInitializer()
+        {
+            var markup = @"
+class A {
+    Action abc;
+    event Action B = $$
+}
+";
+            VerifyItemIsAbsent(markup, "abc");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void StaticMembersInFieldLikeEventInitializer()
+        {
+            var markup = @"
+class A {
+    static Action s_abc;
+    event Action B = $$
+}
+";
+            VerifyItemExists(markup, "s_abc");
+        }
+
+        [WorkItem(5069, "https://github.com/dotnet/roslyn/issues/5069")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void InstanceMembersInTopLevelFieldInitializer()
+        {
+            var markup = @"
+int aaa = 1;
+int bbb = $$
+";
+            VerifyItemExists(markup, "aaa", sourceCodeKind: SourceCodeKind.Interactive);
+        }
+
+        [WorkItem(5069, "https://github.com/dotnet/roslyn/issues/5069")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void InstanceMembersInTopLevelFieldLikeEventInitializer()
+        {
+            var markup = @"
+Action aaa = null;
+event Action bbb = $$
+";
+            VerifyItemExists(markup, "aaa", sourceCodeKind: SourceCodeKind.Interactive);
         }
 
         [WorkItem(33, "https://github.com/dotnet/roslyn/issues/33")]

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -2861,6 +2861,18 @@ End Module
             VerifyItemExists(code, "args")
         End Sub
 
+        <WorkItem(5069, "https://github.com/dotnet/roslyn/issues/5069")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub InTopLevelFieldInitializer()
+            Dim code =
+<Code>
+Dim aaa = 1
+Dim bbb = $$
+</Code>.Value
+
+            VerifyItemExists(code, "aaa")
+        End Sub
+
 #End Region
 
 #Region "SharedMemberSourceTests"

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -114,8 +114,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return node.IsFoundUnder((PropertyDeclarationSyntax p) => p.Initializer);
 
                 case SyntaxKind.FieldDeclaration:
-                    // Inside a field one can only access static members of a type.
-                    return true;
+                case SyntaxKind.EventFieldDeclaration:
+                    // Inside a field one can only access static members of a type (unless it's top-level).
+                    return !memberDeclaration.Parent.IsKind(SyntaxKind.CompilationUnit);
 
                 case SyntaxKind.DestructorDeclaration:
                     return false;


### PR DESCRIPTION
...as if they were locals.

Fixes #5069