### PR TITLE
Implemening Debug-friendly optimization mode for VB

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -61,20 +61,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Emitted = 2,  // return sequence has been emitted
         }
 
-        private enum ILEmitStyle : byte
-        {
-            // no optimizations
-            // add additional debug specific emit 
-            // like nops for sequence points mapping to no IL
-            Debug = 0,                  
-
-            // do optimizations that do not diminish debug experience
-            DebugFriendlyRelease = 1,   
-
-            // do all optimizations
-            Release = 2,
-        }
-
         private LocalDefinition _returnTemp;
 
         public CodeGenerator(

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -57,9 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             //      stack scheduler must be the last one.
 
             var locals = PooledDictionary<LocalSymbol, LocalDefUseInfo>.GetInstance();
-            var evalStack = ArrayBuilder<ValueTuple<BoundExpression, ExprContext>>.GetInstance();
-            src = (BoundStatement)StackOptimizerPass1.Analyze(src, locals, evalStack, debugFriendly);
-            evalStack.Free();
+            src = (BoundStatement)StackOptimizerPass1.Analyze(src, locals, debugFriendly);
 
             FilterValidStackLocals(locals);
 
@@ -366,11 +364,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public static BoundNode Analyze(
             BoundNode node, 
             Dictionary<LocalSymbol, LocalDefUseInfo> locals,
-            ArrayBuilder<ValueTuple<BoundExpression, ExprContext>> evalStack,
             bool debugFriendly)
         {
+            var evalStack = ArrayBuilder<ValueTuple<BoundExpression, ExprContext>>.GetInstance();
             var analyzer = new StackOptimizerPass1(locals, evalStack, debugFriendly);
             var rewritten = analyzer.Visit(node);
+            evalStack.Free();
 
             return rewritten;
         }

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -50,6 +50,7 @@
     <Compile Include="AssemblyUtilities.cs" />
     <Compile Include="Binding\AbstractLookupSymbolsInfo.cs" />
     <Compile Include="CaseInsensitiveComparison.cs" />
+    <Compile Include="CodeGen\ILEmitStyle.cs" />
     <Compile Include="DiagnosticAnalyzer\AnalyzerDriver.CompilationData.cs" />
     <Compile Include="DiagnosticAnalyzer\SuppressMessageInfo.cs" />
     <Compile Include="Diagnostic\SuppressionInfo.cs" />

--- a/src/Compilers/Core/Portable/CodeGen/ILEmitStyle.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILEmitStyle.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CodeGen
+{
+        internal enum ILEmitStyle : byte
+        {
+            // no optimizations
+            // add additional debug specific emit 
+            // like nops for sequence points mapping to no IL
+            Debug = 0,                  
+
+            // do optimizations that do not diminish debug experience
+            DebugFriendlyRelease = 1,   
+
+            // do all optimizations
+            Release = 2,
+        }
+}

--- a/src/Compilers/VisualBasic/Portable/CodeGen/CodeGenerator.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/CodeGenerator.vb
@@ -41,19 +41,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         Private _asyncYieldPoints As ArrayBuilder(Of Integer) = Nothing
         Private _asyncResumePoints As ArrayBuilder(Of Integer) = Nothing
 
-        Private Enum ILEmitStyle As Byte
-            ' no optimizations
-            ' add additional debug specific emit 
-            ' like nops for sequence points mapping to no IL
-            Debug = 0
-
-            ' do optimizations that do Not diminish debug experience
-            DebugFriendlyRelease = 1
-
-            ' do all optimizations
-            Release = 2
-        End Enum
-
         Public Sub New(method As MethodSymbol,
                        boundBody As BoundStatement,
                        builder As ILBuilder,
@@ -268,7 +255,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 instructionsEmitted = EmitStatementAndCountInstructions(statement)
             End If
 
-            If instructionsEmitted = 0 AndAlso syntax IsNot Nothing AndAlso _ilEmitStyle = OptimizationLevel.Debug Then
+            If instructionsEmitted = 0 AndAlso syntax IsNot Nothing AndAlso _ilEmitStyle = ILEmitStyle.Debug Then
                 ' if there was no code emitted, then emit nop 
                 ' otherwise this point could get associated with some random statement, possibly in a wrong scope
                 _builder.EmitOpCode(ILOpCode.Nop)
@@ -287,7 +274,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 instructionsEmitted = EmitStatementAndCountInstructions(statement)
             End If
 
-            If instructionsEmitted = 0 AndAlso span <> Nothing AndAlso _ilEmitStyle = OptimizationLevel.Debug Then
+            If instructionsEmitted = 0 AndAlso span <> Nothing AndAlso _ilEmitStyle = ILEmitStyle.Debug Then
                 ' if there was no code emitted, then emit nop 
                 ' otherwise this point could get associated with some random statement, possibly in a wrong scope
                 _builder.EmitOpCode(ILOpCode.Nop)

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1022,7 +1022,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             EmitSymbolToken(method, [call].Syntax)
             If Not method.IsSub Then
                 EmitPopIfUnused(used)
-            ElseIf _optimizations = OptimizationLevel.Debug Then
+            ElseIf _ilEmitStyle = OptimizationLevel.Debug Then
                 Debug.Assert(Not used, "Using the return value of a void method.")
                 Debug.Assert(_method.GenerateDebugInfo, "Implied by emitSequencePoints")
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1022,7 +1022,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             EmitSymbolToken(method, [call].Syntax)
             If Not method.IsSub Then
                 EmitPopIfUnused(used)
-            ElseIf _ilEmitStyle = OptimizationLevel.Debug Then
+            ElseIf _ilEmitStyle = ILEmitStyle.Debug Then
                 Debug.Assert(Not used, "Using the return value of a void method.")
                 Debug.Assert(_method.GenerateDebugInfo, "Implied by emitSequencePoints")
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitOperators.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitOperators.vb
@@ -527,7 +527,7 @@ BinaryOperatorKindEqual:
 
             Debug.Assert(condition.Type.SpecialType = SpecialType.System_Boolean)
 
-            If _optimizations = OptimizationLevel.Release AndAlso condition.IsConstant Then
+            If _ilEmitStyle = OptimizationLevel.Release AndAlso condition.IsConstant Then
                 Dim constValue = condition.ConstantValueOpt
                 Debug.Assert(constValue.IsBoolean)
                 Dim constant = constValue.BooleanValue

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitOperators.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitOperators.vb
@@ -527,7 +527,7 @@ BinaryOperatorKindEqual:
 
             Debug.Assert(condition.Type.SpecialType = SpecialType.System_Boolean)
 
-            If _ilEmitStyle = OptimizationLevel.Release AndAlso condition.IsConstant Then
+            If _ilEmitStyle = ILEmitStyle.Release AndAlso condition.IsConstant Then
                 Dim constValue = condition.ConstantValueOpt
                 Debug.Assert(constValue.IsBoolean)
                 Dim constant = constValue.BooleanValue

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
@@ -84,7 +84,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         Private Sub EmitNoOpStatement(statement As BoundNoOpStatement)
             Select Case statement.Flavor
                 Case NoOpStatementFlavor.Default
-                    If _ilEmitStyle = OptimizationLevel.Debug Then
+                    If _ilEmitStyle = ILEmitStyle.Debug Then
                         _builder.EmitOpCode(ILOpCode.Nop)
                     End If
 
@@ -1171,7 +1171,7 @@ OtherExpressions:
                         EmitSequencePoint(caseStatement.Syntax)
                     End If
 
-                    If _ilEmitStyle = OptimizationLevel.Debug Then
+                    If _ilEmitStyle = ILEmitStyle.Debug Then
                         ' Emit nop for the case statement otherwise the above sequence point
                         ' will get associated with the first statement in subsequent case block.
                         ' This matches the native compiler codegen.
@@ -1255,7 +1255,7 @@ OtherExpressions:
                 constraints:=constraints,
                 isDynamic:=False,
                 dynamicTransformFlags:=Nothing,
-                isSlotReusable:=synthesizedKind.IsSlotReusable(_ilEmitStyle!= ILEmitStyle.Release))
+                isSlotReusable:=synthesizedKind.IsSlotReusable(_ilEmitStyle <> ILEmitStyle.Release))
 
             ' If named, add it to the local debug scope.
             If localDef.Name IsNot Nothing Then
@@ -1295,7 +1295,7 @@ OtherExpressions:
                 Return Nothing
             End If
 
-            If _ilEmitStyle = OptimizationLevel.Debug Then
+            If _ilEmitStyle = ILEmitStyle.Debug Then
                 Dim syntax = local.GetDeclaratorSyntax()
                 Dim syntaxOffset = _method.CalculateLocalSyntaxOffset(syntax.SpanStart, syntax.SyntaxTree)
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
@@ -84,7 +84,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         Private Sub EmitNoOpStatement(statement As BoundNoOpStatement)
             Select Case statement.Flavor
                 Case NoOpStatementFlavor.Default
-                    If _optimizations = OptimizationLevel.Debug Then
+                    If _ilEmitStyle = OptimizationLevel.Debug Then
                         _builder.EmitOpCode(ILOpCode.Nop)
                     End If
 
@@ -1171,7 +1171,7 @@ OtherExpressions:
                         EmitSequencePoint(caseStatement.Syntax)
                     End If
 
-                    If _optimizations = OptimizationLevel.Debug Then
+                    If _ilEmitStyle = OptimizationLevel.Debug Then
                         ' Emit nop for the case statement otherwise the above sequence point
                         ' will get associated with the first statement in subsequent case block.
                         ' This matches the native compiler codegen.
@@ -1255,7 +1255,7 @@ OtherExpressions:
                 constraints:=constraints,
                 isDynamic:=False,
                 dynamicTransformFlags:=Nothing,
-                isSlotReusable:=synthesizedKind.IsSlotReusable(_optimizations))
+                isSlotReusable:=synthesizedKind.IsSlotReusable(_ilEmitStyle!= ILEmitStyle.Release))
 
             ' If named, add it to the local debug scope.
             If localDef.Name IsNot Nothing Then
@@ -1295,7 +1295,7 @@ OtherExpressions:
                 Return Nothing
             End If
 
-            If _optimizations = OptimizationLevel.Debug Then
+            If _ilEmitStyle = OptimizationLevel.Debug Then
                 Dim syntax = local.GetDeclaratorSyntax()
                 Dim syntaxOffset = _method.CalculateLocalSyntaxOffset(syntax.SpanStart, syntax.SyntaxTree)
 
@@ -1315,7 +1315,7 @@ OtherExpressions:
         End Function
 
         Private Function IsSlotReusable(local As LocalSymbol) As Boolean
-            Return local.SynthesizedKind.IsSlotReusable(_optimizations)
+            Return local.SynthesizedKind.IsSlotReusable(_ilEmitStyle <> ILEmitStyle.Release)
         End Function
 
         Private Sub FreeLocal(local As LocalSymbol)

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/Optimizer.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/Optimizer.vb
@@ -15,12 +15,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
     ''' <remarks></remarks>
     Partial Friend Class Optimizer
 
-        Public Shared Function Optimize(container As Symbol, src As BoundStatement, <Out> ByRef stackLocals As HashSet(Of LocalSymbol)) As BoundStatement
+        Public Shared Function Optimize(
+                         container As Symbol,
+                         src As BoundStatement,
+                         debugFriendly As Boolean,
+                         <Out> ByRef stackLocals As HashSet(Of LocalSymbol)) As BoundStatement
 
             ' TODO: run other optimizing passes here.
             '       stack scheduler must be the last one.
 
-            Return StackScheduler.OptimizeLocalsOut(container, src, stackLocals)
+            Return StackScheduler.OptimizeLocalsOut(container, src, debugFriendly, stackLocals)
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
@@ -11,6 +11,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
     Partial Friend Class StackScheduler
 
         ''' <summary>
+        ''' context of expression evaluation. 
+        ''' it will affect inference of stack behavior
+        ''' it will also affect when expressions can be dup-reused
+        '''     Example:
+        '''         Foo(x, ref x)     x cannot be duped as it is used in different context  
+        ''' </summary>
+        Private Enum ExprContext
+            None
+            Sideeffects
+            Value
+            Address
+            AssignmentTarget
+            Box
+        End Enum
+
+        ''' <summary>
         ''' Analyses the tree trying to figure which locals may live on stack. It is 
         ''' a fairly delicate process and must be very familiar with how CodeGen works. 
         ''' It is essentially a part of CodeGen.
@@ -21,32 +37,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         Private NotInheritable Class Analyzer
             Inherits BoundTreeRewriter
 
-            ''' <summary>
-            ''' context of expression evaluation. 
-            ''' it will affect inference of stack behavior
-            ''' it will also affect when expressions can be dup-reused
-            '''     Example:
-            '''         Foo(x, ref x)     x cannot be duped as it is used in different context  
-            ''' </summary>
-            Private Enum ExprContext
-                None
-                Sideeffects
-                Value
-                Address
-                AssignmentTarget
-                Box
-            End Enum
-
             Private ReadOnly _container As Symbol
 
             Private _counter As Integer = 0
-            Private _evalStack As Integer = 0
+            Private ReadOnly _evalStack As ArrayBuilder(Of ValueTuple(Of BoundExpression, ExprContext))
+            Private ReadOnly _debugFriendly As Boolean
+
             Private _context As ExprContext = ExprContext.None
             Private _assignmentLocal As BoundLocal = Nothing
-
-            Private _lastExpression As BoundExpression = Nothing
-            Private _lastExprContext As ExprContext = ExprContext.None
-            Private _lastExpressionCnt As Integer = 0
 
             Private ReadOnly _locals As New Dictionary(Of LocalSymbol, LocalDefUseInfo)
 
@@ -62,8 +60,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             ' the dummy and will be rejected.
             Private ReadOnly _dummyVariables As New Dictionary(Of Object, DummyLocal)
 
-            Private Sub New(container As Symbol)
+            Private Sub New(container As Symbol,
+                            evalStack As ArrayBuilder(Of ValueTuple(Of BoundExpression, ExprContext)),
+                            debugFriendly As Boolean)
+
                 Me._container = container
+                Me._evalStack = evalStack
+                Me._debugFriendly = debugFriendly
                 Me._empty = New DummyLocal(container)
 
                 ' this is the top of eval stack
@@ -71,8 +74,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 RecordVarWrite(_empty)
             End Sub
 
-            Public Shared Function Analyze(container As Symbol, node As BoundNode, <Out> ByRef locals As Dictionary(Of LocalSymbol, LocalDefUseInfo)) As BoundNode
-                Dim analyzer = New Analyzer(container)
+            Public Shared Function Analyze(
+                             container As Symbol,
+                             node As BoundNode,
+                             evalStack As ArrayBuilder(Of ValueTuple(Of BoundExpression, ExprContext)),
+                             debugFriendly As Boolean,
+                             <Out> ByRef locals As Dictionary(Of LocalSymbol, LocalDefUseInfo)) As BoundNode
+
+                Dim analyzer = New Analyzer(container, evalStack, debugFriendly)
 
                 Dim rewritten As BoundNode = analyzer.Visit(node)
                 locals = analyzer._locals
@@ -94,95 +103,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Return result
             End Function
 
-            Private Shared Function CanDup(prevNode As BoundExpression, curNode As BoundExpression) As Boolean
-                If prevNode Is Nothing Then
-                    Return False
-                End If
-
-                If prevNode.Type <> curNode.Type Then
-                    Return False
-                End If
-
-                ' TODO: constants
-                '       Codegen sometimes folds constants (conditional ops, anything else?) 
-                '       We cannot currently rely on constants being actually emitted so we cannot dup them.
-                '       It could be attractive to do that though for big constants like doubles.
-                Dim prevConst As ConstantValue = prevNode.ConstantValueOpt
-                If prevConst IsNot Nothing Then
-                    Return False
-                End If
-
-                ' locals
-                Dim prevAsLocal = TryCast(prevNode, BoundLocal)
-                Dim curAsLocal = TryCast(curNode, BoundLocal)
-                If prevAsLocal IsNot Nothing AndAlso curAsLocal IsNot Nothing Then
-                    Return prevAsLocal.LocalSymbol Is curAsLocal.LocalSymbol
-                End If
-
-                ' parameters
-                Dim prevAsParam = TryCast(prevNode, BoundParameter)
-                Dim curAsParam = TryCast(curNode, BoundParameter)
-                If prevAsParam IsNot Nothing AndAlso curAsParam IsNot Nothing Then
-                    ' TODO: it may be unnecessary to dup when it is ldloc[0-4]
-                    '       just dup always for now for simplicity.
-                    Return prevAsParam.ParameterSymbol Is curAsParam.ParameterSymbol
-                End If
-
-                ' TODO: fields, constants, sequence points ...
-
-                Return False
-            End Function
-
-            ''' <summary>
-            ''' Recursively rewrites the node or simply replaces it with a dup node
-            ''' if we have just seen exactly same node.
-            ''' </summary>
-            Private Function ReuseOrVisit(node As BoundExpression, context As ExprContext) As BoundExpression
-                ' TODO: can we dup expressions in assignment contexts? 
-                If context = ExprContext.AssignmentTarget OrElse context = ExprContext.Sideeffects Then
-                    Return DirectCast(MyBase.Visit(node), BoundExpression)
-                End If
-
-                ' it must be most recent expression
-                ' it can be a ref when we want a value, but cannot be the other way
-                ' TODO: we could reuse boxed values, but we would need to make the Dup to know it was boxed
-                If Me._counter = Me._lastExpressionCnt + 1 AndAlso
-                        Me._lastExprContext <> ExprContext.Box AndAlso
-                        (Me._lastExprContext = context OrElse Me._lastExprContext <> ExprContext.Value) AndAlso CanDup(Me._lastExpression, node) Then
-
-                    Me._lastExpressionCnt = Me._counter
-
-                    ' when duping something not created in a Value context, we are actually duping a reference.
-                    ' record that so that codegen could know if it is a value or a reference.
-                    Dim dupRef As Boolean = Me._lastExprContext <> ExprContext.Value
-
-                    ' change the context to the most recently used. 
-                    ' Why? If we obtained a value from a duped reference, we now have a value on the stack.
-                    Me._lastExprContext = context
-
-                    Return New BoundDup(node.Syntax, dupRef, node.Type)
-                Else
-
-                    Dim result As BoundExpression = BaseVisitExpression(node)
-
-                    Me._lastExpressionCnt = Me._counter
-                    Me._lastExprContext = context
-                    Me._lastExpression = result
-
-                    Return result
-                End If
-            End Function
-
-            Private Function BaseVisitExpression(node As BoundExpression) As BoundExpression
-                ' Do Not recurse into constant expressions. Their children do Not push any locals.
-                ' TODO: we may consider duping the constants though (see comments in CanDup)
-                If node.ConstantValueOpt Is Nothing Then
-                    node = DirectCast(MyBase.Visit(node), BoundExpression)
-                End If
-
-                Return node
-            End Function
-
             Private Function VisitExpression(node As BoundExpression, context As ExprContext) As BoundExpression
                 If node Is Nothing Then
                     Me._counter += 1
@@ -190,61 +110,85 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 End If
 
                 Dim prevContext As ExprContext = Me._context
-                Dim prevStack As Integer = Me._evalStack
-
+                Dim prevStack As Integer = Me.StackDepth()
                 Me._context = context
-                Dim result As BoundExpression = ReuseOrVisit(node, context)
-                Me._counter += 1
+
+                ' Don not recurse into constant expressions. Their children do Not push any values.
+                Dim result = If(node.ConstantValueOpt Is Nothing,
+                                DirectCast(MyBase.Visit(node), BoundExpression),
+                                node)
+
+                _context = prevContext
+                _counter += 1
 
                 Select Case context
 
                     Case ExprContext.Sideeffects
-                        Me._evalStack = prevStack
-
-                    Case ExprContext.Value,
-                        ExprContext.Address,
-                        ExprContext.Box
-                        Me._evalStack = prevStack + 1
+                        SetStackDepth(prevStack)
 
                     Case ExprContext.AssignmentTarget
-                        Me._evalStack = prevStack
-                        If LhsUsesStackWhenAssignedTo(node, context) Then
-                            Me._evalStack = prevStack + 1
-                        End If
+                        Exit Select
+
+                    Case ExprContext.Value, ExprContext.Address, ExprContext.Box
+                        SetStackDepth(prevStack)
+                        PushEvalStack(node, context)
 
                     Case Else
                         Throw ExceptionUtilities.UnexpectedValue(context)
                 End Select
 
-                Me._context = prevContext
                 Return result
             End Function
+
+            Private Sub PushEvalStack(result As BoundExpression, context As ExprContext)
+                _evalStack.Add(ValueTuple.Create(result, context))
+            End Sub
+
+            Private Function StackDepth() As Integer
+                Return _evalStack.Count
+            End Function
+
+            Private Function EvalStackIsEmpty() As Boolean
+                Return StackDepth() = 0
+            End Function
+
+            Private Sub SetStackDepth(depth As Integer)
+                _evalStack.Clip(depth)
+            End Sub
+
+            Private Sub PopEvalStack()
+                SetStackDepth(_evalStack.Count - 1)
+            End Sub
+
+            Private Sub ClearEvalStack()
+                _evalStack.Clear()
+            End Sub
 
             Public Overrides Function VisitSpillSequence(node As BoundSpillSequence) As BoundNode
                 Throw ExceptionUtilities.Unreachable
             End Function
 
             Private Function VisitStatement(node As BoundNode) As BoundNode
+                Debug.Assert(node Is Nothing OrElse EvalStackIsEmpty())
 
+                Dim origStack = StackDepth()
                 Dim prevContext As ExprContext = Me._context
-                Dim prevStack As Integer = Me._evalStack
 
                 Dim result As BoundNode = MyBase.Visit(node)
 
-                ClearLastExpression()
+                ' prevent cross-statement local optimizations
+                ' when emitting debug-friendly code.
+                If _debugFriendly Then
+                    EnsureOnlyEvalStack()
+                End If
 
-                Me._counter += 1
-                Me._evalStack = prevStack
                 Me._context = prevContext
+                SetStackDepth(origStack)
+                _counter += 1
 
                 Return result
             End Function
 
-            Private Sub ClearLastExpression()
-                Me._lastExpressionCnt = 0
-                Me._lastExpression = Nothing
-                Me._lastExprContext = ExprContext.None
-            End Sub
 
             ''' <summary>
             ''' here we have a case of indirect assignment:  *t1 = expr;
@@ -290,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End Function
 
             Public Overrides Function VisitBlock(node As BoundBlock) As BoundNode
-                Debug.Assert(Me._evalStack = 0, "entering blocks when evaluation stack is not empty?")
+                Debug.Assert(EvalStackIsEmpty(), "entering blocks when evaluation stack is not empty?")
 
                 ' normally we would not allow stack locals
                 ' when evaluation stack is not empty.
@@ -342,7 +286,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 '  We will detect such case and indicate +1 as the desired stack depth at local accesses.
                 ' ---------------------------------------------------
                 '    
-                Dim declarationStack As Integer = Me._evalStack
+                Dim declarationStack As Integer = Me.StackDepth()
 
                 Dim locals = node.Locals
                 If Not locals.IsEmpty Then
@@ -518,10 +462,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                             ' just remember what we are assigning to.
                             Me._assignmentLocal = node
 
-                            ' whatever is available as lastExpression is still available 
-                            ' (adjust for visit of this node)
-                            Me._lastExpressionCnt += 1
-
                         Case ExprContext.Sideeffects
                             ' do nothing
 
@@ -570,12 +510,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 ' must delay recording a write until after RHS is evaluated
                 Dim storedAssignmentLocal = Me._assignmentLocal
                 Me._assignmentLocal = Nothing
+                Debug.Assert(Me._context <> ExprContext.AssignmentTarget, "assignment expression cannot be a target of another assignment")
 
                 ' Left on the right should be Nothing by this time
                 Debug.Assert(node.LeftOnTheRightOpt Is Nothing)
 
                 ' Do not visit "Left on the right"
                 'Me.counter += 1
+
+                Dim rhsContext As ExprContext
+                If Me._context = ExprContext.Address Then
+                    ' we need the address of rhs so we cannot have it on the stack.
+                    rhsContext = ExprContext.Address
+                Else
+
+                    Debug.Assert(Me._context = ExprContext.Value OrElse
+                                 Me._context = ExprContext.Box OrElse
+                                 Me._context = ExprContext.Sideeffects, "assignment expression cannot be a target of another assignment")
+                    ' we only need a value of rhs, so if otherwise possible it can be a stack value.
+                    rhsContext = ExprContext.Value
+                End If
 
                 Dim right As BoundExpression = node.Right
 
@@ -591,29 +545,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     End If
                 End If
 
-                Debug.Assert(Me._context <> ExprContext.AssignmentTarget, "assignment expression cannot be a target of another assignment")
-
-                Dim rhsContext As ExprContext
-                If Me._context = ExprContext.Address Then
-                    ' we need the address of rhs so we cannot have it on the stack.
-                    rhsContext = ExprContext.Address
-                Else
-
-                    Debug.Assert(Me._context = ExprContext.Value OrElse
-                                 Me._context = ExprContext.Box OrElse
-                                 Me._context = ExprContext.Sideeffects, "assignment expression cannot be a target of another assignment")
-                    ' we only need a value of rhs, so if otherwise possible it can be a stack value.
-                    rhsContext = ExprContext.Value
-                End If
-
                 right = VisitExpression(node.Right, rhsContext)
-
-                If cookie IsNot Nothing Then
-                    ' There is still RHS on the stack, adjust for that
-                    Me._evalStack -= 1
-                    EnsureStackState(cookie)
-                    Me._evalStack += 1
-                End If
 
                 ' if assigning to a local, now it is the time to record the Write
                 If storedAssignmentLocal IsNot Nothing Then
@@ -626,6 +558,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     Debug.Assert(Not isIndirect, "indirect assignment is a read, not a write")
 
                     RecordVarWrite(storedAssignmentLocal.LocalSymbol)
+                End If
+
+                If cookie IsNot Nothing Then
+                    ' There is still RHS on the stack, adjust for that
+                    Me.PopEvalStack()
+                    EnsureStackState(cookie)
                 End If
 
                 Return node.Update(left, Nothing, right, node.SuppressObjectClone, node.Type)
@@ -774,10 +712,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                             receiver = VisitExpression(receiver, ExprContext.Value)
                         End If
                     End If
-
-                    ' whatever is available as lastExpression is still available 
-                    ' (adjust for visit of this node)
-                    Me._lastExpressionCnt += 1
                 Else
                     Me._counter += 1
                     receiver = Nothing
@@ -799,13 +733,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             Public Overrides Function VisitConditionalGoto(node As BoundConditionalGoto) As BoundNode
                 Dim result As BoundNode = MyBase.VisitConditionalGoto(node)
-                Me._evalStack -= 1 ' condition gets consumed
+                Me.PopEvalStack() ' condition gets consumed
                 RecordBranch(node.Label)
                 Return result
             End Function
 
             Public Overrides Function VisitBinaryConditionalExpression(node As BoundBinaryConditionalExpression) As BoundNode
-                Dim origStack = Me._evalStack
+                Dim origStack = Me.StackDepth
                 Dim testExpression As BoundExpression = DirectCast(Me.Visit(node.TestExpression), BoundExpression)
 
                 Debug.Assert(node.ConvertedTestExpression Is Nothing)
@@ -817,7 +751,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 ' implicit branch here
                 Dim cookie As Object = GetStackStateCookie()
 
-                Me._evalStack = origStack  ' else expression is evaluated with original stack
+                Me.SetStackDepth(origStack)  ' else expression is evaluated with original stack
                 Dim elseExpression As BoundExpression = DirectCast(Me.Visit(node.ElseExpression), BoundExpression)
 
                 ' implicit label here
@@ -827,17 +761,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End Function
 
             Public Overrides Function VisitTernaryConditionalExpression(node As BoundTernaryConditionalExpression) As BoundNode
-                Dim origStack As Integer = Me._evalStack
+                Dim origStack As Integer = Me.StackDepth
                 Dim condition = DirectCast(Me.Visit(node.Condition), BoundExpression)
 
                 Dim cookie As Object = GetStackStateCookie() ' implicit goto here
 
-                Me._evalStack = origStack ' consequence is evaluated with original stack
+                Me.SetStackDepth(origStack) ' consequence is evaluated with original stack
                 Dim whenTrue = DirectCast(Me.Visit(node.WhenTrue), BoundExpression)
 
                 EnsureStackState(cookie) ' implicit label here
 
-                Me._evalStack = origStack ' alternative is evaluated with original stack
+                Me.SetStackDepth(origStack) ' alternative is evaluated with original stack
                 Dim whenFalse = DirectCast(Me.Visit(node.WhenFalse), BoundExpression)
 
                 EnsureStackState(cookie) ' implicit label here
@@ -853,7 +787,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     EnsureOnlyEvalStack()
                 End If
 
-                Dim origStack = Me._evalStack
+                Dim origStack = StackDepth()
 
                 Dim receiverOrCondition = DirectCast(Me.Visit(node.ReceiverOrCondition), BoundExpression)
 
@@ -861,7 +795,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
                 ' access Is evaluated with original stack 
                 ' (this Is Not entirely true, codegen will keep receiver on the stack, but that Is irrelevant here)
-                Me._evalStack = origStack
+                Me.SetStackDepth(origStack)
 
                 Dim whenNotNull = DirectCast(Me.Visit(node.WhenNotNull), BoundExpression)
 
@@ -870,7 +804,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Dim whenNull As BoundExpression = Nothing
 
                 If node.WhenNullOpt IsNot Nothing Then
-                    Me._evalStack = origStack
+                    Me.SetStackDepth(origStack)
                     whenNull = DirectCast(Me.Visit(node.WhenNullOpt), BoundExpression)
                     EnsureStackState(cookie) ' implicit label here
                 End If
@@ -885,18 +819,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Public Overrides Function VisitComplexConditionalAccessReceiver(node As BoundComplexConditionalAccessReceiver) As BoundNode
                 EnsureOnlyEvalStack()
 
-                Dim origStack As Integer = Me._evalStack
+                Dim origStack As Integer = Me.StackDepth
 
-                Me._evalStack += 1
+                Me.PushEvalStack(Nothing, ExprContext.None)
 
                 Dim cookie As Object = GetStackStateCookie() ' implicit goto here
 
-                Me._evalStack = origStack ' consequence is evaluated with original stack
+                Me.SetStackDepth(origStack) ' consequence is evaluated with original stack
                 Dim valueTypeReceiver = DirectCast(Me.Visit(node.ValueTypeReceiver), BoundExpression)
 
                 EnsureStackState(cookie) ' implicit label here
 
-                Me._evalStack = origStack ' alternative is evaluated with original stack
+                Me.SetStackDepth(origStack) ' alternative is evaluated with original stack
                 Dim referenceTypeReceiver = DirectCast(Me.Visit(node.ReferenceTypeReceiver), BoundExpression)
 
                 EnsureStackState(cookie) ' implicit label here
@@ -909,13 +843,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     Case BinaryOperatorKind.AndAlso, BinaryOperatorKind.OrElse
                         ' Short-circuit operators need to emulate implicit branch/label
 
-                        Dim origStack = Me._evalStack
+                        Dim origStack = Me.StackDepth
                         Dim left As BoundExpression = DirectCast(Me.Visit(node.Left), BoundExpression)
 
                         ' implicit branch here
                         Dim cookie As Object = GetStackStateCookie()
 
-                        Me._evalStack = origStack  ' right is evaluated with original stack
+                        Me.SetStackDepth(origStack)  ' right is evaluated with original stack
                         Dim right As BoundExpression = DirectCast(Me.Visit(node.Right), BoundExpression)
 
                         ' implicit label here
@@ -931,11 +865,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Public Overrides Function VisitUnaryOperator(node As BoundUnaryOperator) As BoundNode
                 ' checked(-x) is emitted as "0 - x"
                 If node.Checked AndAlso (node.OperatorKind And UnaryOperatorKind.OpMask) = UnaryOperatorKind.Minus Then
-                    Dim storedStack = Me._evalStack
-                    Me._evalStack += 1
-                    CannotReusePreviousExpression() ' Loaded 0 on the stack.
+                    Dim storedStack = Me.StackDepth
+                    Me.PushEvalStack(Nothing, ExprContext.None)
                     Dim operand = DirectCast(Me.Visit(node.Operand), BoundExpression)
-                    Me._evalStack = storedStack
+                    Me.SetStackDepth(storedStack)
                     Return node.Update(node.OperatorKind, operand, node.Checked, node.ConstantValueOpt, node.Type)
 
                 Else
@@ -951,15 +884,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 If expressionStatement.Expression.Kind = BoundKind.Local Then
                     ' It is required by code gen that if node.ExpressionStatement 
                     ' is a local it should not be optimized out 
-                    _locals(DirectCast(expressionStatement.Expression, BoundLocal).LocalSymbol).ShouldNotSchedule()
+                    Dim local = DirectCast(expressionStatement.Expression, BoundLocal).LocalSymbol
+                    ShouldNotSchedule(local)
                 End If
 
-                Dim origStack = Me._evalStack
+                Dim origStack = Me.StackDepth
 
                 EnsureOnlyEvalStack()
                 Dim exprPlaceholderOpt As BoundRValuePlaceholder = DirectCast(Me.Visit(node.ExprPlaceholderOpt), BoundRValuePlaceholder)
                 ' expression value is consumed by the switch
-                Me._evalStack = origStack
+                Me.SetStackDepth(origStack)
 
                 EnsureOnlyEvalStack()
 
@@ -990,7 +924,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Public Overrides Function VisitUnstructuredExceptionOnErrorSwitch(node As BoundUnstructuredExceptionOnErrorSwitch) As BoundNode
                 Dim value = DirectCast(Visit(node.Value), BoundExpression)
 
-                Me._evalStack -= 1 ' value gets consumed
+                Me.PopEvalStack() ' value gets consumed
                 Return node.Update(value, Me.VisitList(node.Jumps))
             End Function
 
@@ -999,7 +933,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Dim resumeNextLabel = DirectCast(Visit(node.ResumeNextLabel), BoundLabelStatement)
                 Dim resumeTargetTemporary = DirectCast(Visit(node.ResumeTargetTemporary), BoundLocal)
 
-                Me._evalStack -= 1 ' value gets consumed
+                Me.PopEvalStack() ' value gets consumed
 
                 Return node.Update(resumeTargetTemporary, resumeLabel, resumeNextLabel, node.Jumps)
             End Function
@@ -1026,21 +960,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End Function
 
             Public Overrides Function VisitCatchBlock(node As BoundCatchBlock) As BoundNode
-                Dim origStack As Integer = Me._evalStack
+                Dim origStack As Integer = Me.StackDepth
 
                 DeclareLocal(node.LocalOpt, origStack)
 
                 EnsureOnlyEvalStack()
                 Dim exceptionVariableOpt As BoundExpression = Me.VisitExpression(node.ExceptionSourceOpt, ExprContext.Value)
-                Me._evalStack = origStack
+                Me.SetStackDepth(origStack)
 
                 EnsureOnlyEvalStack()
                 Dim errorLineNumberOpt As BoundExpression = Me.VisitExpression(node.ErrorLineNumberOpt, ExprContext.Value)
-                Me._evalStack = origStack
+                Me.SetStackDepth(origStack)
 
                 EnsureOnlyEvalStack()
                 Dim exceptionFilterOpt As BoundExpression = Me.VisitExpression(node.ExceptionFilterOpt, ExprContext.Value)
-                Me._evalStack = origStack
+                Me.SetStackDepth(origStack)
 
                 EnsureOnlyEvalStack()
                 Dim body As BoundBlock = DirectCast(Me.Visit(node.Body), BoundBlock)
@@ -1092,32 +1026,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             ''' </summary>
             ''' <remarks></remarks>
             Private Sub EnsureOnlyEvalStack()
-                CannotReusePreviousExpression()
                 RecordVarRead(_empty)
             End Sub
 
             Private Function GetStackStateCookie() As Object
-                CannotReusePreviousExpression()
-
                 ' create a dummy and start tracing it
                 Dim dummy As New DummyLocal(Me._container)
                 Me._dummyVariables.Add(dummy, dummy)
-                Me._locals.Add(dummy, New LocalDefUseInfo(Me._evalStack))
+                Me._locals.Add(dummy, New LocalDefUseInfo(Me.StackDepth))
                 RecordVarWrite(dummy)
 
                 Return dummy
             End Function
 
             Private Sub EnsureStackState(cookie As Object)
-                CannotReusePreviousExpression()
                 RecordVarRead(Me._dummyVariables(cookie))
             End Sub
 
             ' called on branches and labels
             Private Sub RecordBranch(label As LabelSymbol)
-
-                CannotReusePreviousExpression()
-
                 Dim dummy As DummyLocal = Nothing
                 If Me._dummyVariables.TryGetValue(label, dummy) Then
                     RecordVarRead(dummy)
@@ -1125,14 +1052,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     ' create a dummy and start tracing it
                     dummy = New DummyLocal(Me._container)
                     Me._dummyVariables.Add(label, dummy)
-                    Me._locals.Add(dummy, New LocalDefUseInfo(Me._evalStack))
+                    Me._locals.Add(dummy, New LocalDefUseInfo(Me.StackDepth))
                     RecordVarWrite(dummy)
                 End If
             End Sub
 
             Private Sub RecordLabel(label As LabelSymbol)
-                CannotReusePreviousExpression()
-
                 Dim dummy As DummyLocal = Nothing
                 If Me._dummyVariables.TryGetValue(label, dummy) Then
                     RecordVarRead(dummy)
@@ -1146,10 +1071,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 End If
             End Sub
 
-            Private Sub CannotReusePreviousExpression()
-                ClearLastExpression()
-            End Sub
-
             Private Sub RecordVarRef(local As LocalSymbol)
                 Debug.Assert(Not local.IsByRef, "can't tke a ref of a ref")
 
@@ -1158,7 +1079,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 End If
 
                 ' if we ever take a reference of a local, it must be a real local.
-                _locals(local).ShouldNotSchedule()
+                ShouldNotSchedule(local)
             End Sub
 
             Private Sub RecordVarRead(local As LocalSymbol)
@@ -1180,14 +1101,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
                 ' if accessing real val, check stack
                 If Not TypeOf local Is DummyLocal Then
-                    If locInfo.StackAtDeclaration <> _evalStack Then
+                    If locInfo.StackAtDeclaration <> StackDepth() AndAlso
+                        Not EvalStackHasLocal(local) Then
                         ' reading at different eval stack.
                         locInfo.ShouldNotSchedule()
                         Return
                     End If
                 Else
                     ' dummy must be accessed on same stack.
-                    Debug.Assert(local Is _empty OrElse locInfo.StackAtDeclaration = _evalStack)
+                    Debug.Assert(local Is _empty OrElse locInfo.StackAtDeclaration = StackDepth())
                 End If
 
                 Dim definedAt As LocalDefUseSpan = locInfo.localDefs.Last()
@@ -1196,6 +1118,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Dim locDef As New LocalDefUseSpan(_counter)
                 locInfo.localDefs.Add(locDef)
             End Sub
+
+            Private Function EvalStackHasLocal(local As LocalSymbol) As Boolean
+                Dim top = _evalStack.Last()
+
+                Return top.Item2 = If(Not local.IsByRef, ExprContext.Value, ExprContext.Address) AndAlso
+                   top.Item1.Kind = BoundKind.Local AndAlso
+                   DirectCast(top.Item1, BoundLocal).LocalSymbol = local
+            End Function
 
             Private Sub RecordVarWrite(local As LocalSymbol)
                 If Not CanScheduleToStack(local) Then
@@ -1211,7 +1141,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 If Not TypeOf local Is DummyLocal Then
 
                     ' -1 because real assignment "consumes" value.
-                    Dim evalStack = Me._evalStack - 1
+                    Dim evalStack = Me.StackDepth - 1
 
                     If locInfo.StackAtDeclaration <> evalStack Then
                         ' writing at different eval stack.
@@ -1220,15 +1150,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     End If
                 Else
                     ' dummy must be accessed on same stack.
-                    Debug.Assert(local Is _empty OrElse locInfo.StackAtDeclaration = _evalStack)
+                    Debug.Assert(local Is _empty OrElse locInfo.StackAtDeclaration = StackDepth())
                 End If
 
                 Dim locDef = New LocalDefUseSpan(Me._counter)
                 locInfo.localDefs.Add(locDef)
             End Sub
 
-            Private Shared Function CanScheduleToStack(local As LocalSymbol) As Boolean
-                Return local.CanScheduleToStack
+            Private Sub ShouldNotSchedule(local As LocalSymbol)
+                Dim localDefInfo As LocalDefUseInfo = Nothing
+                If _locals.TryGetValue(local, localDefInfo) Then
+                    localDefInfo.ShouldNotSchedule()
+                End If
+            End Sub
+
+            Private Function CanScheduleToStack(local As LocalSymbol) As Boolean
+                Return local.CanScheduleToStack AndAlso
+                        (Not _debugFriendly OrElse Not local.SynthesizedKind.IsLongLived())
             End Function
 
             Private Sub DeclareLocals(locals As ImmutableArray(Of LocalSymbol), stack As Integer)

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.Analyzer.vb
@@ -77,13 +77,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Public Shared Function Analyze(
                              container As Symbol,
                              node As BoundNode,
-                             evalStack As ArrayBuilder(Of ValueTuple(Of BoundExpression, ExprContext)),
                              debugFriendly As Boolean,
                              <Out> ByRef locals As Dictionary(Of LocalSymbol, LocalDefUseInfo)) As BoundNode
 
+                Dim evalStack = ArrayBuilder(Of ValueTuple(Of BoundExpression, ExprContext)).GetInstance()
                 Dim analyzer = New Analyzer(container, evalStack, debugFriendly)
-
                 Dim rewritten As BoundNode = analyzer.Visit(node)
+                evalStack.Free()
+
                 locals = analyzer._locals
 
                 Return rewritten

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.vb
@@ -9,10 +9,16 @@ Imports TypeKind = Microsoft.CodeAnalysis.TypeKind
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
     Partial Friend Class StackScheduler
 
-        Public Shared Function OptimizeLocalsOut(container As Symbol, src As BoundStatement, <Out> ByRef stackLocals As HashSet(Of LocalSymbol)) As BoundStatement
+        Public Shared Function OptimizeLocalsOut(
+                         container As Symbol,
+                         src As BoundStatement,
+                         debugFriendly As Boolean,
+                         <Out> ByRef stackLocals As HashSet(Of LocalSymbol)) As BoundStatement
 
             Dim locals As Dictionary(Of LocalSymbol, LocalDefUseInfo) = Nothing
-            src = DirectCast(Analyzer.Analyze(container, src, locals), BoundStatement)
+            Dim evalStack = ArrayBuilder(Of ValueTuple(Of BoundExpression, ExprContext)).GetInstance()
+            src = DirectCast(Analyzer.Analyze(container, src, evalStack, debugFriendly, locals), BoundStatement)
+            evalStack.Free()
 
             locals = FilterValidStackLocals(locals)
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/Optimizer/StackScheduler.vb
@@ -16,9 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                          <Out> ByRef stackLocals As HashSet(Of LocalSymbol)) As BoundStatement
 
             Dim locals As Dictionary(Of LocalSymbol, LocalDefUseInfo) = Nothing
-            Dim evalStack = ArrayBuilder(Of ValueTuple(Of BoundExpression, ExprContext)).GetInstance()
-            src = DirectCast(Analyzer.Analyze(container, src, evalStack, debugFriendly, locals), BoundStatement)
-            evalStack.Free()
+            src = DirectCast(Analyzer.Analyze(container, src, debugFriendly, locals), BoundStatement)
 
             locals = FilterValidStackLocals(locals)
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -1499,7 +1499,7 @@ End Module
             c.VerifyIL("Program.VB$StateMachine_0_Test2.MoveNext",
             <![CDATA[
 {
-  // Code size      489 (0x1e9)
+  // Code size      485 (0x1e5)
   .maxstack  8
   .locals init (Integer V_0,
                 Object V_1,
@@ -1507,10 +1507,9 @@ End Module
                 System.Runtime.CompilerServices.INotifyCompletion V_3,
                 Program.VB$StateMachine_0_Test2 V_4,
                 Object V_5,
-                Object V_6,
-                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_7,
-                System.Runtime.CompilerServices.INotifyCompletion V_8,
-                System.Exception V_9)
+                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_6,
+                System.Runtime.CompilerServices.INotifyCompletion V_7,
+                System.Exception V_8)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
   IL_0006:  stloc.0
@@ -1524,7 +1523,7 @@ End Module
     IL_000e:  beq.s      IL_0017
     IL_0010:  br.s       IL_001c
     IL_0012:  br         IL_00af
-    IL_0017:  br         IL_0178
+    IL_0017:  br         IL_0174
    -IL_001c:  nop
    -IL_001d:  ldarg.0
     IL_001e:  newobj     "Sub MyTask(Of Integer)..ctor()"
@@ -1585,7 +1584,7 @@ End Module
     IL_00a2:  ldloca.s   V_4
     IL_00a4:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
     IL_00a9:  nop
-    IL_00aa:  leave      IL_01e8
+    IL_00aa:  leave      IL_01e4
    >IL_00af:  ldarg.0
     IL_00b0:  ldc.i4.m1
     IL_00b1:  dup
@@ -1607,121 +1606,119 @@ End Module
     IL_00d5:  ldnull
     IL_00d6:  ldnull
     IL_00d7:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_00dc:  stloc.s    V_5
-    IL_00de:  ldnull
-    IL_00df:  stloc.1
-    IL_00e0:  ldloc.s    V_5
-    IL_00e2:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-    IL_00e7:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Object"
-   -IL_00ec:  ldarg.0
-    IL_00ed:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
-    IL_00f2:  ldnull
-    IL_00f3:  ldstr      "GetAwaiter"
-    IL_00f8:  ldc.i4.0
-    IL_00f9:  newarr     "Object"
-    IL_00fe:  ldnull
-    IL_00ff:  ldnull
-    IL_0100:  ldnull
-    IL_0101:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_0106:  stloc.s    V_6
-   ~IL_0108:  ldloc.s    V_6
-    IL_010a:  ldnull
-    IL_010b:  ldstr      "IsCompleted"
-    IL_0110:  ldc.i4.0
-    IL_0111:  newarr     "Object"
-    IL_0116:  ldnull
-    IL_0117:  ldnull
-    IL_0118:  ldnull
-    IL_0119:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
-    IL_011e:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
-    IL_0123:  brfalse.s  IL_0127
-    IL_0125:  br.s       IL_0190
-    IL_0127:  ldarg.0
-    IL_0128:  ldc.i4.1
-    IL_0129:  dup
-    IL_012a:  stloc.0
-    IL_012b:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-   <IL_0130:  ldarg.0
-    IL_0131:  ldloc.s    V_6
-    IL_0133:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_0138:  ldloc.s    V_6
-    IL_013a:  isinst     "System.Runtime.CompilerServices.ICriticalNotifyCompletion"
-    IL_013f:  stloc.s    V_7
-    IL_0141:  ldloc.s    V_7
-    IL_0143:  brfalse.s  IL_015a
-    IL_0145:  ldarg.0
-    IL_0146:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_014b:  ldloca.s   V_7
-    IL_014d:  ldarg.0
-    IL_014e:  stloc.s    V_4
-    IL_0150:  ldloca.s   V_4
-    IL_0152:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.ICriticalNotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.ICriticalNotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
-    IL_0157:  nop
-    IL_0158:  br.s       IL_0176
-    IL_015a:  ldloc.s    V_6
-    IL_015c:  castclass  "System.Runtime.CompilerServices.INotifyCompletion"
-    IL_0161:  stloc.s    V_8
-    IL_0163:  ldarg.0
-    IL_0164:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_0169:  ldloca.s   V_8
-    IL_016b:  ldarg.0
-    IL_016c:  stloc.s    V_4
-    IL_016e:  ldloca.s   V_4
-    IL_0170:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
-    IL_0175:  nop
-    IL_0176:  leave.s    IL_01e8
-   >IL_0178:  ldarg.0
-    IL_0179:  ldc.i4.m1
-    IL_017a:  dup
-    IL_017b:  stloc.0
-    IL_017c:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_0181:  ldarg.0
-    IL_0182:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_0187:  stloc.s    V_6
-    IL_0189:  ldarg.0
-    IL_018a:  ldnull
-    IL_018b:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
-    IL_0190:  ldloc.s    V_6
-    IL_0192:  ldnull
-    IL_0193:  ldstr      "GetResult"
-    IL_0198:  ldc.i4.0
-    IL_0199:  newarr     "Object"
-    IL_019e:  ldnull
-    IL_019f:  ldnull
-    IL_01a0:  ldnull
-    IL_01a1:  ldc.i4.1
-    IL_01a2:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object, System.Type, String, Object(), String(), System.Type(), Boolean(), Boolean) As Object"
-    IL_01a7:  pop
-    IL_01a8:  ldnull
-    IL_01a9:  stloc.s    V_6
-   -IL_01ab:  leave.s    IL_01d2
+    IL_00dc:  ldnull
+    IL_00dd:  stloc.1
+    IL_00de:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+    IL_00e3:  stfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_x$1 As Object"
+   -IL_00e8:  ldarg.0
+    IL_00e9:  ldfld      "Program.VB$StateMachine_0_Test2.$VB$ResumableLocal_o$0 As Object"
+    IL_00ee:  ldnull
+    IL_00ef:  ldstr      "GetAwaiter"
+    IL_00f4:  ldc.i4.0
+    IL_00f5:  newarr     "Object"
+    IL_00fa:  ldnull
+    IL_00fb:  ldnull
+    IL_00fc:  ldnull
+    IL_00fd:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+    IL_0102:  stloc.s    V_5
+   ~IL_0104:  ldloc.s    V_5
+    IL_0106:  ldnull
+    IL_0107:  ldstr      "IsCompleted"
+    IL_010c:  ldc.i4.0
+    IL_010d:  newarr     "Object"
+    IL_0112:  ldnull
+    IL_0113:  ldnull
+    IL_0114:  ldnull
+    IL_0115:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+    IL_011a:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+    IL_011f:  brfalse.s  IL_0123
+    IL_0121:  br.s       IL_018c
+    IL_0123:  ldarg.0
+    IL_0124:  ldc.i4.1
+    IL_0125:  dup
+    IL_0126:  stloc.0
+    IL_0127:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+   <IL_012c:  ldarg.0
+    IL_012d:  ldloc.s    V_5
+    IL_012f:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_0134:  ldloc.s    V_5
+    IL_0136:  isinst     "System.Runtime.CompilerServices.ICriticalNotifyCompletion"
+    IL_013b:  stloc.s    V_6
+    IL_013d:  ldloc.s    V_6
+    IL_013f:  brfalse.s  IL_0156
+    IL_0141:  ldarg.0
+    IL_0142:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_0147:  ldloca.s   V_6
+    IL_0149:  ldarg.0
+    IL_014a:  stloc.s    V_4
+    IL_014c:  ldloca.s   V_4
+    IL_014e:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.ICriticalNotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.ICriticalNotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
+    IL_0153:  nop
+    IL_0154:  br.s       IL_0172
+    IL_0156:  ldloc.s    V_5
+    IL_0158:  castclass  "System.Runtime.CompilerServices.INotifyCompletion"
+    IL_015d:  stloc.s    V_7
+    IL_015f:  ldarg.0
+    IL_0160:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_0165:  ldloca.s   V_7
+    IL_0167:  ldarg.0
+    IL_0168:  stloc.s    V_4
+    IL_016a:  ldloca.s   V_4
+    IL_016c:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted(Of System.Runtime.CompilerServices.INotifyCompletion, Program.VB$StateMachine_0_Test2)(ByRef System.Runtime.CompilerServices.INotifyCompletion, ByRef Program.VB$StateMachine_0_Test2)"
+    IL_0171:  nop
+    IL_0172:  leave.s    IL_01e4
+   >IL_0174:  ldarg.0
+    IL_0175:  ldc.i4.m1
+    IL_0176:  dup
+    IL_0177:  stloc.0
+    IL_0178:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_017d:  ldarg.0
+    IL_017e:  ldfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_0183:  stloc.s    V_5
+    IL_0185:  ldarg.0
+    IL_0186:  ldnull
+    IL_0187:  stfld      "Program.VB$StateMachine_0_Test2.$A0 As Object"
+    IL_018c:  ldloc.s    V_5
+    IL_018e:  ldnull
+    IL_018f:  ldstr      "GetResult"
+    IL_0194:  ldc.i4.0
+    IL_0195:  newarr     "Object"
+    IL_019a:  ldnull
+    IL_019b:  ldnull
+    IL_019c:  ldnull
+    IL_019d:  ldc.i4.1
+    IL_019e:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateCall(Object, System.Type, String, Object(), String(), System.Type(), Boolean(), Boolean) As Object"
+    IL_01a3:  pop
+    IL_01a4:  ldnull
+    IL_01a5:  stloc.s    V_5
+   -IL_01a7:  leave.s    IL_01ce
   }
   catch System.Exception
   {
-  ~$IL_01ad:  dup
-    IL_01ae:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_01b3:  stloc.s    V_9
-   ~IL_01b5:  ldarg.0
-    IL_01b6:  ldc.i4.s   -2
-    IL_01b8:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
-    IL_01bd:  ldarg.0
-    IL_01be:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-    IL_01c3:  ldloc.s    V_9
-    IL_01c5:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)"
-    IL_01ca:  nop
-    IL_01cb:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-    IL_01d0:  leave.s    IL_01e8
+  ~$IL_01a9:  dup
+    IL_01aa:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_01af:  stloc.s    V_8
+   ~IL_01b1:  ldarg.0
+    IL_01b2:  ldc.i4.s   -2
+    IL_01b4:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+    IL_01b9:  ldarg.0
+    IL_01ba:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+    IL_01bf:  ldloc.s    V_8
+    IL_01c1:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)"
+    IL_01c6:  nop
+    IL_01c7:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_01cc:  leave.s    IL_01e4
   }
- -IL_01d2:  ldarg.0
-  IL_01d3:  ldc.i4.s   -2
-  IL_01d5:  dup
-  IL_01d6:  stloc.0
-  IL_01d7:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
- ~IL_01dc:  ldarg.0
-  IL_01dd:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
-  IL_01e2:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()"
-  IL_01e7:  nop
-  IL_01e8:  ret
+ -IL_01ce:  ldarg.0
+  IL_01cf:  ldc.i4.s   -2
+  IL_01d1:  dup
+  IL_01d2:  stloc.0
+  IL_01d3:  stfld      "Program.VB$StateMachine_0_Test2.$State As Integer"
+ ~IL_01d8:  ldarg.0
+  IL_01d9:  ldflda     "Program.VB$StateMachine_0_Test2.$Builder As System.Runtime.CompilerServices.AsyncVoidMethodBuilder"
+  IL_01de:  call       "Sub System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()"
+  IL_01e3:  nop
+  IL_01e4:  ret
 }
 ]]>,
             sequencePoints:="Program+VB$StateMachine_0_Test2.MoveNext")

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -1360,19 +1360,22 @@ End Class
             c.VerifyIL("CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.MoveNext",
             <![CDATA[
 {
-  // Code size      229 (0xe5)
+  // Code size      243 (0xf3)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
-                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_2,
-                System.Exception V_3)
+                System.Threading.Tasks.Task(Of Integer) V_2,
+                Integer V_3, //x
+                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_4,
+                Integer V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
   IL_0006:  stloc.1
   .try
   {
     IL_0007:  ldloc.1
-    IL_0008:  brfalse.s  IL_006b
+    IL_0008:  brfalse.s  IL_0070
     IL_000a:  ldarg.0
     IL_000b:  ldarg.0
     IL_000c:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$NonLocal__Closure$__2-0 As CLAZZ._Closure$__2-0"
@@ -1388,74 +1391,78 @@ End Class
     IL_0032:  ldfld      "CLAZZ._Closure$__2-0.$VB$Me As CLAZZ"
     IL_0037:  call       "Function CLAZZ.f2() As System.Threading.Tasks.Task(Of Integer)"
     IL_003c:  callvirt   "Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
-    IL_0041:  stloc.2
-    IL_0042:  ldloca.s   V_2
-    IL_0044:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
-    IL_0049:  brtrue.s   IL_0087
-    IL_004b:  ldarg.0
-    IL_004c:  ldc.i4.0
-    IL_004d:  dup
-    IL_004e:  stloc.1
-    IL_004f:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
-    IL_0054:  ldarg.0
-    IL_0055:  ldloc.2
-    IL_0056:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
-    IL_005b:  ldarg.0
-    IL_005c:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
-    IL_0061:  ldloca.s   V_2
-    IL_0063:  ldarg.0
-    IL_0064:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0)"
-    IL_0069:  leave.s    IL_00e4
-    IL_006b:  ldarg.0
-    IL_006c:  ldc.i4.m1
-    IL_006d:  dup
-    IL_006e:  stloc.1
-    IL_006f:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
-    IL_0074:  ldarg.0
-    IL_0075:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
-    IL_007a:  stloc.2
-    IL_007b:  ldarg.0
-    IL_007c:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
-    IL_0081:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
-    IL_0087:  ldloca.s   V_2
-    IL_0089:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer"
-    IL_008e:  ldloca.s   V_2
-    IL_0090:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
-    IL_0096:  ldarg.0
-    IL_0097:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$ResumableLocal_result$0 As Integer"
-    IL_009c:  add.ovf
-    IL_009d:  ldarg.0
-    IL_009e:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$NonLocal__Closure$__2-0 As CLAZZ._Closure$__2-0"
-    IL_00a3:  ldfld      "CLAZZ._Closure$__2-0.$VB$Local_p As Integer"
+    IL_0041:  stloc.s    V_4
+    IL_0043:  ldloca.s   V_4
+    IL_0045:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
+    IL_004a:  brtrue.s   IL_008d
+    IL_004c:  ldarg.0
+    IL_004d:  ldc.i4.0
+    IL_004e:  dup
+    IL_004f:  stloc.1
+    IL_0050:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+    IL_0055:  ldarg.0
+    IL_0056:  ldloc.s    V_4
+    IL_0058:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_005d:  ldarg.0
+    IL_005e:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+    IL_0063:  ldloca.s   V_4
+    IL_0065:  ldarg.0
+    IL_0066:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0)"
+    IL_006b:  leave      IL_00f2
+    IL_0070:  ldarg.0
+    IL_0071:  ldc.i4.m1
+    IL_0072:  dup
+    IL_0073:  stloc.1
+    IL_0074:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+    IL_0079:  ldarg.0
+    IL_007a:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_007f:  stloc.s    V_4
+    IL_0081:  ldarg.0
+    IL_0082:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0087:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_008d:  ldloca.s   V_4
+    IL_008f:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer"
+    IL_0094:  stloc.s    V_5
+    IL_0096:  ldloca.s   V_4
+    IL_0098:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_009e:  ldloc.s    V_5
+    IL_00a0:  stloc.3
+    IL_00a1:  ldloc.3
+    IL_00a2:  ldarg.0
+    IL_00a3:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$ResumableLocal_result$0 As Integer"
     IL_00a8:  add.ovf
-    IL_00a9:  stloc.0
-    IL_00aa:  leave.s    IL_00ce
+    IL_00a9:  ldarg.0
+    IL_00aa:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$NonLocal__Closure$__2-0 As CLAZZ._Closure$__2-0"
+    IL_00af:  ldfld      "CLAZZ._Closure$__2-0.$VB$Local_p As Integer"
+    IL_00b4:  add.ovf
+    IL_00b5:  stloc.0
+    IL_00b6:  leave.s    IL_00dc
   }
   catch System.Exception
   {
-    IL_00ac:  dup
-    IL_00ad:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_00b2:  stloc.3
-    IL_00b3:  ldarg.0
-    IL_00b4:  ldc.i4.s   -2
-    IL_00b6:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
-    IL_00bb:  ldarg.0
-    IL_00bc:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
-    IL_00c1:  ldloc.3
-    IL_00c2:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)"
-    IL_00c7:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-    IL_00cc:  leave.s    IL_00e4
+    IL_00b8:  dup
+    IL_00b9:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00be:  stloc.s    V_6
+    IL_00c0:  ldarg.0
+    IL_00c1:  ldc.i4.s   -2
+    IL_00c3:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+    IL_00c8:  ldarg.0
+    IL_00c9:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+    IL_00ce:  ldloc.s    V_6
+    IL_00d0:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)"
+    IL_00d5:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_00da:  leave.s    IL_00f2
   }
-  IL_00ce:  ldarg.0
-  IL_00cf:  ldc.i4.s   -2
-  IL_00d1:  dup
-  IL_00d2:  stloc.1
-  IL_00d3:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
-  IL_00d8:  ldarg.0
-  IL_00d9:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
-  IL_00de:  ldloc.0
-  IL_00df:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)"
-  IL_00e4:  ret
+  IL_00dc:  ldarg.0
+  IL_00dd:  ldc.i4.s   -2
+  IL_00df:  dup
+  IL_00e0:  stloc.1
+  IL_00e1:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+  IL_00e6:  ldarg.0
+  IL_00e7:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+  IL_00ec:  ldloc.0
+  IL_00ed:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)"
+  IL_00f2:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -1318,6 +1318,149 @@ End Class
         End Sub
 
         <Fact()>
+        Public Sub Simple_TaskOfT_Lambda_6_D()
+            Dim c = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Imports System.Threading.Tasks
+
+Module Form1
+    Sub Main()
+        Console.Write("X1 ")
+        Console.Write((New CLAZZ()).F(1000).Result.ToString + " ")
+        Console.Write("X2 ")
+    End Sub
+End Module
+
+Class CLAZZ
+    Public FX As Integer = 1
+
+    Public Async Function F(p As Integer) As Task(Of Integer)
+        Dim outer As Integer = 100
+        Console.Write("0 ")
+        Dim a = Async Function()
+                    Dim result = outer + Me.FX
+                    Dim x = Await f2()
+                    Return x + result + p
+                End Function
+        Console.Write("1 ")
+        Return Await a()
+    End Function
+
+    Async Function f2() As Task(Of Integer)
+        Console.Write("2 ")
+        Await Task.Yield
+        Console.Write("3 ")
+        Return 10
+    End Function
+End Class
+    </file>
+</compilation>, useLatestFramework:=True, options:=TestOptions.ReleaseDebugExe, expectedOutput:="X1 0 1 2 3 1111 X2")
+            c.VerifyIL("CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.MoveNext",
+            <![CDATA[
+{
+  // Code size      229 (0xe5)
+  .maxstack  3
+  .locals init (Integer V_0,
+                Integer V_1,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Integer) V_2,
+                System.Exception V_3)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+  IL_0006:  stloc.1
+  .try
+  {
+    IL_0007:  ldloc.1
+    IL_0008:  brfalse.s  IL_006b
+    IL_000a:  ldarg.0
+    IL_000b:  ldarg.0
+    IL_000c:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$NonLocal__Closure$__2-0 As CLAZZ._Closure$__2-0"
+    IL_0011:  ldfld      "CLAZZ._Closure$__2-0.$VB$Local_outer As Integer"
+    IL_0016:  ldarg.0
+    IL_0017:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$NonLocal__Closure$__2-0 As CLAZZ._Closure$__2-0"
+    IL_001c:  ldfld      "CLAZZ._Closure$__2-0.$VB$Me As CLAZZ"
+    IL_0021:  ldfld      "CLAZZ.FX As Integer"
+    IL_0026:  add.ovf
+    IL_0027:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$ResumableLocal_result$0 As Integer"
+    IL_002c:  ldarg.0
+    IL_002d:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$NonLocal__Closure$__2-0 As CLAZZ._Closure$__2-0"
+    IL_0032:  ldfld      "CLAZZ._Closure$__2-0.$VB$Me As CLAZZ"
+    IL_0037:  call       "Function CLAZZ.f2() As System.Threading.Tasks.Task(Of Integer)"
+    IL_003c:  callvirt   "Function System.Threading.Tasks.Task(Of Integer).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0041:  stloc.2
+    IL_0042:  ldloca.s   V_2
+    IL_0044:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).get_IsCompleted() As Boolean"
+    IL_0049:  brtrue.s   IL_0087
+    IL_004b:  ldarg.0
+    IL_004c:  ldc.i4.0
+    IL_004d:  dup
+    IL_004e:  stloc.1
+    IL_004f:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+    IL_0054:  ldarg.0
+    IL_0055:  ldloc.2
+    IL_0056:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_005b:  ldarg.0
+    IL_005c:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+    IL_0061:  ldloca.s   V_2
+    IL_0063:  ldarg.0
+    IL_0064:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Integer), CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Integer), ByRef CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0)"
+    IL_0069:  leave.s    IL_00e4
+    IL_006b:  ldarg.0
+    IL_006c:  ldc.i4.m1
+    IL_006d:  dup
+    IL_006e:  stloc.1
+    IL_006f:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+    IL_0074:  ldarg.0
+    IL_0075:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_007a:  stloc.2
+    IL_007b:  ldarg.0
+    IL_007c:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0081:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0087:  ldloca.s   V_2
+    IL_0089:  call       "Function System.Runtime.CompilerServices.TaskAwaiter(Of Integer).GetResult() As Integer"
+    IL_008e:  ldloca.s   V_2
+    IL_0090:  initobj    "System.Runtime.CompilerServices.TaskAwaiter(Of Integer)"
+    IL_0096:  ldarg.0
+    IL_0097:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$ResumableLocal_result$0 As Integer"
+    IL_009c:  add.ovf
+    IL_009d:  ldarg.0
+    IL_009e:  ldfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$VB$NonLocal__Closure$__2-0 As CLAZZ._Closure$__2-0"
+    IL_00a3:  ldfld      "CLAZZ._Closure$__2-0.$VB$Local_p As Integer"
+    IL_00a8:  add.ovf
+    IL_00a9:  stloc.0
+    IL_00aa:  leave.s    IL_00ce
+  }
+  catch System.Exception
+  {
+    IL_00ac:  dup
+    IL_00ad:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00b2:  stloc.3
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldc.i4.s   -2
+    IL_00b6:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+    IL_00c1:  ldloc.3
+    IL_00c2:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)"
+    IL_00c7:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_00cc:  leave.s    IL_00e4
+  }
+  IL_00ce:  ldarg.0
+  IL_00cf:  ldc.i4.s   -2
+  IL_00d1:  dup
+  IL_00d2:  stloc.1
+  IL_00d3:  stfld      "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$State As Integer"
+  IL_00d8:  ldarg.0
+  IL_00d9:  ldflda     "CLAZZ._Closure$__2-0.VB$StateMachine___Lambda$__0.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+  IL_00de:  ldloc.0
+  IL_00df:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)"
+  IL_00e4:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
         Public Sub Simple_Finalizer()
             Dim c = CompileAndVerify(
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenClosureLambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenClosureLambdaTests.vb
@@ -211,7 +211,7 @@ End Module
   IL_0019:  dup
   IL_001a:  callvirt   "Sub System.Action.Invoke()"
   IL_001f:  ldloc.0
-  IL_0020:  dup
+  IL_0020:  ldloc.0
   IL_0021:  ldfld      "M1._Closure$__0-0.$VB$Local_X As Integer"
   IL_0026:  ldloc.0
   IL_0027:  ldfld      "M1._Closure$__0-0.$VB$Local_X As Integer"
@@ -268,7 +268,7 @@ End Module
   IL_0019:  dup
   IL_001a:  callvirt   "Sub System.Action.Invoke()"
   IL_001f:  ldloc.0
-  IL_0020:  dup
+  IL_0020:  ldloc.0
   IL_0021:  ldfld      "M1.C1._Closure$__1-0.$VB$Local_X As Integer"
   IL_0026:  ldloc.0
   IL_0027:  ldfld      "M1.C1._Closure$__1-0.$VB$Local_X As Integer"
@@ -338,7 +338,7 @@ End Module
   IL_0020:  dup
   IL_0021:  callvirt   "Sub System.Action.Invoke()"
   IL_0026:  ldloc.0
-  IL_0027:  dup
+  IL_0027:  ldloc.0
   IL_0028:  ldfld      "M1.C1._Closure$__1-0.$VB$Local_X As Integer"
   IL_002d:  ldloc.0
   IL_002e:  ldfld      "M1.C1._Closure$__1-0.$VB$Local_X As Integer"
@@ -411,7 +411,7 @@ End Module
   IL_0028:  add.ovf
   IL_0029:  callvirt   "Sub System.Action(Of Integer).Invoke(Integer)"
   IL_002e:  ldloc.0
-  IL_002f:  dup
+  IL_002f:  ldloc.0
   IL_0030:  ldfld      "M1.C1._Closure$__1-0.$VB$Local_x As Integer"
   IL_0035:  ldloc.0
   IL_0036:  ldfld      "M1.C1._Closure$__1-0.$VB$Local_x As Integer"
@@ -1152,21 +1152,21 @@ End Module
             <![CDATA[
 {
   // Code size       44 (0x2c)
-  .maxstack  4
-  .locals init (M1.C1._Closure$__1-0(Of T) V_0) //$VB$Closure_0
+  .maxstack  3
+  .locals init (System.Action V_0) //d1
   IL_0000:  newobj     "Sub M1.C1._Closure$__1-0(Of T)..ctor()"
-  IL_0005:  stloc.0
-  IL_0006:  ldloc.0
-  IL_0007:  ldftn      "Sub M1.C1._Closure$__1-0(Of T)._Lambda$__0()"
-  IL_000d:  newobj     "Sub System.Action..ctor(Object, System.IntPtr)"
-  IL_0012:  dup
+  IL_0005:  dup
+  IL_0006:  ldftn      "Sub M1.C1._Closure$__1-0(Of T)._Lambda$__0()"
+  IL_000c:  newobj     "Sub System.Action..ctor(Object, System.IntPtr)"
+  IL_0011:  stloc.0
+  IL_0012:  ldloc.0
   IL_0013:  callvirt   "Sub System.Action.Invoke()"
-  IL_0018:  ldloc.0
-  IL_0019:  dup
-  IL_001a:  ldfld      "M1.C1._Closure$__1-0(Of T).$VB$Local_X As Integer"
-  IL_001f:  ldc.i4.5
-  IL_0020:  add.ovf
-  IL_0021:  stfld      "M1.C1._Closure$__1-0(Of T).$VB$Local_X As Integer"
+  IL_0018:  dup
+  IL_0019:  ldfld      "M1.C1._Closure$__1-0(Of T).$VB$Local_X As Integer"
+  IL_001e:  ldc.i4.5
+  IL_001f:  add.ovf
+  IL_0020:  stfld      "M1.C1._Closure$__1-0(Of T).$VB$Local_X As Integer"
+  IL_0025:  ldloc.0
   IL_0026:  callvirt   "Sub System.Action.Invoke()"
   IL_002b:  ret
 }
@@ -1986,7 +1986,7 @@ End Module
   IL_0019:  newobj     "Sub System.Action..ctor(Object, System.IntPtr)"
   IL_001e:  stelem.ref
   IL_001f:  ldloc.2
-  IL_0020:  dup
+  IL_0020:  ldloc.2
   IL_0021:  ldfld      "Module1._Closure$__0-0.$VB$Local_x As Integer"
   IL_0026:  ldc.i4.1
   IL_0027:  add.ovf
@@ -2060,7 +2060,7 @@ End Module
 ]]>)
             c.VerifyIL("Module1.Main", <![CDATA[
 {
-  // Code size      126 (0x7e)
+  // Code size      127 (0x7f)
   .maxstack  4
   .locals init (System.Action() V_0, //a
                 Integer V_1, //S
@@ -2080,7 +2080,7 @@ End Module
   IL_0012:  stloc.3
   IL_0013:  ldc.i4.0
   IL_0014:  stfld      "Module1._Closure$__0-0.$VB$Local_i As Integer"
-  IL_0019:  br.s       IL_0064
+  IL_0019:  br.s       IL_0065
   IL_001b:  ldloc.s    V_4
   IL_001d:  newobj     "Sub Module1._Closure$__0-1..ctor(Module1._Closure$__0-1)"
   IL_0022:  stloc.s    V_4
@@ -2096,32 +2096,32 @@ End Module
   IL_0041:  newobj     "Sub System.Action..ctor(Object, System.IntPtr)"
   IL_0046:  stelem.ref
   IL_0047:  ldloc.s    V_4
-  IL_0049:  dup
-  IL_004a:  ldfld      "Module1._Closure$__0-1.$VB$Local_x As Integer"
-  IL_004f:  ldc.i4.1
-  IL_0050:  add.ovf
-  IL_0051:  stfld      "Module1._Closure$__0-1.$VB$Local_x As Integer"
-  IL_0056:  ldloc.2
-  IL_0057:  dup
-  IL_0058:  ldfld      "Module1._Closure$__0-0.$VB$Local_i As Integer"
-  IL_005d:  ldloc.3
-  IL_005e:  add.ovf
-  IL_005f:  stfld      "Module1._Closure$__0-0.$VB$Local_i As Integer"
-  IL_0064:  ldloc.3
-  IL_0065:  ldc.i4.s   31
-  IL_0067:  shr
-  IL_0068:  ldloc.2
-  IL_0069:  ldfld      "Module1._Closure$__0-0.$VB$Local_i As Integer"
-  IL_006e:  xor
-  IL_006f:  ldloc.3
-  IL_0070:  ldc.i4.s   31
-  IL_0072:  shr
-  IL_0073:  ldc.i4.5
-  IL_0074:  xor
-  IL_0075:  ble.s      IL_001b
-  IL_0077:  ldloc.0
-  IL_0078:  call       "Sub Module1.Dump(System.Action())"
-  IL_007d:  ret
+  IL_0049:  ldloc.s    V_4
+  IL_004b:  ldfld      "Module1._Closure$__0-1.$VB$Local_x As Integer"
+  IL_0050:  ldc.i4.1
+  IL_0051:  add.ovf
+  IL_0052:  stfld      "Module1._Closure$__0-1.$VB$Local_x As Integer"
+  IL_0057:  ldloc.2
+  IL_0058:  ldloc.2
+  IL_0059:  ldfld      "Module1._Closure$__0-0.$VB$Local_i As Integer"
+  IL_005e:  ldloc.3
+  IL_005f:  add.ovf
+  IL_0060:  stfld      "Module1._Closure$__0-0.$VB$Local_i As Integer"
+  IL_0065:  ldloc.3
+  IL_0066:  ldc.i4.s   31
+  IL_0068:  shr
+  IL_0069:  ldloc.2
+  IL_006a:  ldfld      "Module1._Closure$__0-0.$VB$Local_i As Integer"
+  IL_006f:  xor
+  IL_0070:  ldloc.3
+  IL_0071:  ldc.i4.s   31
+  IL_0073:  shr
+  IL_0074:  ldc.i4.5
+  IL_0075:  xor
+  IL_0076:  ble.s      IL_001b
+  IL_0078:  ldloc.0
+  IL_0079:  call       "Sub Module1.Dump(System.Action())"
+  IL_007e:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenGoto.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenGoto.vb
@@ -788,7 +788,7 @@ End Class
   IL_0001:  newobj     "Sub c1._Closure$__1-0..ctor(c1._Closure$__1-0)"
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  dup
+  IL_0008:  ldloc.0
   IL_0009:  ldftn      "Function c1._Closure$__1-0._Lambda$__0(Integer) As Integer"
   IL_000f:  newobj     "Sub del..ctor(Object, System.IntPtr)"
   IL_0014:  stfld      "c1._Closure$__1-0.$VB$Local_q As del"

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenObjectInitializer.vb
@@ -261,7 +261,7 @@ End Class
   IL_0013:  ldc.i4.s   42
   IL_0015:  call       "Sub S2.set_AProperty(Integer)"
   IL_001a:  ldloca.s   V_0
-  IL_001c:  dup
+  IL_001c:  ldloc.0
   IL_001d:  ldfld      "S2.Field As Integer"
   IL_0022:  stfld      "S2.Field2 As Integer"
   IL_0027:  ldloc.0
@@ -404,7 +404,7 @@ End Class
   IL_0013:  ldc.i4.s   42
   IL_0015:  call       "Sub S2.set_AProperty(Integer)"
   IL_001a:  ldloca.s   V_0
-  IL_001c:  dup
+  IL_001c:  ldloc.0
   IL_001d:  ldfld      "S2.Field As Integer"
   IL_0022:  stfld      "S2.Field2 As Integer"
   IL_0027:  ldloc.0
@@ -465,38 +465,38 @@ End Class
   .maxstack  2
   .locals init (S2 V_0) //x
   .try
-{
-  IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S2"
-  IL_0008:  ldloca.s   V_0
-  IL_000a:  ldc.i4.s   23
-  IL_000c:  stfld      "S2.Field As Integer"
-  IL_0011:  ldloca.s   V_0
-  IL_0013:  ldc.i4.s   42
-  IL_0015:  call       "Sub S2.set_AProperty(Integer)"
-  IL_001a:  ldloca.s   V_0
-  IL_001c:  dup
-  IL_001d:  ldfld      "S2.Field As Integer"
-  IL_0022:  stfld      "S2.Field2 As Integer"
-  IL_0027:  ldloc.0
-  IL_0028:  ldfld      "S2.Field As Integer"
-  IL_002d:  call       "Sub System.Console.WriteLine(Integer)"
-  IL_0032:  ldloca.s   V_0
-  IL_0034:  call       "Function S2.get_AProperty() As Integer"
-  IL_0039:  call       "Sub System.Console.WriteLine(Integer)"
-  IL_003e:  ldloc.0
-  IL_003f:  ldfld      "S2.Field2 As Integer"
-  IL_0044:  call       "Sub System.Console.WriteLine(Integer)"
-  IL_0049:  leave.s    IL_0061
-}
+  {
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    "S2"
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldc.i4.s   23
+    IL_000c:  stfld      "S2.Field As Integer"
+    IL_0011:  ldloca.s   V_0
+    IL_0013:  ldc.i4.s   42
+    IL_0015:  call       "Sub S2.set_AProperty(Integer)"
+    IL_001a:  ldloca.s   V_0
+    IL_001c:  ldloc.0
+    IL_001d:  ldfld      "S2.Field As Integer"
+    IL_0022:  stfld      "S2.Field2 As Integer"
+    IL_0027:  ldloc.0
+    IL_0028:  ldfld      "S2.Field As Integer"
+    IL_002d:  call       "Sub System.Console.WriteLine(Integer)"
+    IL_0032:  ldloca.s   V_0
+    IL_0034:  call       "Function S2.get_AProperty() As Integer"
+    IL_0039:  call       "Sub System.Console.WriteLine(Integer)"
+    IL_003e:  ldloc.0
+    IL_003f:  ldfld      "S2.Field2 As Integer"
+    IL_0044:  call       "Sub System.Console.WriteLine(Integer)"
+    IL_0049:  leave.s    IL_0061
+  }
   catch System.Exception
-{
-  IL_004b:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_0050:  ldstr      "failed"
-  IL_0055:  call       "Sub System.Console.WriteLine(String)"
-  IL_005a:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_005f:  leave.s    IL_0061
-}
+  {
+    IL_004b:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_0050:  ldstr      "failed"
+    IL_0055:  call       "Sub System.Console.WriteLine(String)"
+    IL_005a:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_005f:  leave.s    IL_0061
+  }
   IL_0061:  ret
 }
 ]]>)
@@ -552,7 +552,7 @@ End Class
   // Code size      147 (0x93)
   .maxstack  2
   .locals init (S2 V_0, //x
-  S2 V_1) //y
+                S2 V_1) //y
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldc.i4.1
   IL_0003:  call       "Sub S2..ctor(Integer)"
@@ -563,7 +563,7 @@ End Class
   IL_0013:  ldc.i4.s   42
   IL_0015:  call       "Sub S2.set_AProperty(Integer)"
   IL_001a:  ldloca.s   V_0
-  IL_001c:  dup
+  IL_001c:  ldloc.0
   IL_001d:  ldfld      "S2.Field As Integer"
   IL_0022:  stfld      "S2.Field2 As Integer"
   IL_0027:  ldloca.s   V_1
@@ -648,7 +648,7 @@ End Class
   // Code size      147 (0x93)
   .maxstack  2
   .locals init (S2 V_0, //x
-  S2 V_1) //y
+                S2 V_1) //y
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    "S2"
   IL_0008:  ldloca.s   V_0
@@ -658,7 +658,7 @@ End Class
   IL_0013:  ldc.i4.s   42
   IL_0015:  call       "Sub S2.set_AProperty(Integer)"
   IL_001a:  ldloca.s   V_0
-  IL_001c:  dup
+  IL_001c:  ldloc.0
   IL_001d:  ldfld      "S2.Field As Integer"
   IL_0022:  stfld      "S2.Field2 As Integer"
   IL_0027:  ldloca.s   V_1

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSelectCase.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSelectCase.vb
@@ -2528,20 +2528,20 @@ End Module
   // Code size      453 (0x1c5)
   .maxstack  3
   .locals init (Boolean V_0, //Bo
-  Object V_1, //Ob
-  SByte V_2, //SB
-  Byte V_3, //By
-  Short V_4, //Sh
-  UShort V_5, //US
-  Integer V_6, //In
-  UInteger V_7, //UI
-  Long V_8, //Lo
-  ULong V_9, //UL
-  Decimal V_10, //De
-  Single V_11, //Si
-  Double V_12, //Do
-  String V_13, //St
-  Integer V_14)
+                Object V_1, //Ob
+                SByte V_2, //SB
+                Byte V_3, //By
+                Short V_4, //Sh
+                UShort V_5, //US
+                Integer V_6, //In
+                UInteger V_7, //UI
+                Long V_8, //Lo
+                ULong V_9, //UL
+                Decimal V_10, //De
+                Single V_11, //Si
+                Double V_12, //Do
+                String V_13, //St
+                Integer V_14)
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   IL_0002:  ldc.i4.1
@@ -2584,7 +2584,7 @@ End Module
   IL_004e:  neg
   IL_004f:  bne.un.s   IL_0062
   IL_0051:  ldarg.1
-  IL_0052:  dup
+  IL_0052:  ldarg.1
   IL_0053:  ldind.u1
   IL_0054:  brfalse.s  IL_005f
   IL_0056:  ldarg.0
@@ -2603,7 +2603,7 @@ End Module
   IL_006b:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.ConditionalCompareObjectEqual(Object, Object, Boolean) As Boolean"
   IL_0070:  brfalse.s  IL_0084
   IL_0072:  ldarg.1
-  IL_0073:  dup
+  IL_0073:  ldarg.1
   IL_0074:  ldind.u1
   IL_0075:  brfalse.s  IL_0081
   IL_0077:  ldarg.0
@@ -2620,7 +2620,7 @@ End Module
   IL_0086:  ldloc.2
   IL_0087:  bne.un.s   IL_009b
   IL_0089:  ldarg.1
-  IL_008a:  dup
+  IL_008a:  ldarg.1
   IL_008b:  ldind.u1
   IL_008c:  brfalse.s  IL_0098
   IL_008e:  ldarg.0
@@ -2637,7 +2637,7 @@ End Module
   IL_009d:  ldloc.3
   IL_009e:  bne.un.s   IL_00b2
   IL_00a0:  ldarg.1
-  IL_00a1:  dup
+  IL_00a1:  ldarg.1
   IL_00a2:  ldind.u1
   IL_00a3:  brfalse.s  IL_00af
   IL_00a5:  ldarg.0
@@ -2654,7 +2654,7 @@ End Module
   IL_00b4:  ldloc.s    V_4
   IL_00b6:  bne.un.s   IL_00ca
   IL_00b8:  ldarg.1
-  IL_00b9:  dup
+  IL_00b9:  ldarg.1
   IL_00ba:  ldind.u1
   IL_00bb:  brfalse.s  IL_00c7
   IL_00bd:  ldarg.0
@@ -2671,7 +2671,7 @@ End Module
   IL_00cc:  ldloc.s    V_5
   IL_00ce:  bne.un.s   IL_00e2
   IL_00d0:  ldarg.1
-  IL_00d1:  dup
+  IL_00d1:  ldarg.1
   IL_00d2:  ldind.u1
   IL_00d3:  brfalse.s  IL_00df
   IL_00d5:  ldarg.0
@@ -2688,7 +2688,7 @@ End Module
   IL_00e4:  ldloc.s    V_6
   IL_00e6:  bne.un.s   IL_00fa
   IL_00e8:  ldarg.1
-  IL_00e9:  dup
+  IL_00e9:  ldarg.1
   IL_00ea:  ldind.u1
   IL_00eb:  brfalse.s  IL_00f7
   IL_00ed:  ldarg.0
@@ -2706,7 +2706,7 @@ End Module
   IL_00fe:  conv.ovf.i4.un
   IL_00ff:  bne.un.s   IL_0113
   IL_0101:  ldarg.1
-  IL_0102:  dup
+  IL_0102:  ldarg.1
   IL_0103:  ldind.u1
   IL_0104:  brfalse.s  IL_0110
   IL_0106:  ldarg.0
@@ -2724,7 +2724,7 @@ End Module
   IL_0117:  conv.ovf.i4
   IL_0118:  bne.un.s   IL_012c
   IL_011a:  ldarg.1
-  IL_011b:  dup
+  IL_011b:  ldarg.1
   IL_011c:  ldind.u1
   IL_011d:  brfalse.s  IL_0129
   IL_011f:  ldarg.0
@@ -2742,7 +2742,7 @@ End Module
   IL_0130:  conv.ovf.i4.un
   IL_0131:  bne.un.s   IL_0146
   IL_0133:  ldarg.1
-  IL_0134:  dup
+  IL_0134:  ldarg.1
   IL_0135:  ldind.u1
   IL_0136:  brfalse.s  IL_0143
   IL_0138:  ldarg.0
@@ -2762,7 +2762,7 @@ End Module
   IL_0150:  conv.ovf.i4
   IL_0151:  bne.un.s   IL_0166
   IL_0153:  ldarg.1
-  IL_0154:  dup
+  IL_0154:  ldarg.1
   IL_0155:  ldind.u1
   IL_0156:  brfalse.s  IL_0163
   IL_0158:  ldarg.0
@@ -2781,7 +2781,7 @@ End Module
   IL_016f:  conv.ovf.i4
   IL_0170:  bne.un.s   IL_0185
   IL_0172:  ldarg.1
-  IL_0173:  dup
+  IL_0173:  ldarg.1
   IL_0174:  ldind.u1
   IL_0175:  brfalse.s  IL_0182
   IL_0177:  ldarg.0
@@ -2799,7 +2799,7 @@ End Module
   IL_0189:  call       "Function System.Convert.ToInt32(Decimal) As Integer"
   IL_018e:  bne.un.s   IL_01a3
   IL_0190:  ldarg.1
-  IL_0191:  dup
+  IL_0191:  ldarg.1
   IL_0192:  ldind.u1
   IL_0193:  brfalse.s  IL_01a0
   IL_0195:  ldarg.0
@@ -2817,7 +2817,7 @@ End Module
   IL_01a7:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger(String) As Integer"
   IL_01ac:  bne.un.s   IL_01c1
   IL_01ae:  ldarg.1
-  IL_01af:  dup
+  IL_01af:  ldarg.1
   IL_01b0:  ldind.u1
   IL_01b1:  brfalse.s  IL_01be
   IL_01b3:  ldarg.0
@@ -2921,22 +2921,22 @@ End Module
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  switch    (
-  IL_0041,
-  IL_0052,
-  IL_0064,
-  IL_0076,
-  IL_0088,
-  IL_009a,
-  IL_00ac,
-  IL_00be,
-  IL_00d0,
-  IL_00e2,
-  IL_00f5,
-  IL_0108,
-  IL_011b)
+        IL_0041,
+        IL_0052,
+        IL_0064,
+        IL_0076,
+        IL_0088,
+        IL_009a,
+        IL_00ac,
+        IL_00be,
+        IL_00d0,
+        IL_00e2,
+        IL_00f5,
+        IL_0108,
+        IL_011b)
   IL_003c:  br         IL_012e
   IL_0041:  ldarg.1
-  IL_0042:  dup
+  IL_0042:  ldarg.1
   IL_0043:  ldind.u1
   IL_0044:  brfalse.s  IL_004f
   IL_0046:  ldarg.0
@@ -2949,7 +2949,7 @@ End Module
   IL_0050:  stind.i1
   IL_0051:  ret
   IL_0052:  ldarg.1
-  IL_0053:  dup
+  IL_0053:  ldarg.1
   IL_0054:  ldind.u1
   IL_0055:  brfalse.s  IL_0061
   IL_0057:  ldarg.0
@@ -2963,7 +2963,7 @@ End Module
   IL_0062:  stind.i1
   IL_0063:  ret
   IL_0064:  ldarg.1
-  IL_0065:  dup
+  IL_0065:  ldarg.1
   IL_0066:  ldind.u1
   IL_0067:  brfalse.s  IL_0073
   IL_0069:  ldarg.0
@@ -2977,7 +2977,7 @@ End Module
   IL_0074:  stind.i1
   IL_0075:  ret
   IL_0076:  ldarg.1
-  IL_0077:  dup
+  IL_0077:  ldarg.1
   IL_0078:  ldind.u1
   IL_0079:  brfalse.s  IL_0085
   IL_007b:  ldarg.0
@@ -2991,7 +2991,7 @@ End Module
   IL_0086:  stind.i1
   IL_0087:  ret
   IL_0088:  ldarg.1
-  IL_0089:  dup
+  IL_0089:  ldarg.1
   IL_008a:  ldind.u1
   IL_008b:  brfalse.s  IL_0097
   IL_008d:  ldarg.0
@@ -3005,7 +3005,7 @@ End Module
   IL_0098:  stind.i1
   IL_0099:  ret
   IL_009a:  ldarg.1
-  IL_009b:  dup
+  IL_009b:  ldarg.1
   IL_009c:  ldind.u1
   IL_009d:  brfalse.s  IL_00a9
   IL_009f:  ldarg.0
@@ -3019,7 +3019,7 @@ End Module
   IL_00aa:  stind.i1
   IL_00ab:  ret
   IL_00ac:  ldarg.1
-  IL_00ad:  dup
+  IL_00ad:  ldarg.1
   IL_00ae:  ldind.u1
   IL_00af:  brfalse.s  IL_00bb
   IL_00b1:  ldarg.0
@@ -3033,7 +3033,7 @@ End Module
   IL_00bc:  stind.i1
   IL_00bd:  ret
   IL_00be:  ldarg.1
-  IL_00bf:  dup
+  IL_00bf:  ldarg.1
   IL_00c0:  ldind.u1
   IL_00c1:  brfalse.s  IL_00cd
   IL_00c3:  ldarg.0
@@ -3047,7 +3047,7 @@ End Module
   IL_00ce:  stind.i1
   IL_00cf:  ret
   IL_00d0:  ldarg.1
-  IL_00d1:  dup
+  IL_00d1:  ldarg.1
   IL_00d2:  ldind.u1
   IL_00d3:  brfalse.s  IL_00df
   IL_00d5:  ldarg.0
@@ -3061,7 +3061,7 @@ End Module
   IL_00e0:  stind.i1
   IL_00e1:  ret
   IL_00e2:  ldarg.1
-  IL_00e3:  dup
+  IL_00e3:  ldarg.1
   IL_00e4:  ldind.u1
   IL_00e5:  brfalse.s  IL_00f2
   IL_00e7:  ldarg.0
@@ -3075,7 +3075,7 @@ End Module
   IL_00f3:  stind.i1
   IL_00f4:  ret
   IL_00f5:  ldarg.1
-  IL_00f6:  dup
+  IL_00f6:  ldarg.1
   IL_00f7:  ldind.u1
   IL_00f8:  brfalse.s  IL_0105
   IL_00fa:  ldarg.0
@@ -3089,7 +3089,7 @@ End Module
   IL_0106:  stind.i1
   IL_0107:  ret
   IL_0108:  ldarg.1
-  IL_0109:  dup
+  IL_0109:  ldarg.1
   IL_010a:  ldind.u1
   IL_010b:  brfalse.s  IL_0118
   IL_010d:  ldarg.0
@@ -3103,7 +3103,7 @@ End Module
   IL_0119:  stind.i1
   IL_011a:  ret
   IL_011b:  ldarg.1
-  IL_011c:  dup
+  IL_011c:  ldarg.1
   IL_011d:  ldind.u1
   IL_011e:  brfalse.s  IL_012b
   IL_0120:  ldarg.0

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -11637,13 +11637,12 @@ End Module
             VerifyIL("Module1.getTypes",
             <![CDATA[
 {
-  // Code size      118 (0x76)
+  // Code size      116 (0x74)
   .maxstack  6
   .locals init (System.Array V_0, //types
                 System.Array V_1, //arr
                 Integer V_2, //i
-                Integer V_3,
-                Integer V_4)
+                Integer V_3)
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
@@ -11670,35 +11669,35 @@ End Module
   IL_003e:  callvirt   "Function System.Array.get_Length() As Integer"
   IL_0043:  ldc.i4.1
   IL_0044:  sub.ovf
-  IL_0045:  stloc.s    V_4
-  IL_0047:  ldc.i4.0
-  IL_0048:  stloc.2
-  IL_0049:  br.s       IL_006f
-  IL_004b:  ldloc.1
-  IL_004c:  ldc.i4.2
-  IL_004d:  newarr     "Object"
-  IL_0052:  dup
-  IL_0053:  ldc.i4.0
-  IL_0054:  ldloc.2
-  IL_0055:  box        "Integer"
-  IL_005a:  stelem.ref
-  IL_005b:  dup
-  IL_005c:  ldc.i4.1
-  IL_005d:  ldloc.0
-  IL_005e:  ldloc.2
-  IL_005f:  callvirt   "Function System.Array.GetValue(Integer) As Object"
-  IL_0064:  stelem.ref
-  IL_0065:  ldnull
-  IL_0066:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
-  IL_006b:  ldloc.2
-  IL_006c:  ldc.i4.1
-  IL_006d:  add.ovf
-  IL_006e:  stloc.2
-  IL_006f:  ldloc.2
-  IL_0070:  ldloc.s    V_4
-  IL_0072:  ble.s      IL_004b
-  IL_0074:  ldloc.1
-  IL_0075:  ret
+  IL_0045:  stloc.3
+  IL_0046:  ldc.i4.0
+  IL_0047:  stloc.2
+  IL_0048:  br.s       IL_006e
+  IL_004a:  ldloc.1
+  IL_004b:  ldc.i4.2
+  IL_004c:  newarr     "Object"
+  IL_0051:  dup
+  IL_0052:  ldc.i4.0
+  IL_0053:  ldloc.2
+  IL_0054:  box        "Integer"
+  IL_0059:  stelem.ref
+  IL_005a:  dup
+  IL_005b:  ldc.i4.1
+  IL_005c:  ldloc.0
+  IL_005d:  ldloc.2
+  IL_005e:  callvirt   "Function System.Array.GetValue(Integer) As Object"
+  IL_0063:  stelem.ref
+  IL_0064:  ldnull
+  IL_0065:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
+  IL_006a:  ldloc.2
+  IL_006b:  ldc.i4.1
+  IL_006c:  add.ovf
+  IL_006d:  stloc.2
+  IL_006e:  ldloc.2
+  IL_006f:  ldloc.3
+  IL_0070:  ble.s      IL_004a
+  IL_0072:  ldloc.1
+  IL_0073:  ret
 }
 ]]>)
         End Sub
@@ -11744,7 +11743,8 @@ End Module
                 Object() V_2, //s
                 System.Array V_3, //arr
                 Integer V_4, //i
-                Integer V_5)
+                Integer V_5,
+                Integer V_6)
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
@@ -11771,7 +11771,7 @@ End Module
   IL_003f:  callvirt   "Function System.Array.get_Length() As Integer"
   IL_0044:  ldc.i4.1
   IL_0045:  sub.ovf
-  IL_0046:  stloc.s    V_5
+  IL_0046:  stloc.s    V_6
   IL_0048:  ldc.i4.0
   IL_0049:  stloc.s    V_4
   IL_004b:  br.s       IL_0075
@@ -11796,7 +11796,7 @@ End Module
   IL_0072:  add.ovf
   IL_0073:  stloc.s    V_4
   IL_0075:  ldloc.s    V_4
-  IL_0077:  ldloc.s    V_5
+  IL_0077:  ldloc.s    V_6
   IL_0079:  ble.s      IL_004d
   IL_007b:  ldloc.3
   IL_007c:  stloc.0

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -6043,7 +6043,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.ExponentObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret
@@ -6080,7 +6080,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.DivideObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret
@@ -6093,7 +6093,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.ModObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret
@@ -6106,7 +6106,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.IntDivideObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6119,7 +6119,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.ConcatenateObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret
@@ -6144,7 +6144,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.AndObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6175,7 +6175,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.OrObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6206,7 +6206,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.XorObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6219,7 +6219,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.MultiplyObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6232,7 +6232,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.AddObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6245,7 +6245,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.SubtractObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6258,7 +6258,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.LeftShiftObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -6271,7 +6271,7 @@ End Module
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.RightShiftObject(Object, Object) As Object"
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
@@ -8427,26 +8427,26 @@ End Class
   .maxstack  2
   .locals init (System.Exception V_0) //ex
   .try
-{
-  IL_0000:  ldc.i4.1
-  IL_0001:  newobj     "Sub S..ctor(Integer)"
-  IL_0006:  pop
-  IL_0007:  ldc.i4.1
-  IL_0008:  newobj     "Sub S..ctor(Integer)"
-  IL_000d:  pop
-  IL_000e:  ldc.i4.1
-  IL_000f:  newobj     "Sub S..ctor(Integer)"
-  IL_0014:  pop
-  IL_0015:  leave.s    IL_0025
-}
+  {
+    IL_0000:  ldc.i4.1
+    IL_0001:  newobj     "Sub S..ctor(Integer)"
+    IL_0006:  pop
+    IL_0007:  ldc.i4.1
+    IL_0008:  newobj     "Sub S..ctor(Integer)"
+    IL_000d:  pop
+    IL_000e:  ldc.i4.1
+    IL_000f:  newobj     "Sub S..ctor(Integer)"
+    IL_0014:  pop
+    IL_0015:  leave.s    IL_0025
+  }
   catch System.Exception
-{
-  IL_0017:  dup
-  IL_0018:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_001d:  stloc.0
-  IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_0023:  leave.s    IL_0025
-}
+  {
+    IL_0017:  dup
+    IL_0018:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_001d:  stloc.0
+    IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0023:  leave.s    IL_0025
+  }
   IL_0025:  ret
 }
 ]]>)
@@ -10250,7 +10250,8 @@ End Module
   IL_004a:  nop
   IL_004b:  nop
   IL_004c:  ret
-}]]>)
+}
+]]>)
         End Sub
 
         <WorkItem(539392, "DevDiv")>
@@ -11345,18 +11346,19 @@ End Class
             VerifyIL("EdmFunction.SetFunctionAttribute",
             <![CDATA[
 {
-  // Code size       10 (0xa)
+  // Code size       11 (0xb)
   .maxstack  4
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  ldind.u1
-  IL_0003:  dup
-  IL_0004:  ldarg.1
-  IL_0005:  and
-  IL_0006:  add
-  IL_0007:  conv.ovf.u1.un
-  IL_0008:  stind.i1
-  IL_0009:  ret
+  IL_0003:  ldarg.0
+  IL_0004:  ldind.u1
+  IL_0005:  ldarg.1
+  IL_0006:  and
+  IL_0007:  add
+  IL_0008:  conv.ovf.u1.un
+  IL_0009:  stind.i1
+  IL_000a:  ret
 }
 ]]>)
         End Sub
@@ -11450,12 +11452,13 @@ End Module
             VerifyIL("Module1.getTypes",
             <![CDATA[
 {
-  // Code size      116 (0x74)
+  // Code size      118 (0x76)
   .maxstack  6
   .locals init (System.Array V_0, //types
                 System.Array V_1, //arr
                 Integer V_2, //i
-                Integer V_3)
+                Integer V_3,
+                Integer V_4)
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
@@ -11482,35 +11485,35 @@ End Module
   IL_003e:  callvirt   "Function System.Array.get_Length() As Integer"
   IL_0043:  ldc.i4.1
   IL_0044:  sub.ovf
-  IL_0045:  stloc.3
-  IL_0046:  ldc.i4.0
-  IL_0047:  stloc.2
-  IL_0048:  br.s       IL_006e
-  IL_004a:  ldloc.1
-  IL_004b:  ldc.i4.2
-  IL_004c:  newarr     "Object"
-  IL_0051:  dup
-  IL_0052:  ldc.i4.0
-  IL_0053:  ldloc.2
-  IL_0054:  box        "Integer"
-  IL_0059:  stelem.ref
-  IL_005a:  dup
-  IL_005b:  ldc.i4.1
-  IL_005c:  ldloc.0
-  IL_005d:  ldloc.2
-  IL_005e:  callvirt   "Function System.Array.GetValue(Integer) As Object"
-  IL_0063:  stelem.ref
-  IL_0064:  ldnull
-  IL_0065:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
-  IL_006a:  ldloc.2
-  IL_006b:  ldc.i4.1
-  IL_006c:  add.ovf
-  IL_006d:  stloc.2
-  IL_006e:  ldloc.2
-  IL_006f:  ldloc.3
-  IL_0070:  ble.s      IL_004a
-  IL_0072:  ldloc.1
-  IL_0073:  ret
+  IL_0045:  stloc.s    V_4
+  IL_0047:  ldc.i4.0
+  IL_0048:  stloc.2
+  IL_0049:  br.s       IL_006f
+  IL_004b:  ldloc.1
+  IL_004c:  ldc.i4.2
+  IL_004d:  newarr     "Object"
+  IL_0052:  dup
+  IL_0053:  ldc.i4.0
+  IL_0054:  ldloc.2
+  IL_0055:  box        "Integer"
+  IL_005a:  stelem.ref
+  IL_005b:  dup
+  IL_005c:  ldc.i4.1
+  IL_005d:  ldloc.0
+  IL_005e:  ldloc.2
+  IL_005f:  callvirt   "Function System.Array.GetValue(Integer) As Object"
+  IL_0064:  stelem.ref
+  IL_0065:  ldnull
+  IL_0066:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
+  IL_006b:  ldloc.2
+  IL_006c:  ldc.i4.1
+  IL_006d:  add.ovf
+  IL_006e:  stloc.2
+  IL_006f:  ldloc.2
+  IL_0070:  ldloc.s    V_4
+  IL_0072:  ble.s      IL_004b
+  IL_0074:  ldloc.1
+  IL_0075:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -9286,29 +9286,37 @@ End Class
                 VerifyIL("C.Main",
             <![CDATA[
 {
-  // Code size       60 (0x3c)
+  // Code size       84 (0x54)
   .maxstack  1
-  .locals init (S V_0)
+  .locals init (S V_0, //s
+                Object V_1, //a
+                S V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    "S"
-  IL_0008:  ldloc.0
-  IL_0009:  call       "Sub C.SS(S)"
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  initobj    "S"
-  IL_0016:  ldloc.0
-  IL_0017:  call       "Sub C.SS(S)"
-  IL_001c:  ldloca.s   V_0
-  IL_001e:  initobj    "S"
-  IL_0024:  ldloc.0
-  IL_0025:  stloc.0
-  IL_0026:  ldloca.s   V_0
-  IL_0028:  constrained. "S"
-  IL_002e:  callvirt   "Function System.ValueType.ToString() As String"
-  IL_0033:  pop
-  IL_0034:  ldnull
-  IL_0035:  unbox.any  "S"
-  IL_003a:  pop
-  IL_003b:  ret
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  initobj    "S"
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  initobj    "S"
+  IL_0018:  ldloca.s   V_2
+  IL_001a:  initobj    "S"
+  IL_0020:  ldloc.2
+  IL_0021:  call       "Sub C.SS(S)"
+  IL_0026:  ldloca.s   V_2
+  IL_0028:  initobj    "S"
+  IL_002e:  ldloc.2
+  IL_002f:  call       "Sub C.SS(S)"
+  IL_0034:  ldloca.s   V_2
+  IL_0036:  initobj    "S"
+  IL_003c:  ldloc.2
+  IL_003d:  stloc.2
+  IL_003e:  ldloca.s   V_2
+  IL_0040:  constrained. "S"
+  IL_0046:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_004b:  stloc.1
+  IL_004c:  ldnull
+  IL_004d:  unbox.any  "S"
+  IL_0052:  stloc.0
+  IL_0053:  ret
 }
 ]]>)
         End Sub
@@ -10730,45 +10738,60 @@ True
             VerifyIL("Program.Test",
             <![CDATA[
 {
-  // Code size       89 (0x59)
+  // Code size      101 (0x65)
   .maxstack  4
+  .locals init (Boolean() V_0, //arrB1
+                System.Exception() V_1, //arrE1
+                Boolean() V_2, //arrB2
+                System.Exception() V_3, //arrE2
+                Boolean() V_4) //arrB3
   IL_0000:  ldc.i4.3
   IL_0001:  newarr     "Boolean"
-  IL_0006:  ldc.i4.0
-  IL_0007:  ldelem.u1
-  IL_0008:  call       "Sub System.Console.WriteLine(Boolean)"
-  IL_000d:  ldc.i4.3
-  IL_000e:  newarr     "System.Exception"
-  IL_0013:  ldc.i4.0
-  IL_0014:  ldelem.ref
-  IL_0015:  call       "Sub System.Console.WriteLine(Object)"
-  IL_001a:  ldc.i4.3
-  IL_001b:  newarr     "Boolean"
-  IL_0020:  dup
-  IL_0021:  ldc.i4.1
-  IL_0022:  ldc.i4.1
-  IL_0023:  stelem.i1
-  IL_0024:  ldc.i4.1
-  IL_0025:  ldelem.u1
-  IL_0026:  call       "Sub System.Console.WriteLine(Boolean)"
-  IL_002b:  ldc.i4.7
-  IL_002c:  newarr     "System.Exception"
-  IL_0031:  dup
-  IL_0032:  ldc.i4.1
-  IL_0033:  newobj     "Sub System.Exception..ctor()"
-  IL_0038:  stelem.ref
-  IL_0039:  ldc.i4.1
-  IL_003a:  ldelem.ref
-  IL_003b:  call       "Sub System.Console.WriteLine(Object)"
-  IL_0040:  ldc.i4.4
-  IL_0041:  newarr     "Boolean"
-  IL_0046:  dup
-  IL_0047:  ldtoken    "Integer <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108"
-  IL_004c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
-  IL_0051:  ldc.i4.2
-  IL_0052:  ldelem.u1
-  IL_0053:  call       "Sub System.Console.WriteLine(Boolean)"
-  IL_0058:  ret
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  ldc.i4.0
+  IL_0009:  ldelem.u1
+  IL_000a:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_000f:  ldc.i4.3
+  IL_0010:  newarr     "System.Exception"
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
+  IL_0017:  ldc.i4.0
+  IL_0018:  ldelem.ref
+  IL_0019:  call       "Sub System.Console.WriteLine(Object)"
+  IL_001e:  ldc.i4.3
+  IL_001f:  newarr     "Boolean"
+  IL_0024:  dup
+  IL_0025:  ldc.i4.1
+  IL_0026:  ldc.i4.1
+  IL_0027:  stelem.i1
+  IL_0028:  stloc.2
+  IL_0029:  ldloc.2
+  IL_002a:  ldc.i4.1
+  IL_002b:  ldelem.u1
+  IL_002c:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_0031:  ldc.i4.7
+  IL_0032:  newarr     "System.Exception"
+  IL_0037:  dup
+  IL_0038:  ldc.i4.1
+  IL_0039:  newobj     "Sub System.Exception..ctor()"
+  IL_003e:  stelem.ref
+  IL_003f:  stloc.3
+  IL_0040:  ldloc.3
+  IL_0041:  ldc.i4.1
+  IL_0042:  ldelem.ref
+  IL_0043:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0048:  ldc.i4.4
+  IL_0049:  newarr     "Boolean"
+  IL_004e:  dup
+  IL_004f:  ldtoken    "Integer <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108"
+  IL_0054:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0059:  stloc.s    V_4
+  IL_005b:  ldloc.s    V_4
+  IL_005d:  ldc.i4.2
+  IL_005e:  ldelem.u1
+  IL_005f:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_0064:  ret
 }
 ]]>)
         End Sub
@@ -11714,68 +11737,71 @@ End Module
             VerifyIL("Module1.getTypes",
             <![CDATA[
 {
-  // Code size      118 (0x76)
+  // Code size      127 (0x7f)
   .maxstack  6
-  .locals init (System.Array V_0, //types
-                System.Array V_1, //arr
-                Integer V_2, //i
-                Integer V_3,
-                Integer V_4)
+  .locals init (System.Array V_0, //getTypes
+                System.Array V_1, //types
+                Object() V_2, //s
+                System.Array V_3, //arr
+                Integer V_4, //i
+                Integer V_5)
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     "Integer"
   IL_0006:  dup
   IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.1456763F890A84558F99AFA687C36B9037697848"
   IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
-  IL_0011:  stloc.0
-  IL_0012:  ldloc.0
+  IL_0011:  stloc.1
+  IL_0012:  ldloc.1
   IL_0013:  callvirt   "Function System.Array.get_Length() As Integer"
   IL_0018:  ldc.i4.1
   IL_0019:  sub.ovf
   IL_001a:  ldc.i4.1
   IL_001b:  add.ovf
   IL_001c:  newarr     "Object"
-  IL_0021:  pop
-  IL_0022:  ldloca.s   V_3
+  IL_0021:  stloc.2
+  IL_0022:  ldloca.s   V_5
   IL_0024:  initobj    "Integer"
-  IL_002a:  ldloc.3
-  IL_002b:  box        "Integer"
-  IL_0030:  call       "Function Object.GetType() As System.Type"
-  IL_0035:  ldc.i4.s   12
-  IL_0037:  call       "Function System.Array.CreateInstance(System.Type, Integer) As System.Array"
-  IL_003c:  stloc.1
-  IL_003d:  ldloc.0
-  IL_003e:  callvirt   "Function System.Array.get_Length() As Integer"
-  IL_0043:  ldc.i4.1
-  IL_0044:  sub.ovf
-  IL_0045:  stloc.s    V_4
-  IL_0047:  ldc.i4.0
-  IL_0048:  stloc.2
-  IL_0049:  br.s       IL_006f
-  IL_004b:  ldloc.1
-  IL_004c:  ldc.i4.2
-  IL_004d:  newarr     "Object"
-  IL_0052:  dup
-  IL_0053:  ldc.i4.0
-  IL_0054:  ldloc.2
-  IL_0055:  box        "Integer"
-  IL_005a:  stelem.ref
-  IL_005b:  dup
-  IL_005c:  ldc.i4.1
-  IL_005d:  ldloc.0
-  IL_005e:  ldloc.2
-  IL_005f:  callvirt   "Function System.Array.GetValue(Integer) As Object"
-  IL_0064:  stelem.ref
-  IL_0065:  ldnull
-  IL_0066:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
-  IL_006b:  ldloc.2
-  IL_006c:  ldc.i4.1
-  IL_006d:  add.ovf
-  IL_006e:  stloc.2
-  IL_006f:  ldloc.2
-  IL_0070:  ldloc.s    V_4
-  IL_0072:  ble.s      IL_004b
-  IL_0074:  ldloc.1
-  IL_0075:  ret
+  IL_002a:  ldloc.s    V_5
+  IL_002c:  box        "Integer"
+  IL_0031:  call       "Function Object.GetType() As System.Type"
+  IL_0036:  ldc.i4.s   12
+  IL_0038:  call       "Function System.Array.CreateInstance(System.Type, Integer) As System.Array"
+  IL_003d:  stloc.3
+  IL_003e:  ldloc.1
+  IL_003f:  callvirt   "Function System.Array.get_Length() As Integer"
+  IL_0044:  ldc.i4.1
+  IL_0045:  sub.ovf
+  IL_0046:  stloc.s    V_5
+  IL_0048:  ldc.i4.0
+  IL_0049:  stloc.s    V_4
+  IL_004b:  br.s       IL_0075
+  IL_004d:  ldloc.3
+  IL_004e:  ldc.i4.2
+  IL_004f:  newarr     "Object"
+  IL_0054:  dup
+  IL_0055:  ldc.i4.0
+  IL_0056:  ldloc.s    V_4
+  IL_0058:  box        "Integer"
+  IL_005d:  stelem.ref
+  IL_005e:  dup
+  IL_005f:  ldc.i4.1
+  IL_0060:  ldloc.1
+  IL_0061:  ldloc.s    V_4
+  IL_0063:  callvirt   "Function System.Array.GetValue(Integer) As Object"
+  IL_0068:  stelem.ref
+  IL_0069:  ldnull
+  IL_006a:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
+  IL_006f:  ldloc.s    V_4
+  IL_0071:  ldc.i4.1
+  IL_0072:  add.ovf
+  IL_0073:  stloc.s    V_4
+  IL_0075:  ldloc.s    V_4
+  IL_0077:  ldloc.s    V_5
+  IL_0079:  ble.s      IL_004d
+  IL_007b:  ldloc.3
+  IL_007c:  stloc.0
+  IL_007d:  ldloc.0
+  IL_007e:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTryCatchThrow.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTryCatchThrow.vb
@@ -36,42 +36,42 @@ expectedOutput:="TryCatchDivideByZeroExceptionFinally").
   // Code size       70 (0x46)
   .maxstack  2
   .locals init (Integer V_0, //x
-  System.Exception V_1) //ex
+                System.Exception V_1) //ex
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   .try
-{
-  .try
-{
-  IL_0002:  ldstr      "Try"
-  IL_0007:  call       "Sub System.Console.Write(String)"
-  IL_000c:  ldloc.0
-  IL_000d:  dup
-  IL_000e:  div
-  IL_000f:  stloc.0
-  IL_0010:  leave.s    IL_0045
-}
-  catch System.Exception
-{
-  IL_0012:  dup
-  IL_0013:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_0018:  stloc.1
-  IL_0019:  ldstr      "Catch"
-  IL_001e:  ldloc.1
-  IL_001f:  callvirt   "Function System.Exception.GetType() As System.Type"
-  IL_0024:  callvirt   "Function System.Reflection.MemberInfo.get_Name() As String"
-  IL_0029:  call       "Function String.Concat(String, String) As String"
-  IL_002e:  call       "Sub System.Console.Write(String)"
-  IL_0033:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_0038:  leave.s    IL_0045
-}
-}
+  {
+    .try
+    {
+      IL_0002:  ldstr      "Try"
+      IL_0007:  call       "Sub System.Console.Write(String)"
+      IL_000c:  ldloc.0
+      IL_000d:  ldloc.0
+      IL_000e:  div
+      IL_000f:  stloc.0
+      IL_0010:  leave.s    IL_0045
+    }
+    catch System.Exception
+    {
+      IL_0012:  dup
+      IL_0013:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+      IL_0018:  stloc.1
+      IL_0019:  ldstr      "Catch"
+      IL_001e:  ldloc.1
+      IL_001f:  callvirt   "Function System.Exception.GetType() As System.Type"
+      IL_0024:  callvirt   "Function System.Reflection.MemberInfo.get_Name() As String"
+      IL_0029:  call       "Function String.Concat(String, String) As String"
+      IL_002e:  call       "Sub System.Console.Write(String)"
+      IL_0033:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+      IL_0038:  leave.s    IL_0045
+    }
+  }
   finally
-{
-  IL_003a:  ldstr      "Finally"
-  IL_003f:  call       "Sub System.Console.Write(String)"
-  IL_0044:  endfinally
-}
+  {
+    IL_003a:  ldstr      "Finally"
+    IL_003f:  call       "Sub System.Console.Write(String)"
+    IL_0044:  endfinally
+  }
   IL_0045:  ret
 }
 ]]>)
@@ -205,50 +205,50 @@ expectedOutput:="True").
   // Code size       57 (0x39)
   .maxstack  2
   .locals init (Integer V_0, //x
-  System.Exception V_1, //ex
-  System.Exception V_2) //exOrig
+                System.Exception V_1, //ex
+                System.Exception V_2) //exOrig
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   .try
-{
-  IL_0002:  ldloc.0
-  IL_0003:  dup
-  IL_0004:  div
-  IL_0005:  stloc.0
-  IL_0006:  leave.s    IL_0038
-}
+  {
+    IL_0002:  ldloc.0
+    IL_0003:  ldloc.0
+    IL_0004:  div
+    IL_0005:  stloc.0
+    IL_0006:  leave.s    IL_0038
+  }
   catch System.Exception
-{
-  IL_0008:  dup
-  IL_0009:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_000e:  stloc.1
-  IL_000f:  ldloc.1
-  IL_0010:  stloc.2
-  .try
-{
-  IL_0011:  ldloc.0
-  IL_0012:  dup
-  IL_0013:  div
-  IL_0014:  stloc.0
-  IL_0015:  leave.s    IL_0025
-}
-  catch System.Exception
-{
-  IL_0017:  dup
-  IL_0018:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_001d:  stloc.1
-  IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_0023:  leave.s    IL_0025
-}
-  IL_0025:  ldloc.1
-  IL_0026:  ldloc.2
-  IL_0027:  ceq
-  IL_0029:  ldc.i4.0
-  IL_002a:  ceq
-  IL_002c:  call       "Sub System.Console.Write(Boolean)"
-  IL_0031:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_0036:  leave.s    IL_0038
-}
+  {
+    IL_0008:  dup
+    IL_0009:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_000e:  stloc.1
+    IL_000f:  ldloc.1
+    IL_0010:  stloc.2
+    .try
+    {
+      IL_0011:  ldloc.0
+      IL_0012:  ldloc.0
+      IL_0013:  div
+      IL_0014:  stloc.0
+      IL_0015:  leave.s    IL_0025
+    }
+    catch System.Exception
+    {
+      IL_0017:  dup
+      IL_0018:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+      IL_001d:  stloc.1
+      IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+      IL_0023:  leave.s    IL_0025
+    }
+    IL_0025:  ldloc.1
+    IL_0026:  ldloc.2
+    IL_0027:  ceq
+    IL_0029:  ldc.i4.0
+    IL_002a:  ceq
+    IL_002c:  call       "Sub System.Console.Write(Boolean)"
+    IL_0031:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0036:  leave.s    IL_0038
+  }
   IL_0038:  ret
 }
 ]]>)
@@ -291,28 +291,28 @@ expectedOutput:="Attempted to divide by zero.").
   // Code size       26 (0x1a)
   .maxstack  2
   .locals init (Integer V_0, //x
-  System.Exception V_1)
+                System.Exception V_1)
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   .try
-{
-  IL_0002:  ldloc.0
-  IL_0003:  dup
-  IL_0004:  div
-  IL_0005:  stloc.0
-  IL_0006:  leave.s    IL_0019
-}
+  {
+    IL_0002:  ldloc.0
+    IL_0003:  ldloc.0
+    IL_0004:  div
+    IL_0005:  stloc.0
+    IL_0006:  leave.s    IL_0019
+  }
   catch System.Exception
-{
-  IL_0008:  dup
-  IL_0009:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_000e:  stloc.1
-  IL_000f:  ldarg.0
-  IL_0010:  ldloc.1
-  IL_0011:  stind.ref
-  IL_0012:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_0017:  leave.s    IL_0019
-}
+  {
+    IL_0008:  dup
+    IL_0009:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_000e:  stloc.1
+    IL_000f:  ldarg.0
+    IL_0010:  ldloc.1
+    IL_0011:  stind.ref
+    IL_0012:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0017:  leave.s    IL_0019
+  }
   IL_0019:  ret
 }
 ]]>)
@@ -357,45 +357,45 @@ expectedOutput:="TryFilterCatchFinally").
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   .try
-{
-  .try
-{
-  IL_0002:  ldstr      "Try"
-  IL_0007:  call       "Sub System.Console.Write(String)"
-  IL_000c:  ldloc.0
-  IL_000d:  dup
-  IL_000e:  div
-  IL_000f:  stloc.0
-  IL_0010:  leave.s    IL_004a
-}
-  filter
-{
-  IL_0012:  isinst     "System.Exception"
-  IL_0017:  dup
-  IL_0018:  brtrue.s   IL_001e
-  IL_001a:  pop
-  IL_001b:  ldc.i4.0
-  IL_001c:  br.s       IL_002b
-  IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_0023:  call       "Function EmitTest.Filter() As Boolean"
-  IL_0028:  ldc.i4.0
-  IL_0029:  cgt.un
-  IL_002b:  endfilter
-}  // end filter
-{  // handler
-  IL_002d:  pop
-  IL_002e:  ldstr      "Catch"
-  IL_0033:  call       "Sub System.Console.Write(String)"
-  IL_0038:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_003d:  leave.s    IL_004a
-}
-}
+  {
+    .try
+    {
+      IL_0002:  ldstr      "Try"
+      IL_0007:  call       "Sub System.Console.Write(String)"
+      IL_000c:  ldloc.0
+      IL_000d:  ldloc.0
+      IL_000e:  div
+      IL_000f:  stloc.0
+      IL_0010:  leave.s    IL_004a
+    }
+    filter
+    {
+      IL_0012:  isinst     "System.Exception"
+      IL_0017:  dup
+      IL_0018:  brtrue.s   IL_001e
+      IL_001a:  pop
+      IL_001b:  ldc.i4.0
+      IL_001c:  br.s       IL_002b
+      IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+      IL_0023:  call       "Function EmitTest.Filter() As Boolean"
+      IL_0028:  ldc.i4.0
+      IL_0029:  cgt.un
+      IL_002b:  endfilter
+    }  // end filter
+    {  // handler
+      IL_002d:  pop
+      IL_002e:  ldstr      "Catch"
+      IL_0033:  call       "Sub System.Console.Write(String)"
+      IL_0038:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+      IL_003d:  leave.s    IL_004a
+    }
+  }
   finally
-{
-  IL_003f:  ldstr      "Finally"
-  IL_0044:  call       "Sub System.Console.Write(String)"
-  IL_0049:  endfinally
-}
+  {
+    IL_003f:  ldstr      "Finally"
+    IL_0044:  call       "Sub System.Console.Write(String)"
+    IL_0049:  endfinally
+  }
   IL_004a:  ret
 }
 ]]>)
@@ -443,86 +443,86 @@ expectedOutput:="TryCatch228Finally").
   // Code size      156 (0x9c)
   .maxstack  2
   .locals init (Integer V_0, //x
-  System.DivideByZeroException V_1, //ex
-  System.DivideByZeroException V_2) //ex
+                System.DivideByZeroException V_1, //ex
+                System.DivideByZeroException V_2) //ex
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   .try
-{
-  .try
-{
-  IL_0002:  ldstr      "Try"
-  IL_0007:  call       "Sub System.Console.Write(String)"
-  IL_000c:  ldloc.0
-  IL_000d:  dup
-  IL_000e:  div
-  IL_000f:  stloc.0
-  IL_0010:  leave      IL_009b
-}
-  filter
-{
-  IL_0015:  isinst     "System.DivideByZeroException"
-  IL_001a:  dup
-  IL_001b:  brtrue.s   IL_0021
-  IL_001d:  pop
-  IL_001e:  ldc.i4.0
-  IL_001f:  br.s       IL_0034
-  IL_0021:  dup
-  IL_0022:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_0027:  stloc.1
-  IL_0028:  ldloc.1
-  IL_0029:  callvirt   "Function System.Exception.get_Message() As String"
-  IL_002e:  ldnull
-  IL_002f:  ceq
-  IL_0031:  ldc.i4.0
-  IL_0032:  cgt.un
-  IL_0034:  endfilter
-}  // end filter
-{  // handler
-  IL_0036:  pop
-  IL_0037:  ldstr      "Catch1"
-  IL_003c:  call       "Sub System.Console.Write(String)"
-  IL_0041:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_0046:  leave.s    IL_009b
-}
-  filter
-{
-  IL_0048:  isinst     "System.DivideByZeroException"
-  IL_004d:  dup
-  IL_004e:  brtrue.s   IL_0054
-  IL_0050:  pop
-  IL_0051:  ldc.i4.0
-  IL_0052:  br.s       IL_0067
-  IL_0054:  dup
-  IL_0055:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_005a:  stloc.2
-  IL_005b:  ldloc.2
-  IL_005c:  callvirt   "Function System.Exception.get_Message() As String"
-  IL_0061:  ldnull
-  IL_0062:  cgt.un
-  IL_0064:  ldc.i4.0
-  IL_0065:  cgt.un
-  IL_0067:  endfilter
-}  // end filter
-{  // handler
-  IL_0069:  pop
-  IL_006a:  ldstr      "Catch2"
-  IL_006f:  ldloc.2
-  IL_0070:  callvirt   "Function System.Exception.get_Message() As String"
-  IL_0075:  callvirt   "Function String.get_Length() As Integer"
-  IL_007a:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToString(Integer) As String"
-  IL_007f:  call       "Function String.Concat(String, String) As String"
-  IL_0084:  call       "Sub System.Console.Write(String)"
-  IL_0089:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_008e:  leave.s    IL_009b
-}
-}
+  {
+    .try
+    {
+      IL_0002:  ldstr      "Try"
+      IL_0007:  call       "Sub System.Console.Write(String)"
+      IL_000c:  ldloc.0
+      IL_000d:  ldloc.0
+      IL_000e:  div
+      IL_000f:  stloc.0
+      IL_0010:  leave      IL_009b
+    }
+    filter
+    {
+      IL_0015:  isinst     "System.DivideByZeroException"
+      IL_001a:  dup
+      IL_001b:  brtrue.s   IL_0021
+      IL_001d:  pop
+      IL_001e:  ldc.i4.0
+      IL_001f:  br.s       IL_0034
+      IL_0021:  dup
+      IL_0022:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+      IL_0027:  stloc.1
+      IL_0028:  ldloc.1
+      IL_0029:  callvirt   "Function System.Exception.get_Message() As String"
+      IL_002e:  ldnull
+      IL_002f:  ceq
+      IL_0031:  ldc.i4.0
+      IL_0032:  cgt.un
+      IL_0034:  endfilter
+    }  // end filter
+    {  // handler
+      IL_0036:  pop
+      IL_0037:  ldstr      "Catch1"
+      IL_003c:  call       "Sub System.Console.Write(String)"
+      IL_0041:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+      IL_0046:  leave.s    IL_009b
+    }
+    filter
+    {
+      IL_0048:  isinst     "System.DivideByZeroException"
+      IL_004d:  dup
+      IL_004e:  brtrue.s   IL_0054
+      IL_0050:  pop
+      IL_0051:  ldc.i4.0
+      IL_0052:  br.s       IL_0067
+      IL_0054:  dup
+      IL_0055:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+      IL_005a:  stloc.2
+      IL_005b:  ldloc.2
+      IL_005c:  callvirt   "Function System.Exception.get_Message() As String"
+      IL_0061:  ldnull
+      IL_0062:  cgt.un
+      IL_0064:  ldc.i4.0
+      IL_0065:  cgt.un
+      IL_0067:  endfilter
+    }  // end filter
+    {  // handler
+      IL_0069:  pop
+      IL_006a:  ldstr      "Catch2"
+      IL_006f:  ldloc.2
+      IL_0070:  callvirt   "Function System.Exception.get_Message() As String"
+      IL_0075:  callvirt   "Function String.get_Length() As Integer"
+      IL_007a:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToString(Integer) As String"
+      IL_007f:  call       "Function String.Concat(String, String) As String"
+      IL_0084:  call       "Sub System.Console.Write(String)"
+      IL_0089:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+      IL_008e:  leave.s    IL_009b
+    }
+  }
   finally
-{
-  IL_0090:  ldstr      "Finally"
-  IL_0095:  call       "Sub System.Console.Write(String)"
-  IL_009a:  endfinally
-}
+  {
+    IL_0090:  ldstr      "Finally"
+    IL_0095:  call       "Sub System.Console.Write(String)"
+    IL_009a:  endfinally
+  }
   IL_009b:  ret
 }
 ]]>)
@@ -564,48 +564,48 @@ expectedOutput:="TryCatchFinally").
   IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
   .try
-{
-  .try
-{
-  IL_0002:  ldstr      "Try"
-  IL_0007:  call       "Sub System.Console.Write(String)"
-  IL_000c:  ldloc.0
-  IL_000d:  dup
-  IL_000e:  div
-  IL_000f:  stloc.0
-  IL_0010:  leave.s    IL_0052
-}
-  filter
-{
-  IL_0012:  isinst     "System.Exception"
-  IL_0017:  dup
-  IL_0018:  brtrue.s   IL_001e
-  IL_001a:  pop
-  IL_001b:  ldc.i4.0
-  IL_001c:  br.s       IL_0033
-  IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-  IL_0023:  ldsfld     "EmitTest.str As String"
-  IL_0028:  callvirt   "Function String.get_Length() As Integer"
-  IL_002d:  ldc.i4.2
-  IL_002e:  ceq
-  IL_0030:  ldc.i4.0
-  IL_0031:  cgt.un
-  IL_0033:  endfilter
-}  // end filter
-{  // handler
-  IL_0035:  pop
-  IL_0036:  ldstr      "Catch"
-  IL_003b:  call       "Sub System.Console.Write(String)"
-  IL_0040:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_0045:  leave.s    IL_0052
-}
-}
+  {
+    .try
+    {
+      IL_0002:  ldstr      "Try"
+      IL_0007:  call       "Sub System.Console.Write(String)"
+      IL_000c:  ldloc.0
+      IL_000d:  ldloc.0
+      IL_000e:  div
+      IL_000f:  stloc.0
+      IL_0010:  leave.s    IL_0052
+    }
+    filter
+    {
+      IL_0012:  isinst     "System.Exception"
+      IL_0017:  dup
+      IL_0018:  brtrue.s   IL_001e
+      IL_001a:  pop
+      IL_001b:  ldc.i4.0
+      IL_001c:  br.s       IL_0033
+      IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+      IL_0023:  ldsfld     "EmitTest.str As String"
+      IL_0028:  callvirt   "Function String.get_Length() As Integer"
+      IL_002d:  ldc.i4.2
+      IL_002e:  ceq
+      IL_0030:  ldc.i4.0
+      IL_0031:  cgt.un
+      IL_0033:  endfilter
+    }  // end filter
+    {  // handler
+      IL_0035:  pop
+      IL_0036:  ldstr      "Catch"
+      IL_003b:  call       "Sub System.Console.Write(String)"
+      IL_0040:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+      IL_0045:  leave.s    IL_0052
+    }
+  }
   finally
-{
-  IL_0047:  ldstr      "Finally"
-  IL_004c:  call       "Sub System.Console.Write(String)"
-  IL_0051:  endfinally
-}
+  {
+    IL_0047:  ldstr      "Finally"
+    IL_004c:  call       "Sub System.Console.Write(String)"
+    IL_0051:  endfinally
+  }
   IL_0052:  ret
 }
 ]]>)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenUsingStatement.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenUsingStatement.vb
@@ -390,19 +390,18 @@ End Structure
 {
   // Code size       26 (0x1a)
   .maxstack  1
-  .locals init (s1 V_0,
-                s1 V_1)
+  .locals init (s1 V_0)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    "s1"
   IL_0008:  ldloc.0
-  IL_0009:  stloc.1
+  IL_0009:  stloc.0
   .try
   {
     IL_000a:  br.s       IL_000a
   }
   finally
   {
-    IL_000c:  ldloca.s   V_1
+    IL_000c:  ldloca.s   V_0
     IL_000e:  constrained. "s1"
     IL_0014:  callvirt   "Sub System.IDisposable.Dispose()"
     IL_0019:  endfinally

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenUsingStatement.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenUsingStatement.vb
@@ -390,18 +390,19 @@ End Structure
 {
   // Code size       26 (0x1a)
   .maxstack  1
-  .locals init (s1 V_0)
+  .locals init (s1 V_0,
+                s1 V_1)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    "s1"
   IL_0008:  ldloc.0
-  IL_0009:  stloc.0
+  IL_0009:  stloc.1
   .try
   {
     IL_000a:  br.s       IL_000a
   }
   finally
   {
-    IL_000c:  ldloca.s   V_0
+    IL_000c:  ldloca.s   V_1
     IL_000e:  constrained. "s1"
     IL_0014:  callvirt   "Sub System.IDisposable.Dispose()"
     IL_0019:  endfinally

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBCollectionInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBCollectionInitializerTests.vb
@@ -36,19 +36,18 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
                 <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="91"/>
-                <entry offset="0x2d" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x2e">
+            <scope startOffset="0x0" endOffset="0x2c">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="aList1" il_index="0" il_start="0x0" il_end="0x2e" attributes="0"/>
+                <local name="aList1" il_index="0" il_start="0x0" il_end="0x2c" attributes="0"/>
             </scope>
         </method>
     </methods>
@@ -85,19 +84,18 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
                 <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="73"/>
-                <entry offset="0x2d" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x2e">
+            <scope startOffset="0x0" endOffset="0x2c">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="aList2" il_index="0" il_start="0x0" il_end="0x2e" attributes="0"/>
+                <local name="aList2" il_index="0" il_start="0x0" il_end="0x2c" attributes="0"/>
             </scope>
         </method>
     </methods>
@@ -133,20 +131,18 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
                 <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="107"/>
-                <entry offset="0x2f" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x30">
+            <scope startOffset="0x0" endOffset="0x2c">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="aList1" il_index="0" il_start="0x0" il_end="0x30" attributes="0"/>
+                <local name="aList1" il_index="0" il_start="0x0" il_end="0x2c" attributes="0"/>
             </scope>
         </method>
     </methods>
@@ -183,21 +179,20 @@ End Class
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
                     <slot kind="0" offset="12"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
                 <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="19"/>
-                <entry offset="0x2d" startLine="10" startColumn="21" endLine="10" endColumn="27"/>
-                <entry offset="0x59" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x2b" startLine="10" startColumn="21" endLine="10" endColumn="27"/>
+                <entry offset="0x55" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x5a">
+            <scope startOffset="0x0" endOffset="0x56">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="aList1" il_index="0" il_start="0x0" il_end="0x5a" attributes="0"/>
-                <local name="aList2" il_index="1" il_start="0x0" il_end="0x5a" attributes="0"/>
+                <local name="aList1" il_index="0" il_start="0x0" il_end="0x56" attributes="0"/>
+                <local name="aList2" il_index="1" il_start="0x0" il_end="0x56" attributes="0"/>
             </scope>
         </method>
     </methods>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBObjectInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBObjectInitializerTests.vb
@@ -41,19 +41,18 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29"/>
                 <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="78"/>
-                <entry offset="0x19" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x17" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x1a">
+            <scope startOffset="0x0" endOffset="0x18">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="inst" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
+                <local name="inst" il_index="0" il_start="0x0" il_end="0x18" attributes="0"/>
             </scope>
         </method>
     </methods>
@@ -94,19 +93,18 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29"/>
                 <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="68"/>
-                <entry offset="0x19" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x17" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x1a">
+            <scope startOffset="0x0" endOffset="0x18">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="inst" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
+                <local name="inst" il_index="0" il_start="0x0" il_end="0x18" attributes="0"/>
             </scope>
         </method>
     </methods>
@@ -146,20 +144,18 @@ End Class
             <customDebugInfo>
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
-                    <slot kind="temp"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="13" startColumn="5" endLine="13" endColumn="29"/>
                 <entry offset="0x1" startLine="14" startColumn="13" endLine="14" endColumn="90"/>
-                <entry offset="0x1d" startLine="15" startColumn="5" endLine="15" endColumn="12"/>
+                <entry offset="0x19" startLine="15" startColumn="5" endLine="15" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x1e">
+            <scope startOffset="0x0" endOffset="0x1a">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="inst" il_index="0" il_start="0x0" il_end="0x1e" attributes="0"/>
+                <local name="inst" il_index="0" il_start="0x0" il_end="0x1a" attributes="0"/>
             </scope>
         </method>
     </methods>
@@ -201,21 +197,20 @@ End Class
                 <encLocalSlotMap>
                     <slot kind="0" offset="4"/>
                     <slot kind="0" offset="11"/>
-                    <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
                 <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29"/>
                 <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="18"/>
-                <entry offset="0x19" startLine="15" startColumn="20" endLine="15" endColumn="25"/>
-                <entry offset="0x31" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x17" startLine="15" startColumn="20" endLine="15" endColumn="25"/>
+                <entry offset="0x2d" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x32">
+            <scope startOffset="0x0" endOffset="0x2e">
                 <namespace name="System" importlevel="file"/>
                 <namespace name="System.Collections.Generic" importlevel="file"/>
                 <currentnamespace name=""/>
-                <local name="inst1" il_index="0" il_start="0x0" il_end="0x32" attributes="0"/>
-                <local name="inst2" il_index="1" il_start="0x0" il_end="0x32" attributes="0"/>
+                <local name="inst1" il_index="0" il_start="0x0" il_end="0x2e" attributes="0"/>
+                <local name="inst2" il_index="1" il_start="0x0" il_end="0x2e" attributes="0"/>
             </scope>
         </method>
     </methods>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/CompoundAssignment.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/CompoundAssignment.vb
@@ -90,7 +90,7 @@ End Class
   // Code size        7 (0x7)
   .maxstack  3
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  ldind.i4
   IL_0003:  ldc.i4.2
   IL_0004:  add.ovf
@@ -1806,18 +1806,18 @@ Position set for item 'Foo'
             verifier.VerifyIL("Program.Shift",
             <![CDATA[
 {
-  // Code size       34 (0x22)
+  // Code size       35 (0x23)
   .maxstack  3
   IL_0000:  ldarga.s   V_0
-  IL_0002:  dup
-  IL_0003:  constrained. "T"
-  IL_0009:  callvirt   "Function IMoveable.get_Position() As Integer"
-  IL_000e:  ldarga.s   V_0
-  IL_0010:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
-  IL_0015:  add.ovf
-  IL_0016:  constrained. "T"
-  IL_001c:  callvirt   "Sub IMoveable.set_Position(Integer)"
-  IL_0021:  ret
+  IL_0002:  ldarga.s   V_0
+  IL_0004:  constrained. "T"
+  IL_000a:  callvirt   "Function IMoveable.get_Position() As Integer"
+  IL_000f:  ldarga.s   V_0
+  IL_0011:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
+  IL_0016:  add.ovf
+  IL_0017:  constrained. "T"
+  IL_001d:  callvirt   "Sub IMoveable.set_Position(Integer)"
+  IL_0022:  ret
 }
 ]]>)
 
@@ -1912,7 +1912,7 @@ Position set for item 'Foo'
   // Code size       32 (0x20)
   .maxstack  3
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  constrained. "T"
   IL_0008:  callvirt   "Function IMoveable.get_Position() As Integer"
   IL_000d:  ldarg.0
@@ -2013,21 +2013,21 @@ Position set for item 'Foo'
             verifier.VerifyIL("Program.Shift",
             <![CDATA[
 {
-  // Code size       36 (0x24)
+  // Code size       37 (0x25)
   .maxstack  3
   .locals init (T V_0) //lItem
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  dup
-  IL_0005:  constrained. "T"
-  IL_000b:  callvirt   "Function IMoveable.get_Position() As Integer"
-  IL_0010:  ldloca.s   V_0
-  IL_0012:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
-  IL_0017:  add.ovf
-  IL_0018:  constrained. "T"
-  IL_001e:  callvirt   "Sub IMoveable.set_Position(Integer)"
-  IL_0023:  ret
+  IL_0004:  ldloca.s   V_0
+  IL_0006:  constrained. "T"
+  IL_000c:  callvirt   "Function IMoveable.get_Position() As Integer"
+  IL_0011:  ldloca.s   V_0
+  IL_0013:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
+  IL_0018:  add.ovf
+  IL_0019:  constrained. "T"
+  IL_001f:  callvirt   "Sub IMoveable.set_Position(Integer)"
+  IL_0024:  ret
 }
 ]]>)
 
@@ -2358,18 +2358,18 @@ Position set for item 'Foo'
             verifier.VerifyIL("Program.Shift",
             <![CDATA[
 {
-  // Code size       34 (0x22)
+  // Code size       35 (0x23)
   .maxstack  3
   IL_0000:  ldarga.s   V_0
-  IL_0002:  dup
-  IL_0003:  constrained. "T"
-  IL_0009:  callvirt   "Function IMoveable.get_Position() As Integer"
-  IL_000e:  ldarga.s   V_0
-  IL_0010:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
-  IL_0015:  add.ovf
-  IL_0016:  constrained. "T"
-  IL_001c:  callvirt   "Sub IMoveable.set_Position(Integer)"
-  IL_0021:  ret
+  IL_0002:  ldarga.s   V_0
+  IL_0004:  constrained. "T"
+  IL_000a:  callvirt   "Function IMoveable.get_Position() As Integer"
+  IL_000f:  ldarga.s   V_0
+  IL_0011:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
+  IL_0016:  add.ovf
+  IL_0017:  constrained. "T"
+  IL_001d:  callvirt   "Sub IMoveable.set_Position(Integer)"
+  IL_0022:  ret
 }
 ]]>)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/UnstructuredExceptionHandling.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/UnstructuredExceptionHandling.vb
@@ -8833,7 +8833,7 @@ End Module
             compilationVerifier.VerifyIL("Program.Main",
             <![CDATA[
 {
-  // Code size      242 (0xf2)
+  // Code size      243 (0xf3)
   .maxstack  4
   .locals init (Integer V_0,
                 Integer V_1,
@@ -8862,91 +8862,91 @@ End Module
     IL_0023:  stloc.s    V_4
     IL_0025:  ldloc.s    V_4
     IL_0027:  ldloc.s    V_4
-    IL_0029:  dup
-    IL_002a:  call       "Function Program.LoopType.op_Subtraction(Program.LoopType, Program.LoopType) As Program.LoopType"
-    IL_002f:  call       "Function Program.LoopType.op_GreaterThanOrEqual(Program.LoopType, Program.LoopType) As Boolean"
-    IL_0034:  stloc.s    V_5
-    IL_0036:  stloc.s    V_6
-    IL_0038:  br.s       IL_0057
-    IL_003a:  ldc.i4.4
-    IL_003b:  stloc.2
-    IL_003c:  call       "Function Program.M4() As Boolean"
-    IL_0041:  brtrue.s   IL_004a
-    IL_0043:  ldc.i4.6
-    IL_0044:  stloc.2
-    IL_0045:  call       "Sub Program.M1()"
-    IL_004a:  ldc.i4.7
-    IL_004b:  stloc.2
-    IL_004c:  ldloc.s    V_6
-    IL_004e:  ldloc.s    V_4
-    IL_0050:  call       "Function Program.LoopType.op_Addition(Program.LoopType, Program.LoopType) As Program.LoopType"
-    IL_0055:  stloc.s    V_6
-    IL_0057:  ldloc.s    V_5
-    IL_0059:  brtrue.s   IL_0065
-    IL_005b:  ldloc.s    V_6
-    IL_005d:  ldloc.3
-    IL_005e:  call       "Function Program.LoopType.op_GreaterThanOrEqual(Program.LoopType, Program.LoopType) As Boolean"
-    IL_0063:  br.s       IL_006d
-    IL_0065:  ldloc.s    V_6
-    IL_0067:  ldloc.3
-    IL_0068:  call       "Function Program.LoopType.op_LessThanOrEqual(Program.LoopType, Program.LoopType) As Boolean"
-    IL_006d:  brtrue.s   IL_003a
-    IL_006f:  ldc.i4.8
-    IL_0070:  stloc.2
-    IL_0071:  call       "Sub Program.M2()"
-    IL_0076:  leave.s    IL_00e9
-    IL_0078:  ldloc.1
-    IL_0079:  ldc.i4.1
-    IL_007a:  add
-    IL_007b:  ldc.i4.0
-    IL_007c:  stloc.1
-    IL_007d:  switch    (
-        IL_00aa,
+    IL_0029:  ldloc.s    V_4
+    IL_002b:  call       "Function Program.LoopType.op_Subtraction(Program.LoopType, Program.LoopType) As Program.LoopType"
+    IL_0030:  call       "Function Program.LoopType.op_GreaterThanOrEqual(Program.LoopType, Program.LoopType) As Boolean"
+    IL_0035:  stloc.s    V_5
+    IL_0037:  stloc.s    V_6
+    IL_0039:  br.s       IL_0058
+    IL_003b:  ldc.i4.4
+    IL_003c:  stloc.2
+    IL_003d:  call       "Function Program.M4() As Boolean"
+    IL_0042:  brtrue.s   IL_004b
+    IL_0044:  ldc.i4.6
+    IL_0045:  stloc.2
+    IL_0046:  call       "Sub Program.M1()"
+    IL_004b:  ldc.i4.7
+    IL_004c:  stloc.2
+    IL_004d:  ldloc.s    V_6
+    IL_004f:  ldloc.s    V_4
+    IL_0051:  call       "Function Program.LoopType.op_Addition(Program.LoopType, Program.LoopType) As Program.LoopType"
+    IL_0056:  stloc.s    V_6
+    IL_0058:  ldloc.s    V_5
+    IL_005a:  brtrue.s   IL_0066
+    IL_005c:  ldloc.s    V_6
+    IL_005e:  ldloc.3
+    IL_005f:  call       "Function Program.LoopType.op_GreaterThanOrEqual(Program.LoopType, Program.LoopType) As Boolean"
+    IL_0064:  br.s       IL_006e
+    IL_0066:  ldloc.s    V_6
+    IL_0068:  ldloc.3
+    IL_0069:  call       "Function Program.LoopType.op_LessThanOrEqual(Program.LoopType, Program.LoopType) As Boolean"
+    IL_006e:  brtrue.s   IL_003b
+    IL_0070:  ldc.i4.8
+    IL_0071:  stloc.2
+    IL_0072:  call       "Sub Program.M2()"
+    IL_0077:  leave.s    IL_00ea
+    IL_0079:  ldloc.1
+    IL_007a:  ldc.i4.1
+    IL_007b:  add
+    IL_007c:  ldc.i4.0
+    IL_007d:  stloc.1
+    IL_007e:  switch    (
+        IL_00ab,
         IL_0000,
         IL_0007,
         IL_000e,
-        IL_003a,
-        IL_004a,
-        IL_0043,
-        IL_004a,
-        IL_006f,
-        IL_0076)
-    IL_00aa:  leave.s    IL_00de
-    IL_00ac:  ldloc.2
-    IL_00ad:  stloc.1
-    IL_00ae:  ldloc.0
-    IL_00af:  switch    (
-        IL_00bc,
-        IL_0078)
-    IL_00bc:  leave.s    IL_00de
+        IL_003b,
+        IL_004b,
+        IL_0044,
+        IL_004b,
+        IL_0070,
+        IL_0077)
+    IL_00ab:  leave.s    IL_00df
+    IL_00ad:  ldloc.2
+    IL_00ae:  stloc.1
+    IL_00af:  ldloc.0
+    IL_00b0:  switch    (
+        IL_00bd,
+        IL_0079)
+    IL_00bd:  leave.s    IL_00df
   }
   filter
   {
-    IL_00be:  isinst     "System.Exception"
-    IL_00c3:  ldnull
-    IL_00c4:  cgt.un
-    IL_00c6:  ldloc.0
-    IL_00c7:  ldc.i4.0
-    IL_00c8:  cgt.un
-    IL_00ca:  and
-    IL_00cb:  ldloc.1
-    IL_00cc:  ldc.i4.0
-    IL_00cd:  ceq
-    IL_00cf:  and
-    IL_00d0:  endfilter
+    IL_00bf:  isinst     "System.Exception"
+    IL_00c4:  ldnull
+    IL_00c5:  cgt.un
+    IL_00c7:  ldloc.0
+    IL_00c8:  ldc.i4.0
+    IL_00c9:  cgt.un
+    IL_00cb:  and
+    IL_00cc:  ldloc.1
+    IL_00cd:  ldc.i4.0
+    IL_00ce:  ceq
+    IL_00d0:  and
+    IL_00d1:  endfilter
   }  // end filter
   {  // handler
-    IL_00d2:  castclass  "System.Exception"
-    IL_00d7:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_00dc:  leave.s    IL_00ac
+    IL_00d3:  castclass  "System.Exception"
+    IL_00d8:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00dd:  leave.s    IL_00ad
   }
-  IL_00de:  ldc.i4     0x800a0033
-  IL_00e3:  call       "Function Microsoft.VisualBasic.CompilerServices.ProjectData.CreateProjectError(Integer) As System.Exception"
-  IL_00e8:  throw
-  IL_00e9:  ldloc.1
-  IL_00ea:  brfalse.s  IL_00f1
-  IL_00ec:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-  IL_00f1:  ret
+  IL_00df:  ldc.i4     0x800a0033
+  IL_00e4:  call       "Function Microsoft.VisualBasic.CompilerServices.ProjectData.CreateProjectError(Integer) As System.Exception"
+  IL_00e9:  throw
+  IL_00ea:  ldloc.1
+  IL_00eb:  brfalse.s  IL_00f2
+  IL_00ed:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_00f2:  ret
 }
 ]]>)
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/AccessibilityTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/AccessibilityTests.vb
@@ -180,7 +180,7 @@ End Class
   .maxstack  2
   .locals init (Integer V_0) //Test
   IL_0000:  ldarg.0
-  IL_0001:  dup
+  IL_0001:  ldarg.0
   IL_0002:  callvirt   ""Function C.get_P() As Integer""
   IL_0007:  callvirt   ""Function B.M(Integer) As Integer""
   IL_000c:  ret

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -2671,7 +2671,7 @@ End Class
   // Code size        4 (0x4)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  dup
+  IL_0001:  ldarg.1
   IL_0002:  add.ovf
   IL_0003:  ret
 }")

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StatementTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StatementTests.vb
@@ -473,7 +473,7 @@ End Class
   .maxstack  2
   .locals init (ULong V_0) //l
   IL_0000:  ldloc.0
-  IL_0001:  dup
+  IL_0001:  ldloc.0
   IL_0002:  mul.ovf.un
   IL_0003:  stloc.0
   IL_0004:  ret


### PR DESCRIPTION
This is basically the same changes as were done recently to C# and related to #4103

This change:
* Makes stack optimizer more robust similarly to  https://github.com/dotnet/roslyn/commit/93b341d09bdba8bc7f3f530ecaac7884e892c2eb

* Adds  /debug+ mode of optimizations which is the default for Debug ( /o-  )  and can be enabled via /debug+ in Release ( /o+ ).

