### PR TITLE
Update Code Model to allow the WinForms designer to design types that inherit from closed generic types

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/Interop/ICodeClassBase.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Interop/ICodeClassBase.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop
+{
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("23BBD58A-7C59-449b-A93C-43E59EFC080C")]
+    internal interface ICodeClassBase
+    {
+        [PreserveSig]
+        int GetBaseName([MarshalAs(UnmanagedType.BStr)] out string pBaseName);
+    }
+}

--- a/src/VisualStudio/Core/Impl/CodeModel/MetadataNameHelpers.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/MetadataNameHelpers.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.MethodXml
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
     internal static class MetadataNameHelpers
     {

--- a/src/VisualStudio/Core/Impl/CodeModel/RootCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/RootCodeModel.cs
@@ -193,8 +193,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         public string DotNetNameFromLanguageSpecific(string languageName)
         {
-            // VB implemented this but C# never did. Does it matter?
-            throw Exceptions.ThrowENotImpl();
+            var compilation = GetCompilation();
+            var typeSymbol = CodeModelService.GetTypeSymbolFromFullName(languageName, compilation);
+            if (typeSymbol == null)
+            {
+                throw Exceptions.ThrowEInvalidArg();
+            }
+
+            return MetadataNameHelpers.GetMetadataName(typeSymbol);
         }
 
         public EnvDTE.CodeElement ElementFromID(string id)

--- a/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
+++ b/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
@@ -283,6 +283,7 @@
     <Compile Include="CodeModel\InternalElements\CodeVariable.cs" />
     <Compile Include="CodeModel\Interop\ApartmentSensitiveComObject.cs" />
     <Compile Include="CodeModel\Interop\CodeModelInterop.cs" />
+    <Compile Include="CodeModel\Interop\ICodeClassBase.cs" />
     <Compile Include="CodeModel\Interop\ICodeElements.cs" />
     <Compile Include="CodeModel\Interop\ICSCodeModelRefactoring.cs" />
     <Compile Include="CodeModel\Interop\IEventHandler.cs" />
@@ -297,7 +298,7 @@
     <Compile Include="CodeModel\MethodXml\AbstractMethodXmlBuilder.AutoTag.cs" />
     <Compile Include="CodeModel\MethodXml\AbstractMethodXmlBuilder.cs" />
     <Compile Include="CodeModel\MethodXml\BinaryOperatorKind.cs" />
-    <Compile Include="CodeModel\MethodXml\MetadataNameHelpers.cs" />
+    <Compile Include="CodeModel\MetadataNameHelpers.cs" />
     <Compile Include="CodeModel\MethodXml\VariableKind.cs" />
     <Compile Include="CodeModel\NodeKeyValidation.cs" />
     <Compile Include="CodeModel\ParentHandle.cs" />

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeClassTests.vb
@@ -1,5 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop
+
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Public MustInherit Class AbstractCodeClassTests
         Inherits AbstractCodeElementTests(Of EnvDTE80.CodeClass2)
@@ -162,6 +164,20 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
         Protected Overrides Sub RemoveImplementedInterface(codeElement As EnvDTE80.CodeClass2, element As Object)
             codeElement.RemoveInterface(element)
+        End Sub
+
+        Protected Sub TestGetBaseName(code As XElement, expectedBaseName As String)
+            TestElement(code,
+                Sub(codeClass)
+                    Dim codeClassBase = TryCast(codeClass, ICodeClassBase)
+                    Assert.NotNull(codeClassBase)
+
+                    Dim baseName As String = Nothing
+                    Dim hRetVal = codeClassBase.GetBaseName(baseName)
+                    Assert.Equal(VSConstants.S_OK, hRetVal)
+
+                    Assert.Equal(expectedBaseName, baseName)
+                End Sub)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractRootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractRootCodeModelTests.vb
@@ -2,20 +2,20 @@
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Public MustInherit Class AbstractRootCodeModelTests
-        Inherits AbstractCodeModelObjectTests(Of EnvDTE.CodeModel)
+        Inherits AbstractCodeModelObjectTests(Of EnvDTE80.CodeModel2)
 
-        Protected Sub TestRootCodeModel(workspaceDefinition As XElement, action As Action(Of EnvDTE.CodeModel))
+        Protected Sub TestRootCodeModel(workspaceDefinition As XElement, action As Action(Of EnvDTE80.CodeModel2))
             Using state = CreateCodeModelTestState(workspaceDefinition)
-                Dim rootCodeModel = state.RootCodeModel
+                Dim rootCodeModel = TryCast(state.RootCodeModel, EnvDTE80.CodeModel2)
                 Assert.NotNull(rootCodeModel)
 
                 action(rootCodeModel)
             End Using
         End Sub
 
-        Protected Sub TestRootCodeModelWithCodeFile(code As XElement, action As Action(Of EnvDTE.CodeModel))
+        Protected Sub TestRootCodeModelWithCodeFile(code As XElement, action As Action(Of EnvDTE80.CodeModel2))
             Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim rootCodeModel = state.RootCodeModel
+                Dim rootCodeModel = TryCast(state.RootCodeModel, EnvDTE80.CodeModel2)
                 Assert.NotNull(rootCodeModel)
 
                 action(rootCodeModel)

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -3790,6 +3790,28 @@ partial class Foo
 #End Region
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetBaseName1()
+            Dim code =
+<Code>
+using N.M;
+
+namespace N
+{
+    namespace M
+    {
+        class Generic&lt;T&gt; { }
+    }
+}
+
+class $$C : Generic&lt;string&gt;
+{
+}
+</Code>
+
+            TestGetBaseName(code, "N.M.Generic<string>")
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub TypeDescriptor_GetProperties()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
@@ -27,6 +27,28 @@ class Foo { }
 #End Region
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestDotNetNameFromLanguageSpecific()
+            Dim code =
+<code>
+using N.M;
+
+namespace N
+{
+    namespace M
+    {
+        class Generic&lt;T&gt; { }
+    }
+}
+</code>
+
+            TestRootCodeModelWithCodeFile(code,
+                Sub(rootCodeModel)
+                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("N.M.Generic<string>")
+                    Assert.Equal("N.M.Generic`1[System.String]", dotNetName)
+                End Sub)
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub TestExternalNamespaceChildren()
             Dim code =
 <code>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -3103,6 +3103,27 @@ End Module
 #End Region
 
         <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub GetBaseName1()
+            Dim code =
+<Code>
+Imports N.M
+
+Namespace N
+    Namespace M
+        Class Generic(Of T)
+        End Class
+    End Namespace
+End Namespace
+
+Class $$C 
+    Inherits Generic(Of String)
+End Class
+</Code>
+
+            TestGetBaseName(code, "N.M.Generic(Of String)")
+        End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub ExternalClass_ImplementedInterfaces()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
@@ -1,7 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 Imports Roslyn.Test.Utilities
@@ -229,6 +228,27 @@ End Namespace
         End Sub
 
 #End Region
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub TestDotNetNameFromLanguageSpecific()
+            Dim code =
+<code>
+Imports N.M
+
+Namespace N
+    Namespace M
+        Class Generic(Of T)
+        End Class
+    End Namespace
+End Namespace
+</code>
+
+            TestRootCodeModelWithCodeFile(code,
+                Sub(rootCodeModel)
+                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("N.M.Generic(Of String)")
+                    Assert.Equal("N.M.Generic`1[System.String]", dotNetName)
+                End Sub)
+        End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String
             Get

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -3549,8 +3549,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
         Protected Overrides Function GetTypeSymbolFromPartialName(partialName As String, semanticModel As SemanticModel, position As Integer) As ITypeSymbol
             Dim parsedTypeName = SyntaxFactory.ParseTypeName(partialName)
 
-            Dim visualBasicSemanticModel = DirectCast(semanticModel, SemanticModel)
-            Return visualBasicSemanticModel.GetSpeculativeTypeInfo(position, parsedTypeName, SpeculativeBindingOption.BindAsTypeOrNamespace).Type
+            Return semanticModel.GetSpeculativeTypeInfo(position, parsedTypeName, SpeculativeBindingOption.BindAsTypeOrNamespace).Type
         End Function
 
         Public Overrides Function CreateReturnDefaultValueStatement(type As ITypeSymbol) As SyntaxNode
@@ -4322,5 +4321,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
         Public Overrides Sub EnsureBufferFormatted(buffer As ITextBuffer)
             _commitBufferManagerFactory.CreateForBuffer(buffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=Nothing)
         End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #4987

Essentially, the WinForms designer has a code path for handling base types that only VB implemented in the past. Of course, we missed implementing those members in VS 2015. :smile:

The APIs that need to be implemented are:

* ```ICodeClassBase.GetBaseName``` -- prior to VS 2015, this interface was be defined in the VB language service. In essence, this provides a way to get the fully-qualified name of a CodeClass's base type. This name is expected to be returned in a form that has a language-specific form (i.e. generics are represented as they would be in either C# or VB). The WinForms designer looks for it, so we should implement it!
* ```CodeModel2.DotNetNameFromLanguageSpecific``` -- this is needed to take a type name in a language-specific form and turn it into something understood by the CLR. e.g., ```System.Collections.Generic.List(Of String)``` becomes ```System.Collections.Generic.List`1[System.String]```

Since I'm making this work for VB, I went ahead and made sure it works for C# as well. So, this unblocks a long-blocked scenario for C# WinForms.

Tagging @dotnet/mlangide