### PR TITLE
Speed up smart indenting in the presence of many inactive regions

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -272,6 +272,7 @@
     <Compile Include="Formatting\Indentation\FormatterTestsBase.cs" />
     <Compile Include="Formatting\Indentation\SmartIndenterEnterOnTokenTests.cs" />
     <Compile Include="Formatting\Indentation\SmartIndenterTests.cs" />
+    <Compile Include="Formatting\Indentation\SmartIndenterTests_Performance.cs" />
     <Compile Include="Formatting\Indentation\SmartTokenFormatterFormatRangeTests.cs" />
     <Compile Include="Formatting\Indentation\SmartTokenFormatterFormatTokenTests.cs" />
     <Compile Include="Interactive\BraceMatching\InteractiveBraceHighlightingTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -900,6 +900,11 @@ class C
             {
                 throw new NotImplementedException();
             }
+
+            public TextSpan GetInactiveRegionSpanAroundPosition(SyntaxTree tree, int position, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -66,6 +66,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void Preprocessor3()
+        {
+            var code = @"#region stuff
+#endregion
+";
+            AssertIndentNotUsingSmartTokenFormatterButUsingIndenter(
+                code,
+                indentationLine: 2,
+                expectedIndentation: 0);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public void Comments()
         {
             var code = @"using System;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
 {
-    public class SmartIndenterTests : FormatterTestsBase
+    public partial class SmartIndenterTests : FormatterTestsBase
     {
         [Fact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
@@ -2527,6 +2527,26 @@ class Program
                 using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(code, parseOptions: option))
                 {
                     TestIndentation(indentationLine, expectedIndentation, workspace);
+                }
+            }
+        }
+
+        private static void AssertSmartIndent(
+            string code,
+            int? expectedIndentation,
+            CSharpParseOptions options = null)
+        {
+            var optionsSet = options != null
+                ? new[] { options }
+                : new[] { Options.Regular, Options.Script };
+
+            foreach (var option in optionsSet)
+            {
+                using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(code, parseOptions: option))
+                {
+                    var wpfTextView = workspace.Documents.First().GetTextView();
+                    var line = wpfTextView.TextBuffer.CurrentSnapshot.GetLineFromPosition(wpfTextView.Caret.Position.BufferPosition).LineNumber;
+                    TestIndentation(line, expectedIndentation, workspace);
                 }
             }
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests_Performance.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests_Performance.cs
@@ -1,0 +1,2217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
+{
+    public partial class SmartIndenterTests
+    {
+        // TODO: Author this as a performance test.
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void RegionPerformance()
+        {
+            var code =
+            #region very long sample code
+ @"using System;
+using System.Collections.Generic;
+
+class Class1
+{
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }
+    #endregion
+    };
+#endif
+
+#if (false && Var1)
+    Dictionary<int, List<string>> x = new Dictionary<int, List<string>>() {
+    #region Region 1
+        {
+            1,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 2
+        {
+            2,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 3
+        {
+            3,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 4
+        {
+            4,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 5
+        {
+            5,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 6
+        {
+            6,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 7
+        {
+            7,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 8
+        {
+           8,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 9
+        {
+            9,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        },
+    #endregion
+    #region Region 10
+        {
+            10,
+            new List<string>()
+            {
+                ""a"",
+                ""b"",
+                ""c"",
+                ""d"",
+                ""e"",
+                ""f""
+            }
+        }$$
+    
+    #endregion
+    };
+#endif
+}
+
+class Program
+{
+    static void Main()
+    {
+    }
+}
+
+";
+            #endregion
+
+            AssertSmartIndent(
+                code,
+                expectedIndentation: 4);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests_Performance.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests_Performance.cs
@@ -1,4 +1,6 @@
-﻿using System;
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                         continue;
                     }
 
-                    // No preprocessors in the entire tree, so this line
+                    // No preprocessors in the entire tree, so this
                     // line definitely doesn't have one
                     var root = Tree.GetRoot(CancellationToken);
                     if (!root.ContainsDirectives)

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -31,6 +31,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
             protected readonly IEnumerable<IFormattingRule> Rules;
             protected readonly BottomUpBaseIndentationFinder Finder;
 
+            private static readonly Func<SyntaxToken, bool> _tokenHasDirective = tk => tk.ContainsDirectives &&
+                                                  (tk.LeadingTrivia.Any(tr => tr.IsDirective) || tk.TrailingTrivia.Any(tr => tr.IsDirective));
+
             public AbstractIndenter(Document document, IEnumerable<IFormattingRule> rules, OptionSet optionSet, ITextSnapshotLine lineToBeIndented, CancellationToken cancellationToken)
             {
                 this.OptionSet = optionSet;
@@ -114,43 +117,56 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                     throw new ArgumentNullException(nameof(Tree));
                 }
 
-                var line = this.LineToBeIndented;
-                var syntaxFacts = this.Document.Document.GetLanguageService<ISyntaxFactsService>();
-
-                Func<ITextSnapshotLine, bool> predicate = currentLine =>
+                if (LineToBeIndented.LineNumber <= 0)
                 {
-                    // line is empty
-                    if (string.IsNullOrWhiteSpace(currentLine.GetText()))
+                    return null;
+                }
+
+                var syntaxFacts = this.Document.Document.GetLanguageService<ISyntaxFactsService>();
+                var snapshot = this.LineToBeIndented.Snapshot;
+
+                var lineNumber = this.LineToBeIndented.LineNumber - 1;
+                while (lineNumber >= 0)
+                {
+                    var actualLine = snapshot.GetLineFromLineNumber(lineNumber);
+
+                    // Empty line, no indentation to match.
+                    if (string.IsNullOrWhiteSpace(actualLine.GetText()))
                     {
-                        return false;
+                        lineNumber--;
+                        continue;
                     }
 
-                    // okay, now check whether it is preprocessor line or not
+                    // No preprocessors in the entire tree, so this line
+                    // line definitely doesn't have one
                     var root = Tree.GetRoot(CancellationToken);
                     if (!root.ContainsDirectives)
                     {
-                        return true;
+                        return snapshot.GetLineFromLineNumber(lineNumber);
                     }
 
-                    // check whether current position is part of inactive section
-                    if (syntaxFacts.IsInInactiveRegion(this.Tree, currentLine.Extent.Start, CancellationToken))
+                    // This line is inside an inactive region. Examine the 
+                    // first preceeding line not in an inactive region.
+                    var disabledSpan = syntaxFacts.GetInactiveRegionSpanAroundPosition(this.Tree, actualLine.Extent.Start, CancellationToken);
+                    if (disabledSpan != default(TextSpan))
                     {
-                        // well, treat all of this portion as blank lines
-                        return false;
+                        var targetLine = snapshot.GetLineNumberFromPosition(disabledSpan.Start);
+                        lineNumber = targetLine - 1;
+                        continue;
                     }
 
-                    Func<SyntaxToken, bool> tokenHasDirective = tk => tk.ContainsDirectives &&
-                                                                      (tk.LeadingTrivia.Any(tr => tr.IsDirective) || tk.TrailingTrivia.Any(tr => tr.IsDirective));
-                    if (HasPreprocessorCharacter(currentLine) &&
-                        root.DescendantTokens(currentLine.Extent.Span.ToTextSpan(), tk => tk.FullWidth() > 0).Any(tokenHasDirective))
+                    // A preprocessor directive starts on this line.
+                    if (HasPreprocessorCharacter(actualLine) &&
+                        root.DescendantTokens(actualLine.Extent.Span.ToTextSpan(), tk => tk.FullWidth() > 0).Any(_tokenHasDirective))
                     {
-                        return false;
+                        lineNumber--;
+                        continue;
                     }
 
-                    return true;
-                };
+                    return snapshot.GetLineFromLineNumber(lineNumber);
+                }
 
-                return line.GetPreviousMatchingLine(predicate);
+                return null;
             }
 
             protected abstract bool HasPreprocessorCharacter(ITextSnapshotLine currentLine);

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -807,6 +807,10 @@ End Class]]></a>.Value.NormalizeLineEndings()
             Public Function TryGetPredefinedType(token As SyntaxToken, ByRef type As PredefinedType) As Boolean Implements ISyntaxFactsService.TryGetPredefinedType
                 Throw New NotImplementedException()
             End Function
+
+            Public Function GetInactiveRegionSpanAroundPosition(tree As SyntaxTree, position As Integer, cancellationToken As CancellationToken) As TextSpan Implements ISyntaxFactsService.GetInactiveRegionSpanAroundPosition
+                Throw New NotImplementedException()
+            End Function
         End Class
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -135,6 +135,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         int GetMethodLevelMemberId(SyntaxNode root, SyntaxNode node);
         SyntaxNode GetMethodLevelMember(SyntaxNode root, int memberId);
+        TextSpan GetInactiveRegionSpanAroundPosition(SyntaxTree tree, int position, CancellationToken cancellationToken);
 
         /// <summary>
         /// Given a <see cref="SyntaxNode"/>, return the <see cref="TextSpan"/> representing the span of the member body

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1153,5 +1153,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             Next
         End Sub
+
+        Public Function GetInactiveRegionSpanAroundPosition(tree As SyntaxTree, position As Integer, cancellationToken As CancellationToken) As TextSpan Implements ISyntaxFactsService.GetInactiveRegionSpanAroundPosition
+            Dim trivia = tree.FindTriviaToLeft(position, cancellationToken)
+            If trivia.Kind = SyntaxKind.DisabledTextTrivia Then
+                Return trivia.FullSpan
+            End If
+
+            Return Nothing
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Avoid repeatedly calling ISyntaxFactsService.IsInInactiveRegion, which calls SyntaxTree.GetToken. GetToken needs to traverse directive trivia to find the token it is
attached to. This results in n ^ 2 traversals of the tree if there are repeated directive before the line to indent. Additionally, when the indenter determines
that it's examining a line inside a disabled region, instead of examining the previous line, it examines the first line preceeding the current line that isn't
inside a disabled region.

Fixes #5394.