### PR TITLE
The test "SessionNotStartedWhenCaretNotMappableIntoSubjectBuffer" cre…

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1563,6 +1563,7 @@ class C
                 state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, state.SubjectBuffer), Sub() editorOperations.Delete())
 
                 state.AssertNoCompletionSession()
+                view.Close()
             End Using
         End Sub
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1557,13 +1557,16 @@ class C
                 Dim projection = projectionBufferFactory.CreateProjectionBuffer(Nothing, New Object() {otherExposedSpan, subjectBufferExposedSpan}.ToList(), ProjectionBufferOptions.None)
 
                 Dim view = textViewFactory.CreateTextView(projection)
-                view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, 0))
+                Try
+                    view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, 0))
 
-                Dim editorOperations = editorOperationsFactory.GetEditorOperations(view)
-                state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, state.SubjectBuffer), Sub() editorOperations.Delete())
+                    Dim editorOperations = editorOperationsFactory.GetEditorOperations(view)
+                    state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, state.SubjectBuffer), Sub() editorOperations.Delete())
 
-                state.AssertNoCompletionSession()
-                view.Close()
+                    state.AssertNoCompletionSession()
+                Finally
+                    view.Close()
+                End Try
             End Using
         End Sub
     End Class


### PR DESCRIPTION
…ates an ITextView not managed by the test workspace.

To avoid leaking taggers, close that view at the end of the test.

@brettfo @tannergooding This should fix the test failure we're seeing.