### PR TITLE
Change Windows command line argument parsing

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -6,10 +6,10 @@
   <!-- At the moment Jenkins runs on a machine without any build of Visual Studio 2015.  Hence we must
        use a 2013 compatible solution. -->
   <PropertyGroup>
-    <RoslynSolution>$(MSBuildThisFileDirectory)Roslyn.sln</RoslynSolution>
+    <RoslynSolution Condition="'$(RoslynSolution)' == ''">$(MSBuildThisFileDirectory)Roslyn.sln</RoslynSolution>
     <SamplesSolution>$(MSBuildThisFileDirectory)src\Samples\Samples.sln</SamplesSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <RunTestArgs>$(RunTestArgs) -xml</RunTestArgs>
+    <RunTestArgs Condition="'$(ManualTest)' == ''">$(RunTestArgs) -xml</RunTestArgs>
     <RunTestArgs Condition="'$(Test64)' == 'true'">$(RunTestArgs) -test64</RunTestArgs>
     <IncludePattern Condition="'$(IncludePattern)' == ''">*.UnitTests*.dll</IncludePattern>
     <OutputDirectory>Binaries\$(Configuration)</OutputDirectory>
@@ -17,7 +17,7 @@
     <XunitVersion>1.9.2</XunitVersion>
   </PropertyGroup>
 
-  <Target Name="RestorePackages">
+  <Target Name="RestorePackages" Condition="'$(ManualTest)' == ''">
     <Exec Command="nuget.exe restore &quot;$(MSBuildThisFileDirectory)build\ToolsetPackages\project.json&quot; "/>
     <Exec Command="nuget.exe restore &quot;$(RoslynSolution)&quot; "/>
     <Exec Command="nuget.exe restore &quot;$(SamplesSolution)&quot; "/>
@@ -29,6 +29,7 @@
              Properties="RestorePackages=false;TreatWarningsAsErrors=true"
              Targets="Build"/>
     <MSBuild BuildInParallel="true"
+             Condition="'$(ManualTest)' == ''"
              Projects="$(SamplesSolution)"
              Properties="RestorePackages=false;TreatWarningsAsErrors=true"
              Targets="Build"/>
@@ -40,6 +41,7 @@
              Properties="RestorePackages=false"
              Targets="Clean"/>
     <MSBuild BuildInParallel="true"
+             Condition="'$(ManualTest)' == ''"
              Projects="$(SamplesSolution)"
              Properties="RestorePackages=false"
              Targets="Clean"/>
@@ -51,6 +53,7 @@
              Properties="RestorePackages=false;TreatWarningsAsErrors=true"
              Targets="Rebuild"/>
     <MSBuild BuildInParallel="true"
+             Condition="'$(ManualTest)' == ''"
              Projects="$(SamplesSolution)"
              Properties="RestorePackages=false;TreatWarningsAsErrors=true"
              Targets="Rebuild"/>

--- a/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
@@ -1156,7 +1156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             };
         }
 
-        private void ParseAndResolveReferencePaths(string switchName, string switchValue, string baseDirectory, List<string> builder, MessageID origin, List<Diagnostic> diagnostics)
+        private static void ParseAndResolveReferencePaths(string switchName, string switchValue, string baseDirectory, List<string> builder, MessageID origin, List<Diagnostic> diagnostics)
         {
             if (string.IsNullOrEmpty(switchValue))
             {
@@ -1183,7 +1183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private string GetWin32Setting(string arg, string value, List<Diagnostic> diagnostics)
+        private static string GetWin32Setting(string arg, string value, List<Diagnostic> diagnostics)
         {
             if (value == null)
             {

--- a/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -119,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     string name, value;
                     if (TryParseOption(arg, out name, out value) && (name == "ruleset"))
                     {
-                        var unquoted = RemoveAllQuotes(value);
+                        var unquoted = RemoveQuotesAndSlashes(value);
 
                         if (string.IsNullOrEmpty(unquoted))
                         {
@@ -174,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         IEnumerable<Diagnostic> defineDiagnostics;
-                        defines.AddRange(ParseConditionalCompilationSymbols(value, out defineDiagnostics));
+                        defines.AddRange(ParseConditionalCompilationSymbols(RemoveQuotesAndSlashes(value), out defineDiagnostics));
                         diagnostics.AddRange(defineDiagnostics);
                         continue;
 
@@ -259,6 +260,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         continue;
 
                     case "preferreduilang":
+                        value = RemoveQuotesAndSlashes(value);
+
                         if (string.IsNullOrEmpty(value))
                         {
                             AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, "<text>", arg);
@@ -363,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "modulename":
-                            var unquotedModuleName = RemoveAllQuotes(value);
+                            var unquotedModuleName = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrEmpty(unquotedModuleName))
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, MessageID.IDS_Text.Localize(), "modulename");
@@ -388,6 +391,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "recurse":
+                            value = RemoveQuotesAndSlashes(value);
+
                             if (value == null)
                             {
                                 break; // force 'unrecognized option'
@@ -414,7 +419,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, MessageID.IDS_Text.Localize(), arg);
                                 continue;
                             }
-                            string unquoted = RemoveAllQuotes(value);
+                            string unquoted = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrEmpty(unquoted))
                             {
                                 // CONSIDER: This diagnostic exactly matches dev11, but it would be simpler (and more consistent with /out)
@@ -727,7 +732,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else
                             {
-                                keyFileSetting = RemoveAllQuotes(value);
+                                keyFileSetting = RemoveQuotesAndSlashes(value);
                             }
                             // NOTE: Dev11/VB also clears "keycontainer", see also:
                             //
@@ -780,6 +785,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "baseaddress":
+                            value = RemoveQuotesAndSlashes(value);
+
                             ulong newBaseAddress;
                             if (string.IsNullOrEmpty(value) || !TryParseUInt64(value, out newBaseAddress))
                             {
@@ -820,7 +827,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "touchedfiles":
-                            unquoted = RemoveAllQuotes(value);
+                            unquoted = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrEmpty(unquoted))
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, MessageID.IDS_Text.Localize(), "touchedfiles");
@@ -848,7 +855,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         case "main":
                             // Remove any quotes for consistent behavior as MSBuild can return quoted or 
                             // unquoted main.    
-                            unquoted = RemoveAllQuotes(value);
+                            unquoted = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrEmpty(unquoted))
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, "<text>", name);
@@ -866,6 +873,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "filealign":
+                            value = RemoveQuotesAndSlashes(value);
+
                             ushort newAlignment;
                             if (string.IsNullOrEmpty(value))
                             {
@@ -927,10 +936,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "errorlog":
-                            unquoted = RemoveAllQuotes(value);
+                            unquoted = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrEmpty(unquoted))
                             {
-                                AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, ":<file>", RemoveAllQuotes(arg));
+                                AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, ":<file>", RemoveQuotesAndSlashes(arg));
                             }
                             else
                             {
@@ -939,10 +948,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "appconfig":
-                            unquoted = RemoveAllQuotes(value);
+                            unquoted = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrEmpty(unquoted))
                             {
-                                AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, ":<text>", RemoveAllQuotes(arg));
+                                AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, ":<text>", RemoveQuotesAndSlashes(arg));
                             }
                             else
                             {
@@ -951,7 +960,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "runtimemetadataversion":
-                            unquoted = RemoveAllQuotes(value);
+                            unquoted = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrEmpty(unquoted))
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, "<text>", name);
@@ -1147,7 +1156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             };
         }
 
-        private static void ParseAndResolveReferencePaths(string switchName, string switchValue, string baseDirectory, List<string> builder, MessageID origin, List<Diagnostic> diagnostics)
+        private void ParseAndResolveReferencePaths(string switchName, string switchValue, string baseDirectory, List<string> builder, MessageID origin, List<Diagnostic> diagnostics)
         {
             if (string.IsNullOrEmpty(switchValue))
             {
@@ -1174,7 +1183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static string GetWin32Setting(string arg, string value, List<Diagnostic> diagnostics)
+        private string GetWin32Setting(string arg, string value, List<Diagnostic> diagnostics)
         {
             if (value == null)
             {
@@ -1182,7 +1191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                string noQuotes = RemoveAllQuotes(value);
+                string noQuotes = RemoveQuotesAndSlashes(value);
                 if (string.IsNullOrWhiteSpace(noQuotes))
                 {
                     AddDiagnostic(diagnostics, ErrorCode.ERR_NoFileSpec, arg);

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -79,6 +79,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             return CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
+        private static CSharpCommandLineArguments FullParse(string commandLine, string baseDirectory, string sdkDirectory = null, string additionalReferenceDirectories = null)
+        {
+            sdkDirectory = sdkDirectory ?? s_defaultSdkDirectory;
+            var args = CommandLineParser.SplitCommandLineIntoArguments(commandLine, removeHashComments: true);
+            return CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
+        }
+
         [Fact]
         [WorkItem(946954)]
         public void CompilerBinariesAreAnyCPU()
@@ -1292,7 +1299,7 @@ d.cs
             Assert.Equal(Path.Combine(Path.GetPathRoot(_baseDirectory), @"MyFolder\MyPdb.pdb"), parsedArgs.PdbPath);
 
             // Should handle quotes
-            parsedArgs = DefaultParse(new[] { @"/pdb:C:\""My Folder""\MyPdb.pdb", "/debug", "a.cs" }, _baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/pdb:""C:\My Folder\MyPdb.pdb""", "/debug", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\My Folder\MyPdb.pdb", parsedArgs.PdbPath);
 
@@ -2256,7 +2263,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(@"C:\MyFolder", parsedArgs.OutputDirectory);
 
             // Should handle quotes
-            parsedArgs = DefaultParse(new[] { @"/out:C:\""My Folder""\MyBinary.dll", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/out:""C:\My Folder\MyBinary.dll""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"MyBinary", parsedArgs.CompilationName);
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName);
@@ -2506,7 +2513,7 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode);
 
             // Should handle quotes
-            parsedArgs = DefaultParse(new[] { @"/doc:C:\""My Folder""\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs = DefaultParse(new[] { @"/doc:""C:\My Folder\MyBinary.xml""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\My Folder\MyBinary.xml", parsedArgs.DocumentationPath);
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode);
@@ -2604,8 +2611,13 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.Equal(@"C:\MyFolder\MyBinary.xml", parsedArgs.ErrorLogPath);
             Assert.True(parsedArgs.CompilationOptions.ReportSuppressedDiagnostics);
 
-            // Should handle quotes
+            // Escaped quote in the middle is an error
             parsedArgs = DefaultParse(new[] { @"/errorlog:C:\""My Folder""\MyBinary.xml", "a.cs" }, baseDirectory);
+            parsedArgs.Errors.Verify(
+                 Diagnostic(ErrorCode.FTL_InputFileNameTooLong).WithArguments(@"C:""My Folder\MyBinary.xml").WithLocation(1, 1));
+
+            // Should handle quotes
+            parsedArgs = DefaultParse(new[] { @"/errorlog:""C:\My Folder\MyBinary.xml""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(@"C:\My Folder\MyBinary.xml", parsedArgs.ErrorLogPath);
             Assert.True(parsedArgs.CompilationOptions.ReportSuppressedDiagnostics);
@@ -4275,14 +4287,14 @@ class myClass
                 @"a\""a b\\""b c\\\""c d\\\\""d e\\\\\""e f"" g""",
             };
             args = CSharpCommandLineParser.ParseResponseLines(responseFile);
-            AssertEx.Equal(new[] { @"a""a", @"b\b c\""c d\\d", @"e\\""e", @"f g" }, args);
+            AssertEx.Equal(new[] { @"a\""a", @"b\\""b c\\\""c d\\\\""d", @"e\\\\\""e", @"f"" g""" }, args);
 
             // Quoting inside argument is valid.
             responseFile = new string[] {
                 @"  /o:""foo.cs"" /o:""abc def""\baz ""/o:baz bar""bing",
             };
             args = CSharpCommandLineParser.ParseResponseLines(responseFile);
-            AssertEx.Equal(new[] { @"/o:foo.cs", @"/o:abc def\baz", @"/o:baz barbing" }, args);
+            AssertEx.Equal(new[] { @"/o:""foo.cs""", @"/o:""abc def""\baz", @"""/o:baz bar""bing" }, args);
         }
 
         [ConditionalFact(typeof(WindowsOnly))]
@@ -5684,7 +5696,7 @@ namespace System
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", "/t:library", src.ToString(), @"/define:""""" }).Run(outWriter);
             Assert.Equal(0, exitCode);
-            Assert.Equal("warning CS2029: Invalid value for '/define'; '\"\"' is not a valid identifier", outWriter.ToString().Trim());
+            Assert.Equal("warning CS2029: Invalid value for '/define'; '' is not a valid identifier", outWriter.ToString().Trim());
 
             outWriter = new StringWriter(CultureInfo.InvariantCulture);
             exitCode = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", "/t:library", src.ToString(), "/define: " }).Run(outWriter);
@@ -7717,6 +7729,56 @@ class C {
             Assert.Equal(expected, output.Trim());
 
             CleanupAllGeneratedFiles(src.Path);
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void CommandLineMisc()
+        {
+            CSharpCommandLineArguments args = null;
+            string baseDirectory = @"c:\test";
+            Func<string, CSharpCommandLineArguments> parse = (x) => FullParse(x, baseDirectory);
+
+            args = parse(@"/out:""a.exe""");
+            Assert.Equal(@"a.exe", args.OutputFileName);
+
+            args = parse(@"/pdb:""a.pdb""");
+            Assert.Equal(Path.Combine(baseDirectory, @"a.pdb"), args.PdbPath);
+
+            // The \ here causes " to be treated as a quote, not as an escaping construct
+            args = parse(@"a\""b c""\d.cs");
+            Assert.Equal(
+                new[] { @"c:\test\a""b", @"c:\test\c\d.cs" },
+                args.SourceFiles.Select(x => x.Path));
+
+            args = parse(@"a\\""b c""\d.cs");
+            Assert.Equal(
+                new[] { @"c:\test\a\b c\d.cs" },
+                args.SourceFiles.Select(x => x.Path));
+
+            args = parse(@"/nostdlib /r:""a.dll"",""b.dll"" c.cs");
+            Assert.Equal(
+                new[] { @"a.dll", @"b.dll" },
+                args.MetadataReferences.Select(x => x.Reference));
+
+            args = parse(@"/nostdlib /r:""a-s.dll"",""b-s.dll"" c.cs");
+            Assert.Equal(
+                new[] { @"a-s.dll", @"b-s.dll" },
+                args.MetadataReferences.Select(x => x.Reference));
+
+            args = parse(@"/nostdlib /r:""a,;s.dll"",""b,;s.dll"" c.cs");
+            Assert.Equal(
+                new[] { @"a,;s.dll", @"b,;s.dll" },
+                args.MetadataReferences.Select(x => x.Reference));
+        }
+
+        [WorkItem(1211823, "DevDiv")]
+        [Fact]
+        public void ParseSeparatedPaths_QuotedComma()
+        {
+            var paths = CSharpCommandLineParser.ParseSeparatedPaths(@"""a, b""");
+            Assert.Equal(
+                new[] { @"a, b" },
+                paths);
         }
     }
 

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -2,17 +2,23 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.BuildTasks;
+using Roslyn.Utilities;
+
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 {
     public class Program
     {
-        public static int Main(string[] args)
+        public static int Main(string[] args) 
+            => Main(args, SpecializedCollections.EmptyArray<string>());
+
+        public static int Main(string[] args, string[] extraArgs)
             => BuildClient.RunWithConsoleOutput(
-                args,
+                BuildClient.GetCommandLineArgs(args).Concat(extraArgs),
                 clientDir: AppDomain.CurrentDomain.BaseDirectory,
                 workingDir: Directory.GetCurrentDirectory(),
                 sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),

--- a/src/Compilers/CSharp/csc2/Csc2.cs
+++ b/src/Compilers/CSharp/csc2/Csc2.cs
@@ -7,6 +7,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
     public class Csc2
     {
         public static int Main(string[] args)
-            => Program.Main(args.Concat(new[] { "/shared" }).ToArray());
+            => Program.Main(args, new[] {"/shared" });
     }
 }

--- a/src/Compilers/Core/MSBuildTask/NativeMethods.cs
+++ b/src/Compilers/Core/MSBuildTask/NativeMethods.cs
@@ -81,5 +81,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             [In] ref STARTUPINFO lpStartupInfo,
             out PROCESS_INFORMATION lpProcessInformation
         );
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr GetCommandLine();
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis
             outputDirectory = null;
             string invalidPath = null;
 
-            string unquoted = RemoveAllQuotes(value);
+            string unquoted = RemoveQuotesAndSlashes(value);
             ParseAndNormalizeFile(unquoted, baseDirectory, out outputFileName, out outputDirectory, out invalidPath);
             if (outputFileName == null ||
                 !MetadataHelpers.IsValidAssemblyOrModuleName(outputFileName))
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis
             string pdbPath = null;
             string invalidPath = null;
 
-            string unquoted = RemoveAllQuotes(value);
+            string unquoted = RemoveQuotesAndSlashes(value);
             ParseAndNormalizeFile(unquoted, baseDirectory, out outputFileName, out outputDirectory, out invalidPath);
             if (outputFileName == null ||
                 PathUtilities.ChangeExtension(outputFileName, extension: null).Length == 0)
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis
                 if (arg.StartsWith("@", StringComparison.Ordinal))
                 {
                     // response file:
-                    string path = RemoveAllQuotes(arg.Substring(1)).TrimEnd(null);
+                    string path = RemoveQuotesAndSlashes(arg.Substring(1)).TrimEnd(null);
                     string resolvedPath = FileUtilities.ResolveRelativePath(path, baseDirectory);
                     if (resolvedPath != null)
                     {
@@ -496,17 +496,17 @@ namespace Microsoft.CodeAnalysis
 
             if (length >= 1)
             {
-                filePath = RemoveAllQuotes(parts[offset + 0]);
+                filePath = RemoveQuotesAndSlashes(parts[offset + 0]);
             }
 
             if (length >= 2)
             {
-                resourceName = RemoveAllQuotes(parts[offset + 1]);
+                resourceName = RemoveQuotesAndSlashes(parts[offset + 1]);
             }
 
             if (length >= 3)
             {
-                accessibility = RemoveAllQuotes(parts[offset + 2]);
+                accessibility = RemoveQuotesAndSlashes(parts[offset + 2]);
             }
 
             if (String.IsNullOrWhiteSpace(filePath))
@@ -526,15 +526,16 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Remove all double quote characters from the given string.
-        /// </summary>
-        internal static string RemoveAllQuotes(string arg)
-        {
-            return arg != null ? arg.Replace("\"", "") : null;
-        }
-
-        /// <summary>
-        /// Split a command line by the same rules as Main would get the commands.
+        /// Split a command line by the same rules as Main would get the commands except the original
+        /// state of backslashes and quotes are preserved.  For example in normal Windows command line 
+        /// parsing the following command lines would produce equivalent Main arguments:
+        /// 
+        ///     - /r:a,b
+        ///     - /r:"a,b"
+        /// 
+        /// This method will differ as the latter will have the quotes preserved.  The only case where 
+        /// quotes are removed is when the entire argument is surrounded by quotes without any inner
+        /// quotes. 
         /// </summary>
         /// <remarks>
         /// Rules for command line parsing, according to MSDN:
@@ -562,88 +563,197 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments)
         {
-            bool inQuotes = false;
-            int backslashCount = 0;
-
-            // separate the line into multiple arguments on whitespace. 
-            // we maintain the inQuotes state to ensure we do not break line while in a quoted text.
-            // we also need to count slashes since odd number of slashes before a quote 
-            // makes that quote just a regular char
-            return Split(commandLine,
-                (c =>
-                {
-                    if (c == '\\')
-                    {
-                        backslashCount += 1;
-                    }
-                    else if (c == '\"')
-                    {
-                        if ((backslashCount & 1) != 1)
-                        {
-                            inQuotes = !inQuotes;
-                        }
-                        backslashCount = 0;
-                    }
-                    else
-                    {
-                        backslashCount = 0;
-                    }
-
-                    return !inQuotes && IsCommandLineDelimiter(c);
-                }))
-            .Select(arg => arg.Trim())                                                                  // Trim whitespace
-            .TakeWhile(arg => (!removeHashComments || !arg.StartsWith("#", StringComparison.Ordinal)))  // If removeHashComments is true, skip all arguments after one that starts with '#'
-            .Select(arg => UnquoteAndUnescape(NormalizeBackslashes(arg)))                               // Remove quotes and handle backslashes.
-            .Where(arg => !string.IsNullOrEmpty(arg));                        							// Don't produce empty strings.
+            char? unused;
+            return SplitCommandLineIntoArguments(commandLine, removeHashComments, out unused);
         }
 
-        // Once the line is split into arguments we need to remove quotes 
-        // that are not escaped, and need to remove slashes that are used for escaping
-        private static string UnquoteAndUnescape(string v)
+        private static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)
         {
-            if (v.IndexOf('"') < 0 && v.IndexOf('\\') < 0)
-            {
-                return v;
-            }
+            var builder = new StringBuilder(commandLine.Length);
+            var list = new List<string>();
+            var i = 0;
 
-            // split on " 
-            // except for preceded by \ like  \" 
-            // ignore pairs like \\
-            bool afterSingleBackslash = false;
-            var split = Split(v, c =>
+            illegalChar = null;
+            while (i < commandLine.Length)
+            {
+                while (i < commandLine.Length && char.IsWhiteSpace(commandLine[i]))
                 {
-                    if (!afterSingleBackslash && c == '\"')
+                    i++;
+                }
+
+                if (i == commandLine.Length)
+                {
+                    break;
+                }
+
+                if (commandLine[i] == '#' && removeHashComments)
+                {
+                    break;
+                }
+
+                var quoteCount = 0;
+                builder.Length = 0;
+                while (i < commandLine.Length && (!char.IsWhiteSpace(commandLine[i]) || (quoteCount % 2 != 0)))
+                {
+                    var current = commandLine[i];
+                    switch (current)
                     {
-                        return true;
+                        case '\\':
+                            {
+                                var slashCount = 0;
+                                do
+                                {
+                                    builder.Append(commandLine[i]);
+                                    i++;
+                                    slashCount++;
+                                } while (i < commandLine.Length && commandLine[i] == '\\');
+
+                                // Slashes not followed by a quote character can be ignored for now
+                                if (i >= commandLine.Length || commandLine[i] != '"')
+                                {
+                                    break;
+                                }
+
+                                // If there is an odd number of slashes then it is escaping the quote
+                                // otherwise it is just a quote.
+                                if (slashCount % 2 == 0)
+                                {
+                                    quoteCount++;
+                                }
+
+                                builder.Append('"');
+                                i++;
+                                break;
+                            }
+
+                        case '"':
+                            builder.Append(current);
+                            quoteCount++;
+                            i++;
+                            break;
+
+                        default:
+                            if ((current >= 0x1 && current <= 0x1f) || current == '|')
+                            {
+                                if (illegalChar == null)
+                                {
+                                    illegalChar = current;
+                                }
+                            }
+                            else
+                            {
+                                builder.Append(current);
+                            }
+
+                            i++;
+                            break;
                     }
+                }
 
-                    afterSingleBackslash = !afterSingleBackslash & c == '\\';
-                    return false;
-                }).ToArray();
-
-
-            // unescape escaped \"  and \\
-            for (int i = 0; i < split.Length; i++)
-            {
-                if (split[i].IndexOf('\\') >= 0)
+                // If the quote string is surrounded by quotes with no interior quotes then 
+                // remove the quotes here. 
+                if (quoteCount == 2 && builder[0] == '"' && builder[builder.Length - 1] == '"')
                 {
-                    split[i] = split[i].Replace(@"\""", @"""");
-                    split[i] = split[i].Replace(@"\\", @"\");
+                    builder.Remove(0, length: 1);
+                    builder.Remove(builder.Length - 1, length: 1);
+                }
+
+                if (builder.Length > 0)
+                {
+                    list.Add(builder.ToString());
                 }
             }
 
-            // the behavior of unpaired quote seems to be not well defined
-            // Experimentally I can see the following behaviors:
-            // 1) command arg parsing fails (Main is not called)
-            // 2) the text following the last quote is appended to the last argv as-is
-            // We will use strategy #2 for unpaired quote. 
-            // It is a broken and unlikely case but we have to do something.
-            return string.Join("", split);
+            return list;
         }
 
-        private static bool IsCommandLineDelimiter(char c)
+        /// <summary>
+        /// Remove the extraneous quotes and slashes from the argument.  This function is designed to have
+        /// compat behavior with the native compiler.
+        /// </summary>
+        /// <remarks>
+        /// Mimics the function RemoveQuotes from the native C# compiler.  The native VB equivalent of this 
+        /// function is called RemoveQuotesAndSlashes.  It has virtually the same behavior except for a few 
+        /// quirks in error cases.  
+        /// </remarks>
+        internal static string RemoveQuotesAndSlashes(string arg)
         {
-            return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+            if (arg == null)
+            {
+                return arg;
+            }
+
+            var pool = PooledStringBuilder.GetInstance();
+            var builder = pool.Builder;
+            var i = 0;
+            while (i < arg.Length)
+            {
+                var cur = arg[i];
+                switch (cur)
+                {
+                    case '\\':
+                        ProcessSlashes(builder, arg, ref i);
+                        break;
+                    case '"':
+                        // Intentionally dropping quotes that don't have explicit escaping.
+                        i++;
+                        break;
+                    default:
+                        builder.Append(cur);
+                        i++;
+                        break;
+                }
+            }
+
+            return pool.ToStringAndFree();
+        }
+
+        /// <summary>
+        /// Mimic behavior of the native function by the same name.
+        /// </summary>
+        internal static void ProcessSlashes(StringBuilder builder, string arg, ref int i)
+        {
+            Debug.Assert(arg != null);
+            Debug.Assert(i < arg.Length);
+
+            var slashCount = 0;
+            while (i < arg.Length && arg[i] == '\\')
+            {
+                slashCount++;
+                i++;
+            }
+
+            if (i < arg.Length && arg[i] == '"')
+            {
+                // Before a quote slashes are interpretted as escape sequences for other slashes so
+                // output one for every two.
+                while (slashCount >= 2)
+                {
+                    builder.Append('\\');
+                    slashCount -= 2;
+                }
+
+                Debug.Assert(slashCount >= 0);
+
+                // If there is an odd number of slashes then the quote is escaped and hence a part
+                // of the output.  Otherwise it is a normal quote and can be ignored. 
+                if (slashCount == 1)
+                {
+                    // The quote is escaped so eat it.
+                    builder.Append('"');
+                }
+
+                i++;
+            }
+            else
+            {
+                // Slashes that aren't followed by quotes are simply slashes.
+                while (slashCount > 0)
+                {
+                    builder.Append('\\');
+                    slashCount--;
+                }
+            }
         }
 
         /// <summary>
@@ -670,69 +780,12 @@ namespace Microsoft.CodeAnalysis
             yield return str.Substring(nextPiece);
         }
 
-        // In the input, the backslashes not preceding quotes are not escaped 
-        // (possibly to not force the user to type so many slashes). 
-        // That makes it hard to either unescape slashes after quotes are removed 
-        // or remove quotes after slashes are unescaped.
-        // NormalizeBackslashes makes the slashes that do not precede quotes to 
-        // be "escaped" the same way as the slashes that do. 
-        // This way we can later unescape all slashes in the same way and 
-        // not rely on presence of quotes.
-        private static string NormalizeBackslashes(string input)
-        {
-            int i = input.IndexOf('\\');
-
-            // Simple case -- no backslashes.
-            if (i < 0)
-                return input;
-
-            var pooledBuilder = PooledStringBuilder.GetInstance();
-            var builder = pooledBuilder.Builder;
-            builder.Append(input, 0, i);
-
-            int backslashCount = 0;
-            do
-            {
-                char c = input[i];
-                if (c == '\\')
-                {
-                    ++backslashCount;
-                }
-                else
-                {
-                    // Add right amount of pending backslashes.
-                    if (c == '\"')
-                    {
-                        AddBackslashes(builder, backslashCount);
-                    }
-                    else
-                    {
-                        AddBackslashes(builder, backslashCount * 2);
-                    }
-
-                    builder.Append(c);
-                    backslashCount = 0;
-                }
-            } while (++i < input.Length);
-
-            AddBackslashes(builder, backslashCount * 2);
-            return pooledBuilder.ToStringAndFree();
-        }
-
-        /// <summary>
-        /// Add "count" backslashes to a StringBuilder. 
-        /// </summary>
-        private static void AddBackslashes(StringBuilder builder, int count)
-        {
-            builder.Append('\\', count);
-        }
-
         private static readonly char[] s_pathSeparators = { ';', ',' };
         private static readonly char[] s_wildcards = new[] { '*', '?' };
 
         internal static IEnumerable<string> ParseSeparatedPaths(string str)
         {
-            return ParseSeparatedStrings(str, s_pathSeparators, StringSplitOptions.RemoveEmptyEntries).Select(path => RemoveAllQuotes(path));
+            return ParseSeparatedStrings(str, s_pathSeparators, StringSplitOptions.RemoveEmptyEntries).Select(RemoveQuotesAndSlashes);
         }
 
         /// <summary>
@@ -800,7 +853,7 @@ namespace Microsoft.CodeAnalysis
             // becomes
             //   Path With Spaces\foo.cs
 
-            string path = RemoveAllQuotes(arg);
+            string path = RemoveQuotesAndSlashes(arg);
 
             int wildcard = path.IndexOfAny(s_wildcards);
             if (wildcard != -1)

--- a/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineParser.vb
@@ -1318,7 +1318,7 @@ lVbRuntimePlus:
             Return Nothing
         End Function
 
-        Private Function GetWin32Setting(arg As String, value As String, diagnostics As List(Of Diagnostic)) As String
+        Private Shared Function GetWin32Setting(arg As String, value As String, diagnostics As List(Of Diagnostic)) As String
             If value Is Nothing Then
                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, arg, ":<file>")
             Else

--- a/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineParser.vb
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim name As String = Nothing
                     Dim value As String = Nothing
                     If TryParseOption(arg, name, value) AndAlso (name = "ruleset") Then
-                        Dim unquoted = RemoveAllQuotes(value)
+                        Dim unquoted = RemoveQuotesAndSlashes(value)
                         If String.IsNullOrEmpty(unquoted) Then
                             AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<file>")
                             Continue For
@@ -214,6 +214,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Continue For
 
                     Case "optionstrict"
+                        value = RemoveQuotesAndSlashes(value)
                         If value Is Nothing Then
                             optionStrict = VisualBasic.OptionStrict.On
                         ElseIf String.Equals(value, "custom", StringComparison.OrdinalIgnoreCase) Then
@@ -243,6 +244,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Continue For
 
                     Case "optioncompare"
+                        value = RemoveQuotesAndSlashes(value)
                         If value Is Nothing Then
                             AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "optioncompare", ":binary|text")
                         ElseIf String.Equals(value, "text", StringComparison.OrdinalIgnoreCase) Then
@@ -292,6 +294,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Continue For
 
                     Case "codepage"
+                        value = RemoveQuotesAndSlashes(value)
                         If String.IsNullOrEmpty(value) Then
                             AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "codepage", ":<number>")
                             Continue For
@@ -307,6 +310,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Continue For
 
                     Case "checksumalgorithm"
+                        value = RemoveQuotesAndSlashes(value)
                         If String.IsNullOrEmpty(value) Then
                             AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "checksumalgorithm", ":<algorithm>")
                             Continue For
@@ -340,6 +344,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Continue For
 
                     Case "sqmsessionguid"
+                        value = RemoveQuotesAndSlashes(value)
                         If String.IsNullOrWhiteSpace(value) = True Then
                             AddDiagnostic(diagnostics, ERRID.ERR_MissingGuidForOption, value, name)
                         Else
@@ -350,6 +355,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Continue For
 
                     Case "preferreduilang"
+                        value = RemoveQuotesAndSlashes(value)
                         If (String.IsNullOrEmpty(value)) Then
                             AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<string>")
                             Continue For
@@ -401,11 +407,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "t", "target"
+                            value = RemoveQuotesAndSlashes(value)
                             outputKind = ParseTarget(name, value, diagnostics)
                             Continue For
 
                         Case "moduleassemblyname"
-                            value = If(value IsNot Nothing, value.Unquote(), Nothing)
+                            value = RemoveQuotesAndSlashes(value)
                             Dim identity As AssemblyIdentity = Nothing
 
                             ' Note that native compiler also extracts public key, but Roslyn doesn't use it.
@@ -422,6 +429,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "rootnamespace"
+                            value = RemoveQuotesAndSlashes(value)
                             If String.IsNullOrEmpty(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "rootnamespace", ":<string>")
                                 Continue For
@@ -431,13 +439,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "doc"
+                            value = RemoveQuotesAndSlashes(value)
                             parseDocumentationComments = True
                             If value Is Nothing Then
                                 ' Illegal in C#, but works in VB
                                 documentationPath = GenerateFileNameForDocComment
                                 Continue For
                             End If
-                            Dim unquoted = RemoveAllQuotes(value)
+                            Dim unquoted = RemoveQuotesAndSlashes(value)
                             If unquoted.Length = 0 Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "doc", ":<file>")
                             Else
@@ -471,7 +480,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "errorlog"
-                            Dim unquoted = RemoveAllQuotes(value)
+                            Dim unquoted = RemoveQuotesAndSlashes(value)
                             If String.IsNullOrEmpty(unquoted) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "errorlog", ":<file>")
                             Else
@@ -491,7 +500,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 Continue For
                             End If
 
-                            libPaths.AddRange(ParseSeparatedPaths(RemoveAllQuotes(value)))
+                            libPaths.AddRange(ParseSeparatedPaths(value))
                             Continue For
 
                         Case "sdkpath"
@@ -501,10 +510,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             End If
 
                             sdkPaths.Clear()
-                            sdkPaths.AddRange(ParseSeparatedPaths(RemoveAllQuotes(value)))
+                            sdkPaths.AddRange(ParseSeparatedPaths(value))
                             Continue For
 
                         Case "recurse"
+                            value = RemoveQuotesAndSlashes(value)
                             If String.IsNullOrEmpty(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "recurse", ":<wildcard>")
                                 Continue For
@@ -536,15 +546,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "win32resource"
-                            win32ResourceFile = GetWin32Setting(s_win32Res, value, diagnostics)
+                            win32ResourceFile = GetWin32Setting(s_win32Res, RemoveQuotesAndSlashes(value), diagnostics)
                             Continue For
 
                         Case "win32icon"
-                            win32IconFile = GetWin32Setting(s_win32Icon, value, diagnostics)
+                            win32IconFile = GetWin32Setting(s_win32Icon, RemoveQuotesAndSlashes(value), diagnostics)
                             Continue For
 
                         Case "win32manifest"
-                            win32ManifestFile = GetWin32Setting(s_win32Manifest, value, diagnostics)
+                            win32ManifestFile = GetWin32Setting(s_win32Manifest, RemoveQuotesAndSlashes(value), diagnostics)
                             Continue For
 
                         Case "nowin32manifest"
@@ -572,6 +582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Case "debug"
 
                             ' parse only for backwards compat
+                            value = RemoveQuotesAndSlashes(value)
                             If value IsNot Nothing Then
                                 If String.IsNullOrEmpty(value) Then
                                     AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "debug", ":pdbonly|full")
@@ -702,6 +713,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "langversion"
+                            value = RemoveQuotesAndSlashes(value)
                             If value Is Nothing Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "langversion", ":<number>")
                                 Continue For
@@ -757,6 +769,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             ' MSDN: signed with the information in the key file, and the key information is installed 
                             ' MSDN: in the key container (similar to sn -i) so that on the next compilation, 
                             ' MSDN: the key container will be valid.
+                            value = RemoveQuotesAndSlashes(value)
                             keyFileSetting = Nothing
                             If String.IsNullOrEmpty(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "keycontainer", ":<string>")
@@ -776,11 +789,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             ' MSDN: signed with the information in the key file, and the key information is installed 
                             ' MSDN: in the key container (similar to sn -i) so that on the next compilation, 
                             ' MSDN: the key container will be valid.
+                            value = RemoveQuotesAndSlashes(value)
                             keyContainerSetting = Nothing
                             If String.IsNullOrWhiteSpace(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "keyfile", ":<file>")
                             Else
-                                keyFileSetting = RemoveAllQuotes(value)
+                                keyFileSetting = RemoveQuotesAndSlashes(value)
                             End If
                             Continue For
 
@@ -901,7 +915,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             ' MSBuild can result in maintypename being passed in quoted when cyrillic namespace was being used resulting
                             ' in ERRID.ERR_StartupCodeNotFound1 diagnostic.   The additional quotes cause problems and quotes are not a 
                             ' valid character in typename.
-                            value = RemoveAllQuotes(value)
+                            value = RemoveQuotesAndSlashes(value)
                             If String.IsNullOrEmpty(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<class>")
                                 Continue For
@@ -911,6 +925,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "subsystemversion"
+                            value = RemoveQuotesAndSlashes(value)
                             If String.IsNullOrEmpty(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<version>")
                                 Continue For
@@ -925,7 +940,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Continue For
 
                         Case "touchedfiles"
-                            Dim unquoted = RemoveAllQuotes(value)
+                            Dim unquoted = RemoveQuotesAndSlashes(value)
                             If (String.IsNullOrEmpty(unquoted)) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<touchedfiles>")
                                 Continue For
@@ -956,7 +971,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             End If
 
                             ' NOTE: that Dev11 does not report errors on empty or invalid file specified
-                            vbRuntimePath = RemoveAllQuotes(value)
+                            vbRuntimePath = RemoveQuotesAndSlashes(value)
                             includeVbRuntimeReference = True
                             embedVbCoreRuntime = False
                             Continue For
@@ -993,6 +1008,7 @@ lVbRuntimePlus:
                             Continue For
 
                         Case "platform"
+                            value = RemoveQuotesAndSlashes(value)
                             If value IsNot Nothing Then
                                 platform = ParsePlatform(name, value, diagnostics)
                             Else
@@ -1002,11 +1018,11 @@ lVbRuntimePlus:
                             Continue For
 
                         Case "filealign"
-                            fileAlignment = ParseFileAlignment(name, value, diagnostics)
+                            fileAlignment = ParseFileAlignment(name, RemoveQuotesAndSlashes(value), diagnostics)
                             Continue For
 
                         Case "baseaddress"
-                            baseAddress = ParseBaseAddress(name, value, diagnostics)
+                            baseAddress = ParseBaseAddress(name, RemoveQuotesAndSlashes(value), diagnostics)
                             Continue For
 
                         Case "ruleset"
@@ -1017,11 +1033,12 @@ lVbRuntimePlus:
                             If value Is Nothing Then
                                 features.Clear()
                             Else
-                                features.Add(value)
+                                features.Add(RemoveQuotesAndSlashes(value))
                             End If
                             Continue For
 
                         Case "additionalfile"
+                            value = RemoveQuotesAndSlashes(value)
                             If String.IsNullOrEmpty(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<file_list>")
                                 Continue For
@@ -1301,11 +1318,11 @@ lVbRuntimePlus:
             Return Nothing
         End Function
 
-        Private Shared Function GetWin32Setting(arg As String, value As String, diagnostics As List(Of Diagnostic)) As String
+        Private Function GetWin32Setting(arg As String, value As String, diagnostics As List(Of Diagnostic)) As String
             If value Is Nothing Then
                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, arg, ":<file>")
             Else
-                Dim noQuotes As String = RemoveAllQuotes(value)
+                Dim noQuotes As String = RemoveQuotesAndSlashes(value)
                 If String.IsNullOrWhiteSpace(noQuotes) Then
                     AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, arg, ":<file>")
                 Else
@@ -1394,20 +1411,13 @@ lVbRuntimePlus:
             End Select
         End Function
 
-        Private Function ParseAssemblyReferences(name As String, value As String, diagnostics As IList(Of Diagnostic), embedInteropTypes As Boolean) As IEnumerable(Of CommandLineReference)
+        Friend Shared Function ParseAssemblyReferences(name As String, value As String, diagnostics As IList(Of Diagnostic), embedInteropTypes As Boolean) As IEnumerable(Of CommandLineReference)
             If String.IsNullOrEmpty(value) Then
                 ' TODO: localize <file_list>?
                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, name, ":<file_list>")
                 Return SpecializedCollections.EmptyEnumerable(Of CommandLineReference)()
             End If
 
-            ' TODO: how does VB handle quotes, separators, ...?
-
-            ' /r:"reference"
-            ' /r:reference;reference
-            ' /r:"path;containing;semicolons"
-            ' /r:"unterminated_quotes
-            ' /r:"quotes"in"the"middle
             Return ParseSeparatedPaths(value).
                    Select(Function(path) New CommandLineReference(path, New MetadataReferenceProperties(MetadataImageKind.Assembly, embedInteropTypes:=embedInteropTypes)))
         End Function
@@ -1493,7 +1503,7 @@ lVbRuntimePlus:
         End Sub
 
         Private Shared Sub ParseGlobalImports(value As String, globalImports As List(Of GlobalImport), errors As List(Of Diagnostic))
-            Dim importsArray As String() = value.Split({","c}, StringSplitOptions.RemoveEmptyEntries)
+            Dim importsArray = ParseSeparatedPaths(value)
 
             For Each importNamespace In importsArray
                 Dim importDiagnostics As ImmutableArray(Of Diagnostic) = Nothing
@@ -1944,7 +1954,7 @@ lVbRuntimePlus:
         ''' </summary>
         ''' <param name="value">The value for the option.</param>
         Private Shared Function ParseWarnings(value As String) As IEnumerable(Of String)
-            Dim values = value.Split(","c)
+            Dim values = ParseSeparatedPaths(value)
             Dim results = New List(Of String)()
 
             For Each id In values

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -34,6 +34,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
             Return VisualBasicCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
         End Function
 
+        Private Shared Function FullParse(commandLine As String, baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
+            sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
+            Dim args = CommandLineParser.SplitCommandLineIntoArguments(commandLine, removeHashComments:=True)
+            Return VisualBasicCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
+        End Function
+
         Private Shared Function InteractiveParse(args As IEnumerable(Of String), baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
             sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
             Return VisualBasicCommandLineParser.Interactive.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories)
@@ -2247,12 +2253,16 @@ a.vb
             Assert.Equal("MyBinary.dll", parsedArgs.CompilationOptions.ModuleName)
             Assert.Equal("C:\MyFolder", parsedArgs.OutputDirectory)
 
-            parsedArgs = DefaultParse({"/out:C:\""My Folder""\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/out:""C:\My Folder\MyBinary.dll""", "/t:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("MyBinary", parsedArgs.CompilationName)
             Assert.Equal("MyBinary.dll", parsedArgs.OutputFileName)
             Assert.Equal("MyBinary.dll", parsedArgs.CompilationOptions.ModuleName)
             Assert.Equal("C:\My Folder", parsedArgs.OutputDirectory)
+
+            parsedArgs = DefaultParse({"/out:C:\""My Folder""\MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
+            parsedArgs.Errors.Verify(
+                    Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("C:""My Folder\MyBinary.dll").WithLocation(1, 1))
 
             parsedArgs = DefaultParse({"/out:MyBinary.dll", "/t:library", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
@@ -2909,7 +2919,7 @@ End Class
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
 
             ' Should handle quotes
-            parsedArgs = DefaultParse({"/doc:C:\""My Folder""\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/doc:""C:\My Folder\MyBinary.xml""", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\My Folder\MyBinary.xml", parsedArgs.DocumentationPath)
             Assert.Equal(DocumentationMode.Diagnose, parsedArgs.ParseOptions.DocumentationMode)
@@ -3024,10 +3034,15 @@ End Class
             Assert.True(parsedArgs.CompilationOptions.ReportSuppressedDiagnostics)
 
             ' Should handle quotes
-            parsedArgs = DefaultParse({"/errorlog:C:\""My Folder""\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs = DefaultParse({"/errorlog:""C:\My Folder\MyBinary.xml""", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal("C:\My Folder\MyBinary.xml", parsedArgs.ErrorLogPath)
             Assert.True(parsedArgs.CompilationOptions.ReportSuppressedDiagnostics)
+
+            ' Quote after a \ is treated as an escape
+            parsedArgs = DefaultParse({"/errorlog:C:\""My Folder""\MyBinary.xml", "a.vb"}, baseDirectory)
+            parsedArgs.Errors.Verify(
+                    Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("C:""My Folder\MyBinary.xml").WithLocation(1, 1))
 
             ' Should expand partially qualified paths
             parsedArgs = DefaultParse({"/errorlog:MyBinary.xml", "a.vb"}, baseDirectory)
@@ -3144,7 +3159,7 @@ End Class
         <Fact>
         Public Sub ReferencePaths()
             Dim parsedArgs As VisualBasicCommandLineArguments
-            parsedArgs = InteractiveParse({"/rp:a;b", "/referencePath:c", "a.vb"}, _baseDirectory)
+            parsedArgs = InteractiveParse({"/rp:a,b", "/referencePath:c", "a.vb"}, _baseDirectory)
             Assert.Equal(False, parsedArgs.Errors.Any())
             AssertEx.Equal({RuntimeEnvironment.GetRuntimeDirectory(),
                             Path.Combine(_baseDirectory, "a"),
@@ -3375,7 +3390,7 @@ End Class
 
         <Fact()>
         Public Sub AddModule()
-            Dim parsedArgs = DefaultParse({"/nostdlib", "/vbruntime-", "/addMODULE:c:\;d:\x\y\z,abc;;", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/nostdlib", "/vbruntime-", "/addMODULE:c:\,d:\x\y\z,abc,,", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(3, parsedArgs.MetadataReferences.Length)
             Assert.Equal("c:\", parsedArgs.MetadataReferences(0).Reference)
@@ -3402,11 +3417,11 @@ End Class
 
         <Fact()>
         Public Sub LibPathsAndLibEnvVariable()
-            Dim parsedArgs = DefaultParse({"/libpath:c:\;d:\x\y\z;abc;;", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/libpath:c:\,d:\x\y\z,abc,,", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, "c:\", "d:\x\y\z", Path.Combine(_baseDirectory, "abc"))
 
-            parsedArgs = DefaultParse({"/libpath:c:\Windows", "/libpath:abc\def; ; ; ", "a.vb"}, _baseDirectory)
+            parsedArgs = DefaultParse({"/libpath:c:\Windows", "/libpath:abc\def, , , ", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, "c:\Windows", Path.Combine(_baseDirectory, "abc\def"))
 
@@ -3463,7 +3478,7 @@ End Class
 
         <Fact()>
         Public Sub SdkPathAndLibEnvVariable()
-            Dim parsedArgs = DefaultParse({"/libpath:c:lib2", "/sdkpath:<>;d:\sdk1", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/libpath:c:lib2", "/sdkpath:<>,d:\sdk1", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
 
             ' invalid paths are ignored
             parsedArgs.Errors.Verify()
@@ -3473,10 +3488,10 @@ End Class
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, "d:\Windows")
 
-            parsedArgs = DefaultParse({"/sdkpath:""c:\Windows;d:\blah""", "a.vb"}, _baseDirectory)   'Entire path string is wrapped in quotes
+            parsedArgs = DefaultParse({"/sdkpath:c:\Windows,d:\blah", "a.vb"}, _baseDirectory)
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, "c:\Windows", "d:\blah")
 
-            parsedArgs = DefaultParse({"/libpath:""c:\Windows;d:\blah""", "/sdkpath:c:\lib2", "a.vb"}, _baseDirectory)   'Entire path string is wrapped in quotes
+            parsedArgs = DefaultParse({"/libpath:c:\Windows,d:\blah", "/sdkpath:c:\lib2", "a.vb"}, _baseDirectory)
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, "c:\lib2", "c:\Windows", "d:\blah")
 
             parsedArgs = DefaultParse({"/sdkpath", "/vbruntime*", "/nostdlib", "a.vb"}, _baseDirectory)
@@ -3765,7 +3780,7 @@ Class C
             Dim file = Temp.CreateDirectory().CreateFile("vb.rsp")
             file.WriteAllText("")
 
-            Dim parsedArgs = DefaultParse({"/libpath:c:\lib2;", "@" & file.ToString(), "a.vb"}, _baseDirectory)
+            Dim parsedArgs = DefaultParse({"/libpath:c:\lib2,", "@" & file.ToString(), "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, Path.GetDirectoryName(file.ToString()) + "\", "c:\lib2")
 
@@ -7254,6 +7269,119 @@ End Class
         Public Sub SourceFile_BadPath()
             Dim args = DefaultParse({"e:c:\test\test.cs", "/t:library"}, _baseDirectory)
             args.Errors.Verify(Diagnostic(ERRID.FTL_InputFileNameTooLong).WithArguments("e:c:\test\test.cs").WithLocation(1, 1))
+        End Sub
+
+        <ConditionalFact(GetType(WindowsOnly))>
+        Public Sub FilePaths()
+            Dim args = FullParse("\\unc\path\a.vb b.vb c:\path\c.vb", "e:\temp")
+            Assert.Equal(
+                New String() {"\\unc\path\a.vb", "e:\temp\b.vb", "c:\path\c.vb"},
+                args.SourceFiles.Select(Function(x) x.Path))
+
+            args = FullParse("\\unc\path\a.vb ""b.vb"" c:\path\c.vb", "e:\temp")
+            Assert.Equal(
+                New String() {"\\unc\path\a.vb", "e:\temp\b.vb", "c:\path\c.vb"},
+                args.SourceFiles.Select(Function(x) x.Path))
+
+            args = FullParse("""b"".vb""", "e:\temp")
+            Assert.Equal(
+                New String() {"e:\temp\b.vb"},
+                args.SourceFiles.Select(Function(x) x.Path))
+        End Sub
+
+        <ConditionalFact(GetType(WindowsOnly))>
+        Public Sub ReferencePathsEx()
+            Dim args = FullParse("/nostdlib /vbruntime- /noconfig /r:a.dll,b.dll test.vb", "e:\temp")
+            Assert.Equal(
+                New String() {"a.dll", "b.dll"},
+                args.MetadataReferences.Select(Function(x) x.Reference))
+
+            args = FullParse("/nostdlib /vbruntime- /noconfig /r:""a.dll,b.dll"" test.vb", "e:\temp")
+            Assert.Equal(
+                New String() {"a.dll,b.dll"},
+                args.MetadataReferences.Select(Function(x) x.Reference))
+
+            args = FullParse("/nostdlib /vbruntime- /noconfig /r:""lib, ex\a.dll"",b.dll test.vb", "e:\temp")
+            Assert.Equal(
+                New String() {"lib, ex\a.dll", "b.dll"},
+                args.MetadataReferences.Select(Function(x) x.Reference))
+
+            args = FullParse("/nostdlib /vbruntime- /noconfig /r:""lib, ex\a.dll"" test.vb", "e:\temp")
+            Assert.Equal(
+                New String() {"lib, ex\a.dll"},
+                args.MetadataReferences.Select(Function(x) x.Reference))
+        End Sub
+
+        <ConditionalFact(GetType(WindowsOnly))>
+        Public Sub ParseAssemblyReferences()
+
+            Dim parseCore =
+                Sub(value As String, paths As String())
+                    Dim list As New List(Of Diagnostic)
+                    Dim references = VisualBasicCommandLineParser.ParseAssemblyReferences("", value, list, embedInteropTypes:=False)
+                    Assert.Equal(0, list.Count)
+                    Assert.Equal(paths, references.Select(Function(r) r.Reference))
+                End Sub
+
+            parseCore("""a.dll""", New String() {"a.dll"})
+            parseCore("a,b", New String() {"a", "b"})
+            parseCore("""a,b""", New String() {"a,b"})
+
+            ' This is an intentional deviation from the native compiler.  BCL docs on MSDN, MSBuild and the C# compiler 
+            ' treat a semicolon as a separator.  VB compiler was the lone holdout here.  Rather than deviate we decided
+            ' to unify the behavior.
+            parseCore("a;b", New String() {"a", "b"})
+
+            parseCore("""a;b""", New String() {"a;b"})
+
+            ' Note this case can only happen when it is the last option on the command line.  When done
+            ' in another position the command line splitting routine would continue parsing all the text
+            ' after /r:"a as it resides in an unterminated quote.
+            parseCore("""a", New String() {"a"})
+
+            parseCore("a""mid""b", New String() {"amidb"})
+        End Sub
+
+        <ConditionalFact(GetType(WindowsOnly))>
+        Public Sub CommandLineMisc()
+            Dim args As VisualBasicCommandLineArguments
+            Dim baseDir = "c:\test"
+            Dim parse = Function(x As String) FullParse(x, baseDir)
+
+            args = parse("/out:""a.exe""")
+            Assert.Equal("a.exe", args.OutputFileName)
+
+            args = parse("/out:""a-b.exe""")
+            Assert.Equal("a-b.exe", args.OutputFileName)
+
+            args = parse("/out:""a,b.exe""")
+            Assert.Equal("a,b.exe", args.OutputFileName)
+
+            ' The \ here causes " to be treated as a quote, not as an escaping construct
+            args = parse("a\""b c""\d.cs")
+            Assert.Equal(
+                New String() {"c:\test\a""b", "c:\test\c\d.cs"},
+                args.SourceFiles.Select(Function(x) x.Path))
+
+            args = parse("a\\""b c""\d.cs")
+            Assert.Equal(
+                New String() {"c:\test\a\b c\d.cs"},
+                args.SourceFiles.Select(Function(x) x.Path))
+
+            args = parse("/nostdlib /vbruntime- /r:""a.dll"",""b.dll"" c.cs")
+            Assert.Equal(
+                New String() {"a.dll", "b.dll"},
+                args.MetadataReferences.Select(Function(x) x.Reference))
+
+            args = parse("/nostdlib /vbruntime- /r:""a-s.dll"",""b-s.dll"" c.cs")
+            Assert.Equal(
+                New String() {"a-s.dll", "b-s.dll"},
+                args.MetadataReferences.Select(Function(x) x.Reference))
+
+            args = parse("/nostdlib /vbruntime- /r:""a,s.dll"",""b,s.dll"" c.cs")
+            Assert.Equal(
+                New String() {"a,s.dll", "b,s.dll"},
+                args.MetadataReferences.Select(Function(x) x.Reference))
         End Sub
     End Class
 

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -2,17 +2,23 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.BuildTasks;
+using Roslyn.Utilities;
+
 using static Microsoft.CodeAnalysis.CompilerServer.BuildProtocolConstants;
 
 namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 {
     public class Program
     {
-        public static int Main(string[] args)
+        public static int Main(string[] args) 
+            => Main(args, SpecializedCollections.EmptyArray<string>());
+
+        public static int Main(string[] args, string[] extraArgs)
             => BuildClient.RunWithConsoleOutput(
-                args,
+                BuildClient.GetCommandLineArgs(args).Concat(extraArgs),
                 clientDir: AppDomain.CurrentDomain.BaseDirectory,
                 workingDir: Directory.GetCurrentDirectory(),
                 sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),

--- a/src/Compilers/VisualBasic/vbc2/Vbc2.cs
+++ b/src/Compilers/VisualBasic/vbc2/Vbc2.cs
@@ -7,6 +7,6 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
     public class Vbc2
     {
         public static int Main(string[] args)
-            => Program.Main(args.Concat(new[] { "/shared" }).ToArray());
+            => Program.Main(args, new[] { "/shared" });
     }
 }


### PR DESCRIPTION
A process in Windows is provided arguments as a flat string yet main methods in applications receive arguments as an arary of string values.  The transition between the flat string and array is done automatically by the runtime in two phases:

- Break into arguments based on spaces and grouping quotes.
- Remove extraneous quotes and backslashes.

Doing both operations at the same time serves to remove separators that are significant to the compilers.  For example:

1. /r:"a.dll,b.dll"
2. /r:a.dll,b.dll

In the main method both of these argument strings will show up as the latter value (the quotes are considered extraneous by the runtime).  Yet these represent very different values to the compiler:

1. Reference a single file named "a.dll,b.dll"
2. Reference two files named a.dll and b.dll respectively

This change restores the native compiler behavior by manually parsing out the flat argument string.  All of the parsing methods were taken directly from the old compiler.

There are a few small changes of note here:

1. VB now considers semicolon to be a list separator as it does comma (unifies behavior between languages and other tools).
2. VB and C# now have unified behavior for collapsing backslash characters.
3. Fixed several unit tests which were validating incorrect behavior.

closes #4021