### PR TITLE
Stop setting InternalFeatureOnOffOptions

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -97,6 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             if (completionService != null && 
                 workspace != null && 
+                workspace.Kind != WorkspaceKind.Interactive && // TODO (https://github.com/dotnet/roslyn/issues/5107): support in interactive
                 workspace.Options.GetOption(InternalFeatureOnOffOptions.Snippets) && 
                 triggerInfo.TriggerReason != CompletionTriggerReason.Snippets)
             {

--- a/src/EditorFeatures/Core/Shared/Options/InternalFeatureOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/InternalFeatureOnOffOptions.cs
@@ -50,8 +50,12 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
         [ExportOption]
         public static readonly Option<bool> EventHookup = new Option<bool>(OptionName, "Event Hookup", defaultValue: true);
 
+        /// <remarks>
+        /// Due to https://github.com/dotnet/roslyn/issues/5393, the name "Snippets" is unusable.
+        /// (Summary: Some builds incorrectly set it without providing a way to clear it so it exists in many registries.)
+        /// </remarks>
         [ExportOption]
-        public static readonly Option<bool> Snippets = new Option<bool>(OptionName, "Snippets", defaultValue: true);
+        public static readonly Option<bool> Snippets = new Option<bool>(OptionName, "Snippets2", defaultValue: true);
 
         [ExportOption]
         public static readonly Option<bool> TodoComments = new Option<bool>(OptionName, "Todo Comments", defaultValue: true);

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
@@ -25,9 +25,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             // register work coordinator for this workspace
             _registrationService = this.Services.GetService<ISolutionCrawlerRegistrationService>();
             _registrationService.Register(this);
-
-            // TODO (https://github.com/dotnet/roslyn/issues/5107): Enable in Interactive.
-            this.Options = this.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, false);
         }
 
         protected override void Dispose(bool finalize)

--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         {
             AssertIsForeground();
 
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 nextHandler();
                 return;
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         {
             AssertIsForeground();
 
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 return nextHandler();
             }

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler)
         {
             AssertIsForeground();
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 nextHandler();
                 return;
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
             
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 return nextHandler();
             }
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
         {
             AssertIsForeground();
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 nextHandler();
                 return;
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
 
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 return nextHandler();
             }
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler)
         {
             AssertIsForeground();
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 nextHandler();
                 return;
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
 
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 return nextHandler();
             }
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         public void ExecuteCommand(BackTabKeyCommandArgs args, Action nextHandler)
         {
             AssertIsForeground();
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 nextHandler();
                 return;
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
 
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 return nextHandler();
             }
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
 
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 nextHandler();
                 return;
@@ -225,7 +225,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         {
             AssertIsForeground();
 
-            if (!args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets))
+            if (!AreSnippetsEnabled(args))
             {
                 return nextHandler();
             }
@@ -302,6 +302,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
             textManager.GetExpansionManager(out expansionManager);
             return expansionManager != null;
+        }
+
+        protected static bool AreSnippetsEnabled(CommandArgs args)
+        {
+            Workspace workspace;
+            return args.SubjectBuffer.GetOption(InternalFeatureOnOffOptions.Snippets) &&
+                // TODO (https://github.com/dotnet/roslyn/issues/5107): enable in interactive
+                !(Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace) && workspace.Kind == WorkspaceKind.Interactive);
         }
     }
 }


### PR DESCRIPTION
We were doing so to disable snippets in the interactive window, but it
turns out that it's per-user, rather than per-workspace.

Fixes #5393