### PR TITLE
Add a separate package for the Linux coreclr runtime

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -77,6 +77,14 @@ release_sem()
 
 restore_nuget()
 {
+    # restore coreclr runtime package
+    pushd /tmp
+    local coreclr_package_name="coreclr.linux.1.zip"
+    rm $coreclr_package_name
+    curl -O https://dotnetci.blob.core.windows.net/roslyn/$coreclr_package_name
+    unzip -uoq $coreclr_package_name -d ~/
+    popd
+
     acquire_sem_or_wait "restore_nuget"
 
     local package_name="nuget.15.zip"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -80,7 +80,7 @@ restore_nuget()
     # restore coreclr runtime package
     pushd /tmp
     local coreclr_package_name="coreclr.linux.1.zip"
-    rm $coreclr_package_name
+    rm $coreclr_package_name 2>/dev/null
     curl -O https://dotnetci.blob.core.windows.net/roslyn/$coreclr_package_name
     unzip -uoq $coreclr_package_name -d ~/
     popd


### PR DESCRIPTION
The newest NuGet runtime packages (nuget.14,.15) accidentally excluded the tmp_corelr_runtime folder from the packages, which cause PR builds to fail on Linux when it's not present.

This change moves the linux coreclr runtime snapshot to its own package so we don't have to worry about forgetting to include it in the main NuGet package anymore.

@tannergooding @jaredpar 