### PR TITLE
Add null check in SemanticModelService for #load'ed trees...

### DIFF
--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
@@ -485,7 +485,15 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
                         }
 
                         var documentId = newProject.GetDocumentId(newTree);
-                        Contract.Requires(documentId != null);
+
+                        // GetDocumentId will return null for #load'ed trees.
+                        // TODO:  Remove this check and add logic to fetch the #load'ed tree's
+                        // Document once https://github.com/dotnet/roslyn/issues/5260 is fixed.
+                        if (documentId == null)
+                        {
+                            Debug.Assert(newProject.Solution.Workspace.Kind == "Interactive");
+                            continue;
+                        }
 
                         map = map.SetItem(documentId, newTree);
                     }


### PR DESCRIPTION
We already null check below (in ```GetNewTreeMap```), so this should be fine for now.