### PR TITLE
Rename Test() to TestAssignmentExpression1()

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
@@ -140,7 +140,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
-        public void Test()
+        public void TestAssignmentExpression1()
         {
             Test(
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Action lambda = async ( ) => { int myInt = [|MyIntMethodAsync ( )|] ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ",

--- a/src/Features/CSharp/Portable/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
                     case SyntaxKind.ParenthesizedLambdaExpression:
                     case SyntaxKind.SimpleLambdaExpression:
                     case SyntaxKind.AnonymousMethodExpression:
-                        return (node as AnonymousFunctionExpressionSyntax)?.AsyncKeyword.IsMissing == true;
+                        return (node as AnonymousFunctionExpressionSyntax)?.AsyncKeyword.IsMissing == false;
                     case SyntaxKind.MethodDeclaration:
                         return (node as MethodDeclarationSyntax)?.Modifiers.Any(SyntaxKind.AsyncKeyword) == true;
                     default:


### PR DESCRIPTION
Having something named Test() will cause none of the tests in that type to be run.  Causing tests assemblies to silently run without failures.
Also fixed boolean operator issue that would have been found by tests.