### PR TITLE
Fix Roslyn EE to handle function pointers

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -38,9 +38,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
 
             var runtimeType = type.GetLmrType();
-            // Primitives, enums and null values with a declared type that is an interface have no visible members.
+            // Primitives, enums, function pointers, and null values with a declared type that is an interface have no visible members.
             Debug.Assert(!runtimeType.IsInterface || value.IsNull);
-            if (formatter.IsPredefinedType(runtimeType) || runtimeType.IsEnum || runtimeType.IsInterface)
+            if (formatter.IsPredefinedType(runtimeType) || runtimeType.IsEnum || runtimeType.IsInterface || runtimeType.IsFunctionPointer())
             {
                 return null;
             }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DebuggerPlaceholders.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DebuggerPlaceholders.cs
@@ -1,0 +1,19 @@
+﻿namespace Microsoft.VisualStudio.Debugger.Metadata
+{
+    // Starting in Visual Studio 2015, Update 1, a new api exists to detect if a type is a function pointer.
+    // This placeholder method is a temporary shim to allow Roslyn to avoid taking a dependency on Update 1 debugger
+    // binaries until Update 1 ships.  See https://github.com/dotnet/roslyn/issues/5428.
+    internal static class DebuggerMetadataExtensions
+    {
+        public static bool IsFunctionPointer(this Type type)
+        {
+            // Note: The Visual Studio 2015 RTM version of Microsoft.VisualStudio.Debugger.Metadata.dll does not support function pointers at all,
+            // so when running against the RTM version of that dll, this method will always return false.  Against the update 1 version,
+            // we can exploit the fact that the only time a pointer will ever have a null element type will be function pointers.
+            //
+            // Using this shim, rather than simply calling Type.IsFunctionPointer() allows the Update 1 expression evaluator to continue
+            // to work against the RTM debugger.
+            return type.IsPointer && type.GetElementType() == null;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -831,6 +831,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return null;
             }
 
+            if(declaredType.IsFunctionPointer())
+            {
+                // Function pointers have no expansion
+                return null;
+            }
+
             if (declaredType.IsPointer)
             {
                 // If this ever happens, the element type info is just .SkipOne().

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.TypeNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatter.Values.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\DebuggerPlaceholders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\DynamicFlagsCustomTypeInfo_Factory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\TypeAndCustomInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\TypeWalker.cs" />


### PR DESCRIPTION
Fix NullReferenceException's in the result provider when consuming
function pointers.

The VS 2015 Update 1 version of
Microsoft.VisualStudio.Debugger.Metadata.dll adds support for functions
pointers on the metadata api layer.  We represent it in the LMR type
system through new api's to detect if a type is a function pointer and,
if so, get the return type and argument types.  Currently, the result
provider crashes because it doesn't know how to handle a pointer type
with a null element type.  This change adds a couple of checks to
disable expansion on function pointers, which avoids the problem.  With
this change, the EE will simply display the memory address of the
function pointer in the value column, with the function pointer type in
the type column.

To avoid taking a dependency on the Update 1 version of
Microsoft.VisualStudio.Debugger.MetadataReader.dll before it ships, we
temporarily shim Type.IsFunctionPointer() via an extension method.  The
extension method exploits the fact that the function pointer case is the
only time we can have a pointer type with a null element type.  Once
Update 1 ships and the project references are updated, we can remove the
shim layer can just call Type.IsFunctionPointer() directly.