### PR TITLE
Support multiple tabs in the completion list (and add a provider that uses them)

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Extensibility\Commands\ICommandHandler.cs" />
     <Compile Include="Extensibility\Commands\PredefinedCommandHandlerNames.cs" />
     <Compile Include="Extensibility\Completion\CompletionItemEventArgs.cs" />
+    <Compile Include="Extensibility\Completion\CompletionListEventArgs.cs" />
     <Compile Include="Extensibility\Completion\ExportCompletionProviderAttribute.cs" />
     <Compile Include="Extensibility\Completion\IAsyncCompletionService.cs" />
     <Compile Include="Extensibility\Completion\ICompletionPresenterSession.cs" />

--- a/src/EditorFeatures/Core/Extensibility/Completion/CompletionListEventArgs.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/CompletionListEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.VisualStudio.Language.Intellisense;
+using System;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    internal class CompletionListSelectedEventArgs
+    {
+        public readonly int? newValue;
+        public readonly int? oldValue;
+
+        public CompletionListSelectedEventArgs(int? oldValue, int? newValue)
+        {
+            this.oldValue = oldValue;
+            this.newValue = newValue;
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.VisualStudio.Text;
 
@@ -9,8 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal interface ICompletionPresenterSession : IIntelliSensePresenterSession
     {
-        void PresentItems(ITrackingSpan triggerSpan, IList<CompletionItem> items, CompletionItem selectedItem,
-            CompletionItem presetBuilder, bool suggestionMode, bool isSoftSelected);
+        void PresentModels(ITrackingSpan triggerSpan, ImmutableArray<CompletionPresentationData> models, bool suggestionMode);
 
         void SelectPreviousItem();
         void SelectNextItem();
@@ -19,5 +19,35 @@ namespace Microsoft.CodeAnalysis.Editor
 
         event EventHandler<CompletionItemEventArgs> ItemSelected;
         event EventHandler<CompletionItemEventArgs> ItemCommitted;
+        event EventHandler<CompletionListSelectedEventArgs> CompletionListSelected;
+    }
+
+    internal class CompletionPresentationData
+    {
+        public int ModelId { get; }
+
+        public IList<CompletionItem> Items { get; }
+        public CompletionItem SelectedItem { get; }
+        public CompletionItem PresetBuilder { get; }
+        public bool IsSoftSelected { get; }
+        public string Title { get; }
+        public bool IsSelectedList { get; }
+
+        public CompletionPresentationData(IList<CompletionItem> items, 
+            CompletionItem selectedItem, 
+            CompletionItem presetBuilder, 
+            bool isSoftSelected, 
+            int modelId, 
+            string title, 
+            bool isSelectedModel)
+        {
+            this.Items = items;
+            this.SelectedItem = selectedItem;
+            this.PresetBuilder = presetBuilder;
+            this.IsSoftSelected = isSoftSelected;
+            this.ModelId = modelId;
+            this.Title = title;
+            this.IsSelectedList = isSelectedModel;
+        }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_Wait.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_Wait.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
+using System.Linq;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
@@ -11,13 +13,28 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
     {
         internal partial class Session
         {
-            internal Model WaitForModel()
+            internal ImmutableArray<Model> WaitForModels()
             {
                 AssertIsForeground();
 
                 using (Logger.LogBlock(FunctionId.Completion_ModelComputation_WaitForModel, CancellationToken.None))
                 {
                     return Computation.ModelTask.WaitAndGetResult(CancellationToken.None);
+                }
+            }
+
+            internal Model GetSelectedModel()
+            {
+                AssertIsForeground();
+
+                WaitForModels();
+                if (Computation.ModelTask.Result == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    return Computation.ModelTask.Result.SingleOrDefault(m => m.IsSelected);
                 }
             }
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_NavigationKeys.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_NavigationKeys.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editor.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
@@ -62,10 +63,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // If we've finished computing the completions then use the navigation commands to
             // change the selected item.  Otherwise, the user was just typing and is now moving
             // through the file.  In this case stop everything we're doing.
-            var model = sessionOpt.Computation.InitialUnfilteredModel != null ? sessionOpt.Computation.WaitForController() : null;
+            var models = sessionOpt.Computation.InitialUnfilteredModels != default(ImmutableArray<Model>) ? sessionOpt.Computation.WaitForController() : default(ImmutableArray<Model>);
 
             // Check if completion is still active.  Then update the computation appropriately.
-            if (model != null)
+            if (models != default(ImmutableArray<Model>))
             {
                 computationAction();
                 return true;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_OnTextViewBufferPostChanged.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_OnTextViewBufferPostChanged.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // has computed the results, then compare where the caret is with all the items.  If the
             // caret isn't within the bounds of the items, then we dismiss completion. If they have
             // not computed results yet, then chain a task to see if we should dismiss the list.  
-            var model = sessionOpt.Computation.InitialUnfilteredModel;
-            if (model != null && this.IsCaretOutsideAllItemBounds(model, this.GetCaretPointInViewBuffer()))
+            var models = sessionOpt.Computation.InitialUnfilteredModels;
+            if (models != null && this.IsCaretOutsideAllItemBounds(models, this.GetCaretPointInViewBuffer()))
             {
                 // If the caret moved out of bounds of our items, then we want to dismiss the list. 
                 this.StopModelComputation();
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             else
             {
                 // Filter the model, recheck the caret position if we haven't computed the initial model yet
-                sessionOpt.FilterModel(CompletionFilterReason.TypeChar, recheckCaretPosition: model == null);
+                sessionOpt.FilterModel(CompletionFilterReason.TypeChar, recheckCaretPosition: models == null);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             AssertIsForeground();
 
-            var model = sessionOpt.WaitForModel();
+            var model = sessionOpt.GetSelectedModel();
 
             // If there's no model, then there's nothing to commit.
             if (model == null)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             AssertIsForeground();
 
-            var model = sessionOpt.WaitForModel();
+            var model = sessionOpt.GetSelectedModel();
 
             // If there's no model, then there's nothing to commit.
             if (model == null)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/ImmutableArrayExtensions.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/ImmutableArrayExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
+{
+    internal static class ImmutableArrayExtesions
+    {
+        public static Model GetSelectedModelOrNull(this ImmutableArray<Model> models)
+        {
+            if (models == default(ImmutableArray<Model>))
+            {
+                return null;
+            }
+
+            return models.FirstOrDefault(m => m.IsSelected);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -44,6 +44,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         public bool DismissIfEmpty { get; }
 
+        public string Title { get; }
+        public bool IsSelected { get; }
+
         private Model(
             DisconnectedBufferGraph disconnectedBufferGraph,
             IList<CompletionItem> totalItems,
@@ -56,7 +59,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             CompletionItem defaultBuilder,
             CompletionTriggerInfo triggerInfo,
             ITrackingPoint commitSpanEndPoint,
-            bool dismissIfEmpty)
+            bool dismissIfEmpty,
+            bool isSelected, 
+            string title)
         {
             Contract.ThrowIfNull(selectedItem);
             Contract.ThrowIfFalse(totalItems.Count != 0, "Must have at least one item.");
@@ -75,6 +80,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             this.TriggerInfo = triggerInfo;
             this.CommitTrackingSpanEndPoint = commitSpanEndPoint;
             this.DismissIfEmpty = dismissIfEmpty;
+            this.IsSelected = isSelected;
+            this.Title = title;
         }
 
         public static Model CreateModel(
@@ -88,7 +95,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             CompletionItem builder,
             CompletionTriggerInfo triggerInfo,
             ICompletionService completionService,
-            Workspace workspace)
+            Workspace workspace, 
+            string title, 
+            bool isSelected,
+            bool neverDismissIfEmpty)
         {
             var updatedTotalItems = totalItems;
             CompletionItem updatedSelectedItem = selectedItem;
@@ -147,7 +157,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 updatedDefaultBuilder,
                 triggerInfo,
                 GetDefaultTrackingSpanEnd(defaultTrackingSpanInSubjectBuffer, disconnectedBufferGraph),
-                completionService.DismissIfEmpty);
+                !neverDismissIfEmpty && completionService.DismissIfEmpty, 
+                isSelected,
+                title);
         }
 
         private static ITrackingPoint GetDefaultTrackingSpanEnd(
@@ -176,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         public Model WithFilteredItems(IList<CompletionItem> filteredItems)
         {
             return new Model(_disconnectedBufferGraph, TotalItems, filteredItems,
-                filteredItems.First(), IsHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty);
+                filteredItems.First(), IsHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty, IsSelected, Title);
         }
 
         public Model WithSelectedItem(CompletionItem selectedItem)
@@ -184,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return selectedItem == this.SelectedItem
                 ? this
                 : new Model(_disconnectedBufferGraph, TotalItems, FilteredItems,
-                    selectedItem, IsHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty);
+                    selectedItem, IsHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty, IsSelected, Title);
         }
 
         public Model WithHardSelection(bool isHardSelection)
@@ -192,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return isHardSelection == this.IsHardSelection
                 ? this
                 : new Model(_disconnectedBufferGraph, TotalItems, FilteredItems,
-                    SelectedItem, isHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty);
+                    SelectedItem, isHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty, IsSelected, Title);
         }
 
         public Model WithIsUnique(bool isUnique)
@@ -200,7 +212,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return isUnique == this.IsUnique
                 ? this
                 : new Model(_disconnectedBufferGraph, TotalItems, FilteredItems,
-                    SelectedItem, IsHardSelection, isUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty);
+                    SelectedItem, IsHardSelection, isUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty, IsSelected, Title);
         }
 
         public Model WithBuilder(CompletionItem builder)
@@ -208,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return builder == this.Builder
                 ? this
                  : new Model(_disconnectedBufferGraph, TotalItems, FilteredItems,
-                    SelectedItem, IsHardSelection, IsUnique, UseSuggestionCompletionMode, builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty);
+                    SelectedItem, IsHardSelection, IsUnique, UseSuggestionCompletionMode, builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty, IsSelected, Title);
         }
 
         public Model WithUseSuggestionCompletionMode(bool useSuggestionCompletionMode)
@@ -216,13 +228,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return useSuggestionCompletionMode == this.UseSuggestionCompletionMode
                 ? this
                  : new Model(_disconnectedBufferGraph, TotalItems, FilteredItems,
-                    SelectedItem, IsHardSelection, IsUnique, useSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty);
+                    SelectedItem, IsHardSelection, IsUnique, useSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty, IsSelected, Title);
         }
 
         internal Model WithTrackingSpanEnd(ITrackingPoint trackingSpanEnd)
         {
             return new Model(_disconnectedBufferGraph, TotalItems, FilteredItems,
-                SelectedItem, IsHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, trackingSpanEnd, DismissIfEmpty);
+                SelectedItem, IsHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, trackingSpanEnd, DismissIfEmpty, IsSelected, Title);
+        }
+
+        internal Model WithIsSelected(bool isSelected)
+        {
+            return new Model(_disconnectedBufferGraph, TotalItems, FilteredItems,
+                SelectedItem, IsHardSelection, IsUnique, UseSuggestionCompletionMode, Builder, DefaultBuilder, TriggerInfo, CommitTrackingSpanEndPoint, DismissIfEmpty, isSelected, Title);
         }
 
         internal SnapshotSpan GetCurrentSpanInSnapshot(ViewTextSpan originalSpan, ITextSnapshot textSnapshot)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionSet2.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionSet2.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
 using VSCompletion = Microsoft.VisualStudio.Language.Intellisense.Completion;
+using System;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.Presentation
 {
@@ -18,13 +19,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         private readonly CompletionPresenterSession _completionPresenterSession;
         private Dictionary<CompletionItem, VSCompletion> _completionItemMap;
 
-        public CompletionSet2(CompletionPresenterSession completionPresenterSession, ITextView textView, ITextBuffer subjectBuffer)
+        public int Id { get; }
+
+        public CompletionSet2(CompletionPresenterSession completionPresenterSession, ITextView textView, ITextBuffer subjectBuffer, int id, string title)
         {
             _completionPresenterSession = completionPresenterSession;
             _textView = textView;
             _subjectBuffer = subjectBuffer;
-            this.Moniker = "All";
-            this.DisplayName = "All";
+            this.Moniker = title;
+            this.DisplayName = title;
+            this.Id = id;
         }
 
         internal void SetTrackingSpan(ITrackingSpan trackingSpan)
@@ -132,6 +136,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         {
             // Do nothing.  We do *not* want the default behavior that the editor has.  We've
             // already computed the best match.
+
+            if (Selected)
+            {
+                this._completionPresenterSession._editorSessionOpt.SelectedCompletionSet = this;
+            }
         }
 
         public override void Filter()
@@ -144,5 +153,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         {
             // Do nothing.  Our controller will already recalculate if necessary.
         }
+
+        // Hack: When our presenter "augments" the editor's session, we're
+        // unable to specify the selected CompletionSet. Use the call to 
+        // SelectBestMatch to set it
+        internal bool Selected { get; set; }
+
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/IController.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/IController.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 {
     internal interface IController<TModel>
     {
-        void OnModelUpdated(TModel result);
+        void OnModelsUpdated(ImmutableArray<TModel> result);
         IAsyncToken BeginAsyncOperation();
         void StopModelComputation();
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/ISession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/ISession.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 {
     internal interface ISession<TModel>
     {
-        TModel InitialUnfilteredModel { get; }
+        ImmutableArray<TModel> InitialUnfilteredModels { get; }
 
         void Stop();
 
-        TModel WaitForController();
+        ImmutableArray<TModel> WaitForController();
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -30,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             this.PresenterSession.Dismissed += OnPresenterSessionDismissed;
         }
 
-        public TModel InitialUnfilteredModel { get { return this.Computation.InitialUnfilteredModel; } }
+        public ImmutableArray<TModel> InitialUnfilteredModels { get { return this.Computation.InitialUnfilteredModels; } }
 
         private void OnPresenterSessionDismissed(object sender, EventArgs e)
         {
@@ -47,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             this.PresenterSession.Dismiss();
         }
 
-        public TModel WaitForController()
+        public ImmutableArray<TModel> WaitForController()
         {
             AssertIsForeground();
             return Computation.WaitForController();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_SetModelSelectedItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_SetModelSelectedItem.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using Roslyn.Utilities;
 
@@ -19,21 +20,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     updateController: false);
             }
 
-            private Model SetModelExplicitlySelectedItemInBackground(
-                Model model,
+            private ImmutableArray<Model> SetModelExplicitlySelectedItemInBackground(
+                ImmutableArray<Model> models,
                 Func<Model, SignatureHelpItem> selector)
             {
                 AssertIsBackground();
 
-                if (model == null)
+                if (models == default(ImmutableArray<Model>))
                 {
-                    return null;
+                    return default(ImmutableArray<Model>);
                 }
 
+                var model = models[0];
                 var selectedItem = selector(model);
                 Contract.ThrowIfFalse(model.Items.Contains(selectedItem));
 
-                return model.WithSelectedItem(selectedItem);
+                return new[] { model.WithSelectedItem(selectedItem) }.ToImmutableArray();
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -72,8 +73,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             return this.TextView.Caret.Position.BufferPosition;
         }
 
-        internal override void OnModelUpdated(Model modelOpt)
+        internal override void OnModelsUpdated(ImmutableArray<Model> modelsOpt)
         {
+            if (modelsOpt == default(ImmutableArray<Model>))
+            {
+                this.StopModelComputation();
+                return;
+            }
+
+            // Signature Help only computes one model
+            var modelOpt = modelsOpt[0];
+
             AssertIsForeground();
             if (modelOpt == null)
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_NavigationKeys.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_NavigationKeys.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 {
@@ -31,7 +33,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             // If we've finished computing the items then use the navigation commands to change the
             // selected item.  Otherwise, the user was just typing and is now moving through the
             // file.  In this case stop everything we're doing.
-            var model = sessionOpt.InitialUnfilteredModel != null ? WaitForController() : null;
+            var models = sessionOpt.InitialUnfilteredModels != default(ImmutableArray<Model>) ? WaitForController() : default(ImmutableArray<Model>);
+            var model = models.FirstOrDefault();
 
             // Check if completion is still active.  Then update the computation appropriately.
             //

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3,6 +3,7 @@
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.CSharp.Completion.Providers
 Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
@@ -1562,11 +1563,150 @@ class C
 
                     Dim editorOperations = editorOperationsFactory.GetEditorOperations(view)
                     state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, state.SubjectBuffer), Sub() editorOperations.Delete())
-
                     state.AssertNoCompletionSession()
                 Finally
                     view.Close()
                 End Try
+            End Using
+        End Sub
+
+        Private Class ExtraListProvider
+            Inherits CompletionListProvider
+
+            Private ReadOnly text As String
+
+            Sub New()
+                Me.text = "Extra"
+            End Sub
+            Sub New(text As String)
+                Me.text = text
+            End Sub
+
+            Public Overrides Function IsTriggerCharacter(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean
+                Return True
+            End Function
+
+            Public Overrides Async Function ProduceCompletionListAsync(context As CompletionListContext) As Task
+                Dim text = Await context.Document.GetTextAsync().ConfigureAwait(False)
+                Dim item = New CompletionItem(Me, Me.text, CompletionUtilities.GetTextChangeSpan(text, context.Position))
+                item.AddTag("Extra")
+                context.AddItem(item)
+
+                Dim item2 = New CompletionItem(Me, Me.text & "2", CompletionUtilities.GetTextChangeSpan(text, context.Position))
+                item2.AddTag("Extra")
+                context.AddItem(item2)
+            End Function
+        End Class
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub CompletionStartedWithMultipleLists()
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void foo(int x)
+    {
+        $$]]></Document>, extraCompletionProviders:={New ExtraListProvider()})
+                ' Note: the caret is at the file, so the Select All command's movement
+                ' of the caret to the end of the selection isn't responsible for 
+                ' dismissing the session.
+                state.SendInvokeCompletionList()
+                state.AssertListCount(2)
+                state.AssertSelectedTab("Extra")
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub ToggleBetweenRoslynOwnedCompletionTabs()
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void foo(int x)
+    {
+        $$]]></Document>, extraCompletionProviders:={New ExtraListProvider()})
+
+                state.SendInvokeCompletionList()
+                state.AssertListCount(2)
+                state.AssertSelectedTab("Extra")
+                state.CurrentCompletionPresenterSession.SelectTab("All")
+                state.AssertSelectedTab("All")
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub SwitchAwayFromRoslynOwnedTabs()
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void foo(int x)
+    {
+        $$]]></Document>, extraCompletionProviders:={New ExtraListProvider()})
+
+                state.SendInvokeCompletionList()
+                state.AssertListCount(2)
+                state.AssertSelectedTab("Extra")
+                state.SendTypeChars("Ex")
+                state.AssertSelectedCompletionItem("Extra")
+                state.CurrentCompletionPresenterSession.SelectNoTab()
+
+                ' Enter should not commit
+                state.SendReturn()
+                Assert.False(state.TextView.TextBuffer.CurrentSnapshot.GetText().Contains("Extra"))
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub TagsMergedBetweenItemsWithSameText()
+            ' We have code that sometimes takes items with a specific glyph.
+            ' However, we still need CompletionListProviders to be able to
+            ' specify altnerate lists for those items. This test uses
+            ' a provider that provides "True" to verify that we show
+            ' a True (Keyword) in an additional list.
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void foo(int x)
+    {
+        $$]]></Document>, extraCompletionProviders:={New ExtraListProvider("True")})
+
+                state.SendInvokeCompletionList()
+                state.AssertListCount(2)
+                state.AssertSelectedTab("Extra")
+                state.SendTypeChars("Tr")
+                state.AssertSelectedCompletionItem("True")
+                Assert.Equal(state.CurrentCompletionPresenterSession.SelectedItem.Glyph, Glyph.Keyword)
+            End Using
+        End Sub
+
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub ModifyModelStatesIndependently()
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void foo(int x)
+    {
+        $$]]></Document>, extraCompletionProviders:={New ExtraListProvider()})
+
+                state.SendInvokeCompletionList()
+                state.AssertListCount(2)
+                state.AssertSelectedTab("Extra")
+                state.SendTypeChars("Ex")
+                state.AssertSelectedCompletionItem("Extra")
+                state.CurrentCompletionPresenterSession.SelectTab("All")
+                state.AssertSelectedCompletionItem("Exception")
+                state.SendDownKey()
+                state.AssertSelectedCompletionItem("ExecutionEngineException")
+                state.CurrentCompletionPresenterSession.SelectTab("Extra")
+
+                ' First tab should still commit its originally selected item
+                state.SendReturn()
+                Assert.True(state.TextView.TextBuffer.CurrentSnapshot.GetText().Contains("Extra"))
+                Assert.False(state.TextView.TextBuffer.CurrentSnapshot.GetText().Contains("Extra2"))
             End Using
         End Sub
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/ModelTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/ModelTests.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
@@ -53,19 +54,19 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Sub ChainingTaskThatCompletesNotifiesController()
             Dim controller = New Mock(Of IController(Of Model))
             Dim modelComputation = TestModelComputation.Create(controller:=controller.Object)
-            Dim model = New Model()
+            Dim model = {New Model()}.ToImmutableArray()
 
             modelComputation.ChainTaskAndNotifyControllerWhenFinished(Function(m) model)
             modelComputation.Wait()
 
-            controller.Verify(Sub(c) c.OnModelUpdated(model))
+            controller.Verify(Sub(c) c.OnModelsUpdated(model))
         End Sub
 
         <Fact>
         Public Sub ControllerIsOnlyUpdatedAfterLastTaskCompletes()
             Dim controller = New Mock(Of IController(Of Model))
             Dim modelComputation = TestModelComputation.Create(controller:=controller.Object)
-            Dim model = New Model()
+            Dim model = {New Model()}.ToImmutableArray()
             Dim gate = New Object
 
             Monitor.Enter(gate)
@@ -78,7 +79,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Monitor.Exit(gate)
             modelComputation.Wait()
 
-            controller.Verify(Sub(c) c.OnModelUpdated(model), Times.Once)
+            controller.Verify(Sub(c) c.OnModelsUpdated(model), Times.Once)
         End Sub
 
         <Fact>
@@ -87,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim token = New Mock(Of IAsyncToken)
             controller.Setup(Function(c) c.BeginAsyncOperation()).Returns(token.Object)
             Dim modelComputation = TestModelComputation.Create(controller:=controller.Object)
-            Dim model = New Model()
+            Dim model = {New Model()}.ToImmutableArray()
             Dim checkpoint1 = New Checkpoint
             Dim checkpoint2 = New Checkpoint
             Dim checkpoint3 = New Checkpoint
@@ -105,7 +106,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             checkpoint2.Release()
             checkpoint3.PumpingWait()
 
-            controller.Verify(Sub(c) c.OnModelUpdated(model), Times.Never)
+            controller.Verify(Sub(c) c.OnModelsUpdated(model), Times.Never)
         End Sub
 
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/TestCompletionPresenterSession.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestCompletionPresenterSession.vb
@@ -2,9 +2,10 @@
 
 Imports System
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor
-Imports Microsoft.CodeAnalysis.Editor.Implementation.Intellisense.Completion
+Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.Text
@@ -17,26 +18,58 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Private ReadOnly _testState As IIntelliSenseTestState
 
         Public TriggerSpan As ITrackingSpan
-        Public CompletionItems As IList(Of CompletionItem)
-        Public SelectedItem As CompletionItem
-        Public IsSoftSelected As Boolean
-        Public Builder As CompletionItem
+        Public ReadOnly Property CompletionItems As IList(Of CompletionItem)
+            Get
+                Return GetSelectedModel().Items
+            End Get
+        End Property
+        Public Property SelectedItem As CompletionItem
+            Get
+                Return GetSelectedModel().SelectedItem
+            End Get
+            Set(value As CompletionItem)
+                Dim oldModel = GetSelectedModel()
+                Dim index = Array.IndexOf(models, oldModel)
+                models(index) = New CompletionPresentationData(oldModel.Items, value, oldModel.PresetBuilder, oldModel.IsSoftSelected, oldModel.ModelId, "Test", True)
+            End Set
+        End Property
+        Public Property IsSoftSelected As Boolean
+            Get
+                Return GetSelectedModel().IsSoftSelected
+            End Get
+            Set(value As Boolean)
+                Dim oldModel = GetSelectedModel()
+                Dim index = Array.IndexOf(models, oldModel)
+                models(index) = New CompletionPresentationData(oldModel.Items, oldModel.SelectedItem, oldModel.PresetBuilder, value, oldModel.ModelId, "Test", True)
+            End Set
+        End Property
+
+        Public ReadOnly Property Builder As CompletionItem
+            Get
+                Return GetSelectedModel().PresetBuilder
+            End Get
+        End Property
+
+        Public Function GetSelectedModel() As CompletionPresentationData
+            Dim selectedModels = models.Where(Function(m) m.IsSelectedList)
+            Assert.True(selectedModels.Count() <= 1)
+
+            Return selectedModels.FirstOrDefault()
+        End Function
 
         Public Event Dismissed As EventHandler(Of EventArgs) Implements ICompletionPresenterSession.Dismissed
         Public Event ItemSelected As EventHandler(Of CompletionItemEventArgs) Implements ICompletionPresenterSession.ItemSelected
         Public Event ItemCommitted As EventHandler(Of CompletionItemEventArgs) Implements ICompletionPresenterSession.ItemCommitted
+        Public Event CompletionListSelected As EventHandler(Of CompletionListSelectedEventArgs) Implements ICompletionPresenterSession.CompletionListSelected
 
         Public Sub New(testState As IIntelliSenseTestState)
             Me._testState = testState
         End Sub
 
-        Public Sub PresentItems(triggerSpan As ITrackingSpan, completionItems As IList(Of CompletionItem), selectedItem As CompletionItem, presetBuilder As CompletionItem, suggestionMode As Boolean, isSoftSelected As Boolean) Implements ICompletionPresenterSession.PresentItems
+        Public Sub PresentModels(triggerSpan As ITrackingSpan, data As ImmutableArray(Of CompletionPresentationData), suggestionMode As Boolean) Implements ICompletionPresenterSession.PresentModels
             _testState.CurrentCompletionPresenterSession = Me
             Me.TriggerSpan = triggerSpan
-            Me.CompletionItems = completionItems
-            Me.SelectedItem = selectedItem
-            Me.IsSoftSelected = isSoftSelected
-            Me.Builder = presetBuilder
+            Me.models = data.ToArray()
         End Sub
 
         Public Sub Dismiss() Implements ICompletionPresenterSession.Dismiss
@@ -70,6 +103,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Sub
 
         Private Const s_itemsPerPage = 9
+        Public models As CompletionPresentationData()
 
         Public Sub SelectPreviousPageItem() Implements ICompletionPresenterSession.SelectPreviousPageItem
             SetSelectedItem(GetFilteredItemAt(CompletionItems.IndexOf(SelectedItem) - s_itemsPerPage))
@@ -77,6 +111,15 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         Public Sub SelectNextPageItem() Implements ICompletionPresenterSession.SelectNextPageItem
             SetSelectedItem(GetFilteredItemAt(CompletionItems.IndexOf(SelectedItem) + s_itemsPerPage))
+        End Sub
+
+        Friend Sub SelectTab(v As String)
+            Dim modelToSelect = models.First(Function(m) m.Title = v)
+            RaiseEvent CompletionListSelected(Me, New CompletionListSelectedEventArgs(GetSelectedModel()?.ModelId, modelToSelect.ModelId))
+        End Sub
+
+        Friend Sub SelectNoTab()
+            RaiseEvent CompletionListSelected(Me, New CompletionListSelectedEventArgs(GetSelectedModel()?.ModelId, Nothing))
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/TestState.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestState.vb
@@ -238,6 +238,20 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Assert.NotNull(Me.CurrentCompletionPresenterSession)
         End Sub
 
+        Public Sub AssertListCount(count As Integer)
+            WaitForAsynchronousOperations()
+            Assert.Equal(Me.CurrentCompletionPresenterSession.Models.Count(), count)
+        End Sub
+
+        Public Sub AssertSelectedTab(title As String)
+            WaitForAsynchronousOperations()
+            Assert.Equal(Me.CurrentCompletionPresenterSession.GetSelectedModel().Title, title)
+        End Sub
+
+        Public Sub AssertTabCount(count As Integer)
+
+        End Sub
+
         Public Function CompletionItemsContainsAll(displayText As String()) As Boolean
             WaitForAsynchronousOperations()
             Return displayText.All(Function(v) CurrentCompletionPresenterSession.CompletionItems.Any(

--- a/src/Features/Core/Portable/Completion/AbstractCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/AbstractCompletionService.cs
@@ -240,18 +240,29 @@ namespace Microsoft.CodeAnalysis.Completion
             // if they are snippets and the other candidate is preselected.
             if (existingItem.Preselect && item.CompletionProvider is ISnippetCompletionProvider)
             {
-                return existingItem;
+                return CopyTags(item, existingItem);
             }
 
             // If one is a keyword, and the other is some other item that inserts the same text as the keyword,
             // keep the keyword
             var keywordItem = existingItem as KeywordCompletionItem ?? item as KeywordCompletionItem;
+            var other = keywordItem == existingItem ? item : existingItem;
             if (keywordItem != null)
             {
-                return keywordItem;
+                return CopyTags(other, keywordItem);
             }
 
-            return item;
+            return CopyTags(existingItem, item);
+        }
+
+        private static CompletionItem CopyTags(CompletionItem item1, CompletionItem item2)
+        {
+            foreach (var tag in item1.Tags)
+            {
+                item2.AddTag(tag);
+            }
+
+            return item2;
         }
 
         private Dictionary<CompletionListProvider, int> GetCompletionProviderToIndex(IEnumerable<CompletionListProvider> completionProviders)

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Completion
 {
@@ -187,6 +188,25 @@ namespace Microsoft.CodeAnalysis.Completion
         public override string ToString()
         {
             return DisplayText;
+        }
+
+        private List<string> tags = null;
+        public IEnumerable<string> Tags
+        {
+            get
+            {
+                return tags ?? SpecializedCollections.EmptyEnumerable<string>();
+            }
+        }
+
+        public void AddTag(string tag)
+        {
+            if (tags == null)
+            {
+                tags = new List<string>();
+            }
+
+            tags.Add(tag);
         }
     }
 }

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -140,6 +140,7 @@
     <Compile Include="CodeRefactorings\IntroduceVariable\IntroduceVariableCodeRefactoringProvider.vb" />
     <Compile Include="CodeRefactorings\InvertIf\InvertIfCodeRefactoringProvider.vb" />
     <Compile Include="CodeRefactorings\RemoveStatementCodeAction.vb" />
+    <Compile Include="Completion\CompletionProviders\BooleanCompletionProvider.vb" />
     <Compile Include="Completion\CompletionProviders\CompletionListTagCompletionProvider.vb" />
     <Compile Include="Completion\CompletionProviders\CompletionUtilities.vb" />
     <Compile Include="Completion\CompletionProviders\CrefCompletionProvider.ItemRules.vb" />

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/BooleanCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/BooleanCompletionProvider.vb
@@ -1,0 +1,36 @@
+﻿Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
+    Friend Class BooleanCompletionProvider
+        Inherits CompletionListProvider
+
+        Public Overrides Function IsTriggerCharacter(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean
+            Return CompletionUtilities.IsDefaultTriggerCharacterOrParen(text, characterPosition, options)
+        End Function
+
+        Public Overrides Async Function ProduceCompletionListAsync(context As CompletionListContext) As Task
+            Dim typeInferenceService = context.Document.Project.LanguageServices.GetService(Of ITypeInferenceService)()
+            Dim semanticModel = Await context.Document.GetSemanticModelForSpanAsync(New TextSpan(context.Position, 0), context.CancellationToken).ConfigureAwait(False)
+            Dim inferredType = typeInferenceService.InferType(semanticModel, context.Position, objectAsDefault:=False, cancellationToken:=context.CancellationToken)
+
+            If inferredType IsNot Nothing AndAlso inferredType.SpecialType = SpecialType.System_Boolean Then
+                Dim text = Await context.Document.GetTextAsync(context.CancellationToken).ConfigureAwait(False)
+                Dim textChangeSpan = CompletionUtilities.GetTextChangeSpan(text, context.Position)
+
+                Dim trueItem = New CompletionItem(Me, "True", textChangeSpan, glyph:=Glyph.Keyword)
+                trueItem.AddTag("Boolean")
+
+                Dim falseItem = New CompletionItem(Me, "False", textChangeSpan, glyph:=Glyph.Keyword)
+                falseItem.AddTag("Boolean")
+
+                context.AddItem(trueItem)
+                context.AddItem(falseItem)
+            End If
+
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         End Function
 
         Protected Overrides Function CreateItem(displayAndInsertionText As ValueTuple(Of String, String), position As Integer, symbols As List(Of ISymbol), context As AbstractSyntaxContext, textChangeSpan As TextSpan, preselect As Boolean, supportedPlatformData As SupportedPlatformData) As CompletionItem
-            Return New SymbolCompletionItem(
+            Dim item = New SymbolCompletionItem(
                 Me,
                 displayAndInsertionText.Item1,
                 displayAndInsertionText.Item2,
@@ -127,6 +127,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 preselect:=preselect,
                 supportedPlatforms:=supportedPlatformData,
                 rules:=ItemRules.Instance)
+
+            item.AddTag(symbols(0).GetSymbolType().Name)
+            Return item
+
         End Function
 
         Protected Overrides Function GetCompletionItemRules() As CompletionItemRules

--- a/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionService.vb
+++ b/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionService.vb
@@ -28,7 +28,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
             New HandlesClauseCompletionProvider(),
             New PartialTypeCompletionProvider(),
             New CrefCompletionProvider(),
-            New CompletionListTagCompletionProvider
+            New CompletionListTagCompletionProvider,
+            New BooleanCompletionProvider()
         }.ToImmutableArray()
 
         Public Overrides Function GetDefaultCompletionProviders() As IEnumerable(Of CompletionListProvider)


### PR DESCRIPTION
This change updates our integration with the VS editor to respect the idea of multiple CompletionSets within one VS ICompletionSession and plumbs through the state machine the ability to manage and present multiple models at once.

From an API perspective, CompletionItem now has a "Tags" property, which is a list of strings. After all providers have run, one model is created that contains the output of every provider. Additionally, CompletionItems are grouped by their tags and another model is produced for each such group. Those models are presented with the tag as the display text of their tab in the editor's completion list.

Additionally, I have augmented Enum completion to add a tab named after the Enum being preselected, and a provider that provides a tab of booleans.

Tagging @dotnet/mlangide for review.