### PR TITLE
Code Model: Fix CodeFunction.Name for C# conversion operators

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -823,8 +823,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                     return "operator " + ((OperatorDeclarationSyntax)node).OperatorToken.ToString();
                 case SyntaxKind.ConversionOperatorDeclaration:
                     var conversionOperator = (ConversionOperatorDeclarationSyntax)node;
-                    return "operator "
-                        + (conversionOperator.ImplicitOrExplicitKeyword.Kind() == SyntaxKind.ImplicitKeyword ? "implicit " : "explicit ")
+                    return (conversionOperator.ImplicitOrExplicitKeyword.Kind() == SyntaxKind.ImplicitKeyword ? "implicit " : "explicit ")
+                        + "operator "
                         + conversionOperator.Type.ToString();
                 case SyntaxKind.EnumMemberDeclaration:
                     return ((EnumMemberDeclarationSyntax)node).Identifier.ToString();

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeFunctionTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeFunctionTests.cs
@@ -573,7 +573,7 @@ public class Ref<T> where T : Entity
         {
             CodeClass classObject = (CodeClass)GetCodeElement("Ref");
             var element = classObject.Members.Item(1);
-            Assert.Equal("operator implicit Ref<T>", element.Name);
+            Assert.Equal("implicit operator Ref<T>", element.Name);
         }
     }
 }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -423,6 +423,75 @@ public class C1 : I1
             TestFullName(code, "C1.I1.f1")
         End Sub
 
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FullName_ImplicitOperator()
+            Dim code =
+<Code>
+public class ComplexType
+{
+    public ComplexType()
+    {
+    }
+    public static implicit operator $$ComplexType(System.Int32 input) { return new ComplexType(); }
+
+
+    public static ComplexType operator +(ComplexType input0, ComplexType input1)
+    {
+        return default(ComplexType);
+    }
+}
+</Code>
+
+            TestFullName(code, "ComplexType.implicit operator ComplexType")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FullName_ExplicitOperator()
+            Dim code =
+<Code>
+public class ComplexType
+{
+    public ComplexType()
+    {
+    }
+    public static explicit operator $$ComplexType(System.Int32 input) { return new ComplexType(); }
+
+
+    public static ComplexType operator +(ComplexType input0, ComplexType input1)
+    {
+        return default(ComplexType);
+    }
+}
+</Code>
+
+            TestFullName(code, "ComplexType.explicit operator ComplexType")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub FullName_OperatorOverload()
+            Dim code =
+<Code>
+public class ComplexType
+{
+    public ComplexType()
+    {
+    }
+    public static explicit operator ComplexType(System.Int32 input) { return new ComplexType(); }
+
+
+    public static ComplexType operator $$+(ComplexType input0, ComplexType input1)
+    {
+        return default(ComplexType);
+    }
+}
+</Code>
+
+            TestFullName(code, "ComplexType.operator +")
+        End Sub
+
 #End Region
 
 #Region "FunctionKind tests"
@@ -621,6 +690,75 @@ class C
 </Code>
 
             TestName(code, "~C")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub Name_ImplicitOperator()
+            Dim code =
+<Code>
+public class ComplexType
+{
+    public ComplexType()
+    {
+    }
+    public static implicit operator $$ComplexType(System.Int32 input) { return new ComplexType(); }
+
+
+    public static ComplexType operator +(ComplexType input0, ComplexType input1)
+    {
+        return default(ComplexType);
+    }
+}
+</Code>
+
+            TestName(code, "implicit operator ComplexType")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub Name_ExplicitOperator()
+            Dim code =
+<Code>
+public class ComplexType
+{
+    public ComplexType()
+    {
+    }
+    public static explicit operator $$ComplexType(System.Int32 input) { return new ComplexType(); }
+
+
+    public static ComplexType operator +(ComplexType input0, ComplexType input1)
+    {
+        return default(ComplexType);
+    }
+}
+</Code>
+
+            TestName(code, "explicit operator ComplexType")
+        End Sub
+
+        <WorkItem(2437, "https://github.com/dotnet/roslyn/issues/2437")>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub Name_OperatorOverload()
+            Dim code =
+<Code>
+public class ComplexType
+{
+    public ComplexType()
+    {
+    }
+    public static implicit operator ComplexType(System.Int32 input) { return new ComplexType(); }
+
+
+    public static ComplexType operator $$+(ComplexType input0, ComplexType input1)
+    {
+        return default(ComplexType);
+    }
+}
+</Code>
+
+            TestName(code, "operator +")
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -991,7 +991,7 @@ class D
                     Assert.NotNull(parentElement)
 
                     Dim unknownCodeFunction = TryCast(element, EnvDTE.CodeFunction)
-                    Assert.Equal(unknownCodeFunction.Name, "operator implicit D")
+                    Assert.Equal(unknownCodeFunction.Name, "implicit operator D")
                 End Using
             End Using
         End Sub


### PR DESCRIPTION
Fixes #5505

In Visual Studio 2013, CodeFunction.Name for C# conversion operators listed the "implicit/explicit" keyword first and the "operator" keyword second. In Visual Studio 2015, we accidentally swapped these. Unfortunately the v1 Workflow Designer depends on this value and the change broke scenarios where conversion operators are used. That change fixes that discrepancy and adds more unit tests around FullName and Name for operators.