### PR TITLE
Fix issue when pressing ENTER in XML doc comments with a selection

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1264,6 +1264,52 @@ static void Main(string[] args)
             VerifyPressingEnter(code, expected, useTabs: true);
         }
 
+        [WorkItem(5486, "https://github.com/dotnet/roslyn/issues/5486")]
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void PressingEnter_Selection1()
+        {
+            var code =
+@"/// <summary>
+/// Hello [|World|]$$!
+/// </summary>
+class C
+{
+}";
+            var expected =
+@"/// <summary>
+/// Hello 
+/// $$!
+/// </summary>
+class C
+{
+}";
+
+            VerifyPressingEnter(code, expected);
+        }
+
+        [WorkItem(5486, "https://github.com/dotnet/roslyn/issues/5486")]
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void PressingEnter_Selection2()
+        {
+            var code =
+@"/// <summary>
+/// Hello $$[|World|]!
+/// </summary>
+class C
+{
+}";
+            var expected =
+@"/// <summary>
+/// Hello 
+/// $$!
+/// </summary>
+class C
+{
+}";
+
+            VerifyPressingEnter(code, expected);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void Command_Class()
         {

--- a/src/EditorFeatures/Test/DocumentationComments/AbstractDocumentationCommentTests.cs
+++ b/src/EditorFeatures/Test/DocumentationComments/AbstractDocumentationCommentTests.cs
@@ -118,7 +118,23 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
             using (var workspace = CreateTestWorkspace(initialMarkup))
             {
                 var testDocument = workspace.Documents.Single();
+
+                Assert.True(testDocument.CursorPosition.HasValue, "No caret position set!");
+                var startCaretPosition = testDocument.CursorPosition.Value;
+
                 var view = testDocument.GetTextView();
+
+                if (testDocument.SelectedSpans.Any())
+                {
+                    var selectedSpan = testDocument.SelectedSpans[0];
+
+                    var isReversed = selectedSpan.Start == startCaretPosition
+                        ? true
+                        : false;
+
+                    view.Selection.Select(new SnapshotSpan(view.TextSnapshot, selectedSpan.Start, selectedSpan.Length), isReversed);
+                }
+
                 view.Caret.MoveTo(new SnapshotPoint(view.TextSnapshot, testDocument.CursorPosition.Value));
 
                 if (useTabs)
@@ -139,9 +155,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 
                 Assert.Equal(expectedCode, view.TextSnapshot.GetText());
 
-                var caretPosition = view.Caret.Position.BufferPosition.Position;
-                Assert.True(expectedPosition == caretPosition,
-                    string.Format("Caret positioned incorrectly. Should have been {0}, but was {1}.", expectedPosition, caretPosition));
+                var endCaretPosition = view.Caret.Position.BufferPosition.Position;
+                Assert.True(expectedPosition == endCaretPosition,
+                    string.Format("Caret positioned incorrectly. Should have been {0}, but was {1}.", expectedPosition, endCaretPosition));
             }
         }
     }

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -736,6 +736,48 @@ End Class
             VerifyPressingEnter(code, expected, useTabs:=True)
         End Sub
 
+        <WorkItem(5486, "https://github.com/dotnet/roslyn/issues/5486")>
+        <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        Public Sub PressingEnter_Selection1()
+            Const code = "
+''' <summary>
+''' Hello [|World|]$$!
+''' </summary>
+Class C
+End Class
+"
+            Const expected = "
+''' <summary>
+''' Hello 
+''' $$!
+''' </summary>
+Class C
+End Class
+"
+            VerifyPressingEnter(code, expected)
+        End Sub
+
+        <WorkItem(5486, "https://github.com/dotnet/roslyn/issues/5486")>
+        <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        Public Sub PressingEnter_Selection2()
+            Const code = "
+''' <summary>
+''' Hello $$[|World|]!
+''' </summary>
+Class C
+End Class
+"
+            Const expected = "
+''' <summary>
+''' Hello 
+''' $$!
+''' </summary>
+Class C
+End Class
+"
+            VerifyPressingEnter(code, expected)
+        End Sub
+
         <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
         Public Sub Command_Class()
             Const code = "


### PR DESCRIPTION
Fixes #5486 

In order to insert XML doc comment exterior trivia (e.g. /// or '''), we grab the caret position prior to the new line being inserted into the editor and then perform a bit of analysis afterward using that position. However, if there's a selection in the editor and the caret is at the end of that selection, the position will be in an unexpected place in the syntax tree, causing that bit of analysis to fail. So, in this case (and all cases), we use the start of the selection as the position to perform analysis on since that position will be consistent after the new line is inserted.