### PR TITLE
Add a server mutex to VBCSCompiler

### DIFF
--- a/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
+++ b/src/Compilers/Core/VBCSCompiler/ServerDispatcher.cs
@@ -73,6 +73,33 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             var pipeName = args[0].Substring(pipeArgPrefix.Length);
 
+            // Grab the server mutex to prevent multiple servers from starting with the same
+            // pipename and consuming excess resources. If someone else holds the mutex
+            // exit immediately with a non-zero exit code
+            var serverMutexName = $"{pipeName}.server";
+            bool holdsMutex;
+            using (var serverMutex = new Mutex(initiallyOwned: true,
+                                               name: serverMutexName,
+                                               createdNew: out holdsMutex))
+            {
+                if (!holdsMutex)
+                {
+                    return CommonCompiler.Failed;
+                }
+
+                try
+                {
+                    return Run(keepAliveTimeout, compilerExeDirectory, pipeName);
+                }
+                finally
+                {
+                    serverMutex.ReleaseMutex();
+                }
+            }
+        }
+
+        private static int Run(TimeSpan? keepAliveTimeout, string compilerExeDirectory, string pipeName)
+        {
             try
             {
                 int keepAliveValue;

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -2393,5 +2393,58 @@ namespace Class____foo____Library1
             Assert.Equal(0, result.ExitCode);
             Assert.Equal("", result.Errors);
         }
+
+        [Fact]
+        public void MutexStopsServerStarting()
+        {
+            var pipename = Guid.NewGuid().ToString("N");
+            var mutexName = $"{pipename}.server";
+
+            bool holdsMutex;
+            using (var mutex = new Mutex(initiallyOwned: true,
+                                         name: mutexName,
+                                         createdNew: out holdsMutex))
+            {
+                Assert.True(holdsMutex);
+                try
+                {
+                    var result = ProcessUtilities.StartProcess(_compilerServerExecutable,
+                                                               $"-pipename:{pipename}");
+
+                    // Note: can't use async because Mutexes are thread-affinitive
+                    Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                    var exited = result.HasExited;
+                    if (!exited)
+                    {
+                        result.Kill();
+                    }
+                    Assert.True(exited);
+                }
+                finally
+                {
+                    mutex.ReleaseMutex();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ServerWithSamePipeNameExits()
+        {
+            var pipename = Guid.NewGuid().ToString("N");
+            var args = $"-pipename:{pipename}";
+
+            var server1 = ProcessUtilities.StartProcess(_compilerServerExecutable, args);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+
+            var server2 = ProcessUtilities.StartProcess(_compilerServerExecutable, args);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+
+            Assert.False(server1.HasExited);
+            Assert.True(server2.HasExited);
+            Assert.False(server1.HasExited);
+            server1.Kill();
+        }
     }
 }

--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -2435,11 +2435,11 @@ namespace Class____foo____Library1
 
             var server1 = ProcessUtilities.StartProcess(_compilerServerExecutable, args);
 
-            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
 
             var server2 = ProcessUtilities.StartProcess(_compilerServerExecutable, args);
 
-            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
 
             Assert.False(server1.HasExited);
             Assert.True(server2.HasExited);


### PR DESCRIPTION
Issue #2790 describes multiple servers running with the same pipename,
which should never happen. It's probable that this was caused by the
File.Exists line in #3177. This change adopts a different strategy
than attempting to check for the existence of the pipe -- instead we
use both client and server mutexes. The client mutex prevents multiple
clients from trying to start multiple servers simultaneously, while the
server mutex acts as a signal to the client that a server is already
running and a signal to all servers unable to grab the mutex that they
should shut down.

As always, any failed server usage simply results in the use of the
in-proc compiler.

@jaredpar @pharring @VSadov @AlekseyTs @TyOverby @gafter Please review