### PR TITLE
Correctly specify the ComDefaultInterface for Code Model elements

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAccessorFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAccessorFunction.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeFunction))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeFunction2))]
     public sealed partial class CodeAccessorFunction : AbstractCodeElement, EnvDTE.CodeFunction, EnvDTE80.CodeFunction2
     {
         internal static EnvDTE.CodeFunction Create(CodeModelState state, AbstractCodeMember parent, MethodKind kind)

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAttribute.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAttribute.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeAttribute))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeAttribute2))]
     public sealed class CodeAttribute : AbstractCodeElement, ICodeElementContainer<CodeAttributeArgument>, EnvDTE.CodeAttribute, EnvDTE80.CodeAttribute2
     {
         internal static EnvDTE.CodeAttribute Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeClass.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeClass.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Collections;
@@ -9,7 +8,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeClass))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeClass2))]
     public sealed class CodeClass : AbstractCodeType, EnvDTE.CodeClass, EnvDTE80.CodeClass2
     {
         internal static EnvDTE.CodeClass Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeDelegate.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeDelegate.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeDelegate))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeDelegate2))]
     public sealed partial class CodeDelegate : AbstractCodeType, ICodeElementContainer<CodeParameter>, EnvDTE.CodeDelegate, EnvDTE80.CodeDelegate2
     {
         internal static EnvDTE.CodeDelegate Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeEnum.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeEnum.cs
@@ -2,7 +2,6 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunction.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeFunction))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeFunction2))]
     public partial class CodeFunction : AbstractCodeMember, ICodeElementContainer<CodeParameter>, ICodeElementContainer<CodeAttribute>, EnvDTE.CodeFunction, EnvDTE80.CodeFunction2, IMethodXML, IMethodXML2
     {
         internal static EnvDTE.CodeFunction Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeInterface.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeInterface.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeInterface))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeInterface2))]
     public sealed class CodeInterface : AbstractCodeType, EnvDTE.CodeInterface, EnvDTE80.CodeInterface2
     {
         internal static EnvDTE.CodeInterface Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeParameter))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeParameter2))]
     public sealed class CodeParameter : AbstractCodeElement, EnvDTE.CodeParameter, EnvDTE80.CodeParameter2
     {
         internal static EnvDTE.CodeParameter Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeProperty))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeProperty2))]
     public sealed partial class CodeProperty : AbstractCodeMember, ICodeElementContainer<CodeParameter>, ICodeElementContainer<CodeAttribute>, EnvDTE.CodeProperty, EnvDTE80.CodeProperty2
     {
         internal static EnvDTE.CodeProperty Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeStruct.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeStruct.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeStruct))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeStruct2))]
     public sealed class CodeStruct : AbstractCodeType, EnvDTE.CodeStruct, EnvDTE80.CodeStruct2
     {
         internal static EnvDTE.CodeStruct Create(

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeVariable.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeVariable.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 {
     [ComVisible(true)]
-    [ComDefaultInterface(typeof(EnvDTE.CodeVariable))]
+    [ComDefaultInterface(typeof(EnvDTE80.CodeVariable2))]
     public sealed class CodeVariable : AbstractCodeMember, EnvDTE.CodeVariable, EnvDTE80.CodeVariable2
     {
         internal static EnvDTE.CodeVariable Create(

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
@@ -363,6 +363,21 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Throw New NotSupportedException
         End Sub
 
+        Protected Sub TestPropertyDescriptors(code As XElement, ParamArray expectedPropertyNames As String())
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
+                Assert.NotNull(codeElement)
+
+                Dim propertyDescriptors = ComponentModel.TypeDescriptor.GetProperties(codeElement)
+                Dim propertyNames = propertyDescriptors _
+                    .OfType(Of ComponentModel.PropertyDescriptor) _
+                    .Select(Function(pd) pd.Name) _
+                    .ToArray()
+
+                Assert.Equal(expectedPropertyNames, propertyNames)
+            End Using
+        End Sub
+
         Protected Sub TestElement(code As XElement, expected As Action(Of TCodeElement))
             Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
                 Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAccessorFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAccessorFunctionTests.vb
@@ -1,8 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -56,6 +54,26 @@ class C
         End Sub
 
 #End Region
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+class C
+{
+    int P { $$get { return 42; } }
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "FunctionKind", "Type", "Parameters", "Access", "IsOverloaded",
+                 "IsShared", "MustImplement", "Overloads", "Attributes", "DocComment", "Comment",
+                 "CanOverride", "OverrideKind", "IsGeneric"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String
             Get

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
@@ -1008,6 +1008,24 @@ class C { }
         End Sub
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+[$$System.CLSCompliant(true)]
+class C
+{
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Value", "Target", "Arguments"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -3790,6 +3790,34 @@ partial class Foo
 #End Region
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim expectedPropertyNames = {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                                         "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                                         "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
+                                         "DocComment", "Comment", "DerivedTypes", "ImplementedInterfaces", "IsAbstract",
+                                         "ClassKind", "PartialClasses", "DataTypeKind", "Parts", "InheritanceKind", "IsGeneric",
+                                         "IsShared"}
+
+            Dim code =
+<Code>
+class $$C
+{
+}
+</Code>
+
+            TestElement(code,
+                Sub(codeClass)
+                    Dim propertyDescriptors = ComponentModel.TypeDescriptor.GetProperties(codeClass)
+                    Dim propertyNames = propertyDescriptors _
+                        .OfType(Of ComponentModel.PropertyDescriptor) _
+                        .Select(Function(pd) pd.Name) _
+                        .ToArray()
+
+                    Assert.Equal(expectedPropertyNames, propertyNames)
+                End Sub)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub ExternalClass_ImplementedInterfaces()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -3791,13 +3791,6 @@ partial class Foo
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub TypeDescriptor_GetProperties()
-            Dim expectedPropertyNames = {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                                         "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                                         "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
-                                         "DocComment", "Comment", "DerivedTypes", "ImplementedInterfaces", "IsAbstract",
-                                         "ClassKind", "PartialClasses", "DataTypeKind", "Parts", "InheritanceKind", "IsGeneric",
-                                         "IsShared"}
-
             Dim code =
 <Code>
 class $$C
@@ -3805,16 +3798,15 @@ class $$C
 }
 </Code>
 
-            TestElement(code,
-                Sub(codeClass)
-                    Dim propertyDescriptors = ComponentModel.TypeDescriptor.GetProperties(codeClass)
-                    Dim propertyNames = propertyDescriptors _
-                        .OfType(Of ComponentModel.PropertyDescriptor) _
-                        .Select(Function(pd) pd.Name) _
-                        .ToArray()
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
+                 "DocComment", "Comment", "DerivedTypes", "ImplementedInterfaces", "IsAbstract",
+                 "ClassKind", "PartialClasses", "DataTypeKind", "Parts", "InheritanceKind", "IsGeneric",
+                 "IsShared"}
 
-                    Assert.Equal(expectedPropertyNames, propertyNames)
-                End Sub)
+            TestPropertyDescriptors(code, expectedPropertyNames)
         End Sub
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
@@ -367,6 +367,23 @@ delegate void D();
 
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+delegate void $$D();
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind",
+                 "IsCodeType", "InfoLocation", "Children", "Language", "StartPoint",
+                 "EndPoint", "ExtenderNames", "ExtenderCATID", "Parent", "Namespace",
+                 "Bases", "Members", "Access", "Attributes", "DocComment", "Comment",
+                 "DerivedTypes", "BaseClass", "Type", "Parameters", "IsGeneric"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEnumTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEnumTests.vb
@@ -567,6 +567,24 @@ enum Bar
         End Sub
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+enum $$E
+{
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
+                 "DocComment", "Comment", "DerivedTypes"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
@@ -887,6 +887,25 @@ class C
 
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+class C
+{
+    event System.EventHandler $$E;
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Access", "Attributes", "DocComment", "Comment", "Adder",
+                 "Remover", "Thrower", "IsPropertyStyleEvent", "Type", "OverrideKind", "IsShared"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -2660,6 +2660,26 @@ class C
 
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+class C
+{
+    void $$M() { }
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "FunctionKind", "Type", "Parameters", "Access", "IsOverloaded",
+                 "IsShared", "MustImplement", "Overloads", "Attributes", "DocComment", "Comment",
+                 "CanOverride", "OverrideKind", "IsGeneric"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Private Function GetExtensionMethodExtender(codeElement As EnvDTE80.CodeFunction2) As ICSExtensionMethodExtender
             Return CType(codeElement.Extender(ExtenderNames.ExtensionMethod), ICSExtensionMethodExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeImportTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeImportTests.vb
@@ -2,7 +2,6 @@
 
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -73,6 +72,21 @@ namespace Bar
         End Sub
 
 #End Region
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+using $$System;
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Namespace", "Alias", "Parent"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String
             Get

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeInterfaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeInterfaceTests.vb
@@ -411,6 +411,24 @@ interface Bar
         End Sub
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+interface $$I
+{
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
+                 "DocComment", "Comment", "DerivedTypes", "IsGeneric", "DataTypeKind", "Parts"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
@@ -53,6 +53,23 @@ namespace N$$
                          IsElement("C3", EnvDTE.vsCMElement.vsCMElementClass))
         End Sub
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+namespace $$N
+{
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Members", "DocComment", "Comment"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -1,7 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -574,6 +573,24 @@ delegate void Foo(byte?[,] i) { }
         End Sub
 
 #End Region
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+class C
+{
+    void M(int $$p) { }
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Type", "Attributes", "DocComment", "ParameterKind", "DefaultValue"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String
             Get

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
@@ -1450,6 +1450,26 @@ class C
 
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+class C
+{
+    int $$P { get { return 42; } }
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Type", "Getter", "Setter", "Access", "Attributes",
+                 "DocComment", "Comment", "Parameters", "IsGeneric", "OverrideKind", "IsShared",
+                 "IsDefault", "Parent2", "ReadWrite"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Private Function GetAutoImplementedPropertyExtender(codeElement As EnvDTE80.CodeProperty2) As ICSAutoImplementedPropertyExtender
             Return CType(codeElement.Extender(ExtenderNames.AutoImplementedProperty), ICSAutoImplementedPropertyExtender)
         End Function

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeStructTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeStructTests.vb
@@ -515,6 +515,25 @@ struct Bar
         End Sub
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+struct $$S
+{
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
+                 "DocComment", "Comment", "DerivedTypes", "ImplementedInterfaces", "IsAbstract",
+                 "IsGeneric", "DataTypeKind", "Parts"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeVariableTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeVariableTests.vb
@@ -2005,6 +2005,25 @@ class C
 
 #End Region
 
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TypeDescriptor_GetProperties()
+            Dim code =
+<Code>
+class S
+{
+    int $$x;
+}
+</Code>
+
+            Dim expectedPropertyNames =
+                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
+                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
+                 "ExtenderCATID", "Parent", "InitExpression", "Type", "Access", "IsConstant", "Attributes",
+                 "DocComment", "Comment", "IsShared", "ConstKind", "IsGeneric"}
+
+            TestPropertyDescriptors(code, expectedPropertyNames)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp


### PR DESCRIPTION
Fixes #2952 

This ensures that ```System.ComponentModel.TypeDescriptor.GetProperties(...)``` returns the correct set of ```PropertyDescriptors```.

Tagging @dotnet/mlangide 