### PR TITLE
Remove dnx core warnings

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -59,7 +59,10 @@
       <RemoveAssemblyFoldersIfNoTargetFramework>false</RemoveAssemblyFoldersIfNoTargetFramework>
   </PropertyGroup>
 
-  <!-- Work around issue in dotnet/roslyn issue #5213 -->
+  <!-- Work around issue in dotnet/roslyn issue #5213
+       Since MSBuild wants a reference assembly location and DNXCore doesn't have one,
+       trick MSBuild into using the .NETPortable,v5.0 reference assembly path which happens
+       to have the same set of reference assemblies as DNXCore (i.e., none). -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'DNXCore'">
     <_TargetFrameworkDirectories>$([System.String]::Join(";", $([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToReferenceAssemblies(".NETPortable", "v5.0", ""))))</_TargetFrameworkDirectories>
     <_FullFrameworkReferenceAssemblyPaths>$(_TargetFrameworkDirectories)</_FullFrameworkReferenceAssemblyPaths>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -60,14 +60,25 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'DNXCore'">
+    <_TargetFrameworkDirectories>$([System.String]::Join(";", $([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToReferenceAssemblies(".NETPortable", "v5.0", ""))))</_TargetFrameworkDirectories>
+    <_FullFrameworkReferenceAssemblyPaths>$(_TargetFrameworkDirectories)</_FullFrameworkReferenceAssemblyPaths>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'DNXCore'">
       <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win</BaseNuGetRuntimeIdentifier>
       <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Unix'">linux</BaseNuGetRuntimeIdentifier>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.VisualBasic.targets" Condition="'$(ProjectLanguage)' == 'VB' And '$(TargetFrameworkIdentifier)' == '.NETPortable'"/>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" Condition="'$(ProjectLanguage)' == 'CSharp' And '$(TargetFrameworkIdentifier)' == '.NETPortable'"/>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" Condition="'$(ProjectLanguage)' == 'VB' And '$(TargetFrameworkIdentifier)' != '.NETPortable'" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="'$(ProjectLanguage)' == 'CSharp' And '$(TargetFrameworkIdentifier)' != '.NETPortable'" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.VisualBasic.targets"
+          Condition="'$(ProjectLanguage)' == 'VB' And '$(TargetFrameworkIdentifier)' == '.NETPortable'"/>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
+          Condition="'$(ProjectLanguage)' == 'CSharp' And '$(TargetFrameworkIdentifier)' == '.NETPortable'"/>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets"
+          Condition="'$(ProjectLanguage)' == 'VB' And '$(TargetFrameworkIdentifier)' != '.NETPortable'" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"
+          Condition="'$(ProjectLanguage)' == 'CSharp' And '$(TargetFrameworkIdentifier)' != '.NETPortable'" />
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" Condition="'$(ProjectLanguage)' == 'C++'" />
 
   <!-- On Mono on *nix the NuGet targets aren't imported by default, so we do that here -->

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -59,12 +59,13 @@
       <RemoveAssemblyFoldersIfNoTargetFramework>false</RemoveAssemblyFoldersIfNoTargetFramework>
   </PropertyGroup>
 
+  <!-- Work around issue in dotnet/roslyn issue #5213 -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'DNXCore'">
     <_TargetFrameworkDirectories>$([System.String]::Join(";", $([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToReferenceAssemblies(".NETPortable", "v5.0", ""))))</_TargetFrameworkDirectories>
     <_FullFrameworkReferenceAssemblyPaths>$(_TargetFrameworkDirectories)</_FullFrameworkReferenceAssemblyPaths>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'DNXCore'">
+  <PropertyGroup>
       <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win</BaseNuGetRuntimeIdentifier>
       <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Unix'">linux</BaseNuGetRuntimeIdentifier>
   </PropertyGroup>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -65,7 +65,7 @@
     <_FullFrameworkReferenceAssemblyPaths>$(_TargetFrameworkDirectories)</_FullFrameworkReferenceAssemblyPaths>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'DNXCore'">
       <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win</BaseNuGetRuntimeIdentifier>
       <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Unix'">linux</BaseNuGetRuntimeIdentifier>
   </PropertyGroup>


### PR DESCRIPTION
This hacks up our targets to satisfy MSBuild that we don't need a warning about missing target framework assemblies.

 @jaredpar @jasonmalinowski 