### PR TITLE
Missing assembly resolution

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if ((object)bindingResult[i].AssemblySymbol == null)
                         {
-                            // symbols hasn't been found in the cache, create a new one
+                            // symbol hasn't been found in the cache, create a new one
                             var compilationData = (AssemblyDataForMetadataOrCompilation)allAssemblyData[i];
                             bindingResult[i].AssemblySymbol = compilationData.CreateAssemblySymbol();
                             newSymbols.Add(i);

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -369,8 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if ((object)bindingResult[i].AssemblySymbol == null)
                         {
                             // symbol hasn't been found in the cache, create a new one
-                            var compilationData = (AssemblyDataForMetadataOrCompilation)allAssemblyData[i];
-                            bindingResult[i].AssemblySymbol = compilationData.CreateAssemblySymbol();
+                            bindingResult[i].AssemblySymbol = ((AssemblyDataForMetadataOrCompilation)allAssemblyData[i]).CreateAssemblySymbol();
                             newSymbols.Add(i);
                         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -2175,31 +2175,6 @@ public class Source
             Assert.Equal("System.Numerics.Vectors, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", ((IAssemblySymbol)a1).Identity.GetDisplayName());
         }
 
-        private class TestMissingMetadataReferenceResolver : MetadataReferenceResolver
-        {
-            private readonly Dictionary<string, MetadataReference> _map;
-            public readonly List<AssemblyIdentity> ResolutionAttempts = new List<AssemblyIdentity>();
-
-            public TestMissingMetadataReferenceResolver(Dictionary<string, MetadataReference> map)
-            {
-                _map = map;
-            }
-
-            public override PortableExecutableReference ResolveMissingAssembly(AssemblyIdentity identity)
-            {
-                ResolutionAttempts.Add(identity);
-
-                MetadataReference reference;
-                string nameAndVersion = identity.Name + (identity.Version != AssemblyIdentity.NullVersion ? $", {identity.Version}" : "");
-                return _map.TryGetValue(nameAndVersion, out reference) ? (PortableExecutableReference)reference : null;
-            }
-
-            public override bool ResolveMissingAssemblies => true;
-            public override bool Equals(object other) => true;
-            public override int GetHashCode() => 1;
-            public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties) => default(ImmutableArray<PortableExecutableReference>);
-        }
-
         [Fact]
         public void MissingAssemblyResolution1()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -2178,7 +2178,7 @@ public class Source
         private class TestMissingMetadataReferenceResolver : MetadataReferenceResolver
         {
             private readonly Dictionary<string, MetadataReference> _map;
-            public readonly List<AssemblyIdentity> ResolvedIdentities = new List<AssemblyIdentity>();
+            public readonly List<AssemblyIdentity> ResolutionAttempts = new List<AssemblyIdentity>();
 
             public TestMissingMetadataReferenceResolver(Dictionary<string, MetadataReference> map)
             {
@@ -2187,7 +2187,7 @@ public class Source
 
             public override PortableExecutableReference ResolveMissingAssembly(AssemblyIdentity identity)
             {
-                ResolvedIdentities.Add(identity);
+                ResolutionAttempts.Add(identity);
 
                 MetadataReference reference;
                 string nameAndVersion = identity.Name + (identity.Version != AssemblyIdentity.NullVersion ? $", {identity.Version}" : "");
@@ -2242,6 +2242,98 @@ public class C : A
         }
 
         [Fact]
+        public void MissingAssemblyResolution_AliasesMerge()
+        {
+            // c - a -> "b, V1" resolved to "b, V3" with alias X
+            //   - d -> "b, V2" resolved to "b, V3" with alias Y
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+
+            var aRef = CreateCompilationWithMscorlib("public class A : B { }", new[] { b1Ref }, assemblyName: "A").EmitToImageReference();
+            var dRef = CreateCompilationWithMscorlib("public class D : B { }", new[] { b2Ref }, assemblyName: "D").EmitToImageReference();
+
+            var b3RefX = b3Ref.WithAliases(ImmutableArray.Create("X"));
+            var b3RefY = b3Ref.WithAliases(ImmutableArray.Create("Y"));
+
+            var c = CreateCompilationWithMscorlib(@"
+extern alias X;
+extern alias Y;
+
+public class C : A 
+{ 
+    X::B F() => new Y::B(); 
+}
+", new[] { aRef, dRef },
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+                {
+                    { "B, 1.0.0.0", b3RefX },
+                    { "B, 2.0.0.0", b3RefY },
+                })));
+
+            c.VerifyEmitDiagnostics(
+                // (5,18): warning CS1701: Assuming assembly reference 
+                // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity 
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "A").WithArguments(
+                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", 
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
+
+            Assert.Equal("B", ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b3RefY)).Name);
+            Assert.Null(c.GetAssemblyOrModuleSymbol(b3RefX));
+        }
+
+        [Fact]
+        public void MissingAssemblyResolution_WeakIdentities1()
+        {
+            // c - a -> "b,v1,PKT=null" 
+            //   - d -> "b,v2,PKT=null"
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+            var b4Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""4.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+
+            var aRef = CreateCompilationWithMscorlib(@"public interface A : B { }", new[] { b1Ref }, assemblyName: "A").EmitToImageReference();
+            var dRef = CreateCompilationWithMscorlib(@"public interface D : B { }", new[] { b2Ref }, assemblyName: "D").EmitToImageReference();
+
+            var c = CreateCompilationWithMscorlib(@"public interface C : A, D {  }", new[] { aRef, dRef },
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+                {
+                    { "B, 1.0.0.0", b1Ref },
+                    { "B, 2.0.0.0", b2Ref },
+                })));
+
+            c.VerifyEmitDiagnostics(
+                // error CS1704: An assembly with the same simple name 'B' has already been imported. Try removing one of the references (e.g. 'B') or sign them to enable side-by-side.
+                Diagnostic(ErrorCode.ERR_DuplicateImportSimple).WithArguments("B", "B"));
+        }
+
+        [Fact]
+        public void MissingAssemblyResolution_WeakIdentities2()
+        {
+            // c - a -> "b,v1,PKT=null"
+            //   - d -> "b,v2,PKT=null"
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+            var b4Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""4.0.0.0"")] public interface B { }", assemblyName: "B").EmitToImageReference();
+
+            var aRef = CreateCompilationWithMscorlib(@"public interface A : B { }", new[] { b1Ref }, assemblyName: "A").EmitToImageReference();
+            var dRef = CreateCompilationWithMscorlib(@"public interface D : B { }", new[] { b2Ref }, assemblyName: "D").EmitToImageReference();
+
+            var c = CreateCompilationWithMscorlib(@"public interface C : A, D {  }", new[] { aRef, dRef },
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+                {
+                    { "B, 1.0.0.0", b3Ref },
+                    { "B, 2.0.0.0", b4Ref },
+                })));
+
+            c.VerifyEmitDiagnostics(
+                // error CS1704: An assembly with the same simple name 'B' has already been imported. Try removing one of the references (e.g. 'B') or sign them to enable side-by-side.
+                Diagnostic(ErrorCode.ERR_DuplicateImportSimple).WithArguments("B", "B"));
+        }
+
+        [Fact]
         public void MissingAssemblyResolution_None()
         {
             // c - a -> d
@@ -2256,7 +2348,53 @@ public class C : A
 
             c.VerifyDiagnostics();
 
-            Assert.Equal(0, resolver.ResolvedIdentities.Count);
+            Assert.Equal(0, resolver.ResolutionAttempts.Count);
+        }
+
+        [Fact]
+        public void MissingAssemblyResolution_ActualMissing()
+        {
+            // c - a -> d
+            var dRef = CreateCompilationWithMscorlib("public interface D { }", assemblyName: "D").EmitToImageReference();
+            var aRef = CreateCompilationWithMscorlib("public interface A : D { }", new[] { dRef }, assemblyName: "A").ToMetadataReference();
+
+            var resolver = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>());
+
+            var c = CreateCompilationWithMscorlib("public interface C : A { }", new[] { aRef },
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver));
+
+            c.VerifyDiagnostics(
+                // (1,18): error CS0012: The type 'D' is defined in an assembly that is not referenced. You must add a reference to assembly 'D, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "C").WithArguments("D", "D, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
+
+            Assert.Equal(1, resolver.ResolutionAttempts.Count);
+        }
+
+        /// <summary>
+        /// Ignore assemblies returned by the resolver that don't match the reference identity.
+        /// </summary>
+        [Fact]
+        public void MissingAssemblyResolution_MissingDueToResolutionMismatch()
+        {
+            // c - a -> b
+            var bRef = CreateCompilationWithMscorlib("public interface D { }", assemblyName: "B").EmitToImageReference();
+            var aRef = CreateCompilationWithMscorlib("public interface A : D { }", new[] { bRef }, assemblyName: "A").ToMetadataReference();
+
+            var eRef = CreateCompilationWithMscorlib("public interface E { }", assemblyName: "E").ToMetadataReference();
+
+            var resolver = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "B, 1.0.0.0", eRef },
+            });
+
+            var c = CreateCompilationWithMscorlib(@"public interface C : A {  }", new[] { aRef },
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver));
+
+            c.VerifyDiagnostics(
+                // (1,18): error CS0012: The type 'D' is defined in an assembly that is not referenced. You must add a reference to assembly 'B, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "C").WithArguments("D", "B, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
+
+            Assert.Equal(1, resolver.ResolutionAttempts.Count);
         }
 
         [Fact]
@@ -2279,7 +2417,7 @@ public class C : A
             c.VerifyEmitDiagnostics();
 
             Assert.Equal("D", ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(dRef)).Name);
-            Assert.Equal(1, resolver.ResolvedIdentities.Count);
+            Assert.Equal(1, resolver.ResolutionAttempts.Count);
         }
 
         [Fact]
@@ -2312,8 +2450,11 @@ public class C : A
             Assert.Equal("D", ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(dRef)).Name);
         }
 
+        /// <summary>
+        /// Don't try to resolve AssemblyRefs that already match explicitly specified definition.
+        /// </summary>
         [Fact]
-        public void MissingAssemblyResolution_BetterVersion_Higher_vs_Exact()
+        public void MissingAssemblyResolution_BindingToForExplicitReference1()
         {
             // c - a -> "b,v1"
             //   - "b,v3"
@@ -2324,160 +2465,244 @@ public class C : A
 
             var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class A : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "A").EmitToImageReference();
 
+            var resolver = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                // the compiler asked for v1, but we have v2
+                { "B, 1.0.0.0", b2Ref }
+            });
+
             var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef, b3Ref }, 
-                s_signedDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
-                {
-                    // the compiler asked for v1, but we have v2
-                    { "B, 1.0.0.0", b2Ref }
-                })));
+                s_signedDll.WithMetadataReferenceResolver(resolver));
 
             c.VerifyEmitDiagnostics(
                 // (1,18): warning CS1701: Assuming assembly reference 
                 // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity
-                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
                 Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "A").WithArguments(
                     "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", 
-                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
+
+            Assert.Equal(0, resolver.ResolutionAttempts.Count);
 
             Assert.Equal(
-                "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
-                ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b2Ref)).Identity.GetDisplayName());
+                "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
+                ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b3Ref)).Identity.GetDisplayName());
+
+            Assert.Null((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b2Ref));
         }
 
+        /// <summary>
+        /// Don't try to resolve AssemblyRefs that already match explicitly specified definition.
+        /// </summary>
         [Fact]
-        public void MissingAssemblyResolution_BetterVersion_Higher_vs_BetterHigher()
+        public void MissingAssemblyResolution_BindingToExplicitReference_WorseVersion()
         {
-            // c - a -> "b,v1"
-            //   - "b,v3"
-            //      
-            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            // c - a -> d -> "b,v2"
+            //          e -> "b,v1"
+            //   - "b,v1"  
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
 
-            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class A : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "A").EmitToImageReference();
+            var dRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface D : B { }", new[] { b2Ref }, options: s_signedDll, assemblyName: "D").EmitToImageReference();
+            var eRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface E : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "E").EmitToImageReference();
 
-            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef, b3Ref },
-                s_signedDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
-                {
-                    { "B, 1.0.0.0", b2Ref }
-                })));
+            var resolverA = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "B, 2.0.0.0", b2Ref },
+                { "B, 1.0.0.0", b1Ref },
+            });
 
-            c.VerifyEmitDiagnostics(
-                // (1,18): warning CS1701: Assuming assembly reference 
-                // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity 
-                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
-                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "A").WithArguments(
-                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", 
-                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
-        }
+            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface A : D, E { }", new[] { dRef, eRef },
+                s_signedDll.WithMetadataReferenceResolver(resolverA), assemblyName: "A").EmitToImageReference();
 
-        [Fact]
-        public void MissingAssemblyResolution_BetterVersion_Higher_vs_WorseHigher()
-        {
-            // c - a -> "b,v1"
-            //   - "b,v2"
-            //      
-            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            Assert.Equal(2, resolverA.ResolutionAttempts.Count);
 
-            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class A : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "A").EmitToImageReference();
-
-            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef, b2Ref },
-                s_signedDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
-                {
-                    { "B, 1.0.0.0", b3Ref }
-                })));
-
-            c.VerifyEmitDiagnostics(
-                // (1,18): warning CS1701: Assuming assembly reference 
-                // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity 
-                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
-                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "A").WithArguments(
-                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", 
-                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
-        }
-
-        [Fact]
-        public void MissingAssemblyResolution_BetterVersion_Lower_vs_Exact1()
-        {
-            // c - a -> "b,v2"
-            //   - "b,v1"
-            //      
-            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-
-            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class A : B { }", new[] { b2Ref }, options: s_signedDll, assemblyName: "A").EmitToImageReference();
+            var resolverC = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "D, 1.0.0.0", dRef },
+                { "E, 1.0.0.0", eRef },
+            });
 
             var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef, b1Ref },
-                s_signedDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
-                {
-                    { "B, 2.0.0.0", b2Ref }
-                })));
+                s_signedDll.WithMetadataReferenceResolver(resolverC));
+
+            c.VerifyEmitDiagnostics(
+                // (1,14): error CS1705: Assembly 
+                // 'A' with identity 'A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' uses 
+                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' which has a higher version than referenced assembly 
+                // 'B' with identity 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'
+                Diagnostic(ErrorCode.ERR_AssemblyMatchBadVersion, "C").WithArguments(
+                    "A", "A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
+                    "B", "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2"),
+
+                // (1,14): error CS1705: Assembly 
+                // 'D' with identity 'D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' uses 
+                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' which has a higher version than referenced assembly
+                // 'B' with identity 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'
+                Diagnostic(ErrorCode.ERR_AssemblyMatchBadVersion, "C").WithArguments(
+                    "D", "D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
+                    "B", "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2"));
+
+            Assert.Equal(2, resolverC.ResolutionAttempts.Count);
+        }
+
+        /// <summary>
+        /// Don't try to resolve AssemblyRefs that already match explicitly specified definition.
+        /// </summary>
+        [Fact]
+        public void MissingAssemblyResolution_BindingToExplicitReference_BetterVersion()
+        {
+            // c - a -> d -> "b,v2"
+            //          e -> "b,v1"
+            //   - "b,v2"  
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+
+            var dRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface D : B { }", new[] { b2Ref }, options: s_signedDll, assemblyName: "D").EmitToImageReference();
+            var eRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface E : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "E").EmitToImageReference();
+
+            var resolverA = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "B, 2.0.0.0", b2Ref },
+                { "B, 1.0.0.0", b1Ref },
+            });
+
+            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface A : D, E { }", new[] { dRef, eRef },
+                s_signedDll.WithMetadataReferenceResolver(resolverA), assemblyName: "A").EmitToImageReference();
+
+            Assert.Equal(2, resolverA.ResolutionAttempts.Count);
+
+            var resolverC = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "D, 1.0.0.0", dRef },
+                { "E, 1.0.0.0", eRef },
+            });
+
+            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef, b2Ref },
+                s_signedDll.WithMetadataReferenceResolver(resolverC));
+
+            c.VerifyEmitDiagnostics(
+                // (1,14): warning CS1701: Assuming assembly reference
+                // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 
+                // 'A' matches identity 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", 
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"),
+
+                // (1,14): warning CS1701: Assuming assembly reference 
+                // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'E' matches identity
+                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "E", 
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
+
+            Assert.Equal(2, resolverC.ResolutionAttempts.Count);
+        }
+
+        [Fact]
+        public void MissingAssemblyResolution_BindingToImplicitReference1()
+        {
+            // c - a -> d -> "b,v2"
+            //          e -> "b,v1"
+            //          "b,v1"
+            //          "b,v2"
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+
+            var dRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface D : B { }", new[] { b2Ref }, options: s_signedDll, assemblyName: "D").EmitToImageReference();
+            var eRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface E : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "E").EmitToImageReference();
+
+            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface A : D, E { }", new[] { dRef, eRef, b1Ref, b2Ref },
+                s_signedDll, assemblyName: "A").EmitToImageReference();
+
+            var resolverC = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "D, 1.0.0.0", dRef },
+                { "E, 1.0.0.0", eRef },
+                { "B, 1.0.0.0", b1Ref },
+                { "B, 2.0.0.0", b2Ref },
+            });
+
+            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef },
+                s_signedDll.WithMetadataReferenceResolver(resolverC));
 
             c.VerifyEmitDiagnostics();
 
+            Assert.Equal(4, resolverC.ResolutionAttempts.Count);
+
             Assert.Equal(
-                "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
-                ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b2Ref)).Identity.GetDisplayName());
+               "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+               ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b1Ref)).Identity.GetDisplayName());
+
+            Assert.Equal(
+               "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+               ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b2Ref)).Identity.GetDisplayName());
         }
 
         [Fact]
-        public void MissingAssemblyResolution_BetterVersion_Lower_vs_WorseLower()
+        public void MissingAssemblyResolution_BindingToImplicitReference2()
         {
-            // c - a -> "b,v3"
-            //   - "b,v2"
-            //      
-            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            // c - a -> d -> "b,v2"
+            //          e -> "b,v1"
+            //          "b,v1"
+            //          "b,v2"
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b4Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""4.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
 
-            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class A : B { }", new[] { b3Ref }, options: s_signedDll, assemblyName: "A").EmitToImageReference();
+            var dRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface D : B { }", new[] { b2Ref }, options: s_signedDll, assemblyName: "D").EmitToImageReference();
+            var eRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface E : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "E").EmitToImageReference();
 
-            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef, b2Ref },
-                s_signedDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
-                {
-                    { "B, 3.0.0.0", b1Ref }
-                })));
+            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface A : D, E { }", new[] { dRef, eRef, b1Ref, b2Ref },
+                s_signedDll, assemblyName: "A").EmitToImageReference();
 
-            c.VerifyDiagnostics(
-                // (1,18): error CS1705: Assembly
-                // 'A' with identity 'A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' 
-                // uses 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' which has a higher version than referenced assembly 
-                // 'B' with identity 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'
-                Diagnostic(ErrorCode.ERR_AssemblyMatchBadVersion, "A").WithArguments(
-                    "A", "A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
-                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
-                    "B", "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2"));
-        }
+            var resolverC = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "D, 1.0.0.0", dRef },
+                { "E, 1.0.0.0", eRef },
+                { "B, 1.0.0.0", b3Ref },
+                { "B, 2.0.0.0", b4Ref },
+            });
 
-        [Fact]
-        public void MissingAssemblyResolution_BetterVersion_Lower_vs_BetterLower()
-        {
-            // c - a -> "b,v3"
-            //   - "b,v1"
-            //      
-            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
-            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public class B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef },
+                s_signedDll.WithMetadataReferenceResolver(resolverC));
 
-            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class A : B { }", new[] { b3Ref }, options: s_signedDll, assemblyName: "A").EmitToImageReference();
+            c.VerifyEmitDiagnostics(
+                // (1,14): warning CS1701: Assuming assembly reference 
+                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity 
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", 
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"),
 
-            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef, b1Ref },
-                s_signedDll.WithMetadataReferenceResolver(new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
-                {
-                    { "B, 3.0.0.0", b2Ref }
-                })));
+                // (1,14): warning CS1701: Assuming assembly reference 
+                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'D' matches identity
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "D", 
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"),
 
-            c.VerifyDiagnostics(
-                // (1,18): error CS1705: Assembly 
-                // 'A' with identity 'A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' 
-                // uses 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' which has a higher version than referenced assembly 
-                // 'B' with identity 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'
-                Diagnostic(ErrorCode.ERR_AssemblyMatchBadVersion, "A").WithArguments(
-                    "A", "A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
-                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", 
-                    "B", "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2"));
+                // (1,14): warning CS1701: Assuming assembly reference 
+                // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'E' matches identity 
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "E", 
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
+
+            Assert.Equal(4, resolverC.ResolutionAttempts.Count);
+
+            AssertEx.Equal(new[]
+            {
+                "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "B, Version=4.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2"
+            }, c.GetBoundReferenceManager().ReferencedAssemblies.Select(a => a.Identity.GetDisplayName()));
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ArrayBuilderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ArrayBuilderTests.cs
@@ -41,5 +41,29 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             builder = new ArrayBuilder<int> { 1, 2, 3, 2, 4, 5, 1 };
             AssertEx.Equal(new byte[] { 1, 2, 3, 4, 5 }, builder.SelectDistinct(n => (byte)n));
         }
+
+        [Fact]
+        public void AddRange()
+        {
+            var builder = new ArrayBuilder<int>();
+
+            builder.AddRange(new int[0], 0, 0);
+            AssertEx.Equal(new int[0], builder.ToArray());
+
+            builder.AddRange(new[] { 1, 2, 3 }, 0, 3);
+            AssertEx.Equal(new[] { 1, 2, 3 }, builder.ToArray());
+
+            builder.AddRange(new[] { 1, 2, 3 }, 2, 0);
+            AssertEx.Equal(new[] { 1, 2, 3 }, builder.ToArray());
+
+            builder.AddRange(new[] { 1, 2, 3 }, 1, 1);
+            AssertEx.Equal(new[] { 1, 2, 3, 2 }, builder.ToArray());
+
+            builder.AddRange(new[] { 1, 2, 3 }, 1, 2);
+            AssertEx.Equal(new[] { 1, 2, 3, 2, 2, 3 }, builder.ToArray());
+
+            builder.AddRange(new[] { 1, 2, 3 }, 2, 1);
+            AssertEx.Equal(new[] { 1, 2, 3, 2, 2, 3, 3 }, builder.ToArray());
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -139,5 +139,10 @@ namespace Microsoft.CodeAnalysis
         {
             return builder[builder.Count - 1];
         }
+
+        public static ImmutableArray<T> ToImmutableOrEmptyAndFree<T>(this ArrayBuilder<T> builderOpt)
+        {
+            return builderOpt?.ToImmutableAndFree() ?? ImmutableArray<T>.Empty;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceResolver.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceResolver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis
@@ -12,5 +13,18 @@ namespace Microsoft.CodeAnalysis
         public abstract override bool Equals(object other);
         public abstract override int GetHashCode();
         public abstract ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties);
+
+        /// <summary>
+        /// True to instruct the compiler to invoke <see cref="ResolveMissingAssembly(AssemblyIdentity)"/> for each assembly reference that
+        /// doesn't match any of the assemblies explicitly referenced by the <see cref="Compilation"/> (via <see cref="Compilation.ExternalReferences"/>, or #r directives.
+        /// </summary>
+        public virtual bool ResolveMissingAssemblies => false;
+
+        /// <summary>
+        /// Resolves a missing assembly reference.
+        /// </summary>
+        /// <param name="identity">Identity of the assembly reference.</param>
+        /// <returns>Resolved reference or null if the identity can't be resolved.</returns>
+        public virtual PortableExecutableReference ResolveMissingAssembly(AssemblyIdentity identity) => null;
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -60,4 +60,6 @@ static Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetry.GetAnalyze
 static Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetry.GetAnalyzerExecutionTime(this Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers compilationWithAnalyzers, Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer analyzer) -> System.TimeSpan
 static Microsoft.CodeAnalysis.SyntaxNodeExtensions.NormalizeWhitespace<TNode>(this TNode node, string indentation = "    ", string eol = "\r\n", bool elasticTrivia = false) -> TNode
 static Microsoft.CodeAnalysis.SyntaxNodeExtensions.NormalizeWhitespace<TNode>(this TNode node, string indentation, bool elasticTrivia) -> TNode
+virtual Microsoft.CodeAnalysis.MetadataReferenceResolver.ResolveMissingAssemblies.get -> bool
+virtual Microsoft.CodeAnalysis.MetadataReferenceResolver.ResolveMissingAssembly(Microsoft.CodeAnalysis.AssemblyIdentity identity) -> Microsoft.CodeAnalysis.PortableExecutableReference
 virtual Microsoft.CodeAnalysis.SourceReferenceResolver.ReadText(string resolvedPath) -> Microsoft.CodeAnalysis.Text.SourceText

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyData.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyData.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -10,6 +11,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Information about an assembly, used as an input for the Binder class.
         /// </summary>
+        [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
         internal abstract class AssemblyData
         {
             /// <summary>
@@ -63,6 +65,8 @@ namespace Microsoft.CodeAnalysis
             /// Returns null otherwise.
             /// </summary>
             public abstract Compilation SourceCompilation { get; }
+
+            private string GetDebuggerDisplay() => $"{GetType().Name}: [{Identity.GetDisplayName()}]";
         }
     }
 }

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyReferenceBinding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyReferenceBinding.cs
@@ -95,7 +95,6 @@ namespace Microsoft.CodeAnalysis
             {
                 get
                 {
-                    Debug.Assert(IsBound);
                     return _referenceIdentity;
                 }
             }

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis
         /// Implicitly resolved references.
         /// </param>
         /// <param name="implicitlyResolvedReferenceMap">
-        /// Maps index to all references (explicit + implicit) to an index of a resolved assembly in all assemblies (explicit + implicit).
+        /// Maps indices of implicitly resolved references to the corresponding indices of resolved assemblies in <paramref name="allAssemblies"/> (explicit + implicit).
         /// </param>
         /// <param name="resolutionDiagnostics">
         /// Any diagnostics reported while resolving missing assemblies.
@@ -202,10 +202,11 @@ namespace Microsoft.CodeAnalysis
                             continue;
                         }
 
-                        // The resolver may return different version than we asked for, so it may also happen that 
+                        // The resolver may return different version than we asked for, so it may happen that 
                         // it returns the same identity for two different input identities (e.g. if a higher version 
                         // of an assembly is available than what the assemblies reference: "A, v1" -> "A, v3" and "A, v2" -> "A, v3").
                         // If such case occurs merge the properties (aliases) of the resulting references in the same way we do
+                        // during initial explicit references resolution.
 
                         var existingReference = TryAddAssembly(data.Identity, peReference, resolutionDiagnostics, Location.None, ref lazyResolvedReferencesBySimpleName);
                         if (existingReference != null)

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -573,10 +573,17 @@ namespace Microsoft.CodeAnalysis
             modules.Add(module);
         }
 
-        // Returns null if an assembly of an equivalent identity has not been added previously, otherwise returns the reference that added it.
-        // - Both assembly names are strong (have keys) and are either equal or FX unified 
-        // - Both assembly names are weak (no keys) and have the same simple name.
-        private MetadataReference TryAddAssembly(AssemblyIdentity identity, MetadataReference boundReference, DiagnosticBag diagnosticsOpt, Location location,
+        /// <summary>
+        /// Returns null if an assembly of an equivalent identity has not been added previously, otherwise returns the reference that added it.
+        /// Two identities are considered equivalent if
+        /// - both assembly names are strong (have keys) and are either equal or FX unified 
+        /// - both assembly names are weak (no keys) and have the same simple name.
+        /// </summary>
+        private MetadataReference TryAddAssembly(
+            AssemblyIdentity identity,
+            MetadataReference boundReference,
+            DiagnosticBag diagnostics, 
+            Location location,
             ref Dictionary<string, List<ReferencedAssemblyIdentity>> referencesBySimpleName)
         {
             if (referencesBySimpleName == null)
@@ -643,7 +650,7 @@ namespace Microsoft.CodeAnalysis
                     // BREAKING CHANGE in VB: we report an error for both languages
 
                     // Multiple assemblies with equivalent identity have been imported: '{0}' and '{1}'. Remove one of the duplicate references.
-                    MessageProvider.ReportDuplicateMetadataReferenceStrong(diagnosticsOpt, location, boundReference, identity, equivalent.MetadataReference, equivalent.Identity);
+                    MessageProvider.ReportDuplicateMetadataReferenceStrong(diagnostics, location, boundReference, identity, equivalent.MetadataReference, equivalent.Identity);
                 }
                 // If the versions match exactly we ignore duplicates w/o reporting errors while 
                 // Dev12 C# reports:
@@ -664,7 +671,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (identity != equivalent.Identity)
                 {
-                    MessageProvider.ReportDuplicateMetadataReferenceWeak(diagnosticsOpt, location, boundReference, identity, equivalent.MetadataReference, equivalent.Identity);
+                    MessageProvider.ReportDuplicateMetadataReferenceWeak(diagnostics, location, boundReference, identity, equivalent.MetadataReference, equivalent.Identity);
                 }
             }
 

--- a/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
+++ b/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
@@ -385,9 +385,9 @@ namespace Microsoft.CodeAnalysis
 
         public void AddRange(T[] items, int start, int length)
         {
-            for (int i = 0; i < length; i++)
+            for (int i = start, end = start + length; i < end; i++)
             {
-                Add(items[start + i]);
+                Add(items[i]);
             }
         }
 

--- a/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
+++ b/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
@@ -383,6 +383,14 @@ namespace Microsoft.CodeAnalysis
             _builder.AddRange(items, length);
         }
 
+        public void AddRange(T[] items, int start, int length)
+        {
+            for (int i = 0; i < length; i++)
+            {
+                Add(items[start + i]);
+            }
+        }
+
         public void AddRange(IEnumerable<T> items)
         {
             _builder.AddRange(items);

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -317,8 +317,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     For i As Integer = 1 To bindingResult.Length - 1 Step 1
                         If bindingResult(i).AssemblySymbol Is Nothing Then
                             ' symbol hasn't been found in the cache, create a new one
-                            Dim compilationData = DirectCast(allAssemblyData(i), AssemblyDataForMetadataOrCompilation)
-                            bindingResult(i).AssemblySymbol = compilationData.CreateAssemblySymbol()
+                            bindingResult(i).AssemblySymbol = DirectCast(allAssemblyData(i), AssemblyDataForMetadataOrCompilation).CreateAssemblySymbol()
                             newSymbols.Add(i)
                         End If
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
@@ -1665,5 +1665,355 @@ End Class
             Assert.Same(assembly2.CorLibrary, assembly2)
             Assert.True(corlib1.ReferenceManagerEquals(corlib2))
         End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution1()
+            ' c - a -> b
+            Dim bRef = CreateCompilationWithMscorlib({"Public Class B : End Class"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim aRef = CreateCompilationWithMscorlib({"Public Class A : Inherits B : End Class"}, {bRef}, TestOptions.ReleaseDll, assemblyName:="A").EmitToImageReference()
+            Dim c = CreateCompilationWithMscorlib({"Public Class C : Inherits A : End Class"}, {aRef},
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+                {
+                    {"B", bRef}
+                })))
+
+            c.VerifyEmitDiagnostics()
+
+            Assert.Equal("B", DirectCast(c.GetAssemblyOrModuleSymbol(bRef), AssemblySymbol).Name)
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution_WeakIdentities1()
+            ' c - a -> "b,v1,PKT=null" 
+            '   - d -> "b,v2,PKT=null"
+            Dim b1Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim b2Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim b3Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim b4Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""4.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+
+            Dim aRef = CreateCompilationWithMscorlib({"Public Interface A : Inherits B : End Interface"}, {b1Ref}, TestOptions.ReleaseDll, assemblyName:="A").EmitToImageReference()
+            Dim dRef = CreateCompilationWithMscorlib({"Public Interface D : Inherits B : End Interface"}, {b2Ref}, TestOptions.ReleaseDll, assemblyName:="D").EmitToImageReference()
+
+            Dim c = CreateCompilationWithMscorlib({"Public Interface C : Inherits A, D : End Interface"}, {aRef, dRef},
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+                {
+                    {"B, 1.0.0.0", b1Ref},
+                    {"B, 2.0.0.0", b2Ref}
+                })))
+
+            AssertEx.Equal(
+            {
+                "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "A, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "D, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }, c.GetBoundReferenceManager().ReferencedAssemblies.Select(Function(a) a.Identity.GetDisplayName()))
+
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution_WeakIdentities2()
+            ' c - a -> "b,v1,PKT=null"
+            '   - d -> "b,v2,PKT=null"
+            Dim b1Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim b2Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim b3Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim b4Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""4.0.0.0"")> : Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+
+            Dim aRef = CreateCompilationWithMscorlib({"Public Interface A : Inherits B : End Interface"}, {b1Ref}, TestOptions.ReleaseDll, assemblyName:="A").EmitToImageReference()
+            Dim dRef = CreateCompilationWithMscorlib({"Public Interface D : Inherits B : End Interface"}, {b2Ref}, TestOptions.ReleaseDll, assemblyName:="D").EmitToImageReference()
+
+            Dim c = CreateCompilationWithMscorlib({"Public Interface C : Inherits A, D : End Interface"}, {aRef, dRef},
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+                {
+                    {"B, 1.0.0.0", b3Ref},
+                    {"B, 2.0.0.0", b4Ref}
+                })))
+
+            AssertEx.Equal(
+            {
+                "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "A, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "D, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "B, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }, c.GetBoundReferenceManager().ReferencedAssemblies.Select(Function(a) a.Identity.GetDisplayName()))
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution_None()
+            ' c - a -> d
+            '   - d
+            Dim dRef = CreateCompilationWithMscorlib({"Public Interface D : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="D").EmitToImageReference()
+            Dim aRef = CreateCompilationWithMscorlib({"Public Interface A : Inherits D : End Interface"}, {dRef}, TestOptions.ReleaseDll, assemblyName:="A").ToMetadataReference()
+
+            Dim resolver = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference)())
+
+            Dim c = CreateCompilationWithMscorlib({"Public Interface C : Inherits A : End Interface"}, {aRef, dRef},
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver))
+
+            c.VerifyDiagnostics()
+            Assert.Equal(0, resolver.ResolutionAttempts.Count)
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution_ActualMissing()
+            ' c - a -> d
+            Dim dRef = CreateCompilationWithMscorlib({"Public Interface D : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="D").EmitToImageReference()
+            Dim aRef = CreateCompilationWithMscorlib({"Public Interface A : Inherits D : End Interface"}, {dRef}, TestOptions.ReleaseDll, assemblyName:="A").ToMetadataReference()
+
+            Dim resolver = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference)())
+
+            Dim c = CreateCompilationWithMscorlib({"Public Interface C : Inherits A : End Interface"}, {aRef},
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver))
+
+            c.VerifyDiagnostics(
+                Diagnostic(ERRID.ERR_UnreferencedAssembly3, "A").WithArguments("D, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "D"))
+
+            Assert.Equal(1, resolver.ResolutionAttempts.Count)
+        End Sub
+
+        ''' <summary>
+        ''' Ignore assemblies returned by the resolver that don't match the reference identity.
+        ''' </summary>
+        <Fact>
+        Public Sub MissingAssemblyResolution_MissingDueToResolutionMismatch()
+            ' c - a -> b
+            Dim bRef = CreateCompilationWithMscorlib({"Public Interface D : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim aRef = CreateCompilationWithMscorlib({"Public Interface A : Inherits D : End Interface"}, {bRef}, TestOptions.ReleaseDll, assemblyName:="A").ToMetadataReference()
+
+            Dim eRef = CreateCompilationWithMscorlib({"Public Interface E : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="E").ToMetadataReference()
+
+            Dim resolver = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+                {
+                    {"B, 1.0.0.0", eRef}
+                })
+
+            Dim c = CreateCompilationWithMscorlib({"Public Interface C : Inherits A : End Interface"}, {aRef},
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver))
+
+            c.VerifyDiagnostics(
+                Diagnostic(ERRID.ERR_UnreferencedAssembly3, "A").WithArguments("B, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "D"))
+
+            Assert.Equal(1, resolver.ResolutionAttempts.Count)
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution_Modules()
+            ' c - a - d
+            '   - module(m) - b
+            '   - module(n) - d 
+            Dim bRef = CreateCompilationWithMscorlib({"Public Interface B : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="B").EmitToImageReference()
+            Dim dRef = CreateCompilationWithMscorlib({"Public Interface D : End Interface"}, options:=TestOptions.ReleaseDll, assemblyName:="D").EmitToImageReference()
+
+            Dim mRef = CreateCompilationWithMscorlib({"Public Interface M : Inherits B : End Interface"}, {bRef}, TestOptions.ReleaseModule.WithModuleName("M.netmodule")).EmitToImageReference()
+            Dim nRef = CreateCompilationWithMscorlib({"Public Interface N : Inherits D : End Interface"}, {dRef}, TestOptions.ReleaseModule.WithModuleName("N.netmodule")).EmitToImageReference()
+
+            Dim aRef = CreateCompilationWithMscorlib({"Public Interface A : Inherits D : End Interface"}, {dRef}, TestOptions.ReleaseDll, assemblyName:="A").EmitToImageReference()
+
+            Dim resolver = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"B", bRef},
+                {"D", dRef}
+            })
+
+            Dim c = CreateCompilationWithMscorlib({"Public Interface C : Inherits A : End Interface"}, {aRef, mRef, nRef},
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver))
+
+            c.VerifyEmitDiagnostics()
+            Assert.Equal("B", (DirectCast(c.GetAssemblyOrModuleSymbol(bRef), AssemblySymbol)).Name)
+            Assert.Equal("D", (DirectCast(c.GetAssemblyOrModuleSymbol(dRef), AssemblySymbol)).Name)
+        End Sub
+
+        ''' <summary>
+        ''' Don't try to resolve AssemblyRefs that already match explicitly specified definition.
+        ''' </summary>
+        <Fact>
+        Public Sub MissingAssemblyResolution_BindingToForExplicitReference1()
+            ' c - a -> "b,v1"
+            '   - "b,v3"
+            '      
+            Dim b1Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Class B : End Class"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b2Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")> : Public Class B : End Class"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b3Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")> : Public Class B : End Class"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim aRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Class A : Inherits B : End Class"}, {b1Ref}, options:=s_signedDll, assemblyName:="A").EmitToImageReference()
+
+            Dim resolver = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"B, 1.0.0.0", b2Ref}
+            })
+
+            Dim c = CreateCompilationWithMscorlib({"Public Class C : Inherits A : End Class"}, {aRef, b3Ref}, s_signedDll.WithMetadataReferenceResolver(resolver))
+
+            c.VerifyEmitDiagnostics()
+
+            Assert.Equal(0, resolver.ResolutionAttempts.Count)
+
+            Assert.Equal(
+                "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                DirectCast(c.GetAssemblyOrModuleSymbol(b3Ref), AssemblySymbol).Identity.GetDisplayName())
+
+            Assert.Null(DirectCast(c.GetAssemblyOrModuleSymbol(b2Ref), AssemblySymbol))
+        End Sub
+
+        ''' <summary>
+        ''' Don't try to resolve AssemblyRefs that already match explicitly specified definition.
+        ''' </summary>
+        <Fact>
+        Public Sub MissingAssemblyResolution_BindingToExplicitReference_WorseVersion()
+            ' c - a -> d -> "b,v2"
+            '          e -> "b,v1"
+            '   - "b,v1"  
+            Dim b1Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b2Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim dRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface D : Inherits B : End Interface"}, {b2Ref}, options:=s_signedDll, assemblyName:="D").EmitToImageReference()
+            Dim eRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface E : Inherits B : End Interface"}, {b1Ref}, options:=s_signedDll, assemblyName:="E").EmitToImageReference()
+
+            Dim resolverA = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"B, 2.0.0.0", b2Ref},
+                {"B, 1.0.0.0", b1Ref}
+            })
+
+            Dim aRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface A : Inherits D, E : End Interface"},
+                                                     {dRef, eRef},
+                                                     s_signedDll.WithMetadataReferenceResolver(resolverA), assemblyName:="A").EmitToImageReference()
+
+            Assert.Equal(2, resolverA.ResolutionAttempts.Count)
+            Dim resolverC = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"D, 1.0.0.0", dRef},
+                {"E, 1.0.0.0", eRef}
+            })
+
+            Dim c = CreateCompilationWithMscorlib({"Public Class C : Implements A : End Class"}, {aRef, b1Ref}, s_signedDll.WithMetadataReferenceResolver(resolverC))
+
+            c.VerifyEmitDiagnostics(
+                Diagnostic(ERRID.ERR_SxSIndirectRefHigherThanDirectRef3, "A").WithArguments("B", "2.0.0.0", "1.0.0.0"))
+
+            Assert.Equal(2, resolverC.ResolutionAttempts.Count)
+        End Sub
+
+        ''' <summary>
+        ''' Don't try to resolve AssemblyRefs that already match explicitly specified definition.
+        ''' </summary>
+        <Fact>
+        Public Sub MissingAssemblyResolution_BindingToExplicitReference_BetterVersion()
+            ' c - a -> d -> "b,v2"
+            '          e -> "b,v1"
+            '   - "b,v2"  
+            Dim b1Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b2Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+
+            Dim dRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface D : Inherits B : End Interface"}, {b2Ref}, options:=s_signedDll, assemblyName:="D").EmitToImageReference()
+            Dim eRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface E : Inherits B : End Interface"}, {b1Ref}, options:=s_signedDll, assemblyName:="E").EmitToImageReference()
+
+            Dim resolverA = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"B, 2.0.0.0", b2Ref},
+                {"B, 1.0.0.0", b1Ref}
+            })
+
+            Dim aRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface A : Inherits D, E : End Interface"},
+                                                     {dRef, eRef},
+                                                     s_signedDll.WithMetadataReferenceResolver(resolverA),
+                                                     assemblyName:="A").EmitToImageReference()
+
+            Assert.Equal(2, resolverA.ResolutionAttempts.Count)
+            Dim resolverC = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"D, 1.0.0.0", dRef},
+                {"E, 1.0.0.0", eRef}
+            })
+
+            Dim c = CreateCompilationWithMscorlib({"Public Class C : Implements A : End Class"}, {aRef, b2Ref},
+                s_signedDll.WithMetadataReferenceResolver(resolverC))
+
+            c.VerifyEmitDiagnostics()
+
+            Assert.Equal(2, resolverC.ResolutionAttempts.Count)
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution_BindingToImplicitReference1()
+            ' c - a -> d -> "b,v2"
+            '          e -> "b,v1"
+            '          "b,v1"
+            '          "b,v2"
+            Dim b1Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b2Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+
+            Dim dRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface D : Inherits B : End Interface"}, {b2Ref}, options:=s_signedDll, assemblyName:="D").EmitToImageReference()
+            Dim eRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface E : Inherits B : End Interface"}, {b1Ref}, options:=s_signedDll, assemblyName:="E").EmitToImageReference()
+
+            Dim aRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface A : Inherits D, E : End Interface"},
+                                                     {dRef, eRef, b1Ref, b2Ref},
+                                                     s_signedDll,
+                                                     assemblyName:="A").EmitToImageReference()
+
+            Dim resolverC = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"D, 1.0.0.0", dRef},
+                {"E, 1.0.0.0", eRef},
+                {"B, 1.0.0.0", b1Ref},
+                {"B, 2.0.0.0", b2Ref}
+            })
+
+            Dim c = CreateCompilationWithMscorlib({"Public Class C : Implements A : End Class"}, {aRef},
+                s_signedDll.WithMetadataReferenceResolver(resolverC))
+
+            c.VerifyEmitDiagnostics()
+
+            Assert.Equal(4, resolverC.ResolutionAttempts.Count)
+            Assert.Equal(
+                "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                DirectCast(c.GetAssemblyOrModuleSymbol(b1Ref), AssemblySymbol).Identity.GetDisplayName())
+
+            Assert.Equal(
+                "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                DirectCast(c.GetAssemblyOrModuleSymbol(b2Ref), AssemblySymbol).Identity.GetDisplayName())
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyResolution_BindingToImplicitReference2()
+            ' c - a -> d -> "b,v2"
+            '          e -> "b,v1"
+            '          "b,v1"
+            '          "b,v2"
+            Dim b1Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b2Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b3Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+            Dim b4Ref = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""4.0.0.0"")> : Public Interface B : End Interface"}, options:=s_signedDll, assemblyName:="B").EmitToImageReference()
+
+            Dim dRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")>: Public Interface D : Inherits B : End Interface"}, {b2Ref}, options:=s_signedDll, assemblyName:="D").EmitToImageReference()
+            Dim eRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")>: Public Interface E : Inherits B : End Interface"}, {b1Ref}, options:=s_signedDll, assemblyName:="E").EmitToImageReference()
+
+            Dim aRef = CreateCompilationWithMscorlib({"<Assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")>: Public Interface A : Inherits D, E : End Interface"}, {dRef, eRef, b1Ref, b2Ref}, s_signedDll, assemblyName:="A").EmitToImageReference()
+
+            Dim resolverC = New TestMissingMetadataReferenceResolver(New Dictionary(Of String, MetadataReference) From
+            {
+                {"D, 1.0.0.0", dRef},
+                {"E, 1.0.0.0", eRef},
+                {"B, 1.0.0.0", b3Ref},
+                {"B, 2.0.0.0", b4Ref}
+            })
+
+            Dim c = CreateCompilationWithMscorlib({"Public Class C : Implements A : End Class"}, {aRef}, s_signedDll.WithMetadataReferenceResolver(resolverC))
+
+            c.VerifyEmitDiagnostics()
+
+            Assert.Equal(4, resolverC.ResolutionAttempts.Count)
+
+            AssertEx.Equal(
+            {
+                "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "B, Version=4.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2"
+            }, c.GetBoundReferenceManager().ReferencedAssemblies.Select(Function(a) a.Identity.GetDisplayName()))
+        End Sub
     End Class
 End Namespace

--- a/src/Test/Utilities/Shared/Mocks/TestMissingMetadataReferenceResolver.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestMissingMetadataReferenceResolver.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.Test.Utilities
+{
+    internal class TestMissingMetadataReferenceResolver : MetadataReferenceResolver
+    {
+        private readonly Dictionary<string, MetadataReference> _map;
+        public readonly List<AssemblyIdentity> ResolutionAttempts = new List<AssemblyIdentity>();
+
+        public TestMissingMetadataReferenceResolver(Dictionary<string, MetadataReference> map)
+        {
+            _map = map;
+        }
+
+        public override PortableExecutableReference ResolveMissingAssembly(AssemblyIdentity identity)
+        {
+            ResolutionAttempts.Add(identity);
+
+            MetadataReference reference;
+            string nameAndVersion = identity.Name + (identity.Version != AssemblyIdentity.NullVersion ? $", {identity.Version}" : "");
+            return _map.TryGetValue(nameAndVersion, out reference) ? (PortableExecutableReference)reference : null;
+        }
+
+        public override bool ResolveMissingAssemblies => true;
+        public override bool Equals(object other) => true;
+        public override int GetHashCode() => 1;
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties) => default(ImmutableArray<PortableExecutableReference>);
+    }
+}

--- a/src/Test/Utilities/Shared/TestUtilities.projitems
+++ b/src/Test/Utilities/Shared/TestUtilities.projitems
@@ -52,6 +52,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Metadata\TypeAttributesMissing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Metadata\PEModuleTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\TestDocumentationCommentProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\TestMissingMetadataReferenceResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\VirtualizedRelativePathResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pdb\MockSymWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pdb\PdbTestUtilities.cs" />


### PR DESCRIPTION
Implements eager resolution of missing assemblies.

Currently all compilation references have to be specified explicitly and upfront, either via an "external reference" passed to a compilation constructor or via a directive reference (#r). This change enables the host to resolve assembly references that are not explicitly specified as they are discovered during reference binding. 

The main goal is to require less references to be specified by the user in scripts and when executing interactive code. For example, when a portable library is referenced by a Desktop app, the facades need to be referenced as well. With this change the user only needs to #r the library. The compiler will discover that facades are needed and asks the host thru new API on ```MetadataReferenceResolver.ResolveMissingAssembly```. The host can than check whether the required dependency is available at runtime and if so return it to the compiler. Thus not bothering the user with error message like "A reference to System.Runtime is missing and needs to be added" when the host actually knows where to find such reference.

The resolution is transitive -- all references of the explicit references passed to the compilation are examined and can be potentially loaded by the host. Since this resolution is integrated into the reference binding logic it is semantically indistinguishable from explicitly passing all missing references upfront.

I have considered resolving the missing dependencies lazily. Delaying the resolution until the missing symbols are actually used is viable however the implementation is much more complex and to avoid versioning issues certain restrictions need to be enforced (such as no missing assemblies can differ in version, a missing assembly can't be added with aliases or NoPia embedding). 