### PR TITLE
Smart indenter should not throw when enter is pressed after invalid query continuation

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
@@ -363,7 +362,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             {
                 // find containing non terminal node
                 var queryExpressionClause = GetQueryExpressionClause(token);
-                Contract.ThrowIfNull(queryExpressionClause);
+                if (queryExpressionClause == null)
+                {
+                    return GetDefaultIndentationFromTokenLine(token);
+                }
 
                 // find line where first token of the node is
                 var snapshot = LineToBeIndented.Snapshot;

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -2,9 +2,7 @@
 
 using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -12,7 +10,6 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation;
 using Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2481,6 +2481,56 @@ class Program
                 expectedIndentation: 36);
         }
 
+        [WorkItem(5495, "https://github.com/dotnet/roslyn/issues/5495")]
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void AfterBadQueryContinuationWithSelectOrGroupClause()
+        {
+            var code = @"using System.Collections.Generic;
+using System.Linq;
+
+namespace ConsoleApplication1
+{
+    class AutomapperConfig
+    {
+        public static IEnumerable<string> ConfigureMappings(string name)
+        {
+            List<User> anEntireSlewOfItems = new List<User>();
+            List<UserViewModel> viewModels = new List<UserViewModel>();
+
+            var items = (from m in anEntireSlewOfItems into man
+
+             join at in viewModels on m.id equals at.id
+             join c in viewModels on m.name equals c.name
+             join ct in viewModels on m.phonenumber equals ct.phonenumber
+             where m.id == 1 &&
+                 m.name == name
+             select new { M = true, I = at, AT = at }).ToList();
+            //Mapper.CreateMap<User, UserViewModel>()
+            //    .ForMember(t => t.)
+        }
+    }
+
+    class User
+    {
+        public int id { get; set; }
+        public string name { get; set; }
+        public int phonenumber { get; set; }
+    }
+
+    class UserViewModel
+    {
+        public int id { get; set; }
+        public string name { get; set; }
+        public int phonenumber { get; set; }
+    }
+}";
+
+            AssertSmartIndent(
+                code,
+                indentationLine: 13,
+                expectedIndentation: 25);
+        }
+
         private static void AssertSmartIndentInProjection(string markup, int expectedIndentation, CSharpParseOptions options = null)
         {
             var optionsSet = options != null


### PR DESCRIPTION
Fixes #5495

In the smart indenter, we try to find a reasonable query clause. However, in particularly mangled cases  the parenting query body won't have a clause at all. If that happens, just compute the default indentation rather than throwing an InvalidOperationException.

Here's an example of such a case:

```C#
using System.Linq;

class Program
{
    static void Main()
    {
        var q = from n in Enumerable.Range(1, 10) into x
    }
}
```

The tree produced in that case is pretty bad, with a couple of missing nodes inserting:

![image](https://cloud.githubusercontent.com/assets/116161/10150217/34bf0986-65f3-11e5-8392-954e3df71d3c.png)
