### PR TITLE
Ban assembly versions with wildcards in deterministic builds

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2073,8 +2073,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 string verString = (string)attribute.CommonConstructorArguments[0].Value;
                 Version version;
-                bool deterministic = _compilation.Feature("deterministic")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
-                if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: !deterministic, version: out version))
+                if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: !_compilation.IsEmitDeterministic, version: out version))
                 {
                     Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
                     arguments.Diagnostics.Add(ErrorCode.ERR_InvalidVersionFormat, attributeArgumentSyntaxLocation);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2073,7 +2073,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 string verString = (string)attribute.CommonConstructorArguments[0].Value;
                 Version version;
-                if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: true, version: out version))
+                bool deterministic = _compilation.Feature("deterministic")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+                if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: !deterministic, version: out version))
                 {
                     Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
                     arguments.Diagnostics.Add(ErrorCode.ERR_InvalidVersionFormat, attributeArgumentSyntaxLocation);

--- a/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
@@ -51,6 +51,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             return compilation.EmitToArray(EmitOptions.Default.WithDebugInformationFormat(pdbFormat), pdbStream: new MemoryStream());
         }
 
+        [Fact, WorkItem(4578, "https://github.com/dotnet/roslyn/issues/4578")]
+        public void BanVersionWildcards()
+        {
+            string source = @"[assembly: System.Reflection.AssemblyVersion(""10101.0.*"")] public class C {}";
+            var compilationDeterministic = CreateCompilation(source, assemblyName: "DeterminismTest", references: new[] { MscorlibRef },
+                parseOptions: TestOptions.Regular.WithFeature("deterministic", "true"));
+            var compilationNonDeterministic = CreateCompilation(source, assemblyName: "DeterminismTest", references: new[] { MscorlibRef });
+
+            var resultDeterministic = compilationDeterministic.Emit(new MemoryStream(), new MemoryStream());
+            var resultNonDeterministic = compilationNonDeterministic.Emit(new MemoryStream(), new MemoryStream());
+
+            Assert.False(resultDeterministic.Success);   
+            Assert.True(resultNonDeterministic.Success);   
+        }
+
         [Fact, WorkItem(372, "https://github.com/dotnet/roslyn/issues/372")]
         public void Simple()
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
@@ -59,8 +59,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                 parseOptions: TestOptions.Regular.WithFeature("deterministic", "true"));
             var compilationNonDeterministic = CreateCompilation(source, assemblyName: "DeterminismTest", references: new[] { MscorlibRef });
 
-            var resultDeterministic = compilationDeterministic.Emit(new MemoryStream(), new MemoryStream());
-            var resultNonDeterministic = compilationNonDeterministic.Emit(new MemoryStream(), new MemoryStream());
+            var resultDeterministic = compilationDeterministic.Emit(Stream.Null, Stream.Null);
+            var resultNonDeterministic = compilationNonDeterministic.Emit(Stream.Null, Stream.Null);
 
             Assert.False(resultDeterministic.Success);   
             Assert.True(resultNonDeterministic.Success);   

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -998,7 +998,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyVersionAttribute) Then
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).Value, String)
                 Dim version As Version = Nothing
-                If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=True, version:=version) Then
+                Dim deterministic As Boolean = If(_compilation.Feature("deterministic")?.Equals("true", StringComparison.OrdinalIgnoreCase), False)
+                If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=Not deterministic, version:=version) Then
                     arguments.Diagnostics.Add(ERRID.ERR_InvalidVersionFormat, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyVersionAttributeSetting = version

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -998,8 +998,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyVersionAttribute) Then
                 Dim verString = DirectCast(attrData.CommonConstructorArguments(0).Value, String)
                 Dim version As Version = Nothing
-                Dim deterministic As Boolean = If(_compilation.Feature("deterministic")?.Equals("true", StringComparison.OrdinalIgnoreCase), False)
-                If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=Not deterministic, version:=version) Then
+                If Not VersionHelper.TryParseAssemblyVersion(verString, allowWildcard:=Not _compilation.IsEmitDeterministic, version:=version) Then
                     arguments.Diagnostics.Add(ERRID.ERR_InvalidVersionFormat, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
                 End If
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyVersionAttributeSetting = version

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DeterministicTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DeterministicTests.vb
@@ -38,8 +38,8 @@ End Class"
                 parseOptions:=TestOptions.Regular.WithFeature("deterministic", "true"))
             Dim compilationNonDeterministic = CreateCompilationWithMscorlib({source}, assemblyName:="DeterminismTest")
 
-            Dim resultDeterministic = compilationDeterministic.Emit(New MemoryStream(), New MemoryStream())
-            Dim resultNonDeterministic = compilationNonDeterministic.Emit(New MemoryStream(), New MemoryStream())
+            Dim resultDeterministic = compilationDeterministic.Emit(Stream.Null, Stream.Null)
+            Dim resultNonDeterministic = compilationNonDeterministic.Emit(Stream.Null, Stream.Null)
 
             Assert.False(resultDeterministic.Success)
             Assert.True(resultNonDeterministic.Success)

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DeterministicTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DeterministicTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System
+Imports System.IO
 Imports System.Collections.Generic
 Imports System.Collections.Immutable
 Imports System.Threading
@@ -24,6 +25,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Emit
 
             Return compilation.EmitToArray()
         End Function
+
+        <Fact>
+        Public Sub BanVersionWildcards()
+            Dim source =
+"<assembly: System.Reflection.AssemblyVersion(""10101.0.*"")> 
+Class C 
+    Shared Sub Main()
+    End Sub
+End Class"
+            Dim compilationDeterministic = CreateCompilationWithMscorlib({source}, assemblyName:="DeterminismTest",
+                parseOptions:=TestOptions.Regular.WithFeature("deterministic", "true"))
+            Dim compilationNonDeterministic = CreateCompilationWithMscorlib({source}, assemblyName:="DeterminismTest")
+
+            Dim resultDeterministic = compilationDeterministic.Emit(New MemoryStream(), New MemoryStream())
+            Dim resultNonDeterministic = compilationNonDeterministic.Emit(New MemoryStream(), New MemoryStream())
+
+            Assert.False(resultDeterministic.Success)
+            Assert.True(resultNonDeterministic.Success)
+        End Sub
 
         <Fact>
         Public Sub CompareAllBytesEmitted_Release()


### PR DESCRIPTION
Closes #4578 