### PR TITLE
process all attributes in XML documentation comments

### DIFF
--- a/src/EditorFeatures/CSharp/Outlining/Outliners/DocumentationCommentOutliner.cs
+++ b/src/EditorFeatures/CSharp/Outlining/Outliners/DocumentationCommentOutliner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -50,24 +51,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Outlining
                     else if (node is XmlEmptyElementSyntax)
                     {
                         var e = (XmlEmptyElementSyntax)node;
-                        var cref = e.Attributes.OfType<XmlCrefAttributeSyntax>().FirstOrDefault();
-                        if (cref != null)
+                        foreach (var attribute in e.Attributes)
                         {
-                            sb.Append(" ");
-                            sb.Append(cref.Cref.ToString());
-                        }
-
-                        var nameattribute = e.Attributes.OfType<XmlNameAttributeSyntax>().FirstOrDefault();
-                        if (nameattribute != null)
-                        {
-                            sb.Append(" ");
-                            sb.Append(nameattribute.Identifier.Identifier.Text);
-                        }
-
-                        var langword = e.Attributes.OfType<XmlTextAttributeSyntax>().FirstOrDefault(a => a.Name.LocalName.ToString() == "langword");
-                        if (langword != null)
-                        {
-                            AppendTextTokens(sb, langword.TextTokens);
+                            if (attribute is XmlCrefAttributeSyntax)
+                            {
+                                sb.Append(" ");
+                                sb.Append(((XmlCrefAttributeSyntax)attribute).Cref.ToString());
+                            }
+                            else if (attribute is XmlNameAttributeSyntax)
+                            {
+                                sb.Append(" ");
+                                sb.Append(((XmlNameAttributeSyntax)attribute).Identifier.Identifier.Text);
+                            }
+                            else if (attribute is XmlTextAttributeSyntax)
+                            {
+                                AppendTextTokens(sb, ((XmlTextAttributeSyntax)attribute).TextTokens);
+                            }
+                            else
+                            {
+                                Debug.Fail($"Unexpected XML syntax kind {attribute.Kind()}");
+                            }
                         }
                     }
                 }

--- a/src/EditorFeatures/CSharpTest/Outlining/DocumentationCommentOutlinerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/DocumentationCommentOutlinerTests.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
                                   "{",
                                   "    /// <summary>",
                                   "    /// Summary with <see cref=\"SeeClass\" />, <seealso cref=\"SeeAlsoClass\" />, ",
-                                  "    /// <see langword=\"null\" />, <typeparamref name=\"T\" />, and <paramref name=\"t\" />.",
+                                  "    /// <see langword=\"null\" />, <typeparamref name=\"T\" />, <paramref name=\"t\" />, and <see unsupported-attribute=\"not-supported\" />.",
                                   "    /// </summary>",
                                   "    public void M<T>(T t) { }",
                                   "}");
@@ -402,8 +402,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining
             var docComment = (DocumentationCommentTriviaSyntax)trivia.Single(t => t.HasStructure).GetStructure();
             var actualRegion = GetRegion(docComment);
             var expectedRegion = new OutliningSpan(
-                         TextSpan.FromBounds(16, 218),
-                         "/// <summary> Summary with SeeClass , SeeAlsoClass , null , T , and t .",
+                         TextSpan.FromBounds(16, 265),
+                         "/// <summary> Summary with SeeClass , SeeAlsoClass , null , T , t , and not-supported .",
                          autoCollapse: true);
 
             AssertRegion(expectedRegion, actualRegion);

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -4184,5 +4184,27 @@ namespace MyNs
 ",
                 Exceptions($"\r\n{WorkspacesResources.Exceptions}\r\n  MyException1\r\n  MyException2\r\n  int\r\n  double\r\n  Not_A_Class_But_Still_Displayed"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(1516, "https://github.com/dotnet/roslyn/issues/1516")]
+        public void QuickInfoWithNonStandardSeeAttributesAppear()
+        {
+            Test(@"
+class C
+{
+    /// <summary>
+    /// <see cref=""System.String"" />
+    /// <see href=""http://microsoft.com"" />
+    /// <see langword=""null"" />
+    /// <see unsupported-attribute=""cat"" />
+    /// </summary>
+    void M()
+    {
+        M$$();
+    }
+}
+",
+                Documentation(@"string http://microsoft.com null cat"));
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasic/Outlining/Outliners/DocumentationCommentOutliner.vb
+++ b/src/EditorFeatures/VisualBasic/Outlining/Outliners/DocumentationCommentOutliner.vb
@@ -26,22 +26,19 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Outlining
                         AppendTextTokens(sb, textTokens)
                     ElseIf node.Kind() = SyntaxKind.XmlEmptyElement Then
                         Dim elementNode = DirectCast(node, XmlEmptyElementSyntax)
-                        Dim cref = elementNode.Attributes.OfType(Of XmlCrefAttributeSyntax).FirstOrDefault()
-                        If cref IsNot Nothing Then
-                            sb.Append(" ")
-                            sb.Append(cref.Reference.ToString())
-                        End If
-
-                        Dim nameattribute = elementNode.Attributes.OfType(Of XmlNameAttributeSyntax).FirstOrDefault()
-                        If nameattribute IsNot Nothing Then
-                            sb.Append(" ")
-                            sb.Append(nameattribute.Reference.ToString())
-                        End If
-
-                        Dim langword = elementNode.Attributes.OfType(Of XmlAttributeSyntax).FirstOrDefault(Function(a) a.Name.ToString() = "langword")
-                        If langword IsNot Nothing Then
-                            AppendTextTokens(sb, DirectCast(langword.Value, XmlStringSyntax).TextTokens)
-                        End If
+                        For Each attribute In elementNode.Attributes
+                            If TypeOf attribute Is XmlCrefAttributeSyntax Then
+                                sb.Append(" ")
+                                sb.Append(DirectCast(attribute, XmlCrefAttributeSyntax).Reference.ToString())
+                            ElseIf TypeOf attribute Is XmlNameAttributeSyntax Then
+                                sb.Append(" ")
+                                sb.Append(DirectCast(attribute, XmlNameAttributeSyntax).Reference.ToString())
+                            ElseIf TypeOf attribute Is XmlAttributeSyntax Then
+                                AppendTextTokens(sb, DirectCast(DirectCast(attribute, XmlAttributeSyntax).Value, XmlStringSyntax).TextTokens)
+                            Else
+                                Debug.Fail($"Unexpected XML syntax kind {attribute.Kind()}")
+                            End If
+                        Next
                     End If
                 Next
 

--- a/src/EditorFeatures/VisualBasicTest/Outlining/DocumentationCommentOutlinerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/DocumentationCommentOutlinerTests.vb
@@ -236,7 +236,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
             Dim tree = ParseLines("Class C",
                                   "    ''' <summary>",
                                   "    ''' Summary with <see cref=""SeeClass"" />, <seealso cref=""SeeAlsoClass"" />,",
-                                  "    ''' <see langword=""Nothing"" />, <typeparamref name=""T"" />, and <paramref name=""t"" />.",
+                                  "    ''' <see langword=""Nothing"" />, <typeparamref name=""T"" />, <paramref name=""t"" />, and <see unsupported-attribute=""not-supported"" />.",
                                   "    ''' </summary>",
                                   "    Sub M(Of T)(t as T)",
                                   "    End Sub",
@@ -248,8 +248,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
             Dim docComment = DirectCast(trivia.Single(Function(t) t.HasStructure).GetStructure(), DocumentationCommentTriviaSyntax)
             Dim actualRegion = GetRegion(docComment)
             Dim expectedRegion = New OutliningSpan(
-                         TextSpan.FromBounds(13, 217),
-                         "''' <summary> Summary with SeeClass , SeeAlsoClass , Nothing , T , and t .",
+                         TextSpan.FromBounds(13, 264),
+                         "''' <summary> Summary with SeeClass , SeeAlsoClass , Nothing , T , t , and not-supported .",
                          autoCollapse:=True)
 
             AssertRegion(expectedRegion, actualRegion)

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -2059,5 +2059,24 @@ End Namespace
                 Exceptions($"{vbCrLf}{WorkspacesResources.Exceptions}{vbCrLf}  MyException1{vbCrLf}  MyException2{vbCrLf}  Integer{vbCrLf}  Double{vbCrLf}  Not_A_Class_But_Still_Displayed"))
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(1516, "https://github.com/dotnet/roslyn/issues/1516")>
+        Public Sub QuickInfoWithNonStandardSeeAttributesAppear()
+            Test("
+Class C
+    ''' <summary>
+    ''' <see cref=""System.String"" />
+    ''' <see href=""http://microsoft.com"" />
+    ''' <see langword=""Nothing"" />
+    ''' <see unsupported-attribute=""cat"" />
+    ''' </summary>
+    Sub M()
+        M$$()
+    End Sub
+End Class
+",
+                 Documentation("String http://microsoft.com Nothing cat"))
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
The previous behavior was to only process certain well-known doc comment attributes like `cref`.  This specifically adds support for the `langword` attribute which we were ignoring and also processes any other attributes as plain text, regardless of their name, in the declaration order.  That way we preserve as much of the original doc comment as possible.

Fixes #1516.