### PR TITLE
Update VisualBasicSyntaxFactsService.GetExpressionOfMemberAccessExpre…

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -435,7 +435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Public Function GetExpressionOfMemberAccessExpression(node As SyntaxNode) As Microsoft.CodeAnalysis.SyntaxNode Implements ISyntaxFactsService.GetExpressionOfMemberAccessExpression
-            Return DirectCast(node, MemberAccessExpressionSyntax).GetExpressionOfMemberAccessExpression()
+            Return TryCast(node, MemberAccessExpressionSyntax)?.GetExpressionOfMemberAccessExpression()
         End Function
 
         Public Function GetExpressionOfConditionalMemberAccessExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFactsService.GetExpressionOfConditionalMemberAccessExpression


### PR DESCRIPTION
…ssion to match C#

CSharpSyntaxFactsService.GetExpressionOfMemberAccessExpression will return null if the node is not a MemberAccessExpressionSyntax, in VB we throw. This changes VisualBasicSyntaxFactsService.GetExpressionOfMemberAccessExpression to also return null.

Fixes #4395