### PR TITLE
Inline Rename usability improvements

### DIFF
--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -1007,33 +1007,6 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to found 1 reference in 1 file.
-        /// </summary>
-        internal static string FoundReferenceInFile {
-            get {
-                return ResourceManager.GetString("FoundReferenceInFile", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to found {0} references in 1 file.
-        /// </summary>
-        internal static string FoundReferencesInFile {
-            get {
-                return ResourceManager.GetString("FoundReferencesInFile", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to found {0} references in {1} files.
-        /// </summary>
-        internal static string FoundReferencesInMultipleFiles {
-            get {
-                return ResourceManager.GetString("FoundReferencesInMultipleFiles", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to from metadata.
         /// </summary>
         internal static string FromMetadata {
@@ -1169,6 +1142,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Modify any highlighted location to begin renaming..
+        /// </summary>
+        internal static string InlineRenameInstructions {
+            get {
+                return ResourceManager.GetString("InlineRenameInstructions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Inline Rename Resolved Conflict.
         /// </summary>
         internal static string InlineRenameResolvedConflict {
@@ -1273,6 +1255,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string NavigationBars {
             get {
                 return ResourceManager.GetString("NavigationBars", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New name: {0}.
+        /// </summary>
+        internal static string NewName1 {
+            get {
+                return ResourceManager.GetString("NewName1", resourceCulture);
             }
         }
         
@@ -1529,7 +1520,7 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Rename: &apos;{0}&apos;.
         /// </summary>
         internal static string Rename1 {
             get {
@@ -1615,6 +1606,33 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string RenameToTitle {
             get {
                 return ResourceManager.GetString("RenameToTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename will update 1 reference in 1 file..
+        /// </summary>
+        internal static string RenameWillUpdateReferenceInFile {
+            get {
+                return ResourceManager.GetString("RenameWillUpdateReferenceInFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename will update {0} references in 1 file..
+        /// </summary>
+        internal static string RenameWillUpdateReferencesInFile {
+            get {
+                return ResourceManager.GetString("RenameWillUpdateReferencesInFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename will update {0} references in {1} files..
+        /// </summary>
+        internal static string RenameWillUpdateReferencesInMultipleFiles {
+            get {
+                return ResourceManager.GetString("RenameWillUpdateReferencesInMultipleFiles", resourceCulture);
             }
         }
         

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -207,14 +207,14 @@
   <data name="RudeEdit" xml:space="preserve">
     <value>Rude Edit</value>
   </data>
-  <data name="FoundReferenceInFile" xml:space="preserve">
-    <value>found 1 reference in 1 file</value>
+  <data name="RenameWillUpdateReferenceInFile" xml:space="preserve">
+    <value>Rename will update 1 reference in 1 file.</value>
   </data>
-  <data name="FoundReferencesInFile" xml:space="preserve">
-    <value>found {0} references in 1 file</value>
+  <data name="RenameWillUpdateReferencesInFile" xml:space="preserve">
+    <value>Rename will update {0} references in 1 file.</value>
   </data>
-  <data name="FoundReferencesInMultipleFiles" xml:space="preserve">
-    <value>found {0} references in {1} files</value>
+  <data name="RenameWillUpdateReferencesInMultipleFiles" xml:space="preserve">
+    <value>Rename will update {0} references in {1} files.</value>
   </data>
   <data name="ConflictsWillBeResolved" xml:space="preserve">
     <value>{0} conflict(s) will be resolved</value>
@@ -538,7 +538,7 @@
     <value>Variadic SignatureHelpItem must have at least one parameter.</value>
   </data>
   <data name="Rename1" xml:space="preserve">
-    <value>Rename '{0}'</value>
+    <value>Rename: '{0}'</value>
   </data>
   <data name="LightBulbSessionIsAlreadyDismissed" xml:space="preserve">
     <value>Light bulb session is already dismissed.</value>
@@ -738,5 +738,11 @@ Do you want to proceed?</value>
   </data>
   <data name="SymbolHasNoImplementations" xml:space="preserve">
     <value>The symbol has no implementations.</value>
+  </data>
+  <data name="NewName1" xml:space="preserve">
+    <value>New name: {0}</value>
+  </data>
+  <data name="InlineRenameInstructions" xml:space="preserve">
+    <value>Modify any highlighted location to begin renaming.</value>
   </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
@@ -11,7 +11,7 @@
              xmlns:utilities="clr-namespace:Microsoft.CodeAnalysis.Editor.Shared.Utilities"
              x:ClassModifier="internal"
              mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300"
-             MinWidth="180"
+             MinWidth="300"
              Cursor="Arrow"
              Focusable="True"
              AutomationProperties.AutomationId="Rename"
@@ -23,6 +23,8 @@
                 <ResourceDictionary Source="Colors.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            
             <SolidColorBrush x:Key="ForegroundText" Color="{DynamicResource {x:Static utilities:CodeAnalysisColors.SystemCaptionTextColorKey}}"/>
 
             <Style TargetType="CheckBox">
@@ -45,52 +47,52 @@
             <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" BorderBrush="Transparent" 
+        <Border Grid.Row="0" BorderBrush="Transparent"
             Background="{DynamicResource {x:Static utilities:CodeAnalysisColors.BackgroundBrushKey}}"  
             BorderThickness="0" 
             Padding="7">
             <StackPanel>
 
-                <Grid Height="16">
-
+                <!-- Heading: Display the old and new identifier names, and an indication if something is wrong (but not the full description, which goes in the Summary section below) -->
+                
+                <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <!-- error or info icon -->
-                    <imaging:CrispImage Grid.Column="0" Height="16" Width="16" Margin="0,0,4,0" VerticalAlignment="Center">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
 
-                        <!-- determine the image visibility and icon from the severity -->
-                        <imaging:CrispImage.Style>
-                            <Style TargetType="imaging:CrispImage">
-                                <Setter Property="Visibility" Value="Collapsed"/>
+                    <Grid>
+                        <imaging:CrispImage Grid.Row ="0" Grid.Column="0" Height="16" Width="16" Margin="0,0,4,0" VerticalAlignment="Center">
+                            <imaging:CrispImage.Style>
+                                <Style TargetType="imaging:CrispImage">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
 
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Path=Severity}" Value="Error">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                        <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
-                                    </DataTrigger>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=Severity}" Value="Error">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
+                                        </DataTrigger>
 
-                                    <DataTrigger Binding="{Binding Path=Severity}" Value="Info">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                        <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusInformation}"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </imaging:CrispImage.Style>
+                                        <DataTrigger Binding="{Binding Path=Severity}" Value="Info">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusInformation}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </imaging:CrispImage.Style>
+                        </imaging:CrispImage>
+                    </Grid>
 
-                    </imaging:CrispImage>
-
-                    <!-- description text -->
-                    <TextBlock Grid.Column="1" Text="{Binding Path=Description, Mode=OneTime}" FontWeight="Bold" FontSize="14" VerticalAlignment="Center" HorizontalAlignment="Stretch">
-                        
-                        <!-- if severity is error, make the description text red -->
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding HeaderText}" FontWeight="Bold" TextWrapping="Wrap" FontSize="14" MaxWidth="400" VerticalAlignment="Center" HorizontalAlignment="Stretch">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Foreground" Value="{StaticResource ForegroundText}"/>
-
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding Path=Severity}" Value="Error">
                                         <Setter Property="Foreground" Value="{DynamicResource {x:Static utilities:CodeAnalysisColors.RenameErrorTextBrushKey}}"/>
@@ -103,6 +105,7 @@
 
                     <Button 
                     Name="CloseButton"
+                    Grid.Row ="0"
                     Grid.Column="2"
                     Width="18" Height="18"
                     Margin="4,0,0,0"
@@ -113,14 +116,40 @@
                     HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
                     Click="CloseButton_Click"
                     ToolTip="{Binding ElementName=dashboard, Path=CancelToolTip}"/>
-
                 </Grid>
 
-                <TextBlock Text="{Binding Path=SearchText}" Margin="0,4,0,8" Foreground="{StaticResource ForegroundText}"/>
+                <!-- Display the new name if it has been adjusted, or instructional text if it has not. -->
+                
+                <TextBlock Text="{Binding NewNameDescription}" 
+                           TextWrapping="Wrap" 
+                           MaxWidth="400" 
+                           Padding="0,3,0,12" 
+                           VerticalAlignment="Center" 
+                           HorizontalAlignment="Stretch"
+                           Visibility="{Binding ShouldShowNewName, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-                <!-- conflicts and errors -->
-                <StackPanel Margin="0,0,0,8">
+                <TextBlock Name="Instructions" 
+                           Text="{Binding ElementName=dashboard, Path=RenameInstructions}" 
+                           Padding="0,3,0,12"
+                           TextWrapping="Wrap" 
+                           Width="Auto"
+                           Foreground="{StaticResource ForegroundText}" FontStyle="Italic"
+                           Visibility="{Binding ShouldShowInstructions, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                
+                <!-- Settings -->
 
+                <CheckBox Content="{Binding ElementName=dashboard, Path=RenameOverloads}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameOverloadFlag, Mode=TwoWay}"
+                      Name="OverloadsCheckbox" Visibility="{Binding ElementName=dashboard, Path=RenameOverloadsVisibility}" IsEnabled="{Binding ElementName=dashboard, Path=IsRenameOverloadsEditable}" />
+                <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInCommentsFlag, Mode=TwoWay}" />
+                <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInStringsFlag, Mode=TwoWay}" />
+
+                <CheckBox Name="PreviewChangesCheckbox" Content="{Binding ElementName=dashboard, Path=PreviewChanges}" Margin="0,8,0,0" IsChecked="{Binding Path=DefaultPreviewChangesFlag, Mode=TwoWay}" />
+
+                <!-- Summary: Includes the number of references to be updated and any conflict information -->
+                
+                <TextBlock Text="{Binding Path=SearchText}" Margin="0,12,0,0" Foreground="{StaticResource ForegroundText}"/>
+                
+                <StackPanel Margin="0,8,0,0">
                     <StackPanel.Style>
                         <Style TargetType="StackPanel">
                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -180,16 +209,9 @@
                     </TextBlock>
                 </StackPanel>
 
-                <CheckBox Content="{Binding ElementName=dashboard, Path=RenameOverloads}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameOverloadFlag, Mode=TwoWay}"
-                      Name="OverloadsCheckbox" Visibility="{Binding ElementName=dashboard, Path=RenameOverloadsVisibility}" IsEnabled="{Binding ElementName=dashboard, Path=IsRenameOverloadsEditable}" />
-                <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInCommentsFlag, Mode=TwoWay}" />
-                <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=dashboard, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameInStringsFlag, Mode=TwoWay}" />
-
-                <CheckBox Name="PreviewChangesCheckbox" Content="{Binding ElementName=dashboard, Path=PreviewChanges}" Margin="0,8,0,0" IsChecked="{Binding Path=DefaultPreviewChangesFlag, Mode=TwoWay}" />
-
                 <Button Name="ApplyButton" Click="Apply_Click" IsDefault="True" MinWidth="75" MinHeight="23" Padding="10,1,10,1" Margin="0,8,0,0" HorizontalAlignment="Right"
                     ToolTip="{Binding ElementName=dashboard, Path=ApplyToolTip}"
-                    Style="{DynamicResource {x:Static utilities:CodeAnalysisColors.ButtonStyleKey}}" >
+                    Style="{DynamicResource {x:Static utilities:CodeAnalysisColors.ButtonStyleKey}}">
                     <AccessText Text="{Binding ElementName=dashboard, Path=ApplyRename}" />
                 </Button>
             </StackPanel>

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -218,6 +218,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public string SearchInStrings { get { return EditorFeaturesResources.SearchInStrings; } }
         public string ApplyRename { get { return EditorFeaturesResources.ApplyRename; } }
         public string PreviewChanges { get { return EditorFeaturesResources.RenamePreviewChanges; } }
+        public string RenameInstructions {  get { return EditorFeaturesResources.InlineRenameInstructions; } }
         public string ApplyToolTip { get { return EditorFeaturesResources.RenameApplyToolTip + " (Enter)"; } }
         public string CancelToolTip { get { return EditorFeaturesResources.RenameCancelToolTip + " (Esc)"; } }
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             _session.ReferenceLocationsChanged += OnReferenceLocationsChanged;
             _session.ReplacementsComputed += OnReplacementsComputed;
+            _session.ReplacementTextChanged += OnReplacementTextChanged;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -93,6 +94,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             AllPropertiesChanged();
         }
 
+        private void OnReplacementTextChanged(object sender, EventArgs args)
+        {
+            // When the new name changes, we need to update the display of the new name or the
+            // instructional text, depending on whether the new name and the original name are
+            // distinct.
+            NotifyPropertyChanged(nameof(ShouldShowInstructions));
+            NotifyPropertyChanged(nameof(ShouldShowNewName));
+            NotifyPropertyChanged(nameof(NewNameDescription));
+        }
+
         private void NotifyPropertyChanged([CallerMemberName] string name = null)
         {
             var handler = this.PropertyChanged;
@@ -111,15 +122,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             if (referenceCount == 1 && fileCount == 1)
             {
-                _searchText = EditorFeaturesResources.FoundReferenceInFile;
+                _searchText = EditorFeaturesResources.RenameWillUpdateReferenceInFile;
             }
             else if (fileCount == 1)
             {
-                _searchText = string.Format(EditorFeaturesResources.FoundReferencesInFile, referenceCount);
+                _searchText = string.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, referenceCount);
             }
             else
             {
-                _searchText = string.Format(EditorFeaturesResources.FoundReferencesInMultipleFiles, referenceCount, fileCount);
+                _searchText = string.Format(EditorFeaturesResources.RenameWillUpdateReferencesInMultipleFiles, referenceCount, fileCount);
             }
 
             NotifyPropertyChanged("SearchText");
@@ -152,13 +163,38 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             get { return _severity; }
         }
 
-        public string Description
+        public string HeaderText
         {
             get
             {
                 return string.Format(EditorFeaturesResources.Rename1, GetTruncatedName(Session.OriginalSymbolName));
             }
         }
+
+        public string NewNameDescription
+        {
+            get
+            {
+                return string.Format(EditorFeaturesResources.NewName1, GetTruncatedName(Session.ReplacementText));
+            }
+        }
+
+        public bool ShouldShowInstructions
+        {
+            get
+            {
+                return Session.OriginalSymbolName == Session.ReplacementText;
+            }
+        }
+
+        public bool ShouldShowNewName
+        {
+            get
+            {
+                return !ShouldShowInstructions;
+            }
+        }
+
 
         private static string GetTruncatedName(string fullName)
         {
@@ -283,6 +319,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         public void Dispose()
         {
+            _session.ReplacementTextChanged -= OnReplacementTextChanged;
             _session.ReferenceLocationsChanged -= OnReferenceLocationsChanged;
             _session.ReplacementsComputed -= OnReplacementsComputed;
         }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         private bool _dismissed;
         private bool _isApplyingEdit;
+        private string _replacementText;
         private OptionSet _optionSet;
         private Dictionary<ITextBuffer, OpenTextBufferManager> _openTextBuffers = new Dictionary<ITextBuffer, OpenTextBufferManager>();
 
@@ -49,7 +50,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         /// If non-null, the current text of the replacement. Linked spans added will automatically be updated with this
         /// text.
         /// </summary>
-        public string ReplacementText { get; private set; }
+        public string ReplacementText
+        {
+            get
+            {
+                return _replacementText;
+            }
+            private set
+            {
+                _replacementText = value;
+                ReplacementTextChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
 
         /// <summary>
         /// The task which computes the main rename locations against the original workspace
@@ -255,6 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         public event EventHandler<IList<InlineRenameLocation>> ReferenceLocationsChanged;
         public event EventHandler<IInlineRenameReplacementInfo> ReplacementsComputed;
+        public event EventHandler ReplacementTextChanged;
 
         internal OpenTextBufferManager GetBufferManager(ITextBuffer buffer)
         {

--- a/src/EditorFeatures/Test2/Rename/DashboardTests.vb
+++ b/src/EditorFeatures/Test2/Rename/DashboardTests.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                          </Project>
                      </Workspace>),
                     newName:="",
-                    searchResultText:=EditorFeaturesResources.FoundReferenceInFile,
+                    searchResultText:=EditorFeaturesResources.RenameWillUpdateReferenceInFile,
                     changedOptionSet:=changingOptions)
         End Sub
 
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                          </Project>
                      </Workspace>),
                     newName:="",
-                    searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 2),
+                    searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 2),
                     hasRenameOverload:=True,
                     changedOptionSet:=changingOptions)
         End Sub
@@ -94,7 +94,7 @@ class Program
                     </Project>
                 </Workspace>,
                 newName:="Bar",
-                searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 2),
+                searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 2),
                 changedOptionSet:=changingOptions,
                 hasRenameOverload:=True,
                 unresolvableConflictText:=String.Format(EditorFeaturesResources.UnresolvableConflicts, 1),
@@ -116,7 +116,7 @@ class AttributeAttribute : System.Attribute { }
                          </Project>
                      </Workspace>),
                     newName:="AttributeAttributeAttribute",
-                    searchResultText:=EditorFeaturesResources.FoundReferenceInFile,
+                    searchResultText:=EditorFeaturesResources.RenameWillUpdateReferenceInFile,
                     resolvableConflictText:=String.Format(EditorFeaturesResources.ConflictsWillBeResolved, 1),
                     severity:=DashboardSeverity.Info)
         End Sub
@@ -155,7 +155,7 @@ class AttributeAttribute : System.Attribute { }
                          </Project>
                      </Workspace>),
                     newName:="",
-                    searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 5),
+                    searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 5),
                     hasRenameOverload:=True,
                     changedOptionSet:=changingOptions)
         End Sub
@@ -196,7 +196,7 @@ class $$Program
                          </Project>
                      </Workspace>),
                     newName:="P",
-                    searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 6),
+                    searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 6),
                     changedOptionSet:=changingOptions)
         End Sub
 
@@ -236,7 +236,7 @@ class $$Program
                          </Project>
                      </Workspace>),
                     newName:="P",
-                    searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 2),
+                    searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 2),
                     changedOptionSet:=changingOptions)
         End Sub
 
@@ -277,7 +277,7 @@ class $$Program
                          </Project>
                      </Workspace>),
                     newName:="P",
-                    searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 7),
+                    searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 7),
                     changedOptionSet:=changingOptions)
         End Sub
 
@@ -299,7 +299,7 @@ class $$Program
                          </Project>
                      </Workspace>),
                     newName:="",
-                    searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 3))
+                    searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 3))
         End Sub
 
         <Fact>
@@ -320,7 +320,7 @@ class $$Program
                          </Project>
                      </Workspace>),
                     newName:="",
-                    searchResultText:=EditorFeaturesResources.FoundReferenceInFile)
+                    searchResultText:=EditorFeaturesResources.RenameWillUpdateReferenceInFile)
         End Sub
 
         <Fact>
@@ -342,7 +342,7 @@ class $$Program
                      </Project>
                  </Workspace>),
                 newName:="foo",
-                searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 2),
+                searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 2),
                 resolvableConflictText:=String.Format(EditorFeaturesResources.ConflictsWillBeResolved, 1),
                 severity:=DashboardSeverity.Info)
         End Sub
@@ -367,7 +367,7 @@ class $$Program
                      </Project>
                  </Workspace>),
                 newName:="foo",
-                searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 2),
+                searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 2),
                 resolvableConflictText:=String.Format(EditorFeaturesResources.ConflictsWillBeResolved, 2),
                 severity:=DashboardSeverity.Info)
         End Sub
@@ -390,7 +390,7 @@ class $$Program
                      </Project>
                  </Workspace>),
                 newName:="foo",
-                searchResultText:=EditorFeaturesResources.FoundReferenceInFile,
+                searchResultText:=EditorFeaturesResources.RenameWillUpdateReferenceInFile,
                 unresolvableConflictText:=String.Format(EditorFeaturesResources.UnresolvableConflicts, 1),
                 severity:=DashboardSeverity.Error)
         End Sub
@@ -415,7 +415,7 @@ class $$Program
                      </Project>
                  </Workspace>),
                 newName:="foo",
-                searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 3),
+                searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 3),
                 unresolvableConflictText:=String.Format(EditorFeaturesResources.UnresolvableConflicts, 3),
                 severity:=DashboardSeverity.Error)
         End Sub
@@ -452,7 +452,7 @@ class $$Program
                      </Project>
                  </Workspace>),
                    newName:="Bar",
-                   searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInMultipleFiles, 4, 2),
+                   searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInMultipleFiles, 4, 2),
                    resolvableConflictText:=String.Format(EditorFeaturesResources.ConflictsWillBeResolved, 1),
                    severity:=DashboardSeverity.Info)
         End Sub
@@ -476,7 +476,7 @@ class C
                      </Project>
                  </Workspace>),
                    newName:="Mo",
-                   searchResultText:=String.Format(EditorFeaturesResources.FoundReferenceInFile),
+                   searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferenceInFile),
                    hasRenameOverload:=True,
                    isRenameOverloadsEditable:=True)
         End Sub
@@ -500,7 +500,7 @@ class C
                      </Project>
                  </Workspace>),
                    newName:="Mo",
-                   searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 3),
+                   searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 3),
                    hasRenameOverload:=True,
                    isRenameOverloadsEditable:=False)
         End Sub
@@ -537,7 +537,7 @@ class D : B
                      </Project>
                  </Workspace>),
                    newName:="Mo",
-                   searchResultText:=String.Format(EditorFeaturesResources.FoundReferencesInFile, 5),
+                   searchResultText:=String.Format(EditorFeaturesResources.RenameWillUpdateReferencesInFile, 5),
                    changedOptionSet:=changingOptions,
                    hasRenameOverload:=True)
         End Sub


### PR DESCRIPTION
Fixes #5076

- Introduce instructional text when the dashboard is first shown (or when newName = originalName). This should help users who are used to the pre-VS2015 modal dialog learn to edit the identifier inline in the editor. If we at some point add a way to launch Inline Rename with a new name already specified, we'll need to be a bit more careful about how to both show that new name *and* the instructional text.

- Show the newName as the user types it

- Rearranging the info in the window to flow a bit better:
    - Heading (rename from x to y, or show getting started instructions)
    - Settings
    - Summary (# locations to be updated and any conflict info).

- Slightly changed the reference count text from "found 1 reference in 1 file" (which made sense in large solutions where you saw "Searching..." for a while, which then got replaced with this text) to a more standalone version of "Rename will update 1 reference in 1 file."

A preview of the new experience:

![friendlierinlinerename](https://cloud.githubusercontent.com/assets/235241/10082448/9a58f31c-62ae-11e5-8fff-d62c9c4b5c3c.gif)
