### PR TITLE
Fix crash on SelectAll in header

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
@@ -1146,12 +1146,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     index--;
                 }
                 // Find the nearest preceding prompt.
-                while (!IsPrompt(sourceSpans[index]))
+                while (index >= 0 && !IsPrompt(sourceSpans[index]))
                 {
                     index--;
                 }
                 return index;
             }
+
             /// <summary>
             /// Return the index of the span containing the point. Returns the
             /// length of the collection if the point is at the end of the last span.

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -726,6 +726,17 @@ System.Console.WriteLine();",
             Assert.Equal("> ", snapshot.GetText());
         }
 
+        [Fact]
+        public void SelectAllInHeader()
+        {
+            Window.WriteLine("Header");
+            Window.FlushOutput();
+            Assert.Equal("Header\r\n> ", Window.TextView.TextBuffer.CurrentSnapshot.GetText());
+
+            Window.TextView.Caret.MoveTo(new SnapshotPoint(Window.TextView.TextBuffer.CurrentSnapshot, 1));
+            Window.Operations.SelectAll(); // Used to throw.
+        }
+
         private void Submit(string submission, string output)
         {
             Task.Run(() => Window.SubmitAsync(new[] { submission })).PumpingWait();

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -731,10 +731,14 @@ System.Console.WriteLine();",
         {
             Window.WriteLine("Header");
             Window.FlushOutput();
-            Assert.Equal("Header\r\n> ", Window.TextView.TextBuffer.CurrentSnapshot.GetText());
+            var fullText = Window.TextView.TextBuffer.CurrentSnapshot.GetText();
+            Assert.Equal("Header\r\n> ", fullText);
 
             Window.TextView.Caret.MoveTo(new SnapshotPoint(Window.TextView.TextBuffer.CurrentSnapshot, 1));
             Window.Operations.SelectAll(); // Used to throw.
+
+            // Everything is selected.
+            Assert.Equal(new Span(0, fullText.Length), Window.TextView.Selection.SelectedSpans.Single().Span);
         }
 
         private void Submit(string submission, string output)


### PR DESCRIPTION
Before the first prompt, there is no preceding prompt.