### PR TITLE
Ensure that IDisposable temps  in a case of dynamic using have "Using" kind.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: false,
                     constantValueOpt: rewrittenExpression.ConstantValue);
 
-                boundTemp = _factory.StoreToTemp(tempInit, out tempAssignment);
+                boundTemp = _factory.StoreToTemp(tempInit, out tempAssignment, kind: SynthesizedLocalKind.Using);
             }
             else
             {
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: false);
 
                 BoundAssignmentOperator tempAssignment;
-                BoundLocal boundTemp = _factory.StoreToTemp(tempInit, out tempAssignment);
+                BoundLocal boundTemp = _factory.StoreToTemp(tempInit, out tempAssignment, kind: SynthesizedLocalKind.Using);
 
                 BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp);
 


### PR DESCRIPTION
Ensure that IDisposable temps  in a case of dynamic using have "Using" kind.

These temps have special longlived kind "Using", but were produced as regular temps in the case involving dynamic.

Fixes #5323