### PR TITLE
Improve quality of Watson crash dumps when MetadataDecoder.LookupTopLevelTypeDefSymbol throws in context of an Async execution.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -125,8 +125,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             int referencedAssemblyIndex,
             ref MetadataTypeName emittedName)
         {
-            AssemblySymbol assembly = moduleSymbol.GetReferencedAssemblySymbols()[referencedAssemblyIndex];
-            return assembly.LookupTopLevelMetadataType(ref emittedName, digThroughForwardedTypes: true);
+            try
+            {
+                AssemblySymbol assembly = moduleSymbol.GetReferencedAssemblySymbols()[referencedAssemblyIndex];
+                return assembly.LookupTopLevelMetadataType(ref emittedName, digThroughForwardedTypes: true);
+            }
+            catch (Exception e) when (FatalError.Report(e)) // Trying to get more useful Watson dumps.
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
         }
 
         /// <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -124,9 +124,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             referencedAssemblyIndex As Integer,
             ByRef emittedName As MetadataTypeName
         ) As TypeSymbol
-            Dim assembly As AssemblySymbol = moduleSymbol.GetReferencedAssemblySymbols()(referencedAssemblyIndex)
+            Try
+                Dim assembly As AssemblySymbol = moduleSymbol.GetReferencedAssemblySymbols()(referencedAssemblyIndex)
 
-            Return assembly.LookupTopLevelMetadataType(emittedName, digThroughForwardedTypes:=True)
+                Return assembly.LookupTopLevelMetadataType(emittedName, digThroughForwardedTypes:=True)
+            Catch e As Exception When FatalError.Report(e) ' Trying to get more useful Watson dumps.
+                Throw ExceptionUtilities.Unreachable
+            End Try
         End Function
 
         ''' <summary>


### PR DESCRIPTION
Related to DevDiv 132385.

@gafter, @VSadov, @jaredpar, @agocke Please review.