### PR TITLE
Make IDE analyzer tests fail if the analyzer threw an exception

### DIFF
--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Concurrent;
 using System.ComponentModel.Composition;
 using System.Linq;

--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyCodeFixProvider.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyCodeFixProvider.cs
@@ -1,16 +1,13 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Rename;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.UseAutoProperty;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
-        public void TestNotWithFieldWithAttirbute()
+        public void TestNotWithFieldWithAttribute()
         {
             TestMissing(
 @"class Class { [|[A]int i|]; int P { get { return i; } } }");
@@ -243,6 +243,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
             Test(
 @"class Class { [|int i|]; public int P { get { return i; } } public Foo() { i = 1; } }",
 @"class Class { public int P { get; private set; } public Foo() { P = 1; } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public void TestAlreadyAutoPropertyWithGetterWithNoBody()
+        {
+            TestMissing(@"class Class { public int [|P|] { get; } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public void TestAlreadyAutoPropertyWithGetterAndSetterWithNoBody()
+        {
+            TestMissing(@"class Class { public int [|P|] { get; set; } }");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -1,4 +1,5 @@
-﻿
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -1,4 +1,6 @@
-﻿Imports System.Collections.Concurrent
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Concurrent
 Imports System.ComponentModel.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Diagnostics

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -46,10 +46,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
 
         Protected Overrides Function GetGetterExpression(getMethod As IMethodSymbol, cancellationToken As CancellationToken) As ExpressionSyntax
             Dim accessor = TryCast(TryCast(getMethod.DeclaringSyntaxReferences(0).GetSyntax(cancellationToken), AccessorStatementSyntax)?.Parent, AccessorBlockSyntax)
-            Dim firstStatement = accessor?.Statements.SingleOrDefault()
-            If firstStatement?.Kind() = SyntaxKind.ReturnStatement Then
-                Dim expr = DirectCast(firstStatement, ReturnStatementSyntax).Expression
-                Return If(CheckExpressionSyntactically(expr), expr, Nothing)
+            Dim statements = accessor?.Statements
+            If statements?.Count = 1 Then
+                ' this only works with a getter body with exactly one statement
+                Dim firstStatement = statements.Value(0)
+                If firstStatement.Kind() = SyntaxKind.ReturnStatement Then
+                    Dim expr = DirectCast(firstStatement, ReturnStatementSyntax).Expression
+                    Return If(CheckExpressionSyntactically(expr), expr, Nothing)
+                End If
             End If
 
             Return Nothing

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyCodeFixProvider.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyCodeFixProvider.vb
@@ -1,4 +1,6 @@
-﻿Imports System.Composition
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.CodeFixes

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/Utilities.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/Utilities.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
     Friend Module Utilities

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -1,4 +1,5 @@
-﻿
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -177,7 +177,7 @@ NewLines("partial class Class1 \n end class \n partial class Class1 \n ReadOnly 
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
-        Public Sub TestNotWithFieldWithAttirbute()
+        Public Sub TestNotWithFieldWithAttribute()
             TestMissing(
 NewLines("class Class1 \n [|<A>dim i as integer|] \n property P as Integer \n get \n return i \n end property \n end class"))
         End Sub
@@ -220,6 +220,11 @@ NewLines("class Class1 \n [|dim i as integer|] \n public property P as Integer \
             Test(
 NewLines("class Class1 \n [|dim i as integer|] \n public property P as Integer \n get \n return i \n end get \n set \n i = value \n end set \n end property \n public sub Foo() \n i = 1 \n end sub \n end class"),
 NewLines("class Class1 \n public property P as Integer \n public sub Foo() P = 1 \n end sub \n end class"))
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        Public Sub TestAlreadyAutoProperty()
+            TestMissing(NewLines("Class Class1 \n Public Property [|P|] As Integer \n End Class"))
         End Sub
     End Class
 End Namespace

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;


### PR DESCRIPTION
This PR explicitly fails IDE analyzer tests if the analyzer threw an exception (see `AbstractDiagnosticProviderBasedUserDiagnosticTest.cs`) and also corrects some invalid assumptions about the syntax structure of properties that were previously missed due to this issue.

Also add tests for if the backing field has any attributes and add the missing copyright notice to the appropriate auto-property files.