### PR TITLE
update auto-property analyzer to explicitly check for exactly one setter statement

### DIFF
--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -90,10 +90,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
             var statements = getAccessor?.Body?.Statements;
             if (statements?.Count == 1)
             {
-                var firstStatement = statements.Value[0];
-                if (firstStatement.Kind() == SyntaxKind.ReturnStatement)
+                var statement = statements.Value[0];
+                if (statement.Kind() == SyntaxKind.ReturnStatement)
                 {
-                    var expr = ((ReturnStatementSyntax)firstStatement).Expression;
+                    var expr = ((ReturnStatementSyntax)statement).Expression;
                     return CheckExpressionSyntactically(expr) ? expr : null;
                 }
             }
@@ -111,10 +111,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
             var statements = setAccessor?.Body?.Statements;
             if (statements?.Count == 1)
             {
-                var firstStatement = statements.Value[0];
-                if (firstStatement?.Kind() == SyntaxKind.ExpressionStatement)
+                var statement = statements.Value[0];
+                if (statement?.Kind() == SyntaxKind.ExpressionStatement)
                 {
-                    var expressionStatement = (ExpressionStatementSyntax)firstStatement;
+                    var expressionStatement = (ExpressionStatementSyntax)statement;
                     if (expressionStatement.Expression.Kind() == SyntaxKind.SimpleAssignmentExpression)
                     {
                         var assignmentExpression = (AssignmentExpressionSyntax)expressionStatement.Expression;

--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -82,11 +82,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 
         protected override ExpressionSyntax GetGetterExpression(IMethodSymbol getMethod, CancellationToken cancellationToken)
         {
+            // Getter has to be of the form:
+            //
+            //     get { return field; } or
+            //     get { return this.field; }
             var getAccessor = getMethod.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) as AccessorDeclarationSyntax;
             var statements = getAccessor?.Body?.Statements;
             if (statements?.Count == 1)
             {
-                // this only works with a getter body with exactly one statement
                 var firstStatement = statements.Value[0];
                 if (firstStatement.Kind() == SyntaxKind.ReturnStatement)
                 {
@@ -100,11 +103,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 
         protected override ExpressionSyntax GetSetterExpression(IMethodSymbol setMethod, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
+            // Setter has to be of the form:
+            //
+            //     set { field = value; } or
+            //     set { this.field = value; }
             var setAccessor = setMethod.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) as AccessorDeclarationSyntax;
             var statements = setAccessor?.Body?.Statements;
             if (statements?.Count == 1)
             {
-                // this only works with a setter body with exactly one statement
                 var firstStatement = statements.Value[0];
                 if (firstStatement?.Kind() == SyntaxKind.ExpressionStatement)
                 {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -120,6 +120,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public void TestSetterWithMultipleStatementsAndGetterWithSingleStatement()
+        {
+            TestMissing(@"class Class { [|int i|]; int P { get { return i; } set { ; i = value; } } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
         public void TestGetterAndSetterUseDifferentFields()
         {
             TestMissing(

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -59,9 +59,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
             Dim accessor = TryCast(TryCast(getMethod.DeclaringSyntaxReferences(0).GetSyntax(cancellationToken), AccessorStatementSyntax)?.Parent, AccessorBlockSyntax)
             Dim statements = accessor?.Statements
             If statements?.Count = 1 Then
-                Dim firstStatement = statements.Value(0)
-                If firstStatement.Kind() = SyntaxKind.ReturnStatement Then
-                    Dim expr = DirectCast(firstStatement, ReturnStatementSyntax).Expression
+                Dim statement = statements.Value(0)
+                If statement.Kind() = SyntaxKind.ReturnStatement Then
+                    Dim expr = DirectCast(statement, ReturnStatementSyntax).Expression
                     Return If(CheckExpressionSyntactically(expr), expr, Nothing)
                 End If
             End If
@@ -82,9 +82,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
             Dim setAccessor = TryCast(TryCast(setMethod.DeclaringSyntaxReferences(0).GetSyntax(cancellationToken), AccessorStatementSyntax)?.Parent, AccessorBlockSyntax)
             Dim statements = setAccessor?.Statements
             If statements?.Count = 1 Then
-                Dim firstStatement = statements.Value(0)
-                If firstStatement?.Kind() = SyntaxKind.SimpleAssignmentStatement Then
-                    Dim assignmentStatement = DirectCast(firstStatement, AssignmentStatementSyntax)
+                Dim statement = statements.Value(0)
+                If statement?.Kind() = SyntaxKind.SimpleAssignmentStatement Then
+                    Dim assignmentStatement = DirectCast(statement, AssignmentStatementSyntax)
                     If assignmentStatement.Right.Kind() = SyntaxKind.IdentifierName Then
                         Dim identifier = DirectCast(assignmentStatement.Right, IdentifierNameSyntax)
                         Dim symbol = semanticModel.GetSymbolInfo(identifier).Symbol

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -47,10 +47,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
         End Function
 
         Protected Overrides Function GetGetterExpression(getMethod As IMethodSymbol, cancellationToken As CancellationToken) As ExpressionSyntax
+            ' Getter has to be of the form:
+            '
+            '     Get
+            '         Return field
+            '     End Get
+            ' or
+            '     Get
+            '         Return Me.field
+            '     End Get
             Dim accessor = TryCast(TryCast(getMethod.DeclaringSyntaxReferences(0).GetSyntax(cancellationToken), AccessorStatementSyntax)?.Parent, AccessorBlockSyntax)
             Dim statements = accessor?.Statements
             If statements?.Count = 1 Then
-                ' this only works with a getter body with exactly one statement
                 Dim firstStatement = statements.Value(0)
                 If firstStatement.Kind() = SyntaxKind.ReturnStatement Then
                     Dim expr = DirectCast(firstStatement, ReturnStatementSyntax).Expression
@@ -62,10 +70,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
         End Function
 
         Protected Overrides Function GetSetterExpression(setMethod As IMethodSymbol, semanticModel As SemanticModel, cancellationToken As CancellationToken) As ExpressionSyntax
+            ' Setter has to be of the form:
+            '
+            '     Set(value)
+            '         field = value
+            '     End Set
+            ' or
+            '     Set(value)
+            '         Me.field = value
+            '     End Set
             Dim setAccessor = TryCast(TryCast(setMethod.DeclaringSyntaxReferences(0).GetSyntax(cancellationToken), AccessorStatementSyntax)?.Parent, AccessorBlockSyntax)
             Dim statements = setAccessor?.Statements
             If statements?.Count = 1 Then
-                ' this only works with a setter body with exactly one statement
                 Dim firstStatement = statements.Value(0)
                 If firstStatement?.Kind() = SyntaxKind.SimpleAssignmentStatement Then
                     Dim assignmentStatement = DirectCast(firstStatement, AssignmentStatementSyntax)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -107,6 +107,12 @@ NewLines("class Class1 \n [|dim i as integer|] \n property P as Integer \n set \
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        Public Sub TestSetterWithMutipleStatementsAndGetterWithSingleStatement()
+            TestMissing(
+NewLines("class Class1 \n [|dim i as integer|] \n property P as Integer \n get \n Return i \n end get \n \n set \n Foo() \n i = value \n end set \n end property \n end class"))
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
         Public Sub TestGetterAndSetterUseDifferentFields()
             TestMissing(
 NewLines("class Class1 \n [|dim i as integer|] \n dim j as Integer \n property P as Integer \n get \n return i \n end get \n set \n j = value \n end set \n end property \n end class"))


### PR DESCRIPTION
Update UseAutoPropertyAnalyzers to handle a valid getter (e.g., one statement) but an invalid setter (e.g., 0 or 2+ statements).

**Examples:**
``` C#
int i;
int P
{
    get { return i; }
    set
    {
        int x = 1;
        i = value;
    }
}
```

``` VB
Dim i As Integer
Property P As Integer
    Get
        Return i
    End Get
    Set
        Dim x = 1
        i = value
    End Set
End Property
```

Fixes #5291.