### PR TITLE
Fix interactive window behavior when typing in read-only region

### DIFF
--- a/src/InteractiveWindow/Editor/IInteractiveWindowOperations2.cs
+++ b/src/InteractiveWindow/Editor/IInteractiveWindowOperations2.cs
@@ -8,5 +8,10 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         /// Copies the current selection to the clipboard.
         /// </summary>
         void Copy();
+
+        /// <summary>
+        /// Handles the user pressing any alphanumeric key.
+        /// </summary>
+        void TypeChar();
     }
 }

--- a/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
@@ -2105,6 +2105,23 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             public bool Delete()
             {
                 _historySearch = null;
+                return DeleteSelection();
+            }
+
+            /// <summary> Implements <see cref="IInteractiveWindowOperations2.TypeChar"/>. </summary>
+            public void TypeChar()
+            {
+                _historySearch = null;
+                // in case user didn't select anything, we still move the cursor so the character typed 
+                // inside non-editable buffer will be inserted at the closest location in editable buffer.
+                if (!DeleteSelection())
+                {
+                    MoveCaretToClosestEditableBuffer();
+                }   
+            }
+
+            private bool DeleteSelection()
+            {
                 bool handled = false;
                 if (!TextView.Selection.IsEmpty)
                 {
@@ -2115,7 +2132,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                         handled = true;
                     }
                 }
-
                 return handled;
             }
 

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -356,6 +356,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             UIThread(uiOnly => uiOnly.Copy());
         }
 
+        void IInteractiveWindowOperations2.TypeChar()
+        {
+            UIThread(uiOnly => uiOnly.TypeChar());
+        }
+
         bool IInteractiveWindowOperations.Backspace()
         {
             return UIThread(uiOnly => uiOnly.Backspace());

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -386,7 +386,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                 switch ((VSConstants.VSStd2KCmdID)nCmdID)
                 {
                     case VSConstants.VSStd2KCmdID.TYPECHAR:
-                        _window.Operations.Delete();
+                        var operations = _window.Operations as IInteractiveWindowOperations2;
+                        if (operations != null)
+                        {
+                            operations.TypeChar();
+                        }
+                        else
+                        {
+                            _window.Operations.Delete();
+                        }                           
                         break;
 
                     case VSConstants.VSStd2KCmdID.RETURN:


### PR DESCRIPTION
Add `IInteractiveWindowOperations2.TypeChar` to handle typing behavior in interactive window,
which is used to preserve the existing behavior of `IInteractiveWindowOperations.Delete`.
The general design is when user types alphanumeric character when the cursor is in readonly buffer,
the input will be inserted at the closest location in the editable buffer and the cursor moved after it.

This fixes issue https://github.com/dotnet/roslyn/issues/5130