### PR TITLE
Show property accessor accessibility in CSharp QuickInfo

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -1333,6 +1333,28 @@ void M()
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void LocalProperty_Minimal_PrivateSet()
+        {
+            TestInClass(@"public DateTime Prop { get; private set; }
+void M()
+{
+    P$$rop.ToString();
+}",
+                MainDescription("DateTime C.Prop { get; private set; }"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void LocalProperty_Minimal_PrivateSet1()
+        {
+            TestInClass(@"protected internal int Prop { get; private set; }
+void M()
+{
+    P$$rop.ToString();
+}",
+                MainDescription("int C.Prop { get; private set; }"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void LocalProperty_Qualified()
         {
             TestInClass(@"System.IO.FileInfo Prop { get; set; }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -533,7 +533,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                     ToMinimalDisplayParts(symbol, MinimallyQualifiedFormatWithConstants));
             }
 
-            private void AddDescriptionForProperty(IPropertySymbol symbol)
+            protected virtual void AddDescriptionForProperty(IPropertySymbol symbol)
             {
                 if (symbol.IsIndexer)
                 {


### PR DESCRIPTION
Same changes from #5471, not sure why that PR always fail mac git.

Fixes #5094