### PR TITLE
Emit dynamic attribute in generated lambda methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -546,8 +546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (node.IsTypeInContextWhichNeedsDynamicAttribute())
             {
-                if ((object)this.Compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_DynamicAttribute__ctor) == null ||
-                    (object)this.Compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_DynamicAttribute__ctorTransformFlags) == null)
+                if (!Compilation.HasDynamicEmitAttributes())
                 {
                     // CONSIDER:    Native compiler reports error CS1980 for each syntax node which binds to dynamic type, we do the same by reporting a diagnostic here.
                     //              However, this means we generate multiple duplicate diagnostics, when a single one would suffice.

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2867,6 +2867,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion
 
+        /// <summary>
+        /// Returns if the compilation has all of the members necessary to emit metadata about 
+        /// dynamic types.
+        /// </summary>
+        /// <returns></returns>
+        internal bool HasDynamicEmitAttributes()
+        {
+            return
+                (object)GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_DynamicAttribute__ctor) != null &&
+                (object)GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_DynamicAttribute__ctorTransformFlags) != null;
+        }
+
         internal override AnalyzerDriver AnalyzerForLanguage(ImmutableArray<DiagnosticAnalyzer> analyzers, AnalyzerManager analyzerManager)
         {
             return new AnalyzerDriver<SyntaxKind>(analyzers, n => n.Kind(), analyzerManager);

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -363,9 +363,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Lookup declaration for predefined CorLib type in this Assembly.
         /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
-        /// <remarks></remarks>
+        /// <returns>The symbol for the pre-defined type or an error type if the type is not defined in the core library.</returns>
         internal abstract NamedTypeSymbol GetDeclaredSpecialType(SpecialType type);
 
         /// <summary>
@@ -455,7 +453,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Gets the symbol for the pre-defined type from core library associated with this assembly.
         /// </summary>
-        /// <returns>The symbol for the pre-defined type or null if the type is not defined in the core library.</returns>
+        /// <returns>The symbol for the pre-defined type or an error type if the type is not defined in the core library.</returns>
         internal NamedTypeSymbol GetSpecialType(SpecialType type)
         {
             return CorLibrary.GetDeclaredSpecialType(type);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -149,6 +149,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override void AddSynthesizedAttributes(ModuleCompilationState compilationState, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            // Emit [Dynamic] on synthesized parameter symbols when the original parameter was dynamic 
+            // in order to facilitate debugging.  In the case the necessary attributes are missing 
+            // this is a no-op.  Emitting an error here, or when the original parameter was bound, would
+            // adversely effect the compilation or potentially change overload resolution.  
+            var compilation = this.DeclaringCompilation;
+            if (Type.ContainsDynamic() && 
+                compilation.HasDynamicEmitAttributes() &&
+                compilation.GetSpecialType(SpecialType.System_Boolean).SpecialType == SpecialType.System_Boolean)
+            {
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(this.Type, this.CustomModifiers.Length, this.RefKind));
+            }
+        }
+
         /// <summary>
         /// For each parameter of a source method, construct a corresponding synthesized parameter
         /// for a destination method.

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -1182,5 +1182,61 @@ class C
                 }
             });
         }
+
+        [Fact]
+        public void DynamicLambdaParameterChecksDynamic()
+        {
+            var source =
+@"using System;
+
+public class C
+{
+    public static void Main()
+    {
+        Func<dynamic, object> f = x => x;
+        T(f(null));
+    }
+
+    public static void T(object o) { }
+    
+}";
+
+            // Make sure we emit without errors when dynamic attributes are not present. 
+            CompileAndVerify(source, expectedSignatures: new[]
+            {
+                Signature(
+                    "C+<>c", 
+                    "<Main>b__0_0",
+                    ".method assembly hidebysig instance System.Object <Main>b__0_0(System.Object x) cil managed")
+            });
+        }
+
+        [Fact]
+        [WorkItem(4160, "https://github.com/dotnet/roslyn/issues/4160")]
+        public void DynamicLambdaParametersEmitAsDynamic()
+        {
+            var source =
+@"using System;
+
+public class C
+{
+    public static void Main()
+    {
+        Func<dynamic, object> f = x => x;
+        T(f(null));
+    }
+
+    public static void T(object o) { }
+    
+}";
+
+            CompileAndVerify(source, additionalRefs: new[] { CSharpRef, SystemCoreRef }, expectedSignatures: new[]
+            {
+                Signature(
+                    "C+<>c", 
+                    "<Main>b__0_0",
+                    ".method assembly hidebysig instance System.Object <Main>b__0_0([System.Runtime.CompilerServices.DynamicAttribute()] System.Object x) cil managed")
+            });
+        }
     }
 }


### PR DESCRIPTION
When emitting a lambda method that binds to a delegate with dynamic
parameters, emit the dynamic attribute in the corresponding parameter
locations.  This facilitates debugging of the lambda as parameters will
properly light up as dynamic in expression evaluation.

close #4160