### PR TITLE
A bit of ReferenceManager refactoring

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
@@ -122,11 +122,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var referenceManager = ((CSharpCompilation)moduleBuilder.CommonCompilation).GetBoundReferenceManager();
 
-                foreach (var referencedAssembly in referenceManager.ReferencedAssembliesMap.Values)
+                for (int i = 0; i < referenceManager.ReferencedAssemblies.Length; i++)
                 {
-                    if ((object)referencedAssembly.Symbol == containingAssembly)
+                    if ((object)referenceManager.ReferencedAssemblies[i] == containingAssembly)
                     {
-                        if (!referencedAssembly.DeclarationsAccessibleWithoutAlias())
+                        if (!referenceManager.DeclarationsAccessibleWithoutAlias(i))
                         {
                             return moduleBuilder.Translate(containingAssembly, diagnostics);
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -570,15 +570,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (seenNamespaceWithExtensionMethods && seenStaticClassWithExtensionMethods)
             {
-                var methodsNoDuplicates = ArrayBuilder<MethodSymbol>.GetInstance();
-                methodsNoDuplicates.AddRange(methods.Distinct());
-                if (methodsNoDuplicates.Count < methods.Count)
-                {
-                    methods.Clear();
-                    methods.AddRange(methodsNoDuplicates);
-                }
-
-                methodsNoDuplicates.Free();
+                methods.RemoveDuplicates();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -978,33 +978,47 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new CSharpCompilationReference(this, aliases, embedInteropTypes);
         }
 
-        // Get all modules in this compilation, including the source module, added modules, and all
-        // modules of referenced assemblies that do not come from an assembly with an extern alias.
-        // Metadata imported from aliased assemblies is not visible at the source level except through 
-        // the use of an extern alias directive. So exclude them from this list which is used to construct
-        // the global namespace.
-        private IEnumerable<ModuleSymbol> GetAllUnaliasedModules()
+        /// <summary>
+        /// Get all modules in this compilation, including the source module, added modules, and all
+        /// modules of referenced assemblies that do not come from an assembly with an extern alias.
+        /// Metadata imported from aliased assemblies is not visible at the source level except through 
+        /// the use of an extern alias directive. So exclude them from this list which is used to construct
+        /// the global namespace.
+        /// </summary>
+        private void GetAllUnaliasedModules(ArrayBuilder<ModuleSymbol> modules)
         {
-            // Get all assemblies in this compilation, including the source assembly and all referenced assemblies.
-            ArrayBuilder<ModuleSymbol> modules = new ArrayBuilder<ModuleSymbol>();
-
             // NOTE: This includes referenced modules - they count as modules of the compilation assembly.
-            modules.AddRange(this.Assembly.Modules);
+            modules.AddRange(Assembly.Modules);
 
-            foreach (var pair in GetBoundReferenceManager().ReferencedAssembliesMap)
+            var referenceManager = GetBoundReferenceManager();
+
+            for (int i = 0; i < referenceManager.ReferencedAssemblies.Length; i++)
             {
-                MetadataReference reference = pair.Key;
-                ReferenceManager.ReferencedAssembly referencedAssembly = pair.Value;
-                if (reference.Properties.Kind == MetadataImageKind.Assembly) // Already handled modules above.
+                if (referenceManager.DeclarationsAccessibleWithoutAlias(i))
                 {
-                    if (referencedAssembly.DeclarationsAccessibleWithoutAlias())
-                    {
-                        modules.AddRange(referencedAssembly.Symbol.Modules);
-                    }
+                    modules.AddRange(referenceManager.ReferencedAssemblies[i].Modules);
                 }
             }
+        }
 
-            return modules;
+        /// <summary>
+        /// Return a list of assembly symbols than can be accessed without using an alias.
+        /// For example:
+        ///   1) /r:A.dll /r:B.dll -> A, B
+        ///   2) /r:Foo=A.dll /r:B.dll -> B
+        ///   3) /r:Foo=A.dll /r:A.dll -> A
+        /// </summary>
+        internal void GetUnaliasedReferencedAssemblies(ArrayBuilder<AssemblySymbol> assemblies)
+        {
+            var referenceManager = GetBoundReferenceManager();
+
+            for (int i = 0; i < referenceManager.ReferencedAssemblies.Length; i++)
+            {
+                if (referenceManager.DeclarationsAccessibleWithoutAlias(i))
+                {
+                    assemblies.Add(referenceManager.ReferencedAssemblies[i]);
+                }
+            }
         }
 
         /// <summary>
@@ -1012,7 +1026,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public new MetadataReference GetMetadataReference(IAssemblySymbol assemblySymbol)
         {
-            return this.GetBoundReferenceManager().ReferencedAssembliesMap.Where(kvp => object.ReferenceEquals(kvp.Value.Symbol, assemblySymbol)).Select(kvp => kvp.Key).FirstOrDefault();
+            return base.GetMetadataReference(assemblySymbol);
         }
 
         #endregion
@@ -1066,15 +1080,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((object)_lazyGlobalNamespace == null)
                 {
                     // Get the root namespace from each module, and merge them all together
-                    HashSet<NamespaceSymbol> allGlobalNamespaces = new HashSet<NamespaceSymbol>();
-                    foreach (ModuleSymbol module in GetAllUnaliasedModules())
-                    {
-                        allGlobalNamespaces.Add(module.GlobalNamespace);
-                    }
+                    // Get all modules in this compilation, ones referenced directly by the compilation 
+                    // as well as those referenced by all referenced assemblies.
 
-                    var result = MergedNamespaceSymbol.Create(new NamespaceExtent(this),
+                    var modules = ArrayBuilder<ModuleSymbol>.GetInstance();
+                    GetAllUnaliasedModules(modules);
+
+                    var result = MergedNamespaceSymbol.Create(
+                        new NamespaceExtent(this),
                         null,
-                        allGlobalNamespaces.AsImmutable());
+                        modules.SelectDistinct(m => m.GlobalNamespace));
+
+                    modules.Free();
+
                     Interlocked.CompareExchange(ref _lazyGlobalNamespace, result, null);
                 }
 
@@ -1126,12 +1144,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             ArrayBuilder<NamespaceSymbol> builder = null;
-            foreach (var referencedAssembly in GetBoundReferenceManager().ReferencedAssembliesMap.Values)
+            var referenceManager = GetBoundReferenceManager();
+            for (int i = 0; i < referenceManager.ReferencedAssemblies.Length; i++)
             {
-                if (referencedAssembly.Aliases.Contains(aliasName))
+                if (referenceManager.AliasesOfReferencedAssemblies[i].Contains(aliasName))
                 {
                     builder = builder ?? ArrayBuilder<NamespaceSymbol>.GetInstance();
-                    builder.Add(referencedAssembly.Symbol.GlobalNamespace);
+                    builder.Add(referenceManager.ReferencedAssemblies[i].GlobalNamespace);
                 }
             }
 
@@ -2789,19 +2808,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override INamedTypeSymbol CommonObjectType
         {
             get { return this.ObjectType; }
-        }
-
-        protected override MetadataReference CommonGetMetadataReference(IAssemblySymbol assemblySymbol)
-        {
-            var symbol = assemblySymbol as AssemblySymbol;
-            if ((object)symbol != null)
-            {
-                return this.GetMetadataReference(symbol);
-            }
-            else
-            {
-                return null;
-            }
         }
 
         protected override IMethodSymbol CommonGetEntryPoint(CancellationToken cancellationToken)

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -732,12 +732,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(this is SourceAssemblySymbol,
                 "Never include references for a non-source assembly, because they don't know about aliases.");
 
-            // Lookup in references
-            foreach (var reference in GetUnaliasedReferencedAssemblies())
-            {
-                Debug.Assert(!(this is SourceAssemblySymbol && reference.IsMissing)); // Non-source assemblies can have missing references
+            var assemblies = ArrayBuilder<AssemblySymbol>.GetInstance();
+            DeclaringCompilation.GetUnaliasedReferencedAssemblies(assemblies);
 
-                NamedTypeSymbol candidate = GetTopLevelTypeByMetadataName(reference, ref metadataName, assemblyOpt);
+            // Lookup in references
+            foreach (var assembly in assemblies)
+            {
+                Debug.Assert(!(this is SourceAssemblySymbol && assembly.IsMissing)); // Non-source assemblies can have missing references
+
+                NamedTypeSymbol candidate = GetTopLevelTypeByMetadataName(assembly, ref metadataName, assemblyOpt);
 
                 if (isWellKnownType && !IsValidWellKnownType(candidate))
                 {
@@ -756,19 +759,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // duplicate
                     if (warnings == null)
                     {
-                        return null;
+                        result = null;
                     }
                     else
                     {
                         // The predefined type '{0}' is defined in multiple assemblies in the global alias; using definition from '{1}'
                         warnings.Add(ErrorCode.WRN_MultiplePredefTypes, NoLocation.Singleton, result, result.ContainingAssembly);
-                        return result;
                     }
+
+                    break;
                 }
 
                 result = candidate;
             }
 
+            assemblies.Free();
             return result;
         }
 
@@ -783,46 +788,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 "Checking the containing type is the caller's responsibility.");
 
             return result.DeclaredAccessibility == Accessibility.Public || IsSymbolAccessible(result, this);
-        }
-
-        /// <summary>
-        /// Return a list of assembly symbols than can be accessed without using an alias.
-        /// For example:
-        ///   1) /r:A.dll /r:B.dll -> A, B
-        ///   2) /r:Foo=A.dll /r:B.dll -> B
-        ///   3) /r:Foo=A.dll /r:A.dll -> A
-        ///   
-        /// Note that it only makes sense to call this method on a SourceAssemblySymbol since
-        /// alias information is per-compilation.
-        /// </summary>
-        private ImmutableArray<AssemblySymbol> GetUnaliasedReferencedAssemblies()
-        {
-            CSharpCompilation compilation = this.DeclaringCompilation;
-            Debug.Assert(compilation != null, "There's an answer, but we don't expect this to happen");
-            // if (compilation == null)  return this.Modules[0].GetReferencedAssemblySymbols();
-
-            ArrayBuilder<AssemblySymbol> references = null;
-            foreach (var pair in compilation.GetBoundReferenceManager().ReferencedAssembliesMap)
-            {
-                MetadataReference reference = pair.Key;
-                CSharpCompilation.ReferenceManager.ReferencedAssembly referencedAssembly = pair.Value;
-                if (reference.Properties.Kind == MetadataImageKind.Assembly)
-                {
-                    if (referencedAssembly.DeclarationsAccessibleWithoutAlias())
-                    {
-                        if (references == null)
-                        {
-                            references = ArrayBuilder<AssemblySymbol>.GetInstance();
-                        }
-
-                        references.Add(referencedAssembly.Symbol);
-                    }
-                }
-            }
-
-            return references == null
-                ? ImmutableArray<AssemblySymbol>.Empty
-                : references.ToImmutableAndFree();
         }
 
         private static NamedTypeSymbol GetTopLevelTypeByMetadataName(AssemblySymbol assembly, ref MetadataTypeName metadataName, AssemblyIdentity assemblyOpt)

--- a/src/Compilers/CSharp/Portable/Symbols/NonMissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NonMissingModuleSymbol.cs
@@ -39,14 +39,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Returns an array of assembly identities for assemblies referenced by this module.
         /// Items at the same position from GetReferencedAssemblies and from GetReferencedAssemblySymbols 
         /// should correspond to each other.
-        /// 
-        /// The array and its content is provided by ReferenceManager and must not be modified.
         /// </summary>
-        /// <returns></returns>
         internal sealed override ImmutableArray<AssemblyIdentity> GetReferencedAssemblies()
         {
             AssertReferencesInitialized();
-            return _moduleReferences.Names;
+            return _moduleReferences.Identities;
         }
 
         /// <summary>
@@ -55,8 +52,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// from GetReferencedAssemblySymbols should correspond to each other. If reference is 
         /// not resolved by compiler, GetReferencedAssemblySymbols returns MissingAssemblySymbol in the
         /// corresponding item.
-        /// 
-        /// The array and its content is provided by ReferenceManager and must not be modified.
         /// </summary>
         internal sealed override ImmutableArray<AssemblySymbol> GetReferencedAssemblySymbols()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             ImmutableArray<AssemblySymbol> underlyingBoundReferences = _underlyingModule.GetReferencedAssemblySymbols();
             ImmutableArray<AssemblySymbol> referencedAssemblySymbols = moduleReferences.Symbols;
 
-            Debug.Assert(referencedAssemblySymbols.Length == moduleReferences.Names.Length);
+            Debug.Assert(referencedAssemblySymbols.Length == moduleReferences.Identities.Length);
             Debug.Assert(referencedAssemblySymbols.Length <= underlyingBoundReferences.Length); // Linked references are filtered out.
 
             int i, j;
@@ -203,8 +203,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         new AssemblyIdentity(name: originatingSourceAssemblyDebugOnly.Name) :
                         referencedAssemblySymbols[i].Identity;
 
-                Debug.Assert(identityComparer.Compare(moduleReferences.Names[i], definitionIdentity) != AssemblyIdentityComparer.ComparisonResult.NotEquivalent);
-                Debug.Assert(identityComparer.Compare(moduleReferences.Names[i], underlyingBoundReferences[j].Identity) != AssemblyIdentityComparer.ComparisonResult.NotEquivalent);
+                Debug.Assert(identityComparer.Compare(moduleReferences.Identities[i], definitionIdentity) != AssemblyIdentityComparer.ComparisonResult.NotEquivalent);
+                Debug.Assert(identityComparer.Compare(moduleReferences.Identities[i], underlyingBoundReferences[j].Identity) != AssemblyIdentityComparer.ComparisonResult.NotEquivalent);
 #endif
 
                 if (!ReferenceEquals(referencedAssemblySymbols[i], underlyingBoundReferences[j]))

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -24,6 +24,7 @@
     <Compile Include="AnalyzerFileReferenceTests.cs" />
     <Compile Include="AssemblyUtilitiesTests.cs" />
     <Compile Include="AsyncQueueTests.cs" />
+    <Compile Include="Collections\ArrayBuilderTests.cs" />
     <Compile Include="Collections\BoxesTest.cs" />
     <Compile Include="Collections\ByteSequenceComparerTests.cs" />
     <Compile Include="Diagnostics\DiagnosticLocalizationTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ArrayBuilderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ArrayBuilderTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
+{
+    internal class ArrayBuilderTests
+    {
+        [Fact]
+        public void RemoveDuplicates1()
+        {
+            var builder = new ArrayBuilder<int> { 1, 2, 3, 2, 4, 5, 1 };
+            builder.RemoveDuplicates();
+            AssertEx.Equal(new[] { 1, 2, 3, 4, 5 }, builder);
+
+            builder = new ArrayBuilder<int> { 1 };
+            builder.RemoveDuplicates();
+            AssertEx.Equal(new[] { 1 }, builder);
+
+            builder = new ArrayBuilder<int>();
+            builder.RemoveDuplicates();
+            AssertEx.Equal(new int[0], builder);
+        }
+
+        [Fact]
+        public void SelectDistinct1()
+        {
+            var builder = new ArrayBuilder<int> { 1, 2, 3, 2, 4, 5, 1 };
+            AssertEx.Equal(new[] { 1, 2, 3, 4, 5 }, builder.SelectDistinct(n => n));
+
+            builder = new ArrayBuilder<int> { 1 };
+            AssertEx.Equal(new[] { 1 }, builder.SelectDistinct(n => n));
+
+            builder = new ArrayBuilder<int>();
+            AssertEx.Equal(new int[0], builder.SelectDistinct(n => n));
+
+            builder = new ArrayBuilder<int> { 1, 2, 3, 2, 4, 5, 1 };
+            AssertEx.Equal(new[] { 10 }, builder.SelectDistinct(n => 10));
+
+            builder = new ArrayBuilder<int> { 1, 2, 3, 2, 4, 5, 1 };
+            AssertEx.Equal(new byte[] { 1, 2, 3, 4, 5 }, builder.SelectDistinct(n => (byte)n));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -737,10 +737,8 @@ namespace Microsoft.CodeAnalysis
         /// <param name="assemblySymbol">The target symbol.</param>
         public MetadataReference GetMetadataReference(IAssemblySymbol assemblySymbol)
         {
-            return CommonGetMetadataReference(assemblySymbol);
+            return GetBoundReferenceManager().GetMetadataReference(assemblySymbol);
         }
-
-        protected abstract MetadataReference CommonGetMetadataReference(IAssemblySymbol assemblySymbol);
 
         /// <summary>
         /// Assembly identities of all assemblies directly referenced by this compilation.

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyReferenceCandidate.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyReferenceCandidate.cs
@@ -1,12 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
-
 namespace Microsoft.CodeAnalysis
 {
     internal partial class CommonReferenceManager<TCompilation, TAssemblySymbol>

--- a/src/Compilers/Core/Portable/ReferenceManager/BoundInputAssembly.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/BoundInputAssembly.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -25,9 +23,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// 
         /// <param name="assemblies">
-        /// The set of AssemblyData objects describing assemblies, for which this method should
-        /// resolve references and find suitable AssemblySymbols. This array is not modified by the
-        /// method.
+        /// The set of <see cref="AssemblyData"/> objects describing assemblies, for which this method should
+        /// resolve references and find suitable AssemblySymbols.
         /// </param>
         /// <param name="hasCircularReference">
         /// True if the assembly being compiled is indirectly referenced through some of its own references.
@@ -36,18 +33,18 @@ namespace Microsoft.CodeAnalysis
         /// The definition index of the COR library.
         /// </param>
         /// <returns>
-        /// An array of Binding structures describing the result. It has the same amount of items as
-        /// the input assemblies array, Binding structure for each input AssemblyData object resides
+        /// An array of <see cref="BoundInputAssembly"/> structures describing the result. It has the same amount of items as
+        /// the input assemblies array, <see cref="BoundInputAssembly"/> for each input AssemblyData object resides
         /// at the same position.
         /// 
-        /// Each Binding structure contains the following data:
+        /// Each <see cref="BoundInputAssembly"/> contains the following data:
         /// 
         /// -    Suitable AssemblySymbol instance for the corresponding assembly, 
         ///     null reference if none is available/found. Always null for the first element, which corresponds to the assembly being built.
         ///
         /// -    Result of resolving assembly references of the corresponding assembly 
         ///     against provided set of assembly definitions. Essentially, this is an array returned by
-        ///     AssemblyData.BindAssemblyReferences method.
+        ///     <see cref="AssemblyData.BindAssemblyReferences(ImmutableArray{AssemblyData}, AssemblyIdentityComparer)"/> method.
         /// </returns>
         internal BoundInputAssembly[] Bind(
             ImmutableArray<AssemblyData> assemblies,

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -4,12 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -36,33 +32,17 @@ namespace Microsoft.CodeAnalysis
         /// Enumerates all referenced assemblies.
         /// </summary>
         internal abstract IEnumerable<KeyValuePair<MetadataReference, IAssemblySymbol>> GetReferencedAssemblies();
+       
+        /// <summary>
+        /// Enumerates all referenced assemblies and their aliases.
+        /// </summary>
+        internal abstract IEnumerable<ValueTuple<IAssemblySymbol, ImmutableArray<string>>> GetReferencedAssemblyAliases();
 
-        internal abstract bool TryGetReferencedAssemblySymbol(MetadataReference reference, out IAssemblySymbol symbol, out ImmutableArray<string> aliases);
+        internal abstract MetadataReference GetMetadataReference(IAssemblySymbol assemblySymbol);
     }
 
     internal partial class CommonReferenceManager<TCompilation, TAssemblySymbol> : CommonReferenceManager
     {
-        internal struct ReferencedAssembly
-        {
-            public readonly TAssemblySymbol Symbol;
-
-            // All aliases given to this symbol via metadata references, may contain duplicates
-            public readonly ImmutableArray<string> Aliases;
-
-            public ReferencedAssembly(TAssemblySymbol symbol, ImmutableArray<string> aliases)
-            {
-                Debug.Assert(symbol != null && !aliases.IsDefault);
-
-                this.Symbol = symbol;
-                this.Aliases = aliases;
-            }
-
-            public bool DeclarationsAccessibleWithoutAlias()
-            {
-                return Aliases.Length == 0 || Aliases.IndexOf(MetadataReferenceProperties.GlobalAlias) >= 0;
-            }
-        }
-
         /// <summary>
         /// If the compilation being built represents an assembly its assembly name.
         /// If the compilation being built represents a module, the name of the 
@@ -98,10 +78,10 @@ namespace Microsoft.CodeAnalysis
         private ThreeState _lazyHasCircularReference;
 
         /// <summary>
-        /// A map from a metadata reference to an AssemblySymbol used for it. Do not access
-        /// directly, use <see cref="ReferencedAssembliesMap"/> property instead.
+        /// A map from a metadata reference to an index to <see cref="_lazyReferencedAssemblies"/> array. Do not access
+        /// directly, use <see cref="_lazyReferencedAssembliesMap"/> property instead.
         /// </summary>
-        private Dictionary<MetadataReference, ReferencedAssembly> _lazyReferencedAssembliesMap;
+        private Dictionary<MetadataReference, int> _lazyReferencedAssembliesMap;
 
         /// <summary>
         /// A map from a net-module metadata reference to the index of the corresponding module
@@ -109,7 +89,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <remarks>
         /// Subtract one from the index (for the manifest module) to find the corresponding elements
-        /// of lazyReferencedModules and lazyReferencedModulesReferences.
+        /// of <see cref="_lazyReferencedModules"/> and <see cref="_lazyReferencedModulesReferences"/>.
         /// </remarks>
         private Dictionary<MetadataReference, int> _lazyReferencedModuleIndexMap;
 
@@ -126,7 +106,7 @@ namespace Microsoft.CodeAnalysis
         /// The references are in the order they appear in syntax trees. This order is currently preserved 
         /// as syntax trees are added or removed, but we might decide to share reference manager between compilations
         /// with different order of #r's. It doesn't seem this would be an issue since all #r's within the compilation
-        /// has the same "priority" with respect to each other.
+        /// have the same "priority" with respect to each other.
         /// </remarks>
         private ImmutableArray<MetadataReference> _lazyDirectiveReferences;
 
@@ -154,7 +134,7 @@ namespace Microsoft.CodeAnalysis
         /// Standalone modules referenced by the compilation (doesn't include the manifest module of the compilation).
         /// </summary>
         /// <remarks>
-        /// lazyReferencedModules[i] corresponds to lazyReferencedModulesReferences[i].
+        /// <see cref="_lazyReferencedModules"/>[i] corresponds to <see cref="_lazyReferencedModulesReferences"/>[i].
         /// </remarks>
         private ImmutableArray<PEModule> _lazyReferencedModules;
 
@@ -162,7 +142,7 @@ namespace Microsoft.CodeAnalysis
         /// References of standalone modules referenced by the compilation (doesn't include the manifest module of the compilation).
         /// </summary>
         /// <remarks>
-        /// lazyReferencedModules[i] corresponds to lazyReferencedModulesReferences[i].
+        /// <see cref="_lazyReferencedModules"/>[i] corresponds to <see cref="_lazyReferencedModulesReferences"/>[i].
         /// </remarks>
         private ImmutableArray<ModuleReferences<TAssemblySymbol>> _lazyReferencedModulesReferences;
 
@@ -170,6 +150,14 @@ namespace Microsoft.CodeAnalysis
         /// Assemblies referenced directly by the source module of the compilation.
         /// </summary>
         private ImmutableArray<TAssemblySymbol> _lazyReferencedAssemblies;
+
+        /// <summary>
+        /// Assemblies referenced directly by the source module of the compilation.
+        /// </summary>
+        /// <remarks>
+        /// Aliases <see cref="_lazyAliasesOfReferencedAssemblies"/>[i] are of an assembly <see cref="_lazyReferencedAssemblies"/>[i].
+        /// </remarks>
+        private ImmutableArray<ImmutableArray<string>> _lazyAliasesOfReferencedAssemblies;
 
         /// <summary>
         /// Unified assemblies referenced directly by the source module of the compilation.
@@ -204,7 +192,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal Dictionary<MetadataReference, ReferencedAssembly> ReferencedAssembliesMap
+        internal Dictionary<MetadataReference, int> ReferencedAssembliesMap
         {
             get
             {
@@ -278,6 +266,15 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        internal ImmutableArray<ImmutableArray<string>> AliasesOfReferencedAssemblies
+        {
+            get
+            {
+                AssertBound();
+                return _lazyAliasesOfReferencedAssemblies;
+            }
+        }
+
         internal ImmutableArray<UnifiedAssembly<TAssemblySymbol>> UnifiedAssemblies
         {
             get
@@ -304,6 +301,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(_lazyReferencedModules.IsDefault);
             Debug.Assert(_lazyReferencedModulesReferences.IsDefault);
             Debug.Assert(_lazyReferencedAssemblies.IsDefault);
+            Debug.Assert(_lazyAliasesOfReferencedAssemblies.IsDefault);
             Debug.Assert(_lazyUnifiedAssemblies.IsDefault);
             Debug.Assert(_lazyCorLibraryOpt == null);
         }
@@ -320,10 +318,13 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(!_lazyReferencedModules.IsDefault);
             Debug.Assert(!_lazyReferencedModulesReferences.IsDefault);
             Debug.Assert(!_lazyReferencedAssemblies.IsDefault);
+            Debug.Assert(!_lazyAliasesOfReferencedAssemblies.IsDefault);
             Debug.Assert(!_lazyUnifiedAssemblies.IsDefault);
 
             // lazyCorLibrary is null if the compilation is corlib
             Debug.Assert(_lazyReferencedAssemblies.Length == 0 || _lazyCorLibraryOpt != null);
+
+            Debug.Assert(_lazyReferencedAssemblies.Length == _lazyAliasesOfReferencedAssemblies.Length);
         }
 
         [Conditional("DEBUG")]
@@ -344,7 +345,7 @@ namespace Microsoft.CodeAnalysis
         /// Call only while holding <see cref="CommonReferenceManager.SymbolCacheAndReferenceManagerStateGuard"/>.
         /// </summary>
         internal void InitializeNoLock(
-            Dictionary<MetadataReference, ReferencedAssembly> referencedAssembliesMap,
+            Dictionary<MetadataReference, int> referencedAssembliesMap,
             Dictionary<MetadataReference, int> referencedModulesMap,
             IDictionary<string, MetadataReference> boundReferenceDirectiveMap,
             ImmutableArray<MetadataReference> boundReferenceDirectives,
@@ -354,6 +355,7 @@ namespace Microsoft.CodeAnalysis
             ImmutableArray<PEModule> referencedModules,
             ImmutableArray<ModuleReferences<TAssemblySymbol>> referencedModulesReferences,
             ImmutableArray<TAssemblySymbol> referencedAssemblies,
+            ImmutableArray<ImmutableArray<string>> aliasesOfReferencedAssemblies,
             ImmutableArray<UnifiedAssembly<TAssemblySymbol>> unifiedAssemblies)
         {
             AssertUnbound();
@@ -371,6 +373,7 @@ namespace Microsoft.CodeAnalysis
             _lazyReferencedModules = referencedModules;
             _lazyReferencedModulesReferences = referencedModulesReferences;
             _lazyReferencedAssemblies = referencedAssemblies;
+            _lazyAliasesOfReferencedAssemblies = aliasesOfReferencedAssemblies;
             _lazyUnifiedAssemblies = unifiedAssemblies;
             _lazyHasCircularReference = containsCircularReferences.ToThreeState();
 
@@ -381,38 +384,17 @@ namespace Microsoft.CodeAnalysis
         #region Compilation APIs Implementation
 
         // for testing purposes
-        internal IEnumerable<string> ExternAliases
-        {
-            get
-            {
-                return ReferencedAssembliesMap.Values.SelectMany(entry => entry.Aliases);
-            }
-        }
+        internal IEnumerable<string> ExternAliases => AliasesOfReferencedAssemblies.SelectMany(aliases => aliases);
 
         internal sealed override IEnumerable<KeyValuePair<MetadataReference, IAssemblySymbol>> GetReferencedAssemblies()
         {
-            return ReferencedAssembliesMap.Select(ra => KeyValuePair.Create(ra.Key, (IAssemblySymbol)ra.Value.Symbol));
-        }
-
-        internal sealed override bool TryGetReferencedAssemblySymbol(MetadataReference reference, out IAssemblySymbol symbol, out ImmutableArray<string> aliases)
-        {
-            ReferencedAssembly result;
-            if (ReferencedAssembliesMap.TryGetValue(reference, out result))
-            {
-                symbol = result.Symbol;
-                aliases = result.Aliases;
-                return true;
-            }
-
-            symbol = null;
-            aliases = default(ImmutableArray<string>);
-            return false;
+            return ReferencedAssembliesMap.Select(ra => KeyValuePair.Create(ra.Key, (IAssemblySymbol)ReferencedAssemblies[ra.Value]));
         }
 
         internal TAssemblySymbol GetReferencedAssemblySymbol(MetadataReference reference)
         {
-            ReferencedAssembly result;
-            return ReferencedAssembliesMap.TryGetValue(reference, out result) ? result.Symbol : null;
+            int index;
+            return ReferencedAssembliesMap.TryGetValue(reference, out index) ? ReferencedAssemblies[index] : null;
         }
 
         internal int GetReferencedModuleIndex(MetadataReference reference)
@@ -420,6 +402,37 @@ namespace Microsoft.CodeAnalysis
             int index;
             return ReferencedModuleIndexMap.TryGetValue(reference, out index) ? index : -1;
         }
+
+        /// <summary>
+        /// Gets the <see cref="MetadataReference"/> that corresponds to the assembly symbol. 
+        /// </summary>
+        internal override MetadataReference GetMetadataReference(IAssemblySymbol assemblySymbol)
+        {
+            foreach (var entry in ReferencedAssembliesMap)
+            {
+                if ((object)ReferencedAssemblies[entry.Value] == assemblySymbol)
+                {
+                    return entry.Key;
+                }
+            }
+
+            return null;
+        }
+
+        internal override IEnumerable<ValueTuple<IAssemblySymbol, ImmutableArray<string>>> GetReferencedAssemblyAliases()
+        {
+            for (int i = 0; i < ReferencedAssemblies.Length; i++)
+            {
+                yield return ValueTuple.Create((IAssemblySymbol)ReferencedAssemblies[i], AliasesOfReferencedAssemblies[i]);
+            }
+        }
+
+        public bool DeclarationsAccessibleWithoutAlias(int referencedAssemblyIndex)
+        {
+            var aliases = AliasesOfReferencedAssemblies[referencedAssemblyIndex];
+            return aliases.Length == 0 || aliases.IndexOf(MetadataReferenceProperties.GlobalAlias, StringComparer.Ordinal) >= 0;
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/Core/Portable/ReferenceManager/ModuleReferences.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/ModuleReferences.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Names[i] is the identity of assembly Symbols[i].
         /// </remarks>
-        public readonly ImmutableArray<AssemblyIdentity> Names;
+        public readonly ImmutableArray<AssemblyIdentity> Identities;
 
         /// <summary>
         /// Assembly symbols that the identities are resolved against.
@@ -36,16 +36,16 @@ namespace Microsoft.CodeAnalysis
         public readonly ImmutableArray<UnifiedAssembly<TAssemblySymbol>> UnifiedAssemblies;
 
         public ModuleReferences(
-            ImmutableArray<AssemblyIdentity> names,
+            ImmutableArray<AssemblyIdentity> identities,
             ImmutableArray<TAssemblySymbol> symbols,
             ImmutableArray<UnifiedAssembly<TAssemblySymbol>> unifiedAssemblies)
         {
-            Debug.Assert(!names.IsDefault);
+            Debug.Assert(!identities.IsDefault);
             Debug.Assert(!symbols.IsDefault);
-            Debug.Assert(names.Length == symbols.Length);
+            Debug.Assert(identities.Length == symbols.Length);
             Debug.Assert(!unifiedAssemblies.IsDefault);
 
-            this.Names = names;
+            this.Identities = identities;
             this.Symbols = symbols;
             this.UnifiedAssemblies = unifiedAssemblies;
         }

--- a/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
+++ b/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -415,6 +416,43 @@ namespace Microsoft.CodeAnalysis
             {
                 Add(item);
             }
+        }
+
+        public void RemoveDuplicates()
+        {
+            var set = PooledHashSet<T>.GetInstance();
+
+            int j = 0;
+            for (int i = 0; i < Count; i++)
+            {
+                this[j] = this[i];
+
+                if (set.Add(this[i]))
+                {
+                    j++;
+                }
+            }
+
+            Clip(j);
+            set.Free();
+        }
+
+        public ImmutableArray<S> SelectDistinct<S>(Func<T, S> selector)
+        {
+            var result = ArrayBuilder<S>.GetInstance(Count);
+            var set = PooledHashSet<S>.GetInstance();
+
+            foreach (var item in this)
+            {
+                var selected = selector(item);
+                if (set.Add(selected))
+                {
+                    result.Add(selected);
+                }
+            }
+
+            set.Free();
+            return result.ToImmutableAndFree();
         }
     }
 }

--- a/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
+++ b/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
@@ -425,10 +425,9 @@ namespace Microsoft.CodeAnalysis
             int j = 0;
             for (int i = 0; i < Count; i++)
             {
-                this[j] = this[i];
-
                 if (set.Add(this[i]))
                 {
+                    this[j] = this[i];
                     j++;
                 }
             }

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1227,7 +1227,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Gets the <see cref="MetadataReference"/> that corresponds to the assembly symbol.
         ''' </summary>
         Friend Shadows Function GetMetadataReference(assemblySymbol As AssemblySymbol) As MetadataReference
-            Return Me.GetBoundReferenceManager().ReferencedAssembliesMap.Where(Function(kvp) kvp.Value.Symbol Is assemblySymbol).Select(Function(kvp) kvp.Key).FirstOrDefault()
+            Return Me.GetBoundReferenceManager().GetMetadataReference(assemblySymbol)
         End Function
 
         Public Overrides ReadOnly Property ReferencedAssemblyNames As IEnumerable(Of AssemblyIdentity)
@@ -2639,15 +2639,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me.ObjectType
             End Get
         End Property
-
-        Protected Overrides Function CommonGetMetadataReference(_assemblySymbol As IAssemblySymbol) As MetadataReference
-            Dim symbol = TryCast(_assemblySymbol, AssemblySymbol)
-            If symbol IsNot Nothing Then
-                Return Me.GetMetadataReference(symbol)
-            Else
-                Return Nothing
-            End If
-        End Function
 
         Protected Overrides Function CommonGetEntryPoint(cancellationToken As CancellationToken) As IMethodSymbol
             Return Me.GetEntryPoint(cancellationToken)

--- a/src/Compilers/VisualBasic/Portable/Symbols/NonMissingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NonMissingModuleSymbol.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend NotOverridable Overrides Function GetReferencedAssemblies() As ImmutableArray(Of AssemblyIdentity)
             AssertReferencesInitialized()
-            Return _moduleReferences.Names
+            Return _moduleReferences.Identities
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingModuleSymbol.vb
@@ -170,7 +170,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
             Dim underlyingBoundReferences As ImmutableArray(Of AssemblySymbol) = _underlyingModule.GetReferencedAssemblySymbols()
             Dim referencedAssemblySymbols As ImmutableArray(Of AssemblySymbol) = moduleReferences.Symbols
-            Dim referencedAssemblies As ImmutableArray(Of AssemblyIdentity) = moduleReferences.Names
+            Dim referencedAssemblies As ImmutableArray(Of AssemblyIdentity) = moduleReferences.Identities
 
             Debug.Assert(referencedAssemblySymbols.Length = referencedAssemblies.Length)
             Debug.Assert(referencedAssemblySymbols.Length <= underlyingBoundReferences.Length) ' Linked references are filtered out.


### PR DESCRIPTION
Avoid potential non-determinism (enumerating hashtables), use pooled ArrayBuilders, expression-bodied properties, unify C# and VB.

@AlekseyTs @VSadov 