### PR TITLE
Don't support compiling scripts with csc/vbc for now...

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -783,7 +783,9 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                isScriptFile = string.Equals(extension, ScriptFileExtension, StringComparison.OrdinalIgnoreCase);
+                // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+                //isScriptFile = string.Equals(extension, ScriptFileExtension, StringComparison.OrdinalIgnoreCase);
+                isScriptFile = false;
             }
 
             return new CommandLineSourceFile(resolvedPath, isScriptFile);

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
@@ -63,9 +63,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                 return;
             }
 
-            var sourceCodeKind = extension.Equals(".csx", StringComparison.OrdinalIgnoreCase)
-                ? SourceCodeKind.Script
-                : SourceCodeKind.Regular;
+            // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+            //var sourceCodeKind = extension.Equals(".csx", StringComparison.OrdinalIgnoreCase)
+            //    ? SourceCodeKind.Script
+            //    : SourceCodeKind.Regular;
+            var sourceCodeKind = SourceCodeKind.Regular;
 
             IVsHierarchy foundHierarchy;
             uint itemId;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -776,9 +776,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             switch (hostProject.Language)
             {
                 case LanguageNames.CSharp:
-                    return sourceCodeKind == SourceCodeKind.Regular ? ".cs" : ".csx";
+                    // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+                    //return sourceCodeKind == SourceCodeKind.Regular ? ".cs" : ".csx";
+                    return ".cs";
                 case LanguageNames.VisualBasic:
-                    return sourceCodeKind == SourceCodeKind.Regular ? ".vb" : ".vbx";
+                    // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+                    //return sourceCodeKind == SourceCodeKind.Regular ? ".vb" : ".vbx";
+                    return ".vb";
                 default:
                     throw new InvalidOperationException();
             }

--- a/src/VisualStudio/Core/Test/LanguageBlockTests.vb
+++ b/src/VisualStudio/Core/Test/LanguageBlockTests.vb
@@ -208,6 +208,11 @@ namespace N
 var message = ""Hello"";
 System.Console$$.WriteLine(message);
 ", LanguageNames.CSharp, SourceCodeKind.Script)
+
+        VerifyNoBlock("
+var message = ""Hello"";
+System.Console$$.WriteLine(message);
+", LanguageNames.CSharp, SourceCodeKind.Regular)
     End Sub
 
     <Fact, Trait(Traits.Feature, Traits.Features.VsLanguageBlock)>
@@ -216,6 +221,11 @@ System.Console$$.WriteLine(message);
 Dim message = ""Hello""
 System.Console$$.WriteLine(message)
 ", LanguageNames.VisualBasic, SourceCodeKind.Script)
+
+        VerifyNoBlock("
+Dim message = ""Hello""
+System.Console$$.WriteLine(message)
+", LanguageNames.VisualBasic, SourceCodeKind.Regular)
     End Sub
 
     Private Sub VerifyNoBlock(markup As String, languageName As String, Optional sourceCodeKind As SourceCodeKind = SourceCodeKind.Regular)

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -713,7 +713,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (useFullSpan || node.Span.Contains(position))
                 {
-                    if ((node.Kind() != SyntaxKind.GlobalStatement) && (node is MemberDeclarationSyntax))
+                    var kind = node.Kind();
+                    if ((kind != SyntaxKind.GlobalStatement) && (kind != SyntaxKind.IncompleteMember) && (node is MemberDeclarationSyntax))
                     {
                         return node;
                     }
@@ -1030,6 +1031,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.IdentifierName:
                     var identifier = ((IdentifierNameSyntax)node).Identifier;
                     return identifier.IsMissing ? missingTokenPlaceholder : identifier.Text;
+                case SyntaxKind.IncompleteMember:
+                    return missingTokenPlaceholder;
                 case SyntaxKind.NamespaceDeclaration:
                     return GetName(((NamespaceDeclarationSyntax)node).Name, options);
                 case SyntaxKind.QualifiedName:

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.CSharpProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.CSharpProjectFile.cs
@@ -30,20 +30,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override SourceCodeKind GetSourceCodeKind(string documentFileName)
             {
-                return documentFileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)
-                    ? SourceCodeKind.Script
-                    : SourceCodeKind.Regular;
+                // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+                //return documentFileName.EndsWith(".csx", StringComparison.OrdinalIgnoreCase)
+                //    ? SourceCodeKind.Script
+                //    : SourceCodeKind.Regular;
+                return SourceCodeKind.Regular;
             }
 
             public override string GetDocumentExtension(SourceCodeKind sourceCodeKind)
             {
-                switch (sourceCodeKind)
-                {
-                    case SourceCodeKind.Script:
-                        return ".csx";
-                    default:
-                        return ".cs";
-                }
+                // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+                //return (sourceCodeKind != SourceCodeKind.Script) ? ".cs" : ".csx";
+                return ".cs";
             }
 
             public override async Task<ProjectFileInfo> GetProjectFileInfoAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
@@ -46,30 +46,18 @@ namespace Microsoft.CodeAnalysis.VisualBasic
 
             public override SourceCodeKind GetSourceCodeKind(string documentFileName)
             {
-                SourceCodeKind result;
-                if (documentFileName.EndsWith(".vbx", StringComparison.OrdinalIgnoreCase))
-                {
-                    result = SourceCodeKind.Script;
-                }
-                else
-                {
-                    result = SourceCodeKind.Regular;
-                }
-                return result;
+                // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+                //return documentFileName.EndsWith(".vbx", StringComparison.OrdinalIgnoreCase)
+                //    ? SourceCodeKind.Script
+                //    : SourceCodeKind.Regular;
+                return SourceCodeKind.Regular;
             }
 
             public override string GetDocumentExtension(SourceCodeKind sourceCodeKind)
             {
-                string result;
-                if (sourceCodeKind != SourceCodeKind.Script)
-                {
-                    result = ".vb";
-                }
-                else
-                {
-                    result = ".vbx";
-                }
-                return result;
+                // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+                //return (sourceCodeKind != SourceCodeKind.Script) ? ".vb" : ".vbx";
+                return ".vb";
             }
 
             public override async Task<ProjectFileInfo> GetProjectFileInfoAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -940,6 +940,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Case SyntaxKind.IdentifierName
                     Dim identifier = DirectCast(node, IdentifierNameSyntax).Identifier
                     Return If(identifier.IsMissing, missingTokenPlaceholder, identifier.Text)
+                Case SyntaxKind.IncompleteMember
+                    Return missingTokenPlaceholder
                 Case SyntaxKind.NamespaceBlock
                     Dim nameSyntax = CType(node, NamespaceBlockSyntax).NamespaceStatement.Name
                     If nameSyntax.Kind() = SyntaxKind.GlobalName Then


### PR DESCRIPTION
This also disables IDE support for including .csx/.vbx files in a
C# or VB project, and fixes up IVsLanguageBlock service to handle
"incomplete" members (these frequently occur in C# when you parse
global statements in "regular" C# mode).

Fixes #4360