### PR TITLE
Enable GenerateConversionTest tests

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -2730,6 +2730,15 @@ namespace ConsoleApplication1
 @"using System ; class C { void M() { var x = new System.Collections.Generic.Dictionary<int, bool> { { 1, T() } }; } private bool T() { throw new NotImplementedException(); } } ");
         }
 
+        [WorkItem(774321)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public void TestEquivalenceKey()
+        {
+            TestEquivalenceKeyWorker(
+@"class C { void M() { this.[|M1|](System.Exception.M2()); } } ",
+string.Format(FeaturesResources.GenerateMethodIn, "M1", "C"));
+        }
+
         public class GenerateConversionTest : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
@@ -2807,15 +2816,6 @@ namespace ConsoleApplication1
                 Test(
     @"class Digit { public Digit ( double d ) { val = d ; } public double val ; } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = [|( double ) dig|] ; } } ",
     @"using System ; class Digit { public Digit ( double d ) { val = d ; } public double val ; public static explicit operator double ( Digit v ) { throw new NotImplementedException ( ) ; } } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = ( double ) dig ; } } ");
-            }
-
-            [WorkItem(774321)]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public void TestEquivalenceKey()
-            {
-                TestEquivalenceKeyWorker(
-    @"class C { void M() { this.[|M1|](System.Exception.M2()); } } ",
-    string.Format(FeaturesResources.GenerateMethodIn, "C", "M1"));
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -2732,9 +2732,9 @@ namespace ConsoleApplication1
 
         [WorkItem(774321)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-        public void TestEquivalenceKey()
+        public void TestGenerateMethodEquivalenceKey()
         {
-            TestEquivalenceKeyWorker(
+            TestEquivalenceKey(
 @"class C { void M() { this.[|M1|](System.Exception.M2()); } } ",
 string.Format(FeaturesResources.GenerateMethodIn, "M1", "C"));
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -2813,7 +2813,7 @@ namespace ConsoleApplication1
             [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestEquivalenceKey()
             {
-                TestEquivalenceKey(
+                TestEquivalenceKeyWorker(
     @"class C { void M() { this.[|M1|](System.Exception.M2()); } } ",
     string.Format(FeaturesResources.GenerateMethodIn, "C", "M1"));
             }

--- a/src/EditorFeatures/Test/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        protected void TestEquivalenceKeyWorker(string initialMarkup, string equivalenceKey)
+        protected void TestEquivalenceKey(string initialMarkup, string equivalenceKey)
         {
             using (var workspace = CreateWorkspaceFromFile(initialMarkup, parseOptions: null, compilationOptions: null))
             {

--- a/src/EditorFeatures/Test/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        protected void TestEquivalenceKey(string initialMarkup, string equivalenceKey)
+        protected void TestEquivalenceKeyWorker(string initialMarkup, string equivalenceKey)
         {
             using (var workspace = CreateWorkspaceFromFile(initialMarkup, parseOptions: null, compilationOptions: null))
             {


### PR DESCRIPTION
Related to #5422

Due to a limitation of xUnit, the existence of the test method
TestEquivalenceKey() and its overload test helper
TestEquivalenceKey(string, string) causes the test runner to bail on
running any test in the containing type of GenerateConversionTest.
Changing the helper method's name to TestEquivalenceKeyWorker(...)
should get these tests running again.