### PR TITLE
Improve compiler behavior around stack overflow caused by long binary expressions.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1923,10 +1923,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _returns = returns;
             }
 
-            public override BoundNode VisitLambda(BoundLambda node)
+            public override BoundNode Visit(BoundNode node)
             {
-                // Do not recurse into nested lambdas; we don't want their returns.
+                if (!(node is BoundExpression))
+                {
+                    return base.Visit(node);
+                }
+
                 return null;
+            }
+
+            protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+            {
+                throw ExceptionUtilities.Unreachable;
             }
 
             public override BoundNode VisitReturnStatement(BoundReturnStatement node)

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Collections;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -144,10 +145,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return result;
             }
 
-            public override BoundNode VisitLambda(BoundLambda node)
+            public override BoundNode Visit(BoundNode node)
             {
-                // Do not recurse into nested lambdas; we don't want their returns.
+                if (!(node is BoundExpression))
+                {
+                    return base.Visit(node);
+                }
+
                 return null;
+            }
+
+            protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+            {
+                throw ExceptionUtilities.Unreachable;
             }
 
             public override BoundNode VisitReturnStatement(BoundReturnStatement node)

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -115,10 +115,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // This setting only affects generating PDB sequence points, it shall not affect generated IL in any way.
             _emitPdbSequencePoints = emittingPdb && method.GenerateDebugInfo;
 
-            _boundBody = Optimizer.Optimize(
-                boundBody, 
-                debugFriendly: _ilEmitStyle != ILEmitStyle.Release, 
-                stackLocals: out _stackLocals);
+            try
+            {
+                _boundBody = Optimizer.Optimize(
+                    boundBody, 
+                    debugFriendly: _ilEmitStyle != ILEmitStyle.Release, 
+                    stackLocals: out _stackLocals);
+            }
+            catch (BoundTreeVisitor.CancelledByStackGuardException ex)
+            {
+                ex.AddAnError(diagnostics);
+                _boundBody = boundBody;
+            }
 
             _methodBodySyntaxOpt = (method as SourceMethodSymbol)?.BodySyntax;
         }
@@ -236,19 +244,26 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 _builder.DefineInitialHiddenSequencePoint();
             }
 
-            EmitStatement(_boundBody);
-
-            if (_indirectReturnState == IndirectReturnState.Needed)
+            try
             {
-                // it is unfortunate that return was not handled while we were in scope of the method
-                // it can happen in rare cases involving exception handling (for example all returns were from a try)
-                // in such case we can still handle return here.
-                HandleReturn();
+                EmitStatement(_boundBody);
+
+                if (_indirectReturnState == IndirectReturnState.Needed)
+                {
+                    // it is unfortunate that return was not handled while we were in scope of the method
+                    // it can happen in rare cases involving exception handling (for example all returns were from a try)
+                    // in such case we can still handle return here.
+                    HandleReturn();
+                }
+
+                if (!_diagnostics.HasAnyErrors())
+                {
+                    _builder.Realize();
+                }
             }
-
-            if (!_diagnostics.HasAnyErrors())
+            catch (EmitCancelledException)
             {
-                _builder.Realize();
+                Debug.Assert(_diagnostics.HasAnyErrors());
             }
 
             _synthesizedLocalOrdinals.Free();

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -12,6 +12,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 {
     internal partial class CodeGenerator
     {
+        private int _recursionDepth;
+
+        private class EmitCancelledException : Exception
+        { }
+
         private void EmitExpression(BoundExpression expression, bool used)
         {
             if (expression == null)
@@ -35,6 +40,41 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
             }
 
+            _recursionDepth++;
+
+            if (_recursionDepth > 1)
+            {
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
+
+                EmitExpressionCore(expression, used);
+            }
+            else
+            {
+                EmitExpressionCoreWithStackGuard(expression, used);
+            }
+
+            _recursionDepth--;
+        }
+
+        private void EmitExpressionCoreWithStackGuard(BoundExpression expression, bool used)
+        {
+            Debug.Assert(_recursionDepth == 1);
+
+            try
+            {
+                EmitExpressionCore(expression, used);
+                Debug.Assert(_recursionDepth == 1);
+            }
+            catch (Exception ex) when (StackGuard.IsInsufficientExecutionStackException(ex))
+            {
+                _diagnostics.Add(ErrorCode.ERR_InsufficientStack, 
+                                 BoundTreeVisitor.CancelledByStackGuardException.GetTooLongOrComplexExpressionErrorLocation(expression));
+                throw new EmitCancelledException();
+            }
+        }
+
+        private void EmitExpressionCore(BoundExpression expression, bool used)
+        {
             switch (expression.Kind)
             {
                 case BoundKind.AssignmentOperator:

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
     // NOTE: It is always safe to mark a local as not eligible as a stack local
     //       so when situation gets complicated we just refuse to schedule and move on.
     //
-    internal class StackOptimizerPass1 : BoundTreeRewriter
+    internal sealed class StackOptimizerPass1 : BoundTreeRewriter
     {
         private readonly bool _debugFriendly;
         private readonly ArrayBuilder<ValueTuple<BoundExpression, ExprContext>> _evalStack;
@@ -347,6 +347,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         // fake local that represents the eval stack.
         // when we need to ensure that eval stack is not blocked by stack Locals, we record an access to empty.
         public static readonly DummyLocal empty = new DummyLocal();
+
+        private int _recursionDepth;
 
         private StackOptimizerPass1(Dictionary<LocalSymbol, LocalDefUseInfo> locals,
             ArrayBuilder<ValueTuple<BoundExpression, ExprContext>> evalStack,
@@ -392,7 +394,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return result;
         }
 
-        public BoundExpression VisitExpression(BoundExpression node, ExprContext context)
+        private BoundExpression VisitExpressionCore(BoundExpression node, ExprContext context)
         {
             var prevContext = _context;
             int prevStack = StackDepth();
@@ -427,6 +429,47 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             return result;
+        }
+
+        private BoundExpression VisitExpression(BoundExpression node, ExprContext context)
+        {
+            BoundExpression result;
+            _recursionDepth++;
+
+            if (_recursionDepth > 1)
+            {
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
+
+                result = VisitExpressionCore(node, context);
+            }
+            else
+            {
+                result = VisitExpressionCoreWithStackGuard(node, context);
+            }
+
+            _recursionDepth--;
+            return result;
+        }
+
+        private BoundExpression VisitExpressionCoreWithStackGuard(BoundExpression node, ExprContext context)
+        {
+            Debug.Assert(_recursionDepth == 1);
+
+            try
+            {
+                var result = VisitExpressionCore(node, context);
+                Debug.Assert(_recursionDepth == 1);
+                return result;
+            }
+            catch (Exception ex) when (StackGuard.IsInsufficientExecutionStackException(ex))
+            {
+                throw new CancelledByStackGuardException(ex, node);
+            }
+        }
+
+        protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+        {
+            throw ExceptionUtilities.Unreachable; 
         }
 
         private void PushEvalStack(BoundExpression result, ExprContext context)
@@ -620,7 +663,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         // only because it must be returned, otherwise all uses are 
         // confined to the nested sequence that is assigned indirectly of to an instance field (and therefore has +1 stack)
         // in such case the desired stack for this local is +1
-        private static bool IsNestedLocalOfCompoundOperator(LocalSymbol local, BoundSequence node)
+        private bool IsNestedLocalOfCompoundOperator(LocalSymbol local, BoundSequence node)
         {
             var value = node.Value;
 
@@ -640,7 +683,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                             assignment.Right.Kind == BoundKind.Sequence)
                         {
                             // and no other side-effects should use the variable
-                            var localUsedWalker = new LocalUsedWalker(local);
+                            var localUsedWalker = new LocalUsedWalker(local, _recursionDepth);
                             for (int i = 0; i < sideeffects.Length - 1; i++)
                             {
                                 if (localUsedWalker.IsLocalUsedIn(sideeffects[i]))
@@ -668,12 +711,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return false;
         }
 
-        private class LocalUsedWalker : BoundTreeWalker
+        private sealed class LocalUsedWalker : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
         {
             private readonly LocalSymbol _local;
             private bool _found;
 
-            internal LocalUsedWalker(LocalSymbol local)
+            internal LocalUsedWalker(LocalSymbol local, int recursionDepth)
+                : base(recursionDepth)
             {
                 _local = local;
             }
@@ -1116,6 +1160,79 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         }
 
         public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        {
+            BoundExpression child = node.Left;
+
+            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+            {
+                return VisitBinaryOperatorSimple(node);
+            }
+
+            // Do not blow the stack due to a deep recursion on the left.
+            var stack = ArrayBuilder<BoundBinaryOperator>.GetInstance();
+            stack.Push(node);
+
+            BoundBinaryOperator binary = (BoundBinaryOperator)child;
+
+            while (true)
+            {
+                stack.Push(binary);
+                child = binary.Left;
+
+                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+                {
+                    break;
+                }
+
+                binary = (BoundBinaryOperator)child;
+            }
+
+            var prevContext = _context;
+            int prevStack = StackDepth();
+
+            var left = (BoundExpression)this.Visit(child);
+
+            while (true)
+            {
+                binary = stack.Pop();
+
+                var isLogical = (binary.OperatorKind & BinaryOperatorKind.Logical) != 0;
+
+                object cookie = null;
+                if (isLogical)
+                {
+                    cookie = GetStackStateCookie();     // implicit branch here
+                    SetStackDepth(prevStack);  // right is evaluated with original stack
+                }
+
+                var right = (BoundExpression)this.Visit(binary.Right);
+
+                if (isLogical)
+                {
+                    EnsureStackState(cookie);   // implicit label here
+                }
+
+                var type = this.VisitType(binary.Type);
+                left = binary.Update(binary.OperatorKind, left, right, binary.ConstantValueOpt, binary.MethodOpt, binary.ResultKind, type);
+
+                if (stack.Count == 0)
+                {
+                    break;
+                }
+
+                _context = prevContext;
+                _counter += 1;
+                SetStackDepth(prevStack);
+                PushEvalStack(binary, ExprContext.Value);
+            }
+
+            Debug.Assert((object)binary == node);
+            stack.Free();
+
+            return left;
+        }
+
+        private BoundNode VisitBinaryOperatorSimple(BoundBinaryOperator node)
         {
             var isLogical = (node.OperatorKind & BinaryOperatorKind.Logical) != 0;
             if (isLogical)
@@ -1625,7 +1742,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
     //              NotLastUse(X_stackLocal) ===> NotLastUse(Dup)
     //              LastUse(X_stackLocal) ===> LastUse(X_stackLocal)
     //
-    internal class StackOptimizerPass2 : BoundTreeRewriter
+    internal sealed class StackOptimizerPass2 : BoundTreeRewriterWithStackGuard
     {
         private int _nodeCounter;
         private readonly Dictionary<LocalSymbol, LocalDefUseInfo> _info;
@@ -1661,6 +1778,57 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             _nodeCounter += 1;
 
             return result;
+        }
+
+        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        {
+            BoundExpression child = node.Left;
+
+            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+            {
+                return base.VisitBinaryOperator(node);
+            }
+
+            // Do not blow the stack due to a deep recursion on the left.
+            var stack = ArrayBuilder<BoundBinaryOperator>.GetInstance();
+            stack.Push(node);
+
+            BoundBinaryOperator binary = (BoundBinaryOperator)child;
+
+            while (true)
+            {
+                stack.Push(binary);
+                child = binary.Left;
+
+                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+                {
+                    break;
+                }
+
+                binary = (BoundBinaryOperator)child;
+            }
+
+            var left = (BoundExpression)this.Visit(child);
+
+            while (true)
+            {
+                binary = stack.Pop();
+                var right = (BoundExpression)this.Visit(binary.Right);
+                var type = this.VisitType(binary.Type);
+                left = binary.Update(binary.OperatorKind, left, right, binary.ConstantValueOpt, binary.MethodOpt, binary.ResultKind, type);
+
+                if (stack.Count == 0)
+                {
+                    break;
+                }
+
+                _nodeCounter += 1;
+            }
+
+            Debug.Assert((object)binary == node);
+            stack.Free();
+
+            return left;
         }
 
         private static bool IsLastAccess(LocalDefUseInfo locInfo, int counter)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class MemberSemanticModel
     {
-        protected sealed class NodeMapBuilder : BoundTreeWalker
+        protected sealed class NodeMapBuilder : BoundTreeWalkerWithStackGuard
         {
             private NodeMapBuilder(OrderPreservingMultiDictionary<CSharpSyntaxNode, BoundNode> map, CSharpSyntaxNode thisSyntaxNodeOnly)
             {
@@ -248,6 +248,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
             {
                 throw ExceptionUtilities.Unreachable;
+            }
+
+            protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
+            {
+                return false;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.Lowered.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.Lowered.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
     }
 
-    internal abstract partial class MethodToClassRewriter : BoundTreeRewriter
+    internal abstract partial class MethodToClassRewriter 
     {
         private sealed partial class BaseMethodWrapperSymbol : SynthesizedMethodBaseSymbol
         {

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -604,24 +604,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // In case of async lambdas, which synthesize a state machine type during the following rewrite, the containing method has already been uniquely named, 
                 // so there is no need to produce a unique method ordinal for the corresponding state machine type, whose name includes the (unique) containing method name.
                 const int methodOrdinal = -1;
-                BoundStatement bodyWithoutAsync = AsyncRewriter.Rewrite(methodWithBody.Body, method, methodOrdinal, variableSlotAllocatorOpt, compilationState, diagnosticsThisMethod, out stateMachineType);
-
                 MethodBody emittedBody = null;
-                if (!diagnosticsThisMethod.HasAnyErrors() && !_globalHasErrors)
+
+                try
                 {
-                    emittedBody = GenerateMethodBody(
-                        _moduleBeingBuiltOpt,
-                        method,
-                        methodOrdinal,
-                        bodyWithoutAsync,
-                        ImmutableArray<LambdaDebugInfo>.Empty,
-                        ImmutableArray<ClosureDebugInfo>.Empty,
-                        stateMachineType,
-                        variableSlotAllocatorOpt,
-                        diagnosticsThisMethod,
-                        _debugDocumentProvider,
-                        methodWithBody.ImportChainOpt,
-                        emittingPdb: _emittingPdb);
+                    BoundStatement bodyWithoutAsync = AsyncRewriter.Rewrite(methodWithBody.Body, method, methodOrdinal, variableSlotAllocatorOpt, compilationState, diagnosticsThisMethod, out stateMachineType);
+
+                    if (!diagnosticsThisMethod.HasAnyErrors() && !_globalHasErrors)
+                    {
+                        emittedBody = GenerateMethodBody(
+                            _moduleBeingBuiltOpt,
+                            method,
+                            methodOrdinal,
+                            bodyWithoutAsync,
+                            ImmutableArray<LambdaDebugInfo>.Empty,
+                            ImmutableArray<ClosureDebugInfo>.Empty,
+                            stateMachineType,
+                            variableSlotAllocatorOpt,
+                            diagnosticsThisMethod,
+                            _debugDocumentProvider,
+                            methodWithBody.ImportChainOpt,
+                            emittingPdb: _emittingPdb);
+                    }
+                }
+                catch (BoundTreeVisitor.CancelledByStackGuardException ex)
+                {
+                    ex.AddAnError(_diagnostics);
                 }
 
                 _diagnostics.AddRange(diagnosticsThisMethod);
@@ -1146,89 +1154,97 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return body;
             }
 
-            bool sawLambdas;
-            bool sawAwaitInExceptionHandler;
-            var loweredBody = LocalRewriter.Rewrite(
-                method.DeclaringCompilation,
-                method,
-                methodOrdinal,
-                method.ContainingType,
-                body,
-                compilationState,
-                previousSubmissionFields: previousSubmissionFields,
-                allowOmissionOfConditionalCalls: true,
-                diagnostics: diagnostics,
-                sawLambdas: out sawLambdas,
-                sawAwaitInExceptionHandler: out sawAwaitInExceptionHandler);
-
-            if (loweredBody.HasErrors)
+            try
             {
-                return loweredBody;
-            }
-
-            if (sawAwaitInExceptionHandler)
-            {
-                // If we have awaits in handlers, we need to 
-                // replace handlers with synthetic ones which can be consumed by async rewriter.
-                // The reason why this rewrite happens before the lambda rewrite 
-                // is that we may need access to exception locals and it would be fairly hard to do
-                // if these locals are captured into closures (possibly nested ones).
-                Debug.Assert(!method.IsIterator);
-                loweredBody = AsyncExceptionHandlerRewriter.Rewrite(
-                    method,
-                    method.ContainingType,
-                    loweredBody,
-                    compilationState,
-                    diagnostics);
-            }
-
-            if (loweredBody.HasErrors)
-            {
-                return loweredBody;
-            }
-
-            if (lazyVariableSlotAllocator == null)
-            {
-                lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method);
-            }
-
-            BoundStatement bodyWithoutLambdas = loweredBody;
-            if (sawLambdas)
-            {
-                bodyWithoutLambdas = LambdaRewriter.Rewrite(
-                    loweredBody,
-                    method.ContainingType,
-                    method.ThisParameter,
+                bool sawLambdas;
+                bool sawAwaitInExceptionHandler;
+                var loweredBody = LocalRewriter.Rewrite(
+                    method.DeclaringCompilation,
                     method,
                     methodOrdinal,
-                    lambdaDebugInfoBuilder,
-                    closureDebugInfoBuilder,
-                    lazyVariableSlotAllocator,
+                    method.ContainingType,
+                    body,
                     compilationState,
-                    diagnostics,
-                    assignLocals: false);
-            }
+                    previousSubmissionFields: previousSubmissionFields,
+                    allowOmissionOfConditionalCalls: true,
+                    diagnostics: diagnostics,
+                    sawLambdas: out sawLambdas,
+                    sawAwaitInExceptionHandler: out sawAwaitInExceptionHandler);
 
-            if (bodyWithoutLambdas.HasErrors)
+                if (loweredBody.HasErrors)
+                {
+                    return loweredBody;
+                }
+
+                if (sawAwaitInExceptionHandler)
+                {
+                    // If we have awaits in handlers, we need to 
+                    // replace handlers with synthetic ones which can be consumed by async rewriter.
+                    // The reason why this rewrite happens before the lambda rewrite 
+                    // is that we may need access to exception locals and it would be fairly hard to do
+                    // if these locals are captured into closures (possibly nested ones).
+                    Debug.Assert(!method.IsIterator);
+                    loweredBody = AsyncExceptionHandlerRewriter.Rewrite(
+                        method,
+                        method.ContainingType,
+                        loweredBody,
+                        compilationState,
+                        diagnostics);
+                }
+
+                if (loweredBody.HasErrors)
+                {
+                    return loweredBody;
+                }
+
+                if (lazyVariableSlotAllocator == null)
+                {
+                    lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method);
+                }
+
+                BoundStatement bodyWithoutLambdas = loweredBody;
+                if (sawLambdas)
+                {
+                    bodyWithoutLambdas = LambdaRewriter.Rewrite(
+                        loweredBody,
+                        method.ContainingType,
+                        method.ThisParameter,
+                        method,
+                        methodOrdinal,
+                        lambdaDebugInfoBuilder,
+                        closureDebugInfoBuilder,
+                        lazyVariableSlotAllocator,
+                        compilationState,
+                        diagnostics,
+                        assignLocals: false);
+                }
+
+                if (bodyWithoutLambdas.HasErrors)
+                {
+                    return bodyWithoutLambdas;
+                }
+
+                IteratorStateMachine iteratorStateMachine;
+                BoundStatement bodyWithoutIterators = IteratorRewriter.Rewrite(bodyWithoutLambdas, method, methodOrdinal, lazyVariableSlotAllocator, compilationState, diagnostics, out iteratorStateMachine);
+
+                if (bodyWithoutIterators.HasErrors)
+                {
+                    return bodyWithoutIterators;
+                }
+
+                AsyncStateMachine asyncStateMachine;
+                BoundStatement bodyWithoutAsync = AsyncRewriter.Rewrite(bodyWithoutIterators, method, methodOrdinal, lazyVariableSlotAllocator, compilationState, diagnostics, out asyncStateMachine);
+
+                Debug.Assert(iteratorStateMachine == null || asyncStateMachine == null);
+                stateMachineTypeOpt = (StateMachineTypeSymbol)iteratorStateMachine ?? asyncStateMachine;
+
+                return bodyWithoutAsync;
+            }
+            catch (BoundTreeVisitor.CancelledByStackGuardException ex)
             {
-                return bodyWithoutLambdas;
+                ex.AddAnError(diagnostics);
+                return new BoundBadStatement(body.Syntax, ImmutableArray.Create<BoundNode>(body), hasErrors: true);
             }
-
-            IteratorStateMachine iteratorStateMachine;
-            BoundStatement bodyWithoutIterators = IteratorRewriter.Rewrite(bodyWithoutLambdas, method, methodOrdinal, lazyVariableSlotAllocator, compilationState, diagnostics, out iteratorStateMachine);
-
-            if (bodyWithoutIterators.HasErrors)
-            {
-                return bodyWithoutIterators;
-            }
-
-            AsyncStateMachine asyncStateMachine;
-            BoundStatement bodyWithoutAsync = AsyncRewriter.Rewrite(bodyWithoutIterators, method, methodOrdinal, lazyVariableSlotAllocator, compilationState, diagnostics, out asyncStateMachine);
-
-            Debug.Assert(iteratorStateMachine == null || asyncStateMachine == null);
-            stateMachineTypeOpt = (StateMachineTypeSymbol)iteratorStateMachine ?? asyncStateMachine;
-
-            return bodyWithoutAsync;
         }
 
         private static MethodBody GenerateMethodBody(
@@ -1259,6 +1275,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Cci.AsyncMethodBodyDebugInfo asyncDebugInfo = null;
 
                 var codeGen = new CodeGen.CodeGenerator(method, block, builder, moduleBuilder, diagnosticsForThisMethod, optimizations, emittingPdb);
+
+                if (diagnosticsForThisMethod.HasAnyErrors())
+                {
+                    // we are done here. Since there were errors we should not emit anything.
+                    return null;
+                }
 
                 // We need to save additional debugging information for MoveNext of an async state machine.
                 var stateMachineMethod = method as SynthesizedStateMachineMethod;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal abstract partial class PreciseAbstractFlowPass<LocalState> : BoundTreeVisitor
         where LocalState : AbstractFlowPass<LocalState>.AbstractLocalState
     {
+        protected int _recursionDepth;
+
         /// <summary>
         /// The compilation in which the analysis is taking place.  This is needed to determine which
         /// conditional methods will be compiled and which will be omitted.
@@ -271,16 +273,37 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (_trackRegions)
                 {
                     if (node == this.firstInRegion && this.regionPlace == RegionPlace.Before) EnterRegion();
-                    result = base.Visit(node);
+                    result = VisitWithStackGuard(node);
                     if (node == this.lastInRegion && this.regionPlace == RegionPlace.Inside) LeaveRegion();
                 }
                 else
                 {
-                    result = base.Visit(node);
+                    result = VisitWithStackGuard(node);
                 }
             }
 
             return result;
+        }
+
+        private BoundNode VisitWithStackGuard(BoundNode node)
+        {
+            var expression = node as BoundExpression;
+            if (expression != null)
+            {
+                return VisitExpressionWithStackGuard(ref _recursionDepth, expression);
+            }
+
+            return base.Visit(node);
+        }
+
+        protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+        {
+            return (BoundExpression)base.Visit(node);
+        }
+
+        protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
+        {
+            return false; // just let the original exception to bubble up.
         }
 
         /// <summary>
@@ -531,6 +554,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected void VisitCondition(BoundExpression node)
         {
             Visit(node);
+            AdjustConditionalState(node);
+        }
+
+        private void AdjustConditionalState(BoundExpression node)
+        {
             if (IsConstantTrue(node))
             {
                 Unsplit();
@@ -1713,62 +1741,134 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.OperatorKind.IsLogical())
             {
                 Debug.Assert(!node.OperatorKind.IsUserDefined());
-
-                VisitBinaryLogicalOperatorChildren(node.OperatorKind, node.Left, node.Right);
+                VisitBinaryLogicalOperatorChildren(node);
             }
             else
             {
                 VisitBinaryOperatorChildren(node);
             }
 
-            if (_trackExceptions && node.HasExpressionSymbols()) NotePossibleException(node);
             return null;
         }
 
         public override BoundNode VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
         {
-            VisitBinaryLogicalOperatorChildren(node.OperatorKind, node.Left, node.Right);
-
-            if (_trackExceptions && node.HasExpressionSymbols()) NotePossibleException(node);
+            VisitBinaryLogicalOperatorChildren(node);
             return null;
         }
 
-        private void VisitBinaryLogicalOperatorChildren(BinaryOperatorKind kind, BoundExpression left, BoundExpression right)
+        private void VisitBinaryLogicalOperatorChildren(BoundExpression node)
         {
-            var op = kind.Operator();
-            var isAnd = op == BinaryOperatorKind.And;
-            var isBool = kind.OperandTypes() == BinaryOperatorKind.Bool;
+            // Do not blow the stack due to a deep recursion on the left.
+            var stack = ArrayBuilder<BoundExpression>.GetInstance();
 
-            Debug.Assert(isAnd || op == BinaryOperatorKind.Or);
+            BoundExpression binary;
+            BoundExpression child = node;
 
-            VisitCondition(left);
-            var leftTrue = this.StateWhenTrue;
-            var leftFalse = this.StateWhenFalse;
-            SetState(isAnd ? leftTrue : leftFalse);
-
-            VisitCondition(right);
-            if (!isBool)
+            while (true)
             {
-                this.Unsplit();
-                this.Split();
+                var childKind = child.Kind;
+
+                if (childKind == BoundKind.BinaryOperator)
+                {
+                    var binOp = (BoundBinaryOperator)child;
+
+                    if (!binOp.OperatorKind.IsLogical())
+                    {
+                        break;
+                    }
+
+                    binary = child;
+                    child = binOp.Left;
+                }
+                else if (childKind == BoundKind.UserDefinedConditionalLogicalOperator)
+                {
+                    binary = child;
+                    child = ((BoundUserDefinedConditionalLogicalOperator)binary).Left;
+                }
+                else
+                {
+                    break;
+                }
+
+                stack.Push(binary);
             }
 
-            var resultTrue = this.StateWhenTrue;
-            var resultFalse = this.StateWhenFalse;
-            if (isAnd)
-            {
-                IntersectWith(ref resultFalse, ref leftFalse);
-            }
-            else
-            {
-                IntersectWith(ref resultTrue, ref leftTrue);
-            }
-            SetConditionalState(resultTrue, resultFalse);
+            Debug.Assert(stack.Count > 0);
 
-            if (!isBool)
+            VisitCondition(child);
+
+            while (true)
             {
-                this.Unsplit();
+                binary = stack.Pop();
+
+                BinaryOperatorKind kind;
+                BoundExpression right;
+                switch (binary.Kind)
+                {
+                    case BoundKind.BinaryOperator:
+                        var binOp = (BoundBinaryOperator)binary;
+                        kind = binOp.OperatorKind;
+                        right = binOp.Right;
+                        break;
+                    case BoundKind.UserDefinedConditionalLogicalOperator:
+                        var udBinOp = (BoundUserDefinedConditionalLogicalOperator)binary;
+                        kind = udBinOp.OperatorKind;
+                        right = udBinOp.Right;
+                        break;
+                    default:
+                        throw ExceptionUtilities.Unreachable;
+                }
+
+                var op = kind.Operator();
+                var isAnd = op == BinaryOperatorKind.And;
+                var isBool = kind.OperandTypes() == BinaryOperatorKind.Bool;
+
+                Debug.Assert(isAnd || op == BinaryOperatorKind.Or);
+
+                var leftTrue = this.StateWhenTrue;
+                var leftFalse = this.StateWhenFalse;
+                SetState(isAnd ? leftTrue : leftFalse);
+
+                VisitCondition(right);
+                if (!isBool)
+                {
+                    this.Unsplit();
+                    this.Split();
+                }
+
+                var resultTrue = this.StateWhenTrue;
+                var resultFalse = this.StateWhenFalse;
+                if (isAnd)
+                {
+                    IntersectWith(ref resultFalse, ref leftFalse);
+                }
+                else
+                {
+                    IntersectWith(ref resultTrue, ref leftTrue);
+                }
+                SetConditionalState(resultTrue, resultFalse);
+
+                if (!isBool)
+                {
+                    this.Unsplit();
+                }
+
+                if (_trackExceptions && binary.HasExpressionSymbols())
+                {
+                    NotePossibleException(binary);
+                }
+
+                if (stack.Count == 0)
+                {
+                    break;
+                }
+
+                AdjustConditionalState(binary);
             }
+
+            Debug.Assert((object)binary == node);
+            stack.Free();
         }
 
         private void VisitBinaryOperatorChildren(BoundBinaryOperator node)
@@ -1778,24 +1878,45 @@ namespace Microsoft.CodeAnalysis.CSharp
             // hand side. To mitigate the risk of stack overflow we use an explicit stack.
             //
             // Of course we must ensure that we visit the left hand side before the right hand side.
-
-            var stack = ArrayBuilder<BoundExpression>.GetInstance();
+            var stack = ArrayBuilder<BoundBinaryOperator>.GetInstance();
             stack.Push(node);
-            while (stack.Count > 0)
+
+            BoundBinaryOperator binary;
+            BoundExpression child = node.Left;
+
+            while (true)
             {
-                BoundExpression current = stack.Pop();
-                BoundBinaryOperator binOp = current as BoundBinaryOperator;
-                if (binOp == null || binOp.OperatorKind.IsLogical())
+                binary = child as BoundBinaryOperator;
+                if (binary == null || binary.OperatorKind.IsLogical())
                 {
-                    VisitRvalue(current);
+                    break;
                 }
-                else
-                {
-                    stack.Push(binOp.Right);
-                    stack.Push(binOp.Left);
-                }
+
+                stack.Push(binary);
+                child = binary.Left;
             }
 
+            VisitRvalue(child);
+
+            while (true)
+            {
+                binary = stack.Pop();
+                VisitRvalue(binary.Right);
+
+                if (_trackExceptions && binary.HasExpressionSymbols())
+                {
+                    NotePossibleException(binary);
+                }
+
+                if (stack.Count == 0)
+                {
+                    break;
+                }
+
+                Unsplit(); // VisitRvalue does this
+            }
+
+            Debug.Assert((object)binary == node);
             stack.Free();
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedVariablesWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedVariablesWalker.cs
@@ -18,9 +18,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
 
-        internal static HashSet<Symbol> Analyze(CSharpCompilation compilation, Symbol member, BoundNode node)
+        internal static HashSet<Symbol> Analyze(CSharpCompilation compilation, Symbol member, BoundNode node,
+                                                bool convertInsufficientExecutionStackExceptionToCancelledByStackGuardException = false)
         {
             var walker = new UnassignedVariablesWalker(compilation, member, node);
+
+            if (convertInsufficientExecutionStackExceptionToCancelledByStackGuardException)
+            {
+                walker._convertInsufficientExecutionStackExceptionToCancelledByStackGuardException = true;
+            }
+
             try
             {
                 bool badRegion = false;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// with surrogate replacements that keep actual handler code in regular code blocks.
     /// That allows these constructs to be further lowered at the async lowering pass.
     /// </summary>
-    internal sealed class AsyncExceptionHandlerRewriter : BoundTreeRewriter
+    internal sealed class AsyncExceptionHandlerRewriter : BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator 
     {
         private readonly bool _generateDebugInfo;
         private readonly CSharpCompilation _compilation;

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// This part of the partial class focuses on features that cannot be used in expression trees.
     /// CAVEAT: Errors may be produced for ObsoleteAttribute, but such errors don't affect lambda convertibility.
     /// </summary>
-    internal sealed partial class DiagnosticsPass : BoundTreeWalker
+    internal sealed partial class DiagnosticsPass
     {
         private readonly DiagnosticBag _diagnostics;
         private readonly CSharpCompilation _compilation;
@@ -26,8 +26,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node != null);
             Debug.Assert((object)containingSymbol != null);
 
-            var diagnosticPass = new DiagnosticsPass(compilation, diagnostics, containingSymbol);
-            diagnosticPass.Visit(node);
+            try
+            {
+                var diagnosticPass = new DiagnosticsPass(compilation, diagnostics, containingSymbol);
+                diagnosticPass.Visit(node);
+            }
+            catch (CancelledByStackGuardException ex)
+            {
+                ex.AddAnError(diagnostics);
+            }
         }
 
         private DiagnosticsPass(CSharpCompilation compilation, DiagnosticBag diagnostics, MethodSymbol containingSymbol)

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// This pass detects and reports diagnostics that do not affect lambda convertibility.
     /// This part of the partial class focuses on expression and operator warnings.
     /// </summary>
-    internal sealed partial class DiagnosticsPass : BoundTreeWalker
+    internal sealed partial class DiagnosticsPass : BoundTreeWalkerWithStackGuard
     {
         private void CheckArguments(ImmutableArray<RefKind> argumentRefKindsOpt, ImmutableArray<BoundExpression> arguments, Symbol method)
         {

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.YieldsInTryAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.YieldsInTryAnalysis.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyses method body for yields in try blocks and labels that they contain.
         /// </summary>
-        private class YieldsInTryAnalysis : LabelCollector
+        private sealed class YieldsInTryAnalysis : LabelCollector
         {
             // all try blocks with yields in them and complete set of labels inside those try blocks
             // NOTE: non-yielding try blocks are transparently ignored - i.e. their labels are included
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// <summary>
     /// Analyses method body for labels.
     /// </summary>
-    internal abstract class LabelCollector : BoundTreeWalker
+    internal abstract class LabelCollector : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator 
     {
         // transient accumulator.
         protected HashSet<LabelSymbol> currentLabels;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Perform a first analysis pass in preparation for removing all lambdas from a method body.  The entry point is Analyze.
         /// The results of analysis are placed in the fields seenLambda, blockParent, variableBlock, captured, and captures.
         /// </summary>
-        internal sealed class Analysis : BoundTreeWalker
+        internal sealed class Analysis : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator 
         {
             private readonly MethodSymbol _topLevelMethod;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -993,7 +993,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var newType = VisitType(node.Type);
                 var newBody = (BoundBlock)Visit(node.Body);
                 node = node.Update(node.Symbol, newBody, node.Diagnostics, node.Binder, newType);
-                var result0 = wasInExpressionLambda ? node : ExpressionLambdaRewriter.RewriteLambda(node, CompilationState, TypeMap, Diagnostics);
+                var result0 = wasInExpressionLambda ? node : ExpressionLambdaRewriter.RewriteLambda(node, CompilationState, TypeMap, RecursionDepth, Diagnostics);
                 _inExpressionLambda = wasInExpressionLambda;
                 return result0;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.RuntimeMembers;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal sealed partial class LocalRewriter : BoundTreeRewriter
+    internal sealed partial class LocalRewriter : BoundTreeRewriterWithStackGuard
     {
         private readonly CSharpCompilation _compilation;
         private readonly SyntheticBoundNodeFactory _factory;
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            var visited = (BoundExpression)base.Visit(node);
+            var visited = VisitExpressionWithStackGuard(node);
 
             // If you *really* need to change the type, consider using an indirect method
             // like compound assignment does (extra flag only passed when it is an expression

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _lazyUnmatchedLabelCache = new Dictionary<BoundNode, HashSet<LabelSymbol>>();
             }
 
-            HashSet<LabelSymbol> unmatched = UnmatchedGotoFinder.Find(node, _lazyUnmatchedLabelCache);
+            HashSet<LabelSymbol> unmatched = UnmatchedGotoFinder.Find(node, _lazyUnmatchedLabelCache, RecursionDepth);
 
             _lazyUnmatchedLabelCache.Add(node, unmatched);
 

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// a bound node rewriter that rewrites types properly (which in some cases the automatically-generated
     /// base class does not).  This is used in the lambda rewriter, the iterator rewriter, and the async rewriter.
     /// </summary>
-    internal abstract partial class MethodToClassRewriter : BoundTreeRewriter
+    internal abstract partial class MethodToClassRewriter : BoundTreeRewriterWithStackGuard
     {
         // For each captured variable, information about its replacement.  May be populated lazily (that is, not all
         // upfront) by subclasses.  Specifically, the async rewriter produces captured symbols for temps, including

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -47,8 +47,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Returns deterministically ordered list of variables that ought to be hoisted.
         public static OrderedSet<Symbol> Analyze(CSharpCompilation compilation, MethodSymbol method, BoundNode node, DiagnosticBag diagnostics)
         {
-            var initiallyAssignedVariables = UnassignedVariablesWalker.Analyze(compilation, method, node);
+            var initiallyAssignedVariables = UnassignedVariablesWalker.Analyze(compilation, method, node, convertInsufficientExecutionStackExceptionToCancelledByStackGuardException:true);
             var walker = new IteratorAndAsyncCaptureWalker(compilation, method, node, new NeverEmptyStructTypeCache(), initiallyAssignedVariables);
+
+            walker._convertInsufficientExecutionStackExceptionToCancelledByStackGuardException = true;
+
             bool badRegion = false;
             walker.Analyze(ref badRegion);
             Debug.Assert(!badRegion);
@@ -292,23 +295,31 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Locals cannot be used to communicate between the finally block and the rest of the method.
                 // So we just capture any outside variables that are used inside.
-                new OutsideVariablesUsedInside(this, this.topLevelMethod).Visit(finallyBlock);
+                new OutsideVariablesUsedInside(this, this.topLevelMethod, this).Visit(finallyBlock);
             }
 
             base.VisitFinallyBlock(finallyBlock, ref unsetInFinally);
         }
 
-        private sealed class OutsideVariablesUsedInside : BoundTreeWalker
+        private sealed class OutsideVariablesUsedInside : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
         {
             private readonly HashSet<Symbol> _localsInScope;
             private readonly IteratorAndAsyncCaptureWalker _analyzer;
             private readonly MethodSymbol _topLevelMethod;
+            private readonly IteratorAndAsyncCaptureWalker _parent;
 
-            public OutsideVariablesUsedInside(IteratorAndAsyncCaptureWalker analyzer, MethodSymbol topLevelMethod)
+            public OutsideVariablesUsedInside(IteratorAndAsyncCaptureWalker analyzer, MethodSymbol topLevelMethod, IteratorAndAsyncCaptureWalker parent)
+                : base(parent._recursionDepth)
             {
                 _analyzer = analyzer;
                 _topLevelMethod = topLevelMethod;
                 _localsInScope = new HashSet<Symbol>();
+                _parent = parent;
+            }
+
+            protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
+            {
+                return _parent.ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException();
             }
 
             public override BoundNode VisitBlock(BoundBlock node)

--- a/src/Compilers/CSharp/Portable/Lowering/UnmatchedGotoFinder.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/UnmatchedGotoFinder.cs
@@ -13,22 +13,23 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// Compiles a list of all labels that are targeted by gotos within a
     /// node, but are not declared within the node.
     /// </summary>
-    internal sealed class UnmatchedGotoFinder : BoundTreeWalker
+    internal sealed class UnmatchedGotoFinder : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
     {
         private readonly Dictionary<BoundNode, HashSet<LabelSymbol>> _unmatchedLabelsCache; // NB: never modified.
 
         private HashSet<LabelSymbol> _gotos;
         private HashSet<LabelSymbol> _targets;
 
-        private UnmatchedGotoFinder(Dictionary<BoundNode, HashSet<LabelSymbol>> unmatchedLabelsCache)
+        private UnmatchedGotoFinder(Dictionary<BoundNode, HashSet<LabelSymbol>> unmatchedLabelsCache, int recursionDepth)
+            : base(recursionDepth)
         {
             Debug.Assert(unmatchedLabelsCache != null);
             _unmatchedLabelsCache = unmatchedLabelsCache;
         }
 
-        public static HashSet<LabelSymbol> Find(BoundNode node, Dictionary<BoundNode, HashSet<LabelSymbol>> unmatchedLabelsCache)
+        public static HashSet<LabelSymbol> Find(BoundNode node, Dictionary<BoundNode, HashSet<LabelSymbol>> unmatchedLabelsCache, int recursionDepth)
         {
-            UnmatchedGotoFinder finder = new UnmatchedGotoFinder(unmatchedLabelsCache);
+            UnmatchedGotoFinder finder = new UnmatchedGotoFinder(unmatchedLabelsCache, recursionDepth);
             finder.Visit(node);
             HashSet<LabelSymbol> gotos = finder._gotos;
             HashSet<LabelSymbol> targets = finder._targets;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -12,21 +12,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
     internal partial class LanguageParser : SyntaxParser
     {
-        // Keep this value in sync with Parser.vb
-        //
-        // This number is meant to represent the minimum depth which is necessary for a parser implementation
-        // to function.  Anything less than this represents an environment where a sufficiently complex C# 
-        // program could not be compiled.  The following factors went into choosing this number 
-        //
-        //  1. The Task<T> implementation has a similar problem with unbounded recursion and came to similar
-        //     conclusions on how to prevent such a problem (major difference is they use a hand rolled
-        //     implementation of ensureSufficientExecutionStack).  They settled on 20 as a minimum 
-        //     expectation 
-        //  2. A modified version of the parser was run on the Roslyn source base and the maximum depth 
-        //     discovered was 7.  Having 20 as a minimum seems reasonable in that context 
-        //
-        internal const int MaxUncheckedRecursionDepth = 20;
-
         // list pools - allocators for lists that are used to build sequences of nodes. The lists
         // can be reused (hence pooled) since the syntax factory methods don't keep references to
         // them
@@ -414,9 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             {
                 return parseFunc();
             }
-            // TODO (DevDiv workitem 966425): Replace exception name test with a type test once the type 
-            // is available in the PCL
-            catch (Exception ex) when (ex.GetType().Name == "InsufficientExecutionStackException")
+            catch (Exception ex) when (StackGuard.IsInsufficientExecutionStackException(ex))
             {
                 return CreateForGlobalFailure(lexer.TextWindow.Position, createEmptyNodeFunc());
             }
@@ -6356,10 +6339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             try
             {
                 _recursionDepth++;
-                if (_recursionDepth > MaxUncheckedRecursionDepth)
-                {
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
-                }
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
 
                 if (this.IsIncrementalAndFactoryContextMatches && this.CurrentNode is CSharp.Syntax.StatementSyntax)
                 {
@@ -8301,10 +8281,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             _recursionDepth++;
 
-            if (_recursionDepth > MaxUncheckedRecursionDepth)
-            {
-                PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
-            }
+            StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
 
             var result = ParseSubExpressionCore(precedence);
 

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxRewriter.cs
@@ -34,10 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node != null)
             {
                 _recursionDepth++;
-                if (_recursionDepth > Syntax.InternalSyntax.LanguageParser.MaxUncheckedRecursionDepth)
-                {
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
-                }
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
 
                 var result = ((CSharpSyntaxNode)node).Accept(this);
 

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxWalker.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxWalker.cs
@@ -28,10 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node != null)
             {
                 _recursionDepth++;
-                if (_recursionDepth > Syntax.InternalSyntax.LanguageParser.MaxUncheckedRecursionDepth)
-                {
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
-                }
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
 
                 ((CSharpSyntaxNode)node).Accept(this);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -4609,7 +4609,281 @@ class test<T> where T : c0
   IL_0004:  ret
 }
 ");
-
         }
+
+        [Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
+        public void EmitSequenceOfBinaryExpressions_01()
+        {
+            var source =
+@"
+class Test
+{ 
+    static void Main()
+    {
+        var f = new long[4096];
+        for (int i = 0; i < 4096 ; i++)
+        {
+            f[i] = 4096 - i;
+        }
+
+        System.Console.WriteLine((Calculate1(f) == Calculate2(f)) ? ""True"" : ""False"");
+    }
+
+	public static long Calculate1(long[] f)
+    {
+" + $"        return { BuildSequenceOfBinaryExpressions_01() };" + @"
+    }
+
+	public static long Calculate2(long[] f)
+    {
+        long result = 0;
+        int i;
+
+        for (i = 0; i < f.Length; i++)
+        {
+            result+=(i + 1)*f[i];
+        }
+
+        return result + (i + 1);
+    }
+}
+";
+
+            var result = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: "True");
+        }
+
+        private static string BuildSequenceOfBinaryExpressions_01(int count = 4096)
+        {
+            var builder = new System.Text.StringBuilder();
+            int i;
+            for (i = 0; i < count ; i++)
+            {
+                builder.Append(i + 1);
+                builder.Append(" * ");
+                builder.Append("f[");
+                builder.Append(i);
+                builder.Append("] + ");
+            }
+
+            builder.Append(i + 1);
+
+            return builder.ToString();
+        }
+
+        [Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
+        public void EmitSequenceOfBinaryExpressions_02()
+        {
+            var source =
+@"
+class Test
+{ 
+    static void Main()
+    {
+        var f = new long[4096];
+        for (int i = 0; i < 4096 ; i++)
+        {
+            f[i] = 4096 - i;
+        }
+
+        System.Console.WriteLine(Calculate(f));
+    }
+
+	public static double Calculate(long[] f)
+    {
+" + $"        return checked({ BuildSequenceOfBinaryExpressions_01() });" + @"
+    }
+}
+";
+
+            var result = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: "11461640193");
+        }
+        
+        [Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
+        public void EmitSequenceOfBinaryExpressions_03()
+        {
+            var source =
+@"
+class Test
+{ 
+    static void Main()
+    {
+    }
+
+	public static bool Calculate(bool[] a, bool[] f)
+    {
+" + $"        return { BuildSequenceOfBinaryExpressions_03() };" + @"
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe);
+            compilation.VerifyEmitDiagnostics(
+    // (10,16): error CS8078: An expression is too long or complex to compile
+    //         return a[0] && f[0] || a[1] && f[1] || a[2] && f[2] || ...
+    Diagnostic(ErrorCode.ERR_InsufficientStack, "a").WithLocation(10, 16)
+                );
+        }
+
+        private static string BuildSequenceOfBinaryExpressions_03()
+        {
+            var builder = new System.Text.StringBuilder();
+            int i;
+            for (i = 0; i < 4096; i++)
+            {
+                builder.Append("a[");
+                builder.Append(i);
+                builder.Append("]");
+                builder.Append(" && ");
+                builder.Append("f[");
+                builder.Append(i);
+                builder.Append("] || ");
+            }
+
+            builder.Append("a[");
+            builder.Append(i);
+            builder.Append("]");
+
+            return builder.ToString();
+        }
+
+        [Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
+        public void EmitSequenceOfBinaryExpressions_04()
+        {
+            var source =
+@"
+class Test
+{ 
+    static void Main()
+    {
+        var f = new float?[4096];
+        for (int i = 0; i < 4096 ; i++)
+        {
+            f[i] = 4096 - i;
+        }
+
+        System.Console.WriteLine(Calculate(f));
+    }
+
+	public static double? Calculate(float?[] f)
+    {
+" + $"        return { BuildSequenceOfBinaryExpressions_01() };" + @"
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe);
+            compilation.VerifyEmitDiagnostics(
+    // (17,16): error CS8078: An expression is too long or complex to compile
+    //         return 1 * f[0] + 2 * f[1] + 3 * f[2] + 4 * f[3] + ...
+    Diagnostic(ErrorCode.ERR_InsufficientStack, "1").WithLocation(17, 16)
+                );
+        }
+
+        [Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
+        public void EmitSequenceOfBinaryExpressions_05()
+        {
+            int count = 50;
+            var source =
+@"
+class Test
+{ 
+    static void Main()
+    {
+        Test1();
+        Test2();
+    }
+
+    static void Test1()
+    {
+        var f = new double?[" + $"{count}" + @"];
+        for (int i = 0; i < " + $"{count}" + @" ; i++)
+        {
+            f[i] = 4096 - i;
+        }
+
+        System.Console.WriteLine(Calculate(f));
+    }
+
+	public static double? Calculate(double?[] f)
+    {
+" + $"        return { BuildSequenceOfBinaryExpressions_01(count) };" + @"
+    }
+
+    static void Test2()
+    {
+        var f = new double[" + $"{count}" + @"];
+        for (int i = 0; i < " + $"{count}" + @" ; i++)
+        {
+            f[i] = 4096 - i;
+        }
+
+        System.Console.WriteLine(Calculate(f));
+    }
+
+	public static double Calculate(double[] f)
+    {
+" + $"        return { BuildSequenceOfBinaryExpressions_01(count) };" + @"
+    }
+}
+";
+
+            var result = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: @"5180801
+5180801");
+        }
+
+        [Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
+        public void EmitSequenceOfBinaryExpressions_06()
+        {
+            var source =
+@"
+class Test
+{ 
+    static void Main()
+    {
+    }
+
+	public static bool Calculate(S1[] a, S1[] f)
+    {
+" + $"        return { BuildSequenceOfBinaryExpressions_03() };" + @"
+    }
+}
+
+struct S1
+{
+    public static S1 operator & (S1 x, S1 y)
+    {
+        return new S1();
+    }
+
+    public static S1 operator |(S1 x, S1 y)
+    {
+        return new S1();
+    }
+
+    public static bool operator true(S1 x)
+    {
+        return true;
+    }
+
+    public static bool operator false(S1 x)
+    {
+        return true;
+    }
+
+    public static implicit operator bool (S1 x)
+    {
+        return true;
+    } 
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe);
+            compilation.VerifyEmitDiagnostics(
+    // (10,16): error CS8078: An expression is too long or complex to compile
+    //         return a[0] && f[0] || a[1] && f[1] || a[2] && f[2] || ...
+    Diagnostic(ErrorCode.ERR_InsufficientStack, "a").WithLocation(10, 16)
+                );
+        }
+
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2903,7 +2903,7 @@ void f() { if () const int i = 0; }
     }
 
 
-    internal sealed class BoundTreeSequencer : BoundTreeWalker
+    internal sealed class BoundTreeSequencer : BoundTreeWalkerWithStackGuard
     {
         public static IEnumerable<BoundNode> GetNodes(BoundNode root)
         {
@@ -2927,6 +2927,11 @@ void f() { if () const int i = 0; }
                 _list.Add(node);
             }
             return base.Visit(node);
+        }
+
+        protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
+        {
+            return false;
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -6550,9 +6550,13 @@ class P
 
         private sealed class EmptyRewriter : BoundTreeRewriter
         {
+            protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+            {
+                throw new NotImplementedException();
+            }
         }
 
-        private sealed class FindCompoundAssignmentWalker : BoundTreeWalker
+        private sealed class FindCompoundAssignmentWalker : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
         {
             internal BoundCompoundAssignmentOperator FirstNode;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -2280,7 +2280,7 @@ Yes, Parameter 'x' is a non-moveable variable with underlying symbol 'x'
             builder.Free();
         }
 
-        private class NonMoveableVariableVisitor : BoundTreeWalker
+        private class NonMoveableVariableVisitor : BoundTreeWalkerWithStackGuard
         {
             private readonly Binder _binder;
             private readonly ArrayBuilder<string> _builder;
@@ -2324,6 +2324,11 @@ Yes, Parameter 'x' is a non-moveable variable with underlying symbol 'x'
                 }
 
                 return base.Visit(node);
+            }
+
+            protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
+            {
+                return false;
             }
         }
 

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -54,6 +54,7 @@
     <Compile Include="DiagnosticAnalyzer\AnalyzerDriver.CompilationData.cs" />
     <Compile Include="DiagnosticAnalyzer\SuppressMessageInfo.cs" />
     <Compile Include="Diagnostic\SuppressionInfo.cs" />
+    <Compile Include="InternalUtilities\StackGuard.cs" />
     <Compile Include="InternalUtilities\StreamExtensions.cs" />
     <Compile Include="UnicodeCharacterUtilities.cs" />
     <Compile Include="CodeAnalysisResources.Designer.cs">

--- a/src/Compilers/Core/Portable/InternalUtilities/StackGuard.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StackGuard.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class StackGuard
+    {
+        public const int MaxUncheckedRecursionDepth = 20;
+
+        public static void EnsureSufficientExecutionStack(int recursionDepth)
+        {
+            if (recursionDepth > MaxUncheckedRecursionDepth)
+            {
+                Roslyn.Utilities.PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack();
+            }
+        }
+
+        // TODO (DevDiv workitem 966425): Replace exception name test with a type test once the type 
+        // is available in the PCL
+        public static bool IsInsufficientExecutionStackException(Exception ex)
+        {
+            return ex.GetType().Name == "InsufficientExecutionStackException";
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -98,6 +98,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' exposed to public API consumer and disabled when used from command-line compiler. </summary>
         Private ReadOnly _suppressConstantExpressions As Boolean
 
+        Protected _recursionDepth As Integer
+
         ''' <summary>
         ''' Construct an object for outside-region analysis
         ''' </summary>
@@ -655,10 +657,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #Region "Visitors"
 
+        Public NotOverridable Overrides Function Visit(node As BoundNode) As BoundNode
+            Visit(node, dontLeaveRegion:=False)
+            Return Nothing
+        End Function
+
         ''' <summary>
         ''' Visit a node.
         ''' </summary>
-        Protected Overridable Shadows Sub Visit(node As BoundNode, Optional dontLeaveRegion As Boolean = False)
+        Protected Overridable Overloads Sub Visit(node As BoundNode, dontLeaveRegion As Boolean)
             VisitAlways(node, dontLeaveRegion:=dontLeaveRegion)
         End Sub
 
@@ -667,14 +674,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Protected Sub VisitAlways(node As BoundNode, Optional dontLeaveRegion As Boolean = False)
             If Me._firstInRegion Is Nothing Then
-                MyBase.Visit(node)
+                VisitWithStackGuard(node)
             Else
 
                 If node Is Me._firstInRegion AndAlso Me._regionPlace = RegionPlace.Before Then
                     Me.EnterRegion()
                 End If
 
-                MyBase.Visit(node)
+                VisitWithStackGuard(node)
 
                 If Not dontLeaveRegion AndAlso node Is Me._lastInRegion AndAlso IsInside Then
                     Me.LeaveRegion()
@@ -682,6 +689,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             End If
         End Sub
+
+        Private Shadows Function VisitWithStackGuard(node As BoundNode) As BoundNode
+            Dim expression = TryCast(node, BoundExpression)
+
+            If expression IsNot Nothing Then
+                Return VisitExpressionWithStackGuard(_recursionDepth, expression)
+            End If
+
+            Return MyBase.Visit(node)
+        End Function
+
+        Protected Overrides Function VisitExpressionWithoutStackGuard(node As BoundExpression) As BoundExpression
+            Return DirectCast(MyBase.Visit(node), BoundExpression)
+        End Function
+
+        Protected Overrides Function ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException() As Boolean
+            Return False ' just let the original exception to bubble up.
+        End Function
 
         Protected Overridable Sub VisitLvalue(node As BoundExpression, Optional dontLeaveRegion As Boolean = False)
             ' NOTE: we can skip checking if Me._firstInRegion is nothing because 'node' is not nothing
@@ -736,6 +761,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Visit(node, dontLeaveRegion:=True)
+
+            AdjustConditionalState(node)
+
+            ' NOTE: we can skip checking if Me._firstInRegion is nothing because 'node' is not nothing
+            If node Is Me._lastInRegion AndAlso IsInside Then
+                Me.LeaveRegion()
+            End If
+        End Sub
+
+        Private Sub AdjustConditionalState(node As BoundExpression)
             If IsConstantTrue(node) Then
                 Me.Unsplit()
                 Me.SetConditionalState(Me.State, UnreachableState())
@@ -744,11 +779,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Me.SetConditionalState(UnreachableState(), Me.State)
             Else
                 Me.Split()
-            End If
-
-            ' NOTE: we can skip checking if Me._firstInRegion is nothing because 'node' is not nothing
-            If node Is Me._lastInRegion AndAlso IsInside Then
-                Me.LeaveRegion()
             End If
         End Sub
 
@@ -851,8 +881,8 @@ lUnsplitAndFinish:
                 Debug.Assert(Me._lastInRegion IsNot Nothing)
 
                 ' Check if the region defining node is somewhere inside OriginalExpression
-                If BoundNodeFinder.ContainsNode(node.OriginalExpression, Me._firstInRegion) Then
-                    Debug.Assert(BoundNodeFinder.ContainsNode(node.OriginalExpression, Me._lastInRegion))
+                If BoundNodeFinder.ContainsNode(node.OriginalExpression, Me._firstInRegion, _recursionDepth, ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()) Then
+                    Debug.Assert(BoundNodeFinder.ContainsNode(node.OriginalExpression, Me._lastInRegion, _recursionDepth, ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()))
 
                     origExpressionContainsRegion = True
 
@@ -866,7 +896,7 @@ lUnsplitAndFinish:
                         End If
 
                         regionEnclosesInitializers = True
-                        If Me._firstInRegion Is initializerExpr OrElse Not BoundNodeFinder.ContainsNode(Me._firstInRegion, initializerExpr) Then
+                        If Me._firstInRegion Is initializerExpr OrElse Not BoundNodeFinder.ContainsNode(Me._firstInRegion, initializerExpr, _recursionDepth, ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()) Then
                             regionEnclosesInitializers = False
                             Exit For
                         End If
@@ -893,7 +923,7 @@ lUnsplitAndFinish:
 
                     containedByInitializer = False
                     Debug.Assert(initializerExpr IsNot Nothing)
-                    If BoundNodeFinder.ContainsNode(initializerExpr, Me._firstInRegion) Then
+                    If BoundNodeFinder.ContainsNode(initializerExpr, Me._firstInRegion, _recursionDepth, ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()) Then
                         Debug.Assert(Not containedByInitializer)
                         containedByInitializer = True
                         Exit For
@@ -2058,96 +2088,114 @@ lUnsplitAndFinish:
         End Function
 
         Public NotOverridable Overrides Function VisitBinaryOperator(node As BoundBinaryOperator) As BoundNode
-            Select Case node.OperatorKind And BinaryOperatorKind.OpMask
-                Case BinaryOperatorKind.AndAlso
-                    VisitCondition(node.Left)
-                    Dim leftTrue As LocalState = Me.StateWhenTrue
-                    Dim leftFalse As LocalState = Me.StateWhenFalse
-                    Me.SetState(leftTrue)
-                    VisitCondition(node.Right)
-                    Dim resultTrue As LocalState = Me.StateWhenTrue
-                    Dim resultFalse As LocalState = leftFalse
-                    IntersectWith(resultFalse, Me.StateWhenFalse)
-                    Me.SetConditionalState(resultTrue, resultFalse)
-                    Exit Select
-                Case BinaryOperatorKind.OrElse
-                    VisitCondition(node.Left)
-                    Dim leftTrue As LocalState = Me.StateWhenTrue
-                    Dim leftFalse As LocalState = Me.StateWhenFalse
-                    Me.SetState(leftFalse)
-                    VisitCondition(node.Right)
-                    Dim resultTrue As LocalState = Me.StateWhenTrue
-                    IntersectWith(resultTrue, leftTrue)
-                    Dim resultFalse As LocalState = Me.StateWhenFalse
-                    Me.SetConditionalState(resultTrue, resultFalse)
-                    Exit Select
-                Case BinaryOperatorKind.Concatenate
-                    UnwindAndVisitConcatenationOperator(node)
-                Case Else
-                    VisitRvalue(node.Left)
-                    VisitRvalue(node.Right)
-            End Select
-            Return Nothing
-        End Function
+            ' Do not blow the stack due to a deep recursion on the left. 
 
-        Private Sub UnwindAndVisitConcatenationOperator(node As BoundBinaryOperator)
-            Debug.Assert((node.OperatorKind And BinaryOperatorKind.OpMask) = BinaryOperatorKind.Concatenate)
+            Dim stack = ArrayBuilder(Of BoundBinaryOperator).GetInstance()
 
-            ' It is common in machine-generated code for there to be deep recursion on the left side of a binary
-            ' operator, for example, if you have "a + b + c + ... " then the bound tree will be deep on the left
-            ' hand side. To mitigate the risk of stack overflow we use an explicit stack.
-            '
-            ' Of course we must ensure that we visit the left hand side before the right hand side.
+            Dim binary As BoundBinaryOperator = node
+            Dim child As BoundExpression = node.Left
 
-            Dim leftmostConcatExpressions = ArrayBuilder(Of BoundBinaryOperator).GetInstance()
-            leftmostConcatExpressions.Add(node)
-
-            ' Collect all binary concatenation operators along the leftmost 
-            ' expression tree branch in leftmostConcatExpressions
-            Dim lastLeftOperand As BoundExpression = node.Left
             Do
-                If lastLeftOperand.Kind = BoundKind.BinaryOperator Then
-                    Dim binary = DirectCast(lastLeftOperand, BoundBinaryOperator)
-                    If (binary.OperatorKind And BinaryOperatorKind.OpMask) <> BinaryOperatorKind.Concatenate Then
-                        Exit Do
-                    End If
+                If child.Kind <> BoundKind.BinaryOperator Then
+                    Exit Do
+                End If
 
-                    ' As we emulate visiting the concatenate operator: enter the region if needed
-                    If binary Is Me._firstInRegion AndAlso Me._regionPlace = RegionPlace.Before Then
+                stack.Push(binary)
+                binary = DirectCast(child, BoundBinaryOperator)
+                child = binary.Left
+            Loop
+
+            ' As we emulate visiting, enter the region if needed. 
+            ' We shouldn't do this for the top most node, 
+            ' VisitBinaryOperator caller such as VisitRvalue(...) does this.
+            If Me._regionPlace = RegionPlace.Before Then
+                If stack.Count > 0 Then
+                    ' Skipping the first node
+                    Debug.Assert(stack(0) Is node)
+
+                    For i As Integer = 1 To stack.Count - 1
+                        If stack(i) Is Me._firstInRegion Then
+                            Me.EnterRegion()
+                            GoTo EnteredRegion
+                        End If
+                    Next
+
+                    ' Note, the last binary operator is not pushed to the stack, it is stored in [binary].
+                    Debug.Assert(binary IsNot node)
+
+                    If binary Is Me._firstInRegion Then
                         Me.EnterRegion()
                     End If
+EnteredRegion:
+                Else
+                    Debug.Assert(binary Is node)
+                End If
+            End If
 
-                    leftmostConcatExpressions.Push(binary)
-                    lastLeftOperand = binary.Left
+            Select Case binary.OperatorKind And BinaryOperatorKind.OpMask
+                Case BinaryOperatorKind.AndAlso,
+                     BinaryOperatorKind.OrElse
+                    VisitCondition(child)
+                Case Else
+                    VisitRvalue(child)
+            End Select
 
+            Do
+                Select Case binary.OperatorKind And BinaryOperatorKind.OpMask
+                    Case BinaryOperatorKind.AndAlso
+                        Dim leftTrue As LocalState = Me.StateWhenTrue
+                        Dim leftFalse As LocalState = Me.StateWhenFalse
+                        Me.SetState(leftTrue)
+                        VisitCondition(binary.Right)
+                        Dim resultTrue As LocalState = Me.StateWhenTrue
+                        Dim resultFalse As LocalState = leftFalse
+                        IntersectWith(resultFalse, Me.StateWhenFalse)
+                        Me.SetConditionalState(resultTrue, resultFalse)
+                        Exit Select
+                    Case BinaryOperatorKind.OrElse
+                        Dim leftTrue As LocalState = Me.StateWhenTrue
+                        Dim leftFalse As LocalState = Me.StateWhenFalse
+                        Me.SetState(leftFalse)
+                        VisitCondition(binary.Right)
+                        Dim resultTrue As LocalState = Me.StateWhenTrue
+                        IntersectWith(resultTrue, leftTrue)
+                        Dim resultFalse As LocalState = Me.StateWhenFalse
+                        Me.SetConditionalState(resultTrue, resultFalse)
+                        Exit Select
+                    Case Else
+                        VisitRvalue(binary.Right)
+                End Select
+
+                If stack.Count > 0 Then
+                    child = binary
+                    binary = stack.Pop()
+
+                    ' Do things that VisitCondition/VisitRvalue would have done for us if we were to call them
+                    ' for the child
+                    Select Case binary.OperatorKind And BinaryOperatorKind.OpMask
+                        Case BinaryOperatorKind.AndAlso,
+                             BinaryOperatorKind.OrElse
+                            ' Do things that VisitCondition would have done for us if we were to call it
+                            ' for the child
+                            AdjustConditionalState(child) ' VisitCondition does this
+                        Case Else
+                            Me.Unsplit() ' VisitRvalue does this
+                    End Select
+
+                    ' VisitCondition/VisitRvalue do this
+                    If child Is Me._lastInRegion AndAlso IsInside Then
+                        Me.LeaveRegion()
+                    End If
                 Else
                     Exit Do
                 End If
             Loop
 
-            ' Visit leftmost operand
-            VisitRvalue(lastLeftOperand)
+            Debug.Assert(binary Is node)
+            stack.Free()
 
-            ' emulate visiting binary concat operators
-            While leftmostConcatExpressions.Count > 0
-                Dim concat As BoundBinaryOperator = leftmostConcatExpressions.Pop()
-
-                ' Visit right operand
-                VisitRvalue(concat.Right)
-
-                ' Don't leave region for the uppermost concat operator, it should be done by 
-                ' VisitBinaryOperator caller such as VisitRValue(...)
-                If concat IsNot node Then
-                    ' As we emulate visiting the concatenate operator: leave region if needed
-                    Me.Unsplit()
-                    If concat Is Me._lastInRegion AndAlso IsInside Then
-                        Me.LeaveRegion()
-                    End If
-                End If
-            End While
-
-            leftmostConcatExpressions.Free()
-        End Sub
+            Return Nothing
+        End Function
 
         Public Overrides Function VisitUserDefinedBinaryOperator(node As BoundUserDefinedBinaryOperator) As BoundNode
             VisitRvalue(node.UnderlyingExpression)

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractRegionControlFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractRegionControlFlowPass.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             MyBase.New(info, region, False)
         End Sub
 
-        Protected Overrides Sub Visit(node As BoundNode, Optional dontLeaveRegion As Boolean = False)
+        Protected Overrides Sub Visit(node As BoundNode, dontLeaveRegion As Boolean)
             ' Step into expressions as they may contain lambdas
             VisitAlways(node, dontLeaveRegion:=dontLeaveRegion)
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowsInWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowsInWalker.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Inherits AbstractRegionDataFlowPass
 
         ' TODO: normalize the result by removing variables that are unassigned in an unmodified flow analysis.
-        Public Sub New(info As FlowAnalysisInfo, region As FlowAnalysisRegionInfo, unassignedVariables As HashSet(Of Symbol))
+        Private Sub New(info As FlowAnalysisInfo, region As FlowAnalysisRegionInfo, unassignedVariables As HashSet(Of Symbol))
             MyBase.New(info, region, unassignedVariables, trackStructsWithIntrinsicTypedFields:=True)
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowsOutWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowsOutWalker.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _assignedInside As HashSet(Of Symbol) = New HashSet(Of Symbol)()
 #End If
 
-        Public Sub New(info As FlowAnalysisInfo, region As FlowAnalysisRegionInfo,
+        Private Sub New(info As FlowAnalysisInfo, region As FlowAnalysisRegionInfo,
                 unassignedVariables As HashSet(Of Symbol), originalUnassigned As HashSet(Of Symbol), dataFlowsIn As ImmutableArray(Of ISymbol))
 
             MyBase.New(info, region, unassignedVariables, trackUnassignments:=True, trackStructsWithIntrinsicTypedFields:=True)

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/UnassignedVariablesWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/UnassignedVariablesWalker.vb
@@ -12,11 +12,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     ''' before being assigned anywhere within a method.
     ''' </summary>
     ''' <remarks></remarks>
-    Friend Class UnassignedVariablesWalker
+    Friend NotInheritable Class UnassignedVariablesWalker
         Inherits DataFlowPass
 
         ' TODO: normalize the result by removing variables that are unassigned in an unmodified flow analysis.
-        Public Sub New(info As FlowAnalysisInfo)
+        Private Sub New(info As FlowAnalysisInfo)
             MyBase.New(info, suppressConstExpressionsSupport:=False, trackStructsWithIntrinsicTypedFields:=True)
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/VariablesDeclaredWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/VariablesDeclaredWalker.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Scan()
         End Function
 
-        Friend Sub New(info As FlowAnalysisInfo, region As FlowAnalysisRegionInfo)
+        Private Sub New(info As FlowAnalysisInfo, region As FlowAnalysisRegionInfo)
             MyBase.New(info, region)
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Analysis/IteratorAndAsyncAnalysis/IteratorAndAsyncCaptureWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/IteratorAndAsyncAnalysis/IteratorAndAsyncCaptureWalker.vb
@@ -49,6 +49,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(info.Symbol.Kind = SymbolKind.Method)
 
             Dim walker As New IteratorAndAsyncCaptureWalker(info)
+
+            walker._convertInsufficientExecutionStackExceptionToCancelledByStackGuardException = True
+
             walker.Analyze()
             Debug.Assert(Not walker.InvalidRegionDetected)
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
@@ -123,75 +123,78 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             isOperandOfConditionalBranch As Boolean,
             diagnostics As DiagnosticBag
         ) As BoundExpression
+            ' Some tools, such as ASP .NET, generate expressions containing thousands
+            ' of string concatenations. For this reason, for string concatenations,
+            ' avoid the usual recursion along the left side of the parse. Also, attempt
+            ' to flatten whole sequences of string literal concatenations to avoid
+            ' allocating space for intermediate results.
 
             Dim preliminaryOperatorKind As BinaryOperatorKind = OverloadResolution.MapBinaryOperatorKind(node.Kind)
-
-            If preliminaryOperatorKind = BinaryOperatorKind.Add OrElse preliminaryOperatorKind = BinaryOperatorKind.Concatenate Then
-                ' Some tools, such as ASP .NET, generate expressions containing thousands
-                ' of string concatenations. For this reason, for string concatenations,
-                ' avoid the usual recursion along the left side of the parse. Also, attempt
-                ' to flatten whole sequences of string literal concatenations to avoid
-                ' allocating space for intermediate results.
-                Return BindBinaryOperatorUnwound(node, isOperandOfConditionalBranch, preliminaryOperatorKind, diagnostics)
-            End If
-
             Dim propagateIsOperandOfConditionalBranch = isOperandOfConditionalBranch AndAlso
                                                             (preliminaryOperatorKind = BinaryOperatorKind.AndAlso OrElse
                                                                 preliminaryOperatorKind = BinaryOperatorKind.OrElse)
 
-            Dim left As BoundExpression = BindValue(node.Left, diagnostics, propagateIsOperandOfConditionalBranch)
-            Dim right As BoundExpression = BindValue(node.Right, diagnostics, propagateIsOperandOfConditionalBranch)
-
-            Return BindBinaryOperator(node, left, right, node.OperatorToken.Kind, preliminaryOperatorKind, isOperandOfConditionalBranch, diagnostics)
-        End Function
-
-        Private Function BindBinaryOperatorUnwound(
-            node As BinaryExpressionSyntax,
-            isOperandOfConditionalBranch As Boolean,
-            preliminaryOperatorKind As BinaryOperatorKind,
-            diagnostics As DiagnosticBag
-        ) As BoundExpression
-
-            ' Making sure 'propagateIsOperandOfConditionalBranch' is False, see BindBinaryOperator(..., ..., ...)
-            Debug.Assert(((preliminaryOperatorKind And BinaryOperatorKind.Concatenate) <> 0) OrElse
-                         ((preliminaryOperatorKind And BinaryOperatorKind.Add) <> 0))
-
-            Dim expectedSyntaxKind As SyntaxKind = node.Kind
-
-            ' Unwind
-            Dim expressionsStack = ArrayBuilder(Of ExpressionSyntax).GetInstance()
-            expressionsStack.Push(node)
+            Dim binary As BinaryExpressionSyntax = node
+            Dim child As ExpressionSyntax
 
             Do
-                Dim current As ExpressionSyntax = expressionsStack.Peek()
-                If current.Kind <> expectedSyntaxKind Then
-                    Exit Do
-                End If
+                child = binary.Left
 
-                Dim binary = DirectCast(current, BinaryExpressionSyntax)
-                expressionsStack.Pop()
-                expressionsStack.Push(binary.Right)
-                expressionsStack.Push(binary.Left)
+                Select Case child.Kind
+                    Case SyntaxKind.AddExpression,
+                         SyntaxKind.ConcatenateExpression,
+                         SyntaxKind.LikeExpression,
+                         SyntaxKind.EqualsExpression,
+                         SyntaxKind.NotEqualsExpression,
+                         SyntaxKind.LessThanOrEqualExpression,
+                         SyntaxKind.GreaterThanOrEqualExpression,
+                         SyntaxKind.LessThanExpression,
+                         SyntaxKind.GreaterThanExpression,
+                         SyntaxKind.SubtractExpression,
+                         SyntaxKind.MultiplyExpression,
+                         SyntaxKind.ExponentiateExpression,
+                         SyntaxKind.DivideExpression,
+                         SyntaxKind.ModuloExpression,
+                         SyntaxKind.IntegerDivideExpression,
+                         SyntaxKind.LeftShiftExpression,
+                         SyntaxKind.RightShiftExpression,
+                         SyntaxKind.ExclusiveOrExpression,
+                         SyntaxKind.OrExpression,
+                         SyntaxKind.AndExpression
+
+                        If propagateIsOperandOfConditionalBranch Then
+                            Exit Do
+                        End If
+
+                    Case SyntaxKind.OrElseExpression,
+                         SyntaxKind.AndAlsoExpression
+                        Exit Select
+
+                    Case Else
+                        Exit Do
+                End Select
+
+                binary = DirectCast(child, BinaryExpressionSyntax)
             Loop
 
-            ' Bind
-            Dim leftmost As BoundExpression = BindValue(expressionsStack.Pop(), diagnostics, False)
             Dim compoundStringLength As Integer = 0
+            Dim left As BoundExpression = BindValue(child, diagnostics, propagateIsOperandOfConditionalBranch)
 
-            While expressionsStack.Count > 0
-                Dim rightSyntax As ExpressionSyntax = expressionsStack.Pop()
-                Dim binarySyntax = DirectCast(rightSyntax.Parent, BinaryExpressionSyntax)
-                Dim right As BoundExpression = BindValue(rightSyntax, diagnostics, False)
+            Do
+                binary = DirectCast(child.Parent, BinaryExpressionSyntax)
 
-                leftmost = BindBinaryOperator(binarySyntax,
-                                              leftmost,
-                                              right,
-                                              binarySyntax.OperatorToken.Kind, preliminaryOperatorKind, isOperandOfConditionalBranch, diagnostics,
-                                              compoundStringLength:=compoundStringLength)
-            End While
+                Dim right As BoundExpression = BindValue(binary.Right, diagnostics, propagateIsOperandOfConditionalBranch)
 
-            expressionsStack.Free()
-            Return leftmost
+                left = BindBinaryOperator(binary, left, right, binary.OperatorToken.Kind,
+                                          OverloadResolution.MapBinaryOperatorKind(binary.Kind),
+                                          If(binary Is node, isOperandOfConditionalBranch, propagateIsOperandOfConditionalBranch),
+                                          diagnostics,
+                                          compoundStringLength:=compoundStringLength)
+
+                child = binary
+            Loop While child IsNot node
+
+            Return left
         End Function
 
         Private Function BindBinaryOperator(

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -499,7 +499,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' We should always be able to get at least an error binding for a lambda, so assert
                         ' if this isn't true.
 
-                        Dim boundlambda = TryCast(GetLowerBoundNode(lambdaSyntax), boundlambda)
+                        Dim boundlambda = TryCast(GetLowerBoundNode(lambdaSyntax), BoundLambda)
                         Debug.Assert(boundlambda IsNot Nothing)
 
                         If boundlambda IsNot Nothing Then
@@ -585,7 +585,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentException(VBResources.AnonymousObjectCreationExpressionSyntaxNotWithinTree)
             End If
 
-            Dim boundExpression = TryCast(GetLowerBoundNode(anonymousObjectCreationExpressionSyntax), boundExpression)
+            Dim boundExpression = TryCast(GetLowerBoundNode(anonymousObjectCreationExpressionSyntax), BoundExpression)
             If boundExpression Is Nothing Then
                 Return Nothing
             End If
@@ -611,7 +611,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing
             End If
 
-            Dim boundExpression = TryCast(GetLowerBoundNode(anonymousObjectCreation), boundExpression)
+            Dim boundExpression = TryCast(GetLowerBoundNode(anonymousObjectCreation), BoundExpression)
             If boundExpression Is Nothing Then
                 Return Nothing
             End If
@@ -728,7 +728,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' NOTE: What VB calls the current conversion is used to convert the current placeholder to the iteration
                     ' variable type.  In the terminology of the public API, this is a conversion from the element type to the
                     ' iteration variable type, and is referred to as the element conversion.
-                    Dim boundConversion = DirectCast(enumeratorInfo.CurrentConversion, boundConversion)
+                    Dim boundConversion = DirectCast(enumeratorInfo.CurrentConversion, BoundConversion)
                     elementConversion = New Conversion(KeyValuePair.Create(boundConversion.ConversionKind, TryCast(boundConversion.ExpressionSymbol, MethodSymbol)))
                 End If
 
@@ -1011,7 +1011,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend NotOverridable Overrides Function TryGetSpeculativeSemanticModelCore(parentModel As SyntaxTreeSemanticModel, position As Integer, type As TypeSyntax, bindingOption As SpeculativeBindingOption, <Out> ByRef speculativeModel As SemanticModel) As Boolean
-            Dim binder As binder = Me.GetSpeculativeBinderForExpression(position, type, bindingOption)
+            Dim binder As Binder = Me.GetSpeculativeBinderForExpression(position, type, bindingOption)
             If binder Is Nothing Then
                 speculativeModel = Nothing
                 Return False
@@ -1045,7 +1045,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Class CompilerGeneratedNodeFinder
-            Inherits BoundTreeWalker
+            Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
             Private ReadOnly _targetSyntax As VisualBasicSyntaxNode
             Private ReadOnly _targetBoundKind As BoundKind
@@ -1057,6 +1057,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Sub
 
             Public Shared Function FindIn(context As BoundNode, targetSyntax As VisualBasicSyntaxNode, targetBoundKind As BoundKind) As BoundNode
+                Debug.Assert(targetBoundKind <> BoundKind.BinaryOperator) ' Otherwise VisitBinaryOperator should be adjusted
+
                 Dim finder As New CompilerGeneratedNodeFinder(targetSyntax, targetBoundKind)
                 finder.Visit(context)
                 Return finder._found
@@ -1076,6 +1078,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Return MyBase.Visit(node)
+            End Function
+
+            Protected Overrides Function ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException() As Boolean
+                Return False
             End Function
         End Class
 
@@ -1167,7 +1173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As VisualBasicSyntaxNode,
             position As Integer
         ) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             EnsureFullyBoundIfImplicitVariablesAllowed()
 
@@ -1315,7 +1321,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetAggregateClauseLambdaBinder(aggregate As AggregateClauseSyntax, position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             ' If position were in context of an additional query operator that operator would have handled it, unless there were 
             ' no need for a special binder.
@@ -1324,7 +1330,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If SyntaxFacts.InSpanOrEffectiveTrailingOfNode(aggregate, position) Then
                 If Not aggregate.IntoKeyword.IsMissing AndAlso aggregate.IntoKeyword.SpanStart <= position Then
                     ' Should return binder for the Into clause - the last one associated with the node.
-                    Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(aggregate)
+                    Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(aggregate)
 #If DEBUG Then
                     Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound(aggregate, guard:=True))
                     Debug.Assert(binders.IsDefault OrElse (binders.Length > 0 AndAlso binders.Length < 3))
@@ -1345,7 +1351,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         '   - Into clause binder.
                         ' If this Aggregate begins the query, it has only one binder - the Into clause binder.
 
-                        Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(aggregate)
+                        Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(aggregate)
 #If DEBUG Then
                         Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound(aggregate, guard:=True))
                         Debug.Assert(binders.IsDefault OrElse (binders.Length > 0 AndAlso binders.Length < 3 AndAlso binders(0) IsNot Nothing))
@@ -1362,12 +1368,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 
         Private Function GetGroupJoinClauseLambdaBinder(join As GroupJoinClauseSyntax, position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             If SyntaxFacts.InSpanOrEffectiveTrailingOfNode(join, position) Then
                 If Not join.IntoKeyword.IsMissing AndAlso join.IntoKeyword.SpanStart <= position Then
                     ' Should return binder to lookup aggregate functions.
-                    Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(join)
+                    Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(join)
 #If DEBUG Then
                     Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound(join, guard:=True))
                     Debug.Assert(binders.IsDefault OrElse binders.Length = 3)
@@ -1386,7 +1392,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetJoinClauseLambdaBinder(join As JoinClauseSyntax, position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             ' If position were in context of an additional join that join would have handled it, unless there were 
             ' no need for a special binder.
@@ -1394,7 +1400,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' If position is in context of an 'On' clause, there is a binder that we need to return. 
 
             If Not join.OnKeyword.IsMissing AndAlso join.OnKeyword.SpanStart <= position AndAlso SyntaxFacts.InSpanOrEffectiveTrailingOfNode(join, position) Then
-                Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(join)
+                Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(join)
 #If DEBUG Then
                 Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound(join, guard:=True))
                 Debug.Assert(binders.IsDefault OrElse (binders.Length > 1 AndAlso binders.Length < 4 AndAlso binders(0) IsNot Nothing))
@@ -1410,7 +1416,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetFromClauseLambdaBinder(from As FromClauseSyntax, position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             If SyntaxFacts.InSpanOrEffectiveTrailingOfNode(from, position) Then
                 binder = GetCollectionRangeVariablesLambdaBinder(from.Variables, position)
@@ -1420,7 +1426,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetCollectionRangeVariablesLambdaBinder(variables As SeparatedSyntaxList(Of CollectionRangeVariableSyntax), position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             For i As Integer = 0 To variables.Count - 1
                 Dim item As CollectionRangeVariableSyntax = variables(i)
@@ -1435,7 +1441,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                        Not (item.Parent.Parent.Kind = SyntaxKind.QueryExpression AndAlso
                                 DirectCast(item.Parent.Parent, QueryExpressionSyntax).Clauses.FirstOrDefault Is item.Parent)) Then
 
-                        Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(item)
+                        Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(item)
 #If DEBUG Then
                         Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound(item, guard:=True))
                         Debug.Assert(binders.IsDefault OrElse (binders.Length > 0 AndAlso binders.Length < 3 AndAlso binders(0) IsNot Nothing))
@@ -1456,13 +1462,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 
         Private Function GetLetClauseLambdaBinder([let] As LetClauseSyntax, position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             If SyntaxFacts.InSpanOrEffectiveTrailingOfNode([let], position) Then
 
                 For Each item As ExpressionRangeVariableSyntax In [let].Variables
                     If SyntaxFacts.InSpanOrEffectiveTrailingOfNode(item, position) OrElse position < item.SpanStart Then
-                        Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(item)
+                        Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(item)
 #If DEBUG Then
                         Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound([let], guard:=True))
                         Debug.Assert(binders.IsDefault OrElse (binders.Length = 1 AndAlso binders(0) IsNot Nothing))
@@ -1482,10 +1488,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetGroupByClauseLambdaBinder(groupBy As GroupByClauseSyntax, position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             If SyntaxFacts.InSpanOrEffectiveTrailingOfNode(groupBy, position) Then
-                Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(groupBy)
+                Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(groupBy)
 #If DEBUG Then
                 Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound(groupBy, guard:=True))
                 Debug.Assert(binders.IsDefault OrElse (binders.Length = 2 OrElse binders.Length = 3))
@@ -1518,12 +1524,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetFunctionAggregationLambdaBinder(func As FunctionAggregationSyntax, position As Integer) As Binder
-            Dim binder As binder = Nothing
+            Dim binder As Binder = Nothing
 
             If Not func.OpenParenToken.IsMissing AndAlso func.OpenParenToken.SpanStart <= position AndAlso
                ((func.CloseParenToken.IsMissing AndAlso SyntaxFacts.InSpanOrEffectiveTrailingOfNode(func, position)) OrElse position < func.CloseParenToken.SpanStart) Then
 
-                Dim binders As ImmutableArray(Of binder) = GetQueryClauseLambdaBinders(func)
+                Dim binders As ImmutableArray(Of Binder) = GetQueryClauseLambdaBinders(func)
 #If DEBUG Then
                 Debug.Assert(Not binders.IsDefault OrElse Not ShouldHaveFound(func, guard:=True))
                 Debug.Assert(binders.IsDefault OrElse (binders.Length = 1 AndAlso binders(0) IsNot Nothing))
@@ -1613,7 +1619,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If SyntaxFacts.InSpanOrEffectiveTrailingOfNode(initialization, position) Then
 
-                    Dim cachedBinder As binder.AnonymousTypeFieldInitializerBinder = Nothing
+                    Dim cachedBinder As Binder.AnonymousTypeFieldInitializerBinder = Nothing
 
                     _rwLock.EnterReadLock()
                     Try
@@ -1627,7 +1633,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ' Get bound node for the whole AnonymousType initializer expression.
                     ' This will build required maps for it.
-                    Dim boundNode As boundNode = GetUpperBoundNode(initialization.Parent.Parent)
+                    Dim boundNode As BoundNode = GetUpperBoundNode(initialization.Parent.Parent)
 
                     _rwLock.EnterReadLock()
                     Try
@@ -1665,7 +1671,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetLambdaBodyBinder(lambda As LambdaExpressionSyntax) As LambdaBodyBinder
-            Dim boundLambda As boundLambda = GetBoundLambda(lambda)
+            Dim boundLambda As BoundLambda = GetBoundLambda(lambda)
 
             If boundLambda IsNot Nothing Then
                 Return boundLambda.LambdaBinderOpt
@@ -1934,7 +1940,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ''' in effect on nested binders.
             ''' </summary>
             Public Overrides Function GetBinder(node As VisualBasicSyntaxNode) As Binder
-                Dim binder As binder = Me.ContainingBinder.GetBinder(node)
+                Dim binder As Binder = Me.ContainingBinder.GetBinder(node)
 
                 If binder IsNot Nothing Then
                     Debug.Assert(Not (TypeOf binder Is IncrementalBinder))
@@ -1949,7 +1955,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ''' in effect on nested binders.
             ''' </summary>
             Public Overrides Function GetBinder(list As SyntaxList(Of StatementSyntax)) As Binder
-                Dim binder As binder = Me.ContainingBinder.GetBinder(list)
+                Dim binder As Binder = Me.ContainingBinder.GetBinder(list)
 
                 If binder IsNot Nothing Then
                     Debug.Assert(Not (TypeOf binder Is IncrementalBinder))
@@ -2002,7 +2008,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         '''                                     Binder.AnonymousTypeFieldInitializerBinder used to bind its expression.
         '''</summary>
         Private Class SemanticModelMapsBuilder
-            Inherits BoundTreeWalker
+            Inherits BoundTreeWalkerWithStackGuard
 
             Private ReadOnly _semanticModel As MemberSemanticModel
             Private ReadOnly _thisSyntaxNodeOnly As VisualBasicSyntaxNode ' If not Nothing, record nodes for this syntax node only.
@@ -2112,6 +2118,50 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Return MyBase.Visit(node)
+            End Function
+
+            Protected Overrides Function ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException() As Boolean
+                Return False
+            End Function
+
+            Public Overrides Function VisitBinaryOperator(node As BoundBinaryOperator) As BoundNode
+                If node.Left.Kind <> BoundKind.BinaryOperator Then
+                    Return MyBase.VisitBinaryOperator(node)
+                End If
+
+                Dim rightOperands = ArrayBuilder(Of BoundExpression).GetInstance()
+
+                rightOperands.Push(node.Right)
+
+                Dim binary = DirectCast(node.Left, BoundBinaryOperator)
+
+                If RecordNode(binary) Then
+                    _nodeCache.Add(binary.Syntax, binary)
+                End If
+
+                rightOperands.Push(binary.Right)
+
+                Dim current As BoundExpression = binary.Left
+
+                While current.Kind = BoundKind.BinaryOperator
+                    binary = DirectCast(current, BoundBinaryOperator)
+
+                    If RecordNode(binary) Then
+                        _nodeCache.Add(binary.Syntax, binary)
+                    End If
+
+                    rightOperands.Push(binary.Right)
+                    current = binary.Left
+                End While
+
+                Me.Visit(current)
+
+                While rightOperands.Count > 0
+                    Me.Visit(rightOperands.Pop())
+                End While
+
+                rightOperands.Free()
+                Return Nothing
             End Function
 
             Public Overrides Function VisitUnboundLambda(node As UnboundLambda) As BoundNode

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundTreeWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundTreeWalker.vb
@@ -19,5 +19,102 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
             End If
         End Sub
+
+    End Class
+
+    Friend MustInherit Class BoundTreeWalkerWithStackGuard
+        Inherits BoundTreeWalker
+
+        Private _recursionDepth As Integer
+
+        Protected Sub New()
+        End Sub
+
+        Protected Sub New(recursionDepth As Integer)
+            _recursionDepth = recursionDepth
+        End Sub
+
+        Protected ReadOnly Property RecursionDepth As Integer
+            Get
+                Return _recursionDepth
+            End Get
+        End Property
+
+        Public Overrides Function Visit(node As BoundNode) As BoundNode
+            Dim expression = TryCast(node, BoundExpression)
+
+            If expression IsNot Nothing Then
+                Return VisitExpressionWithStackGuard(_recursionDepth, expression)
+            End If
+
+            Return MyBase.Visit(node)
+        End Function
+
+        Protected Overloads Function VisitExpressionWithStackGuard(expression As BoundExpression) As BoundExpression
+            Return VisitExpressionWithStackGuard(_recursionDepth, expression)
+        End Function
+
+        Protected NotOverridable Overrides Function VisitExpressionWithoutStackGuard(node As BoundExpression) As BoundExpression
+            Return DirectCast(MyBase.Visit(node), BoundExpression)
+        End Function
+
+    End Class
+
+    Friend MustInherit Class BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+        Inherits BoundTreeWalkerWithStackGuard
+
+        Protected Sub New()
+        End Sub
+
+        Protected Sub New(recursionDepth As Integer)
+            MyBase.New(recursionDepth)
+        End Sub
+
+        Public NotOverridable Overrides Function VisitBinaryOperator(node As BoundBinaryOperator) As BoundNode
+            If node.Left.Kind <> BoundKind.BinaryOperator Then
+                Return MyBase.VisitBinaryOperator(node)
+            End If
+
+            Dim rightOperands = ArrayBuilder(Of BoundExpression).GetInstance()
+
+            rightOperands.Push(node.Right)
+
+            Dim binary = DirectCast(node.Left, BoundBinaryOperator)
+
+            rightOperands.Push(binary.Right)
+
+            Dim current As BoundExpression = binary.Left
+
+            While current.Kind = BoundKind.BinaryOperator
+                binary = DirectCast(current, BoundBinaryOperator)
+                rightOperands.Push(binary.Right)
+                current = binary.Left
+            End While
+
+            Me.Visit(current)
+
+            While rightOperands.Count > 0
+                Me.Visit(rightOperands.Pop())
+            End While
+
+            rightOperands.Free()
+            Return Nothing
+        End Function
+
+    End Class
+
+    Friend Class StatementWalker
+        Inherits BoundTreeWalker
+
+#If DEBUG Then
+        Public Overrides Function Visit(node As BoundNode) As BoundNode
+            Debug.Assert(TypeOf node IsNot BoundExpression)
+            Return MyBase.Visit(node)
+        End Function
+#End If
+
+        Protected Overrides Function VisitExpressionWithoutStackGuard(node As BoundExpression) As BoundExpression
+            Throw ExceptionUtilities.Unreachable
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/CodeGen/CodeGenerator.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/CodeGenerator.vb
@@ -83,7 +83,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             ' This setting only affects generating PDB sequence points, it shall Not affect generated IL in any way.
             _emitPdbSequencePoints = emittingPdb AndAlso method.GenerateDebugInfo
 
-            _block = Optimizer.Optimize(method, boundBody, debugFriendly:=_ilEmitStyle <> ILEmitStyle.Release, stackLocals:=_stackLocals)
+            Try
+                _block = Optimizer.Optimize(method, boundBody, debugFriendly:=_ilEmitStyle <> ILEmitStyle.Release, stackLocals:=_stackLocals)
+            Catch ex As BoundTreeVisitor.CancelledByStackGuardException
+                ex.AddAnError(diagnostics)
+                _block = boundBody
+            End Try
 
             _checkCallsForUnsafeJITOptimization = (_method.ImplementationAttributes And MethodSymbol.DisableJITOptimizationFlags) <> MethodSymbol.DisableJITOptimizationFlags
             Debug.Assert(Not _module.JITOptimizationIsDisabled(_method))
@@ -154,15 +159,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 _builder.DefineInitialHiddenSequencePoint()
             End If
 
-            EmitStatement(_block)
+            Try
+                EmitStatement(_block)
 
-            If _unhandledReturn Then
-                HandleReturn()
-            End If
+                If _unhandledReturn Then
+                    HandleReturn()
+                End If
 
-            If Not _diagnostics.HasAnyErrors Then
-                _builder.Realize()
-            End If
+                If Not _diagnostics.HasAnyErrors Then
+                    _builder.Realize()
+                End If
+
+            Catch e As EmitCancelledException
+                Debug.Assert(_diagnostics.HasAnyErrors())
+            End Try
 
             _synthesizedLocalOrdinals.Free()
         End Sub

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -12,6 +12,12 @@ Imports TypeKind = Microsoft.CodeAnalysis.TypeKind
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
     Friend Partial Class CodeGenerator
+        Private _recursionDepth As Integer
+
+        Private Class EmitCancelledException
+            Inherits Exception
+        End Class
+
         Private Sub EmitExpression(expression As BoundExpression, used As Boolean)
             If expression Is Nothing Then
                 Return
@@ -31,6 +37,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     Return
                 End If
             End If
+
+            _recursionDepth += 1
+
+            If _recursionDepth > 1 Then
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth)
+
+                EmitExpressionCore(expression, used)
+            Else
+                EmitExpressionCoreWithStackGuard(expression, used)
+            End If
+
+            _recursionDepth -= 1
+        End Sub
+
+        Private Sub EmitExpressionCoreWithStackGuard(expression As BoundExpression, used As Boolean)
+            Debug.Assert(_recursionDepth = 1)
+
+            Try
+                EmitExpressionCore(expression, used)
+                Debug.Assert(_recursionDepth = 1)
+
+            Catch ex As Exception When StackGuard.IsInsufficientExecutionStackException(ex)
+                _diagnostics.Add(ERRID.ERR_TooLongOrComplexExpression,
+                                 BoundTreeVisitor.CancelledByStackGuardException.GetTooLongOrComplexExpressionErrorLocation(expression))
+                Throw New EmitCancelledException()
+            End Try
+        End Sub
+
+        Private Sub EmitExpressionCore(expression As BoundExpression, used As Boolean)
 
             Select Case expression.Kind
                 Case BoundKind.AssignmentOperator

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitOperators.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitOperators.vb
@@ -100,17 +100,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Return
             End If
 
-            Select Case (operationKind And BinaryOperatorKind.OpMask)
-                Case BinaryOperatorKind.Add,
-                     BinaryOperatorKind.Subtract,
-                     BinaryOperatorKind.Multiply,
-                     BinaryOperatorKind.Modulo,
-                     BinaryOperatorKind.Divide,
-                     BinaryOperatorKind.IntegerDivide,
-                     BinaryOperatorKind.LeftShift,
-                     BinaryOperatorKind.RightShift
-                    EmitBinaryArithOperator(expression)
+            If IsCondOperator(operationKind) Then
+                EmitBinaryCondOperator(expression, True)
+            Else
+                EmitBinaryOperator(expression)
+            End If
 
+            EmitPopIfUnused(used)
+        End Sub
+
+        Private Function IsCondOperator(operationKind As BinaryOperatorKind) As Boolean
+            Select Case (operationKind And BinaryOperatorKind.OpMask)
                 Case BinaryOperatorKind.OrElse,
                      BinaryOperatorKind.AndAlso,
                      BinaryOperatorKind.Equals,
@@ -122,8 +122,77 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                      BinaryOperatorKind.Is,
                      BinaryOperatorKind.IsNot
 
-                    EmitBinaryCondOperator(expression, True)
+                    Return True
 
+                Case Else
+                    Return False
+            End Select
+        End Function
+
+        Private Sub EmitBinaryOperator(expression As BoundBinaryOperator)
+            ' Do not blow the stack due to a deep recursion on the left. 
+
+            Dim child As BoundExpression = expression.Left
+
+            If child.Kind <> BoundKind.BinaryOperator OrElse child.ConstantValueOpt IsNot Nothing Then
+                EmitBinaryOperatorSimple(expression)
+                Return
+            End If
+
+            Dim binary As BoundBinaryOperator = DirectCast(child, BoundBinaryOperator)
+
+            If IsCondOperator(binary.OperatorKind) Then
+                EmitBinaryOperatorSimple(expression)
+                Return
+            End If
+
+            Dim stack = ArrayBuilder(Of BoundBinaryOperator).GetInstance()
+            stack.Push(expression)
+
+            Do
+                stack.Push(binary)
+                child = binary.Left
+
+                If child.Kind <> BoundKind.BinaryOperator OrElse child.ConstantValueOpt IsNot Nothing Then
+                    Exit Do
+                End If
+
+                binary = DirectCast(child, BoundBinaryOperator)
+
+                If IsCondOperator(binary.OperatorKind) Then
+                    Exit Do
+                End If
+            Loop
+
+            EmitExpression(child, True)
+
+            Do
+                binary = stack.Pop()
+
+                EmitExpression(binary.Right, True)
+
+                Select Case (binary.OperatorKind And BinaryOperatorKind.OpMask)
+                    Case BinaryOperatorKind.And
+                        _builder.EmitOpCode(ILOpCode.And)
+
+                    Case BinaryOperatorKind.Xor
+                        _builder.EmitOpCode(ILOpCode.Xor)
+
+                    Case BinaryOperatorKind.Or
+                        _builder.EmitOpCode(ILOpCode.Or)
+
+                    Case Else
+                        EmitBinaryArithOperatorInstructionAndDowncast(binary)
+                End Select
+            Loop While binary IsNot expression
+
+            Debug.Assert(stack.Count = 0)
+            stack.Free()
+        End Sub
+
+        Private Sub EmitBinaryOperatorSimple(expression As BoundBinaryOperator)
+
+            Select Case (expression.OperatorKind And BinaryOperatorKind.OpMask)
                 Case BinaryOperatorKind.And
                     EmitExpression(expression.Left, True)
                     EmitExpression(expression.Right, True)
@@ -140,11 +209,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     _builder.EmitOpCode(ILOpCode.Or)
 
                 Case Else
-                    ' BinaryOperatorKind.Power, BinaryOperatorKind.Like and BinaryOperatorKind.Concatenate should go here.
-                    Throw ExceptionUtilities.UnexpectedValue(operationKind)
+                    EmitBinaryArithOperator(expression)
             End Select
-
-            EmitPopIfUnused(used)
         End Sub
 
         Private Function OperatorHasSideEffects(expression As BoundBinaryOperator) As Boolean
@@ -171,6 +237,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             EmitExpression(expression.Left, True)
             EmitExpression(expression.Right, True)
 
+            EmitBinaryArithOperatorInstructionAndDowncast(expression)
+        End Sub
+
+        Private Sub EmitBinaryArithOperatorInstructionAndDowncast(expression As BoundBinaryOperator)
             Dim targetPrimitiveType = expression.Type.PrimitiveTypeCode
             Dim opKind = expression.OperatorKind And BinaryOperatorKind.OpMask
 
@@ -262,6 +332,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     End If
 
                 Case Else
+                    ' BinaryOperatorKind.Power, BinaryOperatorKind.Like and BinaryOperatorKind.Concatenate should go here.
                     Throw ExceptionUtilities.UnexpectedValue(opKind)
             End Select
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -1475,6 +1475,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim asyncDebugInfo As Cci.AsyncMethodBodyDebugInfo = Nothing
                 Dim codeGen = New CodeGen.CodeGenerator(method, block, builder, moduleBuilder, diagnostics, optimizations, emittingPdb)
 
+                If diagnostics.HasAnyErrors() Then
+                    Return Nothing
+                End If
+
                 ' We need to save additional debugging information for MoveNext of an async state machine.
                 Dim stateMachineMethod = TryCast(method, SynthesizedStateMachineMethod)
 
@@ -1627,7 +1631,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(method.IsFromCompilation(compilationState.Compilation))
             If Not method.IsShared AndAlso compilationState.InitializeComponentOpt IsNot Nothing AndAlso
                Not method.IsImplicitlyDeclared Then
-                InitializeComponentCallTreeBuilder.CollectCallees(compilationState, method, body)
+                Try
+                    InitializeComponentCallTreeBuilder.CollectCallees(compilationState, method, body)
+                Catch ex As BoundTreeVisitor.CancelledByStackGuardException
+                    ex.AddAnError(diagnostics)
+                End Try
             End If
 
             '  Instance constructor should return the referenced constructor in 'referencedConstructor'
@@ -1669,8 +1677,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return body
         End Function
 
-        Private Class InitializeComponentCallTreeBuilder
-            Inherits BoundTreeWalker
+        Private NotInheritable Class InitializeComponentCallTreeBuilder
+            Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
             Private _calledMethods As HashSet(Of MethodSymbol)
             Private ReadOnly _containingType As NamedTypeSymbol

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
@@ -604,7 +604,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     ' We need to revisit the whenNotNull expression to replace placeholder
-                    Dim rewriter As New ConditionalAccessReceiverPlaceholderReplacement(node.PlaceholderId, placeholderReplacement)
+                    Dim rewriter As New ConditionalAccessReceiverPlaceholderReplacement(node.PlaceholderId, placeholderReplacement, RecursionDepth)
                     whenNotNull = DirectCast(rewriter.Visit(whenNotNull), BoundExpression)
                     Debug.Assert(rewriter.Replaced)
 
@@ -651,14 +651,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             End Function
 
-            Private Class ConditionalAccessReceiverPlaceholderReplacement
-                Inherits BoundTreeRewriter
+            Private NotInheritable Class ConditionalAccessReceiverPlaceholderReplacement
+                Inherits BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
                 Private ReadOnly _placeholderId As Integer
                 Private ReadOnly _replaceWith As BoundExpression
                 Private _replaced As Boolean
 
-                Public Sub New(placeholderId As Integer, replaceWith As BoundExpression)
+                Public Sub New(placeholderId As Integer, replaceWith As BoundExpression, recursionDepth As Integer)
+                    MyBase.New(recursionDepth)
                     Me._placeholderId = placeholderId
                     Me._replaceWith = replaceWith
                 End Sub

--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
@@ -8,7 +8,6 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Partial Friend Class DiagnosticsPass
-        Inherits BoundTreeWalker
 
         Private ReadOnly _expressionTreePlaceholders As New HashSet(Of BoundNode)(ReferenceEqualityComparer.Instance)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.vb
@@ -16,8 +16,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Perform a first analysis pass in preparation for removing all lambdas from a method body.  The entry point is Analyze.
         ''' The results of analysis are placed in the fields seenLambda, blockParent, variableBlock, captured, and captures.
         ''' </summary>
-        Friend Class Analysis
-            Inherits BoundTreeWalker
+        Friend NotInheritable Class Analysis
+            Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
             Private ReadOnly _diagnostics As DiagnosticBag
             Private ReadOnly _method As MethodSymbol

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     ''' the returned bound node.  For example, the caller will typically perform iterator method and
     ''' asynchronous method transformations, and emit IL instructions into an assembly.
     ''' </summary>
-    Partial Friend Class LambdaRewriter
+    Partial Friend NotInheritable Class LambdaRewriter
         Inherits MethodToClassRewriter(Of FieldSymbol)
 
         Private ReadOnly _analysis As Analysis
@@ -1029,7 +1029,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If Not wasInExpressionLambda Then
                     ' Rewritten outermost lambda as expression tree
                     Dim delegateType = type.ExpressionTargetDelegate(CompilationState.Compilation)
-                    rewrittenNode = ExpressionLambdaRewriter.RewriteLambda(node, Me._currentMethod, delegateType, Me.CompilationState, Me.TypeMap, Me.Diagnostics, Me._rewrittenNodes)
+                    rewrittenNode = ExpressionLambdaRewriter.RewriteLambda(node, Me._currentMethod, delegateType, Me.CompilationState, Me.TypeMap, Me.Diagnostics, Me._rewrittenNodes, Me.RecursionDepth)
                 End If
 
                 _inExpressionLambda = wasInExpressionLambda

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
@@ -9,7 +9,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Partial Friend NotInheritable Class LocalRewriter
-        Inherits BoundTreeRewriter
+        Inherits BoundTreeRewriterWithStackGuard
 
         Private ReadOnly _topMethod As MethodSymbol
         Private ReadOnly _emitModule As PEModuleBuilder
@@ -118,8 +118,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             previousSubmissionFields As SynthesizedSubmissionFields,
             generateDebugInfo As Boolean,
             diagnostics As DiagnosticBag,
-            flags As RewritingFlags
+            flags As RewritingFlags,
+            recursionDepth As Integer
         )
+            MyBase.New(recursionDepth)
+
             Me._topMethod = topMethod
             Me._currentMethodOrLambda = currentMethod
             Me._globalGenerateDebugInfo = generateDebugInfo
@@ -146,11 +149,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             <[In], Out> ByRef rewrittenNodes As HashSet(Of BoundNode),
                                             <Out> ByRef hasLambdas As Boolean,
                                             <Out> ByRef symbolsCapturedWithoutCtor As ISet(Of Symbol),
-                                            flags As RewritingFlags) As BoundNode
+                                            flags As RewritingFlags,
+                                            recursionDepth As Integer) As BoundNode
 
             Debug.Assert(node Is Nothing OrElse Not node.HasErrors, "node has errors")
 
-            Dim rewriter = New LocalRewriter(topMethod, currentMethod, compilationState, previousSubmissionFields, generateDebugInfo, diagnostics, flags)
+            Dim rewriter = New LocalRewriter(topMethod, currentMethod, compilationState, previousSubmissionFields, generateDebugInfo, diagnostics, flags, recursionDepth)
 
 #If DEBUG Then
             If rewrittenNodes IsNot Nothing Then
@@ -207,7 +211,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' if the node already contains debug info, don't generate more debug info
             Dim generateDebugInfo = (flags And RewritingFlags.AllowSequencePoints) = 0
 
-            Return DirectCast(RewriteNode(node, topMethod, If(currentMethod, topMethod), compilationState, previousSubmissionFields, generateDebugInfo, diagnostics, rewrittenNodes, hasLambdas, symbolsCapturedWithoutCopyCtor, flags), BoundBlock)
+            Return DirectCast(RewriteNode(node,
+                                          topMethod,
+                                          If(currentMethod, topMethod),
+                                          compilationState,
+                                          previousSubmissionFields,
+                                          generateDebugInfo,
+                                          diagnostics,
+                                          rewrittenNodes,
+                                          hasLambdas,
+                                          symbolsCapturedWithoutCopyCtor,
+                                          flags,
+                                          recursionDepth:=0), BoundBlock)
         End Function
 
         Public Shared Function RewriteExpressionTree(node As BoundExpression,
@@ -215,12 +230,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      compilationState As TypeCompilationState,
                                                      previousSubmissionFields As SynthesizedSubmissionFields,
                                                      diagnostics As DiagnosticBag,
-                                                     rewrittenNodes As HashSet(Of BoundNode)) As BoundExpression
+                                                     rewrittenNodes As HashSet(Of BoundNode),
+                                                     recursionDepth As Integer) As BoundExpression
 
             Debug.Assert(rewrittenNodes IsNot Nothing)
             Dim hasLambdas As Boolean = False
             Const generateDebugInfo = False ' don't generate debug information in expression tree lambdas
-            Dim result = DirectCast(RewriteNode(node, method, method, compilationState, previousSubmissionFields, generateDebugInfo, diagnostics, rewrittenNodes, hasLambdas, SpecializedCollections.EmptySet(Of Symbol), RewritingFlags.Default), BoundExpression)
+            Dim result = DirectCast(RewriteNode(node,
+                                                method,
+                                                method,
+                                                compilationState,
+                                                previousSubmissionFields,
+                                                generateDebugInfo,
+                                                diagnostics,
+                                                rewrittenNodes,
+                                                hasLambdas,
+                                                SpecializedCollections.EmptySet(Of Symbol),
+                                                RewritingFlags.Default,
+                                                recursionDepth), BoundExpression)
             Debug.Assert(Not hasLambdas)
             Return result
         End Function
@@ -274,7 +301,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If constantValue IsNot Nothing Then
                 result = RewriteConstant(node, constantValue)
             Else
-                result = DirectCast(MyBase.Visit(node), BoundExpression)
+                result = VisitExpressionWithStackGuard(node)
             End If
 
             If createSequencePoint Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperators.vb
@@ -81,10 +81,53 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function VisitBinaryOperator(node As BoundBinaryOperator) As BoundNode
-            Dim opKind = node.OperatorKind
+            ' Do not blow the stack due to a deep recursion on the left. 
 
-            If (opKind And BinaryOperatorKind.Lifted) <> 0 Then
-                Return RewriteLiftedIntrinsicBinaryOperator(node)
+            Dim child As BoundExpression = node.Left
+
+            If child.Kind <> BoundKind.BinaryOperator Then
+                Return RewriteBinaryOperatorSimple(node)
+            End If
+
+            Dim stack = ArrayBuilder(Of BoundBinaryOperator).GetInstance()
+            stack.Push(node)
+
+            Dim binary As BoundBinaryOperator = DirectCast(child, BoundBinaryOperator)
+
+            Do
+                stack.Push(binary)
+                child = binary.Left
+
+                If child.Kind <> BoundKind.BinaryOperator Then
+                    Exit Do
+                End If
+
+                binary = DirectCast(child, BoundBinaryOperator)
+            Loop
+
+            Dim left = VisitExpressionNode(child)
+
+            Do
+                binary = stack.Pop()
+
+                Dim right = VisitExpressionNode(binary.Right)
+
+                If (binary.OperatorKind And BinaryOperatorKind.Lifted) <> 0 Then
+                    left = FinishRewriteOfLiftedIntrinsicBinaryOperator(binary, left, right)
+                Else
+                    left = TransformRewrittenBinaryOperator(binary.Update(binary.OperatorKind, left, right, binary.Checked, binary.ConstantValueOpt, Me.VisitType(binary.Type)))
+                End If
+            Loop While binary IsNot node
+
+            Debug.Assert(stack.Count = 0)
+            stack.Free()
+
+            Return left
+        End Function
+
+        Private Function RewriteBinaryOperatorSimple(node As BoundBinaryOperator) As BoundNode
+            If (node.OperatorKind And BinaryOperatorKind.Lifted) <> 0 Then
+                Return RewriteLiftedIntrinsicBinaryOperatorSimple(node)
             End If
 
             Return TransformRewrittenBinaryOperator(DirectCast(MyBase.VisitBinaryOperator(node), BoundBinaryOperator))
@@ -717,11 +760,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return result
         End Function
 
-        Private Function RewriteLiftedIntrinsicBinaryOperator(node As BoundBinaryOperator) As BoundNode
-            Debug.Assert((node.OperatorKind And BinaryOperatorKind.Lifted) <> 0)
-
+        Private Function RewriteLiftedIntrinsicBinaryOperatorSimple(node As BoundBinaryOperator) As BoundNode
             Dim left As BoundExpression = VisitExpressionNode(node.Left)
             Dim right As BoundExpression = VisitExpressionNode(node.Right)
+
+            Return FinishRewriteOfLiftedIntrinsicBinaryOperator(node, left, right)
+        End Function
+
+        Private Function FinishRewriteOfLiftedIntrinsicBinaryOperator(node As BoundBinaryOperator, left As BoundExpression, right As BoundExpression) As BoundExpression
+            Debug.Assert((node.OperatorKind And BinaryOperatorKind.Lifted) <> 0)
 
             If Me._inExpressionLambda Then
                 Return node.Update(node.OperatorKind, left, right, node.Checked, node.ConstantValueOpt, node.Type)
@@ -852,7 +899,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                             leftHasNoValue As Boolean,
                                                             rightHasNoValue As Boolean,
                                                             leftHasValue As Boolean,
-                                                            rightHasValue As Boolean) As BoundNode
+                                                            rightHasValue As Boolean) As BoundExpression
 
             Debug.Assert(left.Type.IsNullableOfBoolean AndAlso right.Type.IsNullableOfBoolean AndAlso node.Type.IsNullableOfBoolean)
             Debug.Assert(Not (leftHasNoValue And rightHasNoValue))

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Flags.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Flags.vb
@@ -3,7 +3,6 @@
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Partial Friend NotInheritable Class LocalRewriter
-        Inherits BoundTreeRewriter
 
         <Flags>
         Friend Enum RewritingFlags As Byte

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ForEach.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ForEach.vb
@@ -94,6 +94,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 replacedCollection = DirectCast(LocalVariableSubstituter.Replace(originalCollection,
                                                                                  node.DeclaredOrInferredLocalOpt,
                                                                                  tempLocal,
+                                                                                 RecursionDepth,
                                                                                  replacedControlVariable), BoundExpression)
 
                 ' if a reference to the control variable was found we add the temporary local and we need to make sure
@@ -777,8 +778,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Internal helper class to replace local symbols in bound locals of a given bound tree.
         ''' </summary>
-        Private Class LocalVariableSubstituter
-            Inherits BoundTreeRewriter
+        Private NotInheritable Class LocalVariableSubstituter
+            Inherits BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
             Private ReadOnly _original As LocalSymbol
             Private ReadOnly _replacement As LocalSymbol
@@ -788,9 +789,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 node As BoundNode,
                 original As LocalSymbol,
                 replacement As LocalSymbol,
+                recursionDepth As Integer,
                 ByRef replacedNode As Boolean
             ) As BoundNode
-                Dim rewriter As New LocalVariableSubstituter(original, replacement)
+                Dim rewriter As New LocalVariableSubstituter(original, replacement, recursionDepth)
 
                 Dim result = rewriter.Visit(node)
                 replacedNode = rewriter.ReplacedNode
@@ -804,7 +806,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End Get
             End Property
 
-            Private Sub New(original As LocalSymbol, replacement As LocalSymbol)
+            Private Sub New(original As LocalSymbol, replacement As LocalSymbol, recursionDepth As Integer)
+                MyBase.New(recursionDepth)
                 _original = original
                 _replacement = replacement
             End Sub

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.MyBaseMyClassWrapper.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.MyBaseMyClassWrapper.vb
@@ -16,7 +16,6 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Partial Friend MustInherit Class MethodToClassRewriter(Of TProxy)
-        Inherits BoundTreeRewriter
 
         Private Function SubstituteMethodForMyBaseOrMyClassCall(receiverOpt As BoundExpression, originalMethodBeingCalled As MethodSymbol) As MethodSymbol
             If (originalMethodBeingCalled.IsMetadataVirtual OrElse Me.IsInExpressionLambda) AndAlso

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     ''' This is used in the lambda rewriter, the iterator rewriter, and the async rewriter.
     ''' </summary>    
     Partial Friend MustInherit Class MethodToClassRewriter(Of TProxy)
-        Inherits BoundTreeRewriter
+        Inherits BoundTreeRewriterWithStackGuard
 
         ''' <summary>
         ''' For each captured variable, the corresponding field of its frame

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -50,9 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Try
                 _recursionDepth += 1
-                If _recursionDepth >= MaxUncheckedRecursionDepth Then
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
-                End If
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth)
 
                 '// Note: this function will only ever return NULL if the flag "BailIfFirstTokenIsRejected" is set,
                 '// and if the first token isn't a valid way to start an expression. In all other error scenarios

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
@@ -35,9 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If node IsNot Nothing Then
                 _recursionDepth += 1
 
-                If _recursionDepth > Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth Then
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
-                End If
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth)
 
                 Dim result = DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
@@ -20,10 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If node IsNot Nothing Then
                 _recursionDepth += 1
 
-                If _recursionDepth > Syntax.InternalSyntax.Parser.MaxUncheckedRecursionDepth Then
-                    PortableShim.RuntimeHelpers.EnsureSufficientExecutionStack()
-                End If
-
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth)
                 DirectCast(node, VisualBasicSyntaxNode).Accept(Me)
 
                 _recursionDepth -= 1

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -548,9 +548,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 return null;
             }
 
-            if (MayHaveSideEffectsVisitor.MayHaveSideEffects(expression))
+            try
             {
-                flags |= DkmClrCompilationResultFlags.PotentialSideEffect;
+                if (MayHaveSideEffectsVisitor.MayHaveSideEffects(expression))
+                {
+                    flags |= DkmClrCompilationResultFlags.PotentialSideEffect;
+                }
+            }
+            catch (BoundTreeVisitor.CancelledByStackGuardException ex)
+            {
+                ex.AddAnError(diagnostics);
+                resultProperties = default(ResultProperties);
+                return null;
             }
 
             var expressionType = expression.Type;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    internal sealed class CapturedVariableRewriter : BoundTreeRewriter
+    internal sealed class CapturedVariableRewriter : BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
     {
         internal static BoundNode Rewrite(
             ParameterSymbol targetMethodThisParameter,

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    internal sealed class MayHaveSideEffectsVisitor : BoundTreeWalker
+    internal sealed class MayHaveSideEffectsVisitor : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
     {
         private bool _mayHaveSideEffects;
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    internal sealed class PlaceholderLocalRewriter : BoundTreeRewriter
+    internal sealed class PlaceholderLocalRewriter : BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
     {
         internal static BoundNode Rewrite(CSharpCompilation compilation, EENamedTypeSymbol container, HashSet<LocalSymbol> declaredLocals, BoundNode node, DiagnosticBag diagnostics)
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -425,181 +425,188 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 return;
             }
 
-            var declaredLocals = PooledHashSet<LocalSymbol>.GetInstance();
             try
             {
-                // Rewrite local declaration statement.
-                body = (BoundStatement)LocalDeclarationRewriter.Rewrite(compilation, _container, declaredLocals, body);
-
-                // Verify local declaration names.
-                foreach (var local in declaredLocals)
+                var declaredLocals = PooledHashSet<LocalSymbol>.GetInstance();
+                try
                 {
-                    Debug.Assert(local.Locations.Length > 0);
-                    var name = local.Name;
-                    if (name.StartsWith("$", StringComparison.Ordinal))
+                    // Rewrite local declaration statement.
+                    body = (BoundStatement)LocalDeclarationRewriter.Rewrite(compilation, _container, declaredLocals, body);
+
+                    // Verify local declaration names.
+                    foreach (var local in declaredLocals)
                     {
-                        diagnostics.Add(ErrorCode.ERR_UnexpectedCharacter, local.Locations[0], name[0]);
+                        Debug.Assert(local.Locations.Length > 0);
+                        var name = local.Name;
+                        if (name.StartsWith("$", StringComparison.Ordinal))
+                        {
+                            diagnostics.Add(ErrorCode.ERR_UnexpectedCharacter, local.Locations[0], name[0]);
+                            return;
+                        }
+                    }
+
+                    // Rewrite references to placeholder "locals".
+                    body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, _container, declaredLocals, body, diagnostics);
+
+                    if (diagnostics.HasAnyErrors())
+                    {
                         return;
                     }
                 }
+                finally
+                {
+                    declaredLocals.Free();
+                }
 
-                // Rewrite references to placeholder "locals".
-                body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, _container, declaredLocals, body, diagnostics);
+                var syntax = body.Syntax;
+                var statementsBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+                statementsBuilder.Add(body);
+                // Insert an implicit return statement if necessary.
+                if (body.Kind != BoundKind.ReturnStatement)
+                {
+                    statementsBuilder.Add(new BoundReturnStatement(syntax, expressionOpt: null));
+                }
+
+                var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+                var localsSet = PooledHashSet<LocalSymbol>.GetInstance();
+                foreach (var local in this.LocalsForBinding)
+                {
+                    Debug.Assert(!localsSet.Contains(local));
+                    localsBuilder.Add(local);
+                    localsSet.Add(local);
+                }
+                foreach (var local in this.Locals)
+                {
+                    if (!localsSet.Contains(local))
+                    {
+                        localsBuilder.Add(local);
+                    }
+                }
+                localsSet.Free();
+
+                body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
+
+                Debug.Assert(!diagnostics.HasAnyErrors());
+                Debug.Assert(!body.HasErrors);
+
+                bool sawLambdas;
+                bool sawAwaitInExceptionHandler;
+                body = LocalRewriter.Rewrite(
+                    compilation: this.DeclaringCompilation,
+                    method: this,
+                    methodOrdinal: _methodOrdinal,
+                    containingType: _container,
+                    statement: body,
+                    compilationState: compilationState,
+                    previousSubmissionFields: null,
+                    allowOmissionOfConditionalCalls: false,
+                    diagnostics: diagnostics,
+                    sawLambdas: out sawLambdas,
+                    sawAwaitInExceptionHandler: out sawAwaitInExceptionHandler);
+
+                Debug.Assert(!sawAwaitInExceptionHandler);
+
+                if (body.HasErrors)
+                {
+                    return;
+                }
+
+                // Variables may have been captured by lambdas in the original method
+                // or in the expression, and we need to preserve the existing values of
+                // those variables in the expression. This requires rewriting the variables
+                // in the expression based on the closure classes from both the original
+                // method and the expression, and generating a preamble that copies
+                // values into the expression closure classes.
+                //
+                // Consider the original method:
+                // static void M()
+                // {
+                //     int x, y, z;
+                //     ...
+                //     F(() => x + y);
+                // }
+                // and the expression in the EE: "F(() => x + z)".
+                //
+                // The expression is first rewritten using the closure class and local <1>
+                // from the original method: F(() => <1>.x + z)
+                // Then lambda rewriting introduces a new closure class that includes
+                // the locals <1> and z, and a corresponding local <2>: F(() => <2>.<1>.x + <2>.z)
+                // And a preamble is added to initialize the fields of <2>:
+                //     <2> = new <>c__DisplayClass0();
+                //     <2>.<1> = <1>;
+                //     <2>.z = z;
+
+                // Rewrite "this" and "base" references to parameter in this method.
+                // Rewrite variables within body to reference existing display classes.
+                body = (BoundStatement)CapturedVariableRewriter.Rewrite(
+                    this.SubstitutedSourceMethod.IsStatic ? null : _parameters[0],
+                    compilation.Conversions,
+                    _displayClassVariables,
+                    body,
+                    diagnostics);
+
+                if (body.HasErrors)
+                {
+                    Debug.Assert(false, "Please add a test case capturing whatever caused this assert.");
+                    return;
+                }
 
                 if (diagnostics.HasAnyErrors())
                 {
                     return;
                 }
-            }
-            finally
-            {
-                declaredLocals.Free();
-            }
 
-            var syntax = body.Syntax;
-            var statementsBuilder = ArrayBuilder<BoundStatement>.GetInstance();
-            statementsBuilder.Add(body);
-            // Insert an implicit return statement if necessary.
-            if (body.Kind != BoundKind.ReturnStatement)
-            {
-                statementsBuilder.Add(new BoundReturnStatement(syntax, expressionOpt: null));
-            }
-
-            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
-            var localsSet = PooledHashSet<LocalSymbol>.GetInstance();
-            foreach (var local in this.LocalsForBinding)
-            {
-                Debug.Assert(!localsSet.Contains(local));
-                localsBuilder.Add(local);
-                localsSet.Add(local);
-            }
-            foreach (var local in this.Locals)
-            {
-                if (!localsSet.Contains(local))
+                if (sawLambdas)
                 {
-                    localsBuilder.Add(local);
+                    var closureDebugInfoBuilder = ArrayBuilder<ClosureDebugInfo>.GetInstance();
+                    var lambdaDebugInfoBuilder = ArrayBuilder<LambdaDebugInfo>.GetInstance();
+
+                    body = LambdaRewriter.Rewrite(
+                        loweredBody: body,
+                        thisType: this.SubstitutedSourceMethod.ContainingType,
+                        thisParameter: _thisParameter,
+                        method: this,
+                        methodOrdinal: _methodOrdinal,
+                        closureDebugInfoBuilder: closureDebugInfoBuilder,
+                        lambdaDebugInfoBuilder: lambdaDebugInfoBuilder,
+                        slotAllocatorOpt: null,
+                        compilationState: compilationState,
+                        diagnostics: diagnostics,
+                        assignLocals: true);
+
+                    // we don't need this information:
+                    closureDebugInfoBuilder.Free();
+                    lambdaDebugInfoBuilder.Free();
                 }
-            }
-            localsSet.Free();
 
-            body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
-
-            Debug.Assert(!diagnostics.HasAnyErrors());
-            Debug.Assert(!body.HasErrors);
-
-            bool sawLambdas;
-            bool sawAwaitInExceptionHandler;
-            body = LocalRewriter.Rewrite(
-                compilation: this.DeclaringCompilation,
-                method: this,
-                methodOrdinal: _methodOrdinal,
-                containingType: _container,
-                statement: body,
-                compilationState: compilationState,
-                previousSubmissionFields: null,
-                allowOmissionOfConditionalCalls: false,
-                diagnostics: diagnostics,
-                sawLambdas: out sawLambdas,
-                sawAwaitInExceptionHandler: out sawAwaitInExceptionHandler);
-
-            Debug.Assert(!sawAwaitInExceptionHandler);
-
-            if (body.HasErrors)
-            {
-                return;
-            }
-
-            // Variables may have been captured by lambdas in the original method
-            // or in the expression, and we need to preserve the existing values of
-            // those variables in the expression. This requires rewriting the variables
-            // in the expression based on the closure classes from both the original
-            // method and the expression, and generating a preamble that copies
-            // values into the expression closure classes.
-            //
-            // Consider the original method:
-            // static void M()
-            // {
-            //     int x, y, z;
-            //     ...
-            //     F(() => x + y);
-            // }
-            // and the expression in the EE: "F(() => x + z)".
-            //
-            // The expression is first rewritten using the closure class and local <1>
-            // from the original method: F(() => <1>.x + z)
-            // Then lambda rewriting introduces a new closure class that includes
-            // the locals <1> and z, and a corresponding local <2>: F(() => <2>.<1>.x + <2>.z)
-            // And a preamble is added to initialize the fields of <2>:
-            //     <2> = new <>c__DisplayClass0();
-            //     <2>.<1> = <1>;
-            //     <2>.z = z;
-
-            // Rewrite "this" and "base" references to parameter in this method.
-            // Rewrite variables within body to reference existing display classes.
-            body = (BoundStatement)CapturedVariableRewriter.Rewrite(
-                this.SubstitutedSourceMethod.IsStatic ? null : _parameters[0],
-                compilation.Conversions,
-                _displayClassVariables,
-                body,
-                diagnostics);
-
-            if (body.HasErrors)
-            {
-                Debug.Assert(false, "Please add a test case capturing whatever caused this assert.");
-                return;
-            }
-
-            if (diagnostics.HasAnyErrors())
-            {
-                return;
-            }
-
-            if (sawLambdas)
-            {
-                var closureDebugInfoBuilder = ArrayBuilder<ClosureDebugInfo>.GetInstance();
-                var lambdaDebugInfoBuilder = ArrayBuilder<LambdaDebugInfo>.GetInstance();
-
-                body = LambdaRewriter.Rewrite(
-                    loweredBody: body,
-                    thisType: this.SubstitutedSourceMethod.ContainingType,
-                    thisParameter: _thisParameter,
-                    method: this,
-                    methodOrdinal: _methodOrdinal,
-                    closureDebugInfoBuilder: closureDebugInfoBuilder,
-                    lambdaDebugInfoBuilder: lambdaDebugInfoBuilder,
-                    slotAllocatorOpt: null,
-                    compilationState: compilationState,
-                    diagnostics: diagnostics,
-                    assignLocals: true);
-
-                // we don't need this information:
-                closureDebugInfoBuilder.Free();
-                lambdaDebugInfoBuilder.Free();
-            }
-
-            // Insert locals from the original method,
-            // followed by any new locals.
-            var block = (BoundBlock)body;
-            var localBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
-            foreach (var local in this.Locals)
-            {
-                Debug.Assert(!(local is EELocalSymbol) || (((EELocalSymbol)local).Ordinal == localBuilder.Count));
-                localBuilder.Add(local);
-            }
-            foreach (var local in block.Locals)
-            {
-                var oldLocal = local as EELocalSymbol;
-                if (oldLocal != null)
+                // Insert locals from the original method,
+                // followed by any new locals.
+                var block = (BoundBlock)body;
+                var localBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+                foreach (var local in this.Locals)
                 {
-                    Debug.Assert(localBuilder[oldLocal.Ordinal] == oldLocal);
-                    continue;
+                    Debug.Assert(!(local is EELocalSymbol) || (((EELocalSymbol)local).Ordinal == localBuilder.Count));
+                    localBuilder.Add(local);
                 }
-                localBuilder.Add(local);
-            }
+                foreach (var local in block.Locals)
+                {
+                    var oldLocal = local as EELocalSymbol;
+                    if (oldLocal != null)
+                    {
+                        Debug.Assert(localBuilder[oldLocal.Ordinal] == oldLocal);
+                        continue;
+                    }
+                    localBuilder.Add(local);
+                }
 
-            body = block.Update(localBuilder.ToImmutableAndFree(), block.Statements);
-            TypeParameterChecker.Check(body, _allTypeParameters);
-            compilationState.AddSynthesizedMethod(this, body);
+                body = block.Update(localBuilder.ToImmutableAndFree(), block.Statements);
+                TypeParameterChecker.Check(body, _allTypeParameters);
+                compilationState.AddSynthesizedMethod(this, body);
+            }
+            catch (BoundTreeVisitor.CancelledByStackGuardException ex)
+            {
+                ex.AddAnError(diagnostics);
+            }
         }
 
         private static TypeSymbol CalculateReturnType(CSharpCompilation compilation, BoundStatement bodyOpt)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/TypeParameterChecker.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/TypeParameterChecker.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 : null;
         }
 
-        private class BlockChecker : BoundTreeWalker
+        private class BlockChecker : BoundTreeWalkerWithStackGuard
         {
             private readonly TypeParameterChecker _typeParameterChecker;
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -466,9 +466,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             If Not IsAssignableExpression(binder, expression) Then
                 flags = flags Or DkmClrCompilationResultFlags.ReadOnlyResult
             End If
-            If MayHaveSideEffectsVisitor.MayHaveSideEffects(expression) Then
-                flags = flags Or DkmClrCompilationResultFlags.PotentialSideEffect
-            End If
+
+            Try
+                If MayHaveSideEffectsVisitor.MayHaveSideEffects(expression) Then
+                    flags = flags Or DkmClrCompilationResultFlags.PotentialSideEffect
+                End If
+            Catch ex As BoundTreeVisitor.CancelledByStackGuardException
+                ex.AddAnError(diagnostics)
+            End Try
 
             If IsStatement(expression) Then
                 expression = binder.ReclassifyInvocationExpressionAsStatement(expression, diagnostics)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
@@ -5,7 +5,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     Friend NotInheritable Class CapturedVariableRewriter
-        Inherits BoundTreeRewriter
+        Inherits BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
         Friend Shared Function Rewrite(
             targetMethodMeParameter As ParameterSymbol,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         ' Find all implicitly declared locals.
         Private NotInheritable Class LocalDeclarationWalker
-            Inherits BoundTreeWalker
+            Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
             Private ReadOnly _locals As HashSet(Of LocalSymbol)
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.vb
@@ -3,9 +3,12 @@
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     Friend NotInheritable Class MayHaveSideEffectsVisitor
-        Inherits BoundTreeWalker
+        Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
         Private _mayHaveSideEffects As Boolean
+
+        Private Sub New()
+        End Sub
 
         Friend Shared Function MayHaveSideEffects(node As BoundNode) As Boolean
             Dim visitor = New MayHaveSideEffectsVisitor()
@@ -17,6 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             If _mayHaveSideEffects Then
                 Return Nothing
             End If
+
             Return MyBase.Visit(node)
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
@@ -5,7 +5,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     Friend NotInheritable Class PlaceholderLocalRewriter
-        Inherits BoundTreeRewriter
+        Inherits BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
         Friend Shared Function Rewrite(compilation As VisualBasicCompilation, container As EENamedTypeSymbol, node As BoundNode, diagnostics As DiagnosticBag) As BoundNode
             Dim rewriter As New PlaceholderLocalRewriter(compilation, container, diagnostics)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -477,80 +477,86 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             ' NOTE: In C#, EE rewriting happens AFTER local rewriting.  However, that order would be difficult
             ' to accommodate in VB, so we reverse it.
 
-            ' Rewrite local declaration statement.
-            newBody = LocalDeclarationRewriter.Rewrite(_compilation, _container, newBody)
+            Try
+                ' Rewrite local declaration statement.
+                newBody = LocalDeclarationRewriter.Rewrite(_compilation, _container, newBody)
 
-            ' Rewrite pseudo-variable references to helper method calls.
-            newBody = DirectCast(PlaceholderLocalRewriter.Rewrite(_compilation, _container, newBody, diagnostics), BoundBlock)
-            If diagnostics.HasAnyErrors() Then
-                Return newBody
-            End If
+                ' Rewrite pseudo-variable references to helper method calls.
+                newBody = DirectCast(PlaceholderLocalRewriter.Rewrite(_compilation, _container, newBody, diagnostics), BoundBlock)
+                If diagnostics.HasAnyErrors() Then
+                    Return newBody
+                End If
 
-            ' Create a map from original local to target local.
-            Dim localMap = PooledDictionary(Of LocalSymbol, LocalSymbol).GetInstance()
-            Dim targetLocals = newBody.Locals
-            Debug.Assert(originalLocals.Length = targetLocals.Length)
-            For i = 0 To originalLocals.Length - 1
-                Dim originalLocal = originalLocals(i)
-                Dim targetLocal = targetLocals(i)
-                Debug.Assert(TypeOf originalLocal IsNot EELocalSymbol OrElse
+                ' Create a map from original local to target local.
+                Dim localMap = PooledDictionary(Of LocalSymbol, LocalSymbol).GetInstance()
+                Dim targetLocals = newBody.Locals
+                Debug.Assert(originalLocals.Length = targetLocals.Length)
+                For i = 0 To originalLocals.Length - 1
+                    Dim originalLocal = originalLocals(i)
+                    Dim targetLocal = targetLocals(i)
+                    Debug.Assert(TypeOf originalLocal IsNot EELocalSymbol OrElse
                         DirectCast(originalLocal, EELocalSymbol).Ordinal = DirectCast(targetLocal, EELocalSymbol).Ordinal)
-                localMap.Add(originalLocal, targetLocal)
-            Next
+                    localMap.Add(originalLocal, targetLocal)
+                Next
 
-            ' Variables may have been captured by lambdas in the original method
-            ' or in the expression, and we need to preserve the existing values of
-            ' those variables in the expression. This requires rewriting the variables
-            ' in the expression based on the closure classes from both the original
-            ' method and the expression, and generating a preamble that copies
-            ' values into the expression closure classes.
-            '
-            ' Consider the original method:
-            ' Shared Sub M()
-            '     Dim x, y, z as Integer
-            '     ...
-            '     F(Function() x + y)
-            ' End Sub
-            ' and the expression in the EE: "F(Function() x + z)".
-            '
-            ' The expression is first rewritten using the closure class and local <1>
-            ' from the original method: F(Function() <1>.x + z)
-            ' Then lambda rewriting introduces a new closure class that includes
-            ' the locals <1> and z, and a corresponding local <2>: F(Function() <2>.<1>.x + <2>.z)
-            ' And a preamble is added to initialize the fields of <2>:
-            '     <2> = New <>c__DisplayClass0()
-            '     <2>.<1> = <1>
-            '     <2>.z = z
-            '
-            ' Note: The above behavior is actually implemented in the LambdaRewriter and
-            '       is triggered by overriding PreserveOriginalLocals to return "True".
+                ' Variables may have been captured by lambdas in the original method
+                ' or in the expression, and we need to preserve the existing values of
+                ' those variables in the expression. This requires rewriting the variables
+                ' in the expression based on the closure classes from both the original
+                ' method and the expression, and generating a preamble that copies
+                ' values into the expression closure classes.
+                '
+                ' Consider the original method:
+                ' Shared Sub M()
+                '     Dim x, y, z as Integer
+                '     ...
+                '     F(Function() x + y)
+                ' End Sub
+                ' and the expression in the EE: "F(Function() x + z)".
+                '
+                ' The expression is first rewritten using the closure class and local <1>
+                ' from the original method: F(Function() <1>.x + z)
+                ' Then lambda rewriting introduces a new closure class that includes
+                ' the locals <1> and z, and a corresponding local <2>: F(Function() <2>.<1>.x + <2>.z)
+                ' And a preamble is added to initialize the fields of <2>:
+                '     <2> = New <>c__DisplayClass0()
+                '     <2>.<1> = <1>
+                '     <2>.z = z
+                '
+                ' Note: The above behavior is actually implemented in the LambdaRewriter and
+                '       is triggered by overriding PreserveOriginalLocals to return "True".
 
-            ' Create a map from variable name to display class field.
-            Dim displayClassVariables = SubstituteDisplayClassVariables(_displayClassVariables, localMap, Me, Me.TypeMap)
+                ' Create a map from variable name to display class field.
+                Dim displayClassVariables = SubstituteDisplayClassVariables(_displayClassVariables, localMap, Me, Me.TypeMap)
 
-            ' Rewrite references to "Me" to refer to this method's "Me" parameter.
-            ' Rewrite variables within body to reference existing display classes.
-            newBody = DirectCast(CapturedVariableRewriter.Rewrite(
+                ' Rewrite references to "Me" to refer to this method's "Me" parameter.
+                ' Rewrite variables within body to reference existing display classes.
+                newBody = DirectCast(CapturedVariableRewriter.Rewrite(
                 If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
                 displayClassVariables,
                 newBody,
                 diagnostics), BoundBlock)
 
-            If diagnostics.HasAnyErrors() Then
-                Return newBody
-            End If
+                If diagnostics.HasAnyErrors() Then
+                    Return newBody
+                End If
 
-            ' Insert locals from the original method, followed by any new locals.
-            Dim localBuilder = ArrayBuilder(Of LocalSymbol).GetInstance()
-            For Each originalLocal In Me.Locals
-                Dim targetLocal = localMap(originalLocal)
-                Debug.Assert(TypeOf targetLocal IsNot EELocalSymbol OrElse DirectCast(targetLocal, EELocalSymbol).Ordinal = localBuilder.Count)
-                localBuilder.Add(targetLocal)
-            Next
+                ' Insert locals from the original method, followed by any new locals.
+                Dim localBuilder = ArrayBuilder(Of LocalSymbol).GetInstance()
+                For Each originalLocal In Me.Locals
+                    Dim targetLocal = localMap(originalLocal)
+                    Debug.Assert(TypeOf targetLocal IsNot EELocalSymbol OrElse DirectCast(targetLocal, EELocalSymbol).Ordinal = localBuilder.Count)
+                    localBuilder.Add(targetLocal)
+                Next
 
-            localMap.Free()
-            newBody = newBody.Update(newBody.StatementListSyntax, localBuilder.ToImmutableAndFree(), newBody.Statements)
-            TypeParameterChecker.Check(newBody, _allTypeParameters)
+                localMap.Free()
+                newBody = newBody.Update(newBody.StatementListSyntax, localBuilder.ToImmutableAndFree(), newBody.Statements)
+                TypeParameterChecker.Check(newBody, _allTypeParameters)
+
+            Catch ex As BoundTreeVisitor.CancelledByStackGuardException
+                ex.AddAnError(diagnostics)
+            End Try
+
             Return newBody
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/TypeParameterChecker.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/TypeParameterChecker.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         Private Class BlockChecker
-            Inherits BoundTreeWalker
+            Inherits BoundTreeWalkerWithStackGuard
 
             Private ReadOnly _typeParameterChecker As TypeParameterChecker
 
@@ -43,6 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 If expression IsNot Nothing Then
                     _typeParameterChecker.Visit(expression.ExpressionSymbol)
                 End If
+
                 Return MyBase.Visit(node)
             End Function
         End Class


### PR DESCRIPTION
Fixes #5395.

Adjusted Binder, Optimizer, Flow Analysis and code generator to not use recursion to handle binary expressions nested on the left side of another binary expression.
Adjusted CodeGenerator to detect that stack overflow is about to happen while trying to emit IL for an expression and report a diagnostic pointing to the expression at fault instead of crashing compiler.

This change is for C# compiler, VB to follow.

@gafter, @VSadov, @jaredpar, @agocke, @TyOverby Please review. 