### PR TITLE
Stop double-reporting Interactive telemetry

### DIFF
--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
@@ -42,6 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             shell.LoadPackage(Guids.RoslynPackageId, out roslynPackage);
             Debug.Assert(core::Microsoft.CodeAnalysis.ErrorReporting.FatalError.Handler != null);
             Debug.Assert(core::Microsoft.CodeAnalysis.ErrorReporting.FatalError.NonFatalHandler != null);
+            Debug.Assert(core::Microsoft.CodeAnalysis.Internal.Log.Logger.GetLogger() != null);
 
             // Explicitly set up FatalError handlers for the InteractiveWindowPackage.
             // NB: Microsoft.CodeAnalysis.ErrorReporting.FatalError (InteractiveWindow), not 
@@ -55,12 +56,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             var menuCommandService = (OleMenuCommandService)GetService(typeof(IMenuCommandService));
             InitializeMenuCommands(menuCommandService);
             InitializeResetInteractiveFromProjectCommand(menuCommandService);
-
-            var telemetrySetupExtensions = _componentModel.GetExtensions<IRoslynTelemetrySetup>();
-            foreach (var telemetrySetup in telemetrySetupExtensions)
-            {
-                telemetrySetup.Initialize(this);
-            }
         }
 
         protected TVsInteractiveWindowProvider InteractiveWindowProvider


### PR DESCRIPTION
```IRoslynTelemetrySetup``` was initialized once by the Roslyn package and
then again by the ```VsInteractiveWindowPackage```, resulting in an
```AggregateLogger``` containing two ```EtwLogger```s and two
```VsTelemetryLogger```s.