### PR TITLE
De-dup C# global usings

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -80,14 +81,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            Dictionary<string, AliasAndUsingDirective> aliasSymbols = Imports.UsingAliases;
-            if (aliasSymbols != null)
+            ImmutableDictionary<string, AliasAndUsingDirective> aliasSymbols = Imports.UsingAliases;
+            if (!aliasSymbols.IsEmpty)
             {
-                foreach (var pair in aliasSymbols)
+                var aliases = ArrayBuilder<string>.GetInstance(aliasSymbols.Count);
+                aliases.AddRange(aliasSymbols.Keys);
+                aliases.Sort(StringComparer.Ordinal); // Actual order doesn't matter - just want to be deterministic.
+
+                foreach (var alias in aliases)
                 {
-                    var alias = pair.Key;
-                    var symbol = pair.Value.Alias;
-                    var syntax = pair.Value.UsingDirective;
+                    var aliasAndUsingDirective = aliasSymbols[alias];
+                    var symbol = aliasAndUsingDirective.Alias;
+                    var syntax = aliasAndUsingDirective.UsingDirective;
                     Debug.Assert(!symbol.IsExtern);
 
                     NamespaceOrTypeSymbol target = symbol.Target;
@@ -105,6 +110,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         usedNamespaces.Add(Cci.UsedNamespaceOrType.CreateType(typeRef, alias));
                     }
                 }
+
+                aliases.Free();
             }
 
             return usedNamespaces.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -17,8 +17,12 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal sealed class Imports
     {
-        internal static readonly Imports Empty = new Imports(null, null,
-            ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, ImmutableArray<AliasAndExternAliasDirective>.Empty, null);
+        internal static readonly Imports Empty = new Imports(
+            null,
+            ImmutableDictionary<string, AliasAndUsingDirective>.Empty,
+            ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, 
+            ImmutableArray<AliasAndExternAliasDirective>.Empty, 
+            null);
 
         private readonly CSharpCompilation _compilation;
         private readonly DiagnosticBag _diagnostics;
@@ -26,18 +30,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         // completion state that tracks whether validation was done/not done/currently in process. 
         private SymbolCompletionState _state;
 
-        public readonly Dictionary<string, AliasAndUsingDirective> UsingAliases;
+        public readonly ImmutableDictionary<string, AliasAndUsingDirective> UsingAliases;
         public readonly ImmutableArray<NamespaceOrTypeAndUsingDirective> Usings;
         public readonly ImmutableArray<AliasAndExternAliasDirective> ExternAliases;
 
         private Imports(
             CSharpCompilation compilation,
-            Dictionary<string, AliasAndUsingDirective> usingAliases,
+            ImmutableDictionary<string, AliasAndUsingDirective> usingAliases,
             ImmutableArray<NamespaceOrTypeAndUsingDirective> usings,
             ImmutableArray<AliasAndExternAliasDirective> externs,
             DiagnosticBag diagnostics)
         {
-            Debug.Assert(!usings.IsDefault && !externs.IsDefault);
+            Debug.Assert(usingAliases != null);
+            Debug.Assert(!usings.IsDefault);
+            Debug.Assert(!externs.IsDefault);
 
             _compilation = compilation;
             this.UsingAliases = usingAliases;
@@ -88,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var externAliases = BuildExternAliases(externAliasDirectives, binder, diagnostics);
             var usings = ArrayBuilder<NamespaceOrTypeAndUsingDirective>.GetInstance();
-            Dictionary<string, AliasAndUsingDirective> usingAliases = null;
+            ImmutableDictionary<string, AliasAndUsingDirective>.Builder usingAliases = null;
 
             if (usingDirectives.Count > 0)
             {
@@ -98,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Top-level usings in interactive code are resolved in the context of global namespace, w/o extern aliases:
                     new InContainerBinder(binder.Compilation.GlobalNamespace, new BuckStopsHereBinder(binder.Compilation)) :
                     new InContainerBinder(binder.Container, binder.Next,
-                        new Imports(binder.Compilation, null, ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, externAliases, null));
+                        new Imports(binder.Compilation, ImmutableDictionary<string, AliasAndUsingDirective>.Empty, ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, externAliases, null));
 
                 var uniqueUsings = PooledHashSet<NamespaceOrTypeSymbol>.GetInstance();
 
@@ -138,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             if (usingAliases == null)
                             {
-                                usingAliases = new Dictionary<string, AliasAndUsingDirective>();
+                                usingAliases = ImmutableDictionary.CreateBuilder<string, AliasAndUsingDirective>();
                             }
 
                             // construct the alias sym with the binder for which we are building imports. That
@@ -212,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics = null;
             }
 
-            return new Imports(binder.Compilation, usingAliases, usings.ToImmutableAndFree(), externAliases, diagnostics);
+            return new Imports(binder.Compilation, usingAliases.ToImmutableDictionaryOrEmpty(), usings.ToImmutableAndFree(), externAliases, diagnostics);
         }
 
         public static Imports FromGlobalUsings(CSharpCompilation compilation)
@@ -252,16 +258,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics = null;
             }
 
-            return new Imports(compilation, null, boundUsings.ToImmutableAndFree(), ImmutableArray<AliasAndExternAliasDirective>.Empty, diagnostics);
+            return new Imports(compilation, ImmutableDictionary<string, AliasAndUsingDirective>.Empty, boundUsings.ToImmutableAndFree(), ImmutableArray<AliasAndExternAliasDirective>.Empty, diagnostics);
         }
 
         public static Imports FromCustomDebugInfo(
             CSharpCompilation compilation,
-            Dictionary<string, AliasAndUsingDirective> usingAliases,
+            ImmutableDictionary<string, AliasAndUsingDirective> usingAliases,
             ImmutableArray<NamespaceOrTypeAndUsingDirective> usings,
             ImmutableArray<AliasAndExternAliasDirective> externs)
         {
-            return new Imports(compilation, usingAliases, usings, externs, null);
+            return new Imports(compilation, usingAliases, usings, externs, diagnostics: null);
         }
 
         private static ImmutableArray<AliasAndExternAliasDirective> BuildExternAliases(
@@ -360,21 +366,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             DiagnosticBag semanticDiagnostics = _compilation.DeclarationDiagnostics;
 
-            if (UsingAliases != null)
+            // Check constraints within named aliases.
+
+            // Force resolution of named aliases.
+            foreach (var alias in UsingAliases.Values)
             {
-                // Check constraints within named aliases.
+                alias.Alias.GetAliasTarget(basesBeingResolved: null);
+                semanticDiagnostics.AddRange(alias.Alias.AliasTargetDiagnostics);
+            }
 
-                // Force resolution of named aliases.
-                foreach (var alias in UsingAliases.Values)
-                {
-                    alias.Alias.GetAliasTarget(basesBeingResolved: null);
-                    semanticDiagnostics.AddRange(alias.Alias.AliasTargetDiagnostics);
-                }
-
-                foreach (var alias in UsingAliases.Values)
-                {
-                    alias.Alias.CheckConstraints(semanticDiagnostics);
-                }
+            foreach (var alias in UsingAliases.Values)
+            {
+                alias.Alias.CheckConstraints(semanticDiagnostics);
             }
 
             // Force resolution of extern aliases.
@@ -393,7 +396,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool IsUsingAlias(string name, bool callerIsSemanticModel)
         {
             AliasAndUsingDirective node;
-            if (this.UsingAliases != null && this.UsingAliases.TryGetValue(name, out node))
+            if (this.UsingAliases.TryGetValue(name, out node))
             {
                 // This method is called by InContainerBinder.LookupSymbolsInSingleBinder to see if
                 // there's a conflict between an alias and a member.  As a conflict may cause a
@@ -437,7 +440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool callerIsSemanticModel = originalBinder.IsSemanticModelBinder;
 
             AliasAndUsingDirective alias;
-            if (this.UsingAliases != null && this.UsingAliases.TryGetValue(name, out alias))
+            if (this.UsingAliases.TryGetValue(name, out alias))
             {
                 // Found a match in our list of normal aliases.  Mark the alias as being seen so that
                 // it won't be reported to the user as something that can be removed.
@@ -593,16 +596,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal void AddLookupSymbolsInfoInAliases(Binder originalBinder, LookupSymbolsInfo result, LookupOptions options)
         {
-            if (this.UsingAliases != null)
+            foreach (var usingAlias in this.UsingAliases.Values)
             {
-                foreach (var usingAlias in this.UsingAliases.Values)
+                var usingAliasSymbol = usingAlias.Alias;
+                var usingAliasTargetSymbol = usingAliasSymbol.GetAliasTarget(basesBeingResolved: null);
+                if (originalBinder.CanAddLookupSymbolInfo(usingAliasTargetSymbol, options, null))
                 {
-                    var usingAliasSymbol = usingAlias.Alias;
-                    var usingAliasTargetSymbol = usingAliasSymbol.GetAliasTarget(basesBeingResolved: null);
-                    if (originalBinder.CanAddLookupSymbolInfo(usingAliasTargetSymbol, options, null))
-                    {
-                        result.AddSymbol(usingAliasSymbol, usingAliasSymbol.Name, 0);
-                    }
+                    result.AddSymbol(usingAliasSymbol, usingAliasSymbol.Name, 0);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -223,14 +223,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var boundUsings = ArrayBuilder<NamespaceOrTypeAndUsingDirective>.GetInstance();
             var uniqueUsings = PooledHashSet<NamespaceOrTypeSymbol>.GetInstance();
 
-            foreach (string targetString in usings)
+            foreach (string @using in usings)
             {
-                if (!targetString.IsValidClrNamespaceName())
+                if (!@using.IsValidClrNamespaceName())
                 {
                     continue;
                 }
 
-                string[] identifiers = targetString.Split('.');
+                string[] identifiers = @using.Split('.');
                 NameSyntax qualifiedName = SyntaxFactory.IdentifierName(identifiers[0]);
 
                 for (int j = 1; j < identifiers.Length; j++)

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -210,11 +210,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var imports = GetImports(basesBeingResolved: null);
 
-                imports.AddLookupSymbolsInfoInAliases(this, result, options);
+                imports.AddLookupSymbolsInfoInAliases(originalBinder, result, options);
 
                 // Add types within namespaces imported through usings, but don't add nested namespaces.
                 LookupOptions usingOptions = (options & ~(LookupOptions.NamespaceAliasesOnly | LookupOptions.NamespacesOrTypesOnly)) | LookupOptions.MustNotBeNamespace;
-                Imports.AddLookupSymbolsInfoInUsings(imports.Usings, this, result, usingOptions);
+                Imports.AddLookupSymbolsInfoInUsings(imports.Usings, originalBinder, result, usingOptions);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingsBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingsBinder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             LookupResult tmp = LookupResult.GetInstance();
 
             // usings:
-            Imports.Empty.LookupSymbolInUsings(ConsolidatedUsings, originalBinder, tmp, name, arity, basesBeingResolved, options, diagnose, ref useSiteDiagnostics);
+            Imports.LookupSymbolInUsings(ConsolidatedUsings, originalBinder, tmp, name, arity, basesBeingResolved, options, diagnose, ref useSiteDiagnostics);
 
             // if we found a viable result in imported namespaces, use it instead of unviable symbols found in source:
             if (tmp.IsMultiViable)

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
@@ -2125,9 +2125,9 @@ class C
                     "DebuggableAttribute",
                     "DebuggingModes",
                     "Object",
+                    "Func`1",
                     "Enumerable",
-                    "DataColumn",
-                    "Func`1"
+                    "DataColumn"
                 }, reader.TypeReferences.Select(h => reader.GetString(reader.GetTypeReference(h).Name)));
 
                 Assert.Equal(1, reader.GetTableRowCount(TableIndex.TypeSpec));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InteractiveUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InteractiveUsingTests.cs
@@ -282,6 +282,24 @@ using static Path;
         }
 
         [Fact]
+        public void DuplicateGlobalUsing_SameSubmission()
+        {
+            CreateSubmission("typeof(String)", options: TestOptions.DebugDll.WithUsings("System", "System")).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void DuplicateGlobalUsing_PreviousSubmission()
+        {
+            var options = TestOptions.DebugDll.WithUsings("System");
+
+            var sub1 = CreateSubmission("typeof(String)", options: options);
+            sub1.VerifyDiagnostics();
+
+            var sub2 = CreateSubmission("typeof(String)", options: options, previous: sub1);
+            sub2.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void UsingsRebound()
         {
             const string libSourceTemplate = @"

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -842,10 +842,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 binder = new InContainerBinder(
                     binder.Container,
                     binder,
-                    Imports.FromCustomDebugInfo(binder.Compilation, new Dictionary<string, AliasAndUsingDirective>(), ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, externs));
+                    Imports.FromCustomDebugInfo(binder.Compilation, ImmutableDictionary<string, AliasAndUsingDirective>.Empty, ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, externs));
             }
 
-            var usingAliases = new Dictionary<string, AliasAndUsingDirective>();
+            var usingAliases = ImmutableDictionary.CreateBuilder<string, AliasAndUsingDirective>();
             var usingsBuilder = ArrayBuilder<NamespaceOrTypeAndUsingDirective>.GetInstance();
 
             foreach (var importRecord in importRecords)
@@ -968,7 +968,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 }
             }
 
-            return Imports.FromCustomDebugInfo(binder.Compilation, usingAliases, usingsBuilder.ToImmutableAndFree(), externs);
+            return Imports.FromCustomDebugInfo(binder.Compilation, usingAliases.ToImmutableDictionary(), usingsBuilder.ToImmutableAndFree(), externs);
         }
 
         private static NamespaceSymbol BindNamespace(string namespaceName, NamespaceSymbol globalNamespace)
@@ -993,7 +993,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             string alias,
             NamespaceOrTypeSymbol targetSymbol,
             ArrayBuilder<NamespaceOrTypeAndUsingDirective> usingsBuilder,
-            Dictionary<string, AliasAndUsingDirective> usingAliases,
+            ImmutableDictionary<string, AliasAndUsingDirective>.Builder usingAliases,
             InContainerBinder binder,
             ImportRecord importRecord)
         {


### PR DESCRIPTION
...so that we don't incorrectly look in each copy and report a false
ambiguity (causing an assert).

Bonus: switch ```this``` to ```originalBinder``` in a SemanticModel import
case.

Part of #5450.