### PR TITLE
Change generate type behavior to prefer rightmost name

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -970,30 +970,10 @@ index: 1);
 
         [WorkItem(539339)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void InLeftSideOfAssignment()
-        {
-            Test(
-@"class Class { void M(int i) { [|Foo|].Bar = 2; } }",
-@"class Class { void M(int i) { Foo.Bar = 2; } } internal class Foo { }",
-index: 1);
-        }
-
-        [WorkItem(539339)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NotInRightSideOfAssignment()
         {
             TestMissing(
 @"class Class { void M(int i) { x = [|Foo|]; } }");
-        }
-
-        [WorkItem(539339)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void InRightSideOfAssignment()
-        {
-            Test(
-@"class Class { void M(int i) { x = [|Foo|].Bar; } }",
-@"class Class { void M(int i) { x = Foo.Bar; } } internal class Foo { }",
-index: 1);
         }
 
         [WorkItem(539489)]
@@ -1638,18 +1618,15 @@ namespace A
                 </Workspace>";
 
             var expected = @"
-namespace A
+namespace A.B.C
 {
-    public class B
+    internal class D
     {
-        public class C
-        {
-        }
     }
 }
 ";
 
-            Test(code, expected, compareTokens: false);
+            Test(code, expected);
         }
 
         [WorkItem(932602)]
@@ -2017,6 +1994,62 @@ index: 1);
 @"class A { public B<int> b = new [|B|]<int>(); }",
 @"class A { public B<int> b = new B<int>(); public class B<T>{ public B(){}}}",
 index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public void TestGenerateRightMostType()
+        {
+            Test(
+@"class Program { static void Main ( string [ ] args ) { [|MyCompany|] . MyProduct . MyArea . MyClass a ; } } ",
+@"namespace MyCompany.MyProduct.MyArea { internal class MyClass { } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public void TestGenerateRightMostTypeInsideNameOf()
+        {
+            Test(
+@"class Program { static void Main ( string [ ] args ) { var a = nameof ( [|MyCompany|] . MyProduct . MyArea . MyClass ) ; } } ",
+@"internal class MyCompany { }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public void TestGenerateRightMostTypeNotPresentInConditional()
+        {
+            Test(
+@"class Program { static void Main ( string [ ] args ) { [|MyCompany . MyProduct ? . MyArea . MyClass a |]; } }",
+@"internal class MyCompany { }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public void TestGenerateRightMostTypeNotPresentInConditionalWithNameOf()
+        {
+            Test(
+@"class Program { static void Main ( string [ ] args ) { var a = nameof ( [|MyCompany|] . MyProduct ? . MyArea . MyClass ) ; } } ",
+@"internal class MyCompany { }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public void TestGenerateRightMostTypeInAssignmentExpression()
+        {
+            Test(
+@"class Program { static void Main ( string [ ] args ) { var a = [|MyCompany|] . MyProduct ? . MyArea . MyClass ; } } ",
+@"internal class MyCompany { }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public void TestGenerateRightMostTypeInLambda()
+        {
+            Test(
+@"using System ; class Program { static void Main ( string [ ] args ) { Action b = ( ) => { [|MyCompany|] . MyProduct . MyArea . MyClass a ; } ; } } ",
+@"namespace MyCompany.MyProduct.MyArea { internal class MyClass { } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public void TestGenerateRightMostTypeAsArgumentInMethodCall()
+        {
+            Test(
+@"using System ; class Program { static void Main ( string [ ] args ) { Test ( new [|MyCompany|] . MyProduct . MyArea . MyClass ( ) ) ; } private static void Test ( object v ) { } } ",
+@"namespace MyCompany.MyProduct.MyArea { internal class MyClass { public MyClass() { } } }");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests_Dialog.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests_Dialog.cs
@@ -1917,9 +1917,9 @@ namespace A
                     </Project>
                 </Workspace>",
 languageName: LanguageNames.CSharp,
-typeName: "Foo",
-expected: @"Namespace Global.A
-    Public Module Foo
+typeName: "Bar",
+expected: @"Namespace Global.A.Foo
+    Public Module Bar
     End Module
 End Namespace
 ",
@@ -1930,7 +1930,7 @@ isNewFile: true,
 newFileName: "Test2.vb",
 newFileFolderContainers: Array.Empty<string>(),
 projectName: "Assembly2",
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Module));
+assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions));
         }
 
         #endregion
@@ -2006,114 +2006,6 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOptions.Interface, false));
         }
 
-        [WorkItem(861362)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GenerateTypeInMemberAccessExpression()
-        {
-            TestWithMockedGenerateTypeDialog(
-initial: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = [|$$A.B|];
-    }
-}",
-languageName: LanguageNames.CSharp,
-typeName: "A",
-expected: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = A.B;
-    }
-}
-
-public class A
-{
-}",
-accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
-isNewFile: false,
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.MemberAccessWithNamespace));
-        }
-
-        [WorkItem(861362)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GenerateTypeInMemberAccessExpressionInNamespace()
-        {
-            TestWithMockedGenerateTypeDialog(
-initial: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = [|$$A.B.C|];
-    }
-}
-
-namespace A
-{
-}",
-languageName: LanguageNames.CSharp,
-typeName: "B",
-expected: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = A.B.C;
-    }
-}
-
-namespace A
-{
-    public class B
-    {
-    }
-}",
-accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
-isNewFile: false,
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.MemberAccessWithNamespace));
-        }
-
-        [WorkItem(861600)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GenerateTypeWithoutEnumForGenericsInMemberAccess()
-        {
-            TestWithMockedGenerateTypeDialog(
-initial: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = [|$$Foo<Bar>|].D;
-    }
-}
-
-class Bar
-{
-}",
-languageName: LanguageNames.CSharp,
-typeName: "Foo",
-expected: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = Foo<Bar>.D;
-    }
-}
-
-class Bar
-{
-}
-
-public class Foo<T>
-{
-}",
-accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
-isNewFile: false,
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure));
-        }
-
         [WorkItem(861600)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeWithoutEnumForGenericsInNameContext()
@@ -2155,75 +2047,6 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
 
         [WorkItem(861600)]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GenerateTypeInMemberAccessWithNSForModule()
-        {
-            TestWithMockedGenerateTypeDialog(
-initial: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = [|Foo.$$Bar|].Baz;
-    }
-}
-
-namespace Foo
-{
-}",
-languageName: LanguageNames.CSharp,
-typeName: "Bar",
-expected: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = Foo.Bar.Baz;
-    }
-}
-
-namespace Foo
-{
-    public class Bar
-    {
-    }
-}",
-accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
-isNewFile: false,
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.MemberAccessWithNamespace));
-        }
-
-        [WorkItem(861600)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GenerateTypeInMemberAccessWithGlobalNSForModule()
-        {
-            TestWithMockedGenerateTypeDialog(
-initial: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = [|$$Bar|].Baz;
-    }
-}",
-languageName: LanguageNames.CSharp,
-typeName: "Bar",
-expected: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s = Bar.Baz;
-    }
-}
-
-public class Bar
-{
-}",
-accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
-isNewFile: false,
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.MemberAccessWithNamespace));
-        }
-
-        [WorkItem(861600)]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeInMemberAccessWithoutNS()
         {
             TestWithMockedGenerateTypeDialog(
@@ -2239,8 +2062,25 @@ namespace Bar
 {
 }",
 languageName: LanguageNames.CSharp,
-typeName: "Bar",
-isMissing: true);
+typeName: "Baz",
+expected: @"class Program
+{
+    static void Main(string[] args)
+    {
+        var s = Bar.Baz;
+    }
+}
+
+namespace Bar
+{
+    public class Baz
+    {
+    }
+}",
+accessibility: Accessibility.Public,
+typeKind: TypeKind.Class,
+isNewFile: false,
+assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.MemberAccessWithNamespace));
         }
 
         [WorkItem(876202)]
@@ -2991,73 +2831,6 @@ isNewFile: false);
         #endregion 
         #region Dev12Filtering
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GenerateDelegateType_NoEnum_InvocationExpression_0()
-        {
-            TestWithMockedGenerateTypeDialog(
-initial: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s2 = [|$$B|].C();
-    }
-}",
-languageName: LanguageNames.CSharp,
-typeName: "B",
-expected: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s2 = B.C();
-    }
-}
-
-public class B
-{
-}",
-accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
-isNewFile: false,
-assertTypeKindAbsent: new[] { TypeKindOptions.Enum });
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GenerateDelegateType_NoEnum_InvocationExpression_1()
-        {
-            TestWithMockedGenerateTypeDialog(
-initial: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s2 = [|A.$$B|].C();
-    }
-}
-
-namespace A
-{
-}",
-languageName: LanguageNames.CSharp,
-typeName: "B",
-expected: @"class Program
-{
-    static void Main(string[] args)
-    {
-        var s2 = A.B.C();
-    }
-}
-
-namespace A
-{
-    public class B
-    {
-    }
-}",
-accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
-isNewFile: false,
-assertTypeKindAbsent: new[] { TypeKindOptions.Enum });
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateType_TypeConstraint_1()
         {
             TestWithMockedGenerateTypeDialog(
@@ -3413,11 +3186,11 @@ class A
     }
 }
 
-namespace NS
+namespace NS.foo
 {
 }",
 languageName: LanguageNames.CSharp,
-typeName: "foo",
+typeName: "Mydel",
 expected: @"
 class A
 {
@@ -3428,16 +3201,14 @@ class A
     }
 }
 
-namespace NS
+namespace NS.foo
 {
-    public class foo
-    {
-    }
+    public delegate void Mydel();
 }",
 accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
+typeKind: TypeKind.Delegate,
 isNewFile: false,
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Module));
+assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Delegate));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
@@ -3450,27 +3221,25 @@ class A
     public event [|$$NS.foo.Mydel|] name2;
 }
 
-namespace NS
+namespace NS.foo
 {
 }",
 languageName: LanguageNames.CSharp,
-typeName: "foo",
+typeName: "Mydel",
 expected: @"
 class A
 {
     public event NS.foo.Mydel name2;
 }
 
-namespace NS
+namespace NS.foo
 {
-    public class foo
-    {
-    }
+    public delegate void Mydel();
 }",
 accessibility: Accessibility.Public,
-typeKind: TypeKind.Class,
+typeKind: TypeKind.Delegate,
 isNewFile: false,
-assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Module));
+assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Delegate));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
@@ -678,14 +678,12 @@ End Namespace</Document>
                           </Workspace>.ToString()
 
             Dim expected = <Text>
-Namespace A
-    Public Class B
-        Public Class C
-        End Class
+Namespace A.B.C
+    Friend Class D
     End Class
 End Namespace</Text>.NormalizedValue
 
-            Test(initial, expected, compareTokens:=False)
+            Test(initial, expected)
         End Sub
 
         <WorkItem(940003)>
@@ -755,8 +753,8 @@ index:=0)
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForNestedType()
             Test(
-NewLines("Public Interface I \n  Sub Foo(a As [|X.Y.Z|]) \n End Interface \n Public Class X \n End Class"),
-NewLines("Public Interface I \n  Sub Foo(a As X.Y.Z) \n End Interface \n Public Class X \n Public Class Y \n End Class \n End Class"),
+NewLines("Public Interface I \n  Sub Foo(a As [|X.Y|]) \n End Interface \n Public Class X \n End Class"),
+NewLines("Public Interface I \n  Sub Foo(a As X.Y) \n End Interface \n Public Class X \n Public Class Y \n End Class \n End Class"),
 index:=0)
         End Sub
 
@@ -856,6 +854,54 @@ index:=1)
 NewLines("Public Class A \n Public B As New [|B(Of Integer)|] \n End Class"),
 NewLines("Public Class A \n Public B As New B(Of Integer) \n Public Class B(Of T) \n End Class \n End Class"),
 index:=2)
+        End Sub
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeRightMostName()
+            Test(
+NewLines("Module Program \n Sub Main(args As String()) \n Dim a As [|MyCompany.MyProduct.MyArea.MyClass|] \n End Sub \n End Module"),
+NewLines("Namespace MyCompany.MyProduct.MyArea \n Friend Class [MyClass] \n End Class \n End Namespace"))
+        End Sub
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeRightMostNameInsideNameOf()
+            Test(
+NewLines("Module Program \n Sub Main(args As String()) \n Dim a = NameOf([|MyCompany.MyProduct.MyArea.MyClass|]) \n End Sub \n End Module"),
+NewLines("Friend Class MyCompany \n End Class"))
+        End Sub
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeInConditionalExpression()
+            TestMissing(
+NewLines("Module Program \n Sub Main(args As String()) \n Dim a As [|MyCompany?.MyProduct.MyArea.MyClass|] \n End Sub \n End Module"))
+        End Sub
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeInConditionalExpressionWithNameOf()
+            TestMissing(
+NewLines("Module Program \n Sub Main(args As String()) \n Dim a = NameOf([|MyCompany.MyProduct.MyArea?.MyClass|]) \n End Sub \n End Module"))
+        End Sub
+
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeAssignmentWithConditionalExpression()
+            Test(
+NewLines("Module Program \n Sub Main(args As String()) \n Dim a = [|MyCompany|].MyProduct.MyArea?.MyClass \n End Sub \n End Module"),
+NewLines("Friend Class MyCompany \n End Class"))
+        End Sub
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeWihtRightMostNameInLambda()
+            Test(
+NewLines("Module Program \n Sub Main(args As String()) \n Dim b = Function() \n Dim a As [|MyCompany.MyProduct.MyArea.MyClass|] \n End Function \n End Sub \n End Module"),
+NewLines("Namespace MyCompany.MyProduct.MyArea \n Friend Class [MyClass] \n End Class \n End Namespace"))
+        End Sub
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        Public Sub TestGenerateTypeWihtRightMostNameAsMethodArgument()
+            Test(
+NewLines("Module Program \n Sub Main(args As String()) \n Test(New [|MyCompany.MyProduct.MyArea.MyClass|]) \n End Sub \n Sub Test(a As Object) \n End Sub \n End Module"),
+NewLines("Namespace MyCompany.MyProduct.MyArea \n Friend Class [MyClass] \n End Class \n End Namespace"))
         End Sub
 
         Public Class AddImportTestsWithAddImportDiagnosticProvider

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests_Dialog.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests_Dialog.vb
@@ -1462,78 +1462,23 @@ initial:=<Text>Module Program
     End Sub
 End Module
 
-Namespace A
+Namespace A.B
 End Namespace</Text>.NormalizedValue,
 languageName:=LanguageNames.VisualBasic,
-typeName:="B",
+typeName:="C",
 expected:=<Text>Module Program
     Sub Main(args As String())
         Dim s as A.B.C
     End Sub
 End Module
 
-Namespace A
-    Module B
+Namespace A.B
+    Module C
     End Module
 End Namespace</Text>.NormalizedValue,
 isNewFile:=False,
 typeKind:=TypeKind.Module,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Class Or TypeKindOptions.Structure Or TypeKindOptions.Module))
-        End Sub
-
-        <WorkItem(861362)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateTypeInMemberAccessExpression()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = [|$$A.B|]
-    End Sub
-End Module</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="A",
-expected:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = A.B
-    End Sub
-End Module
-
-Public Module A
-End Module
-</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Module,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.MemberAccessWithNamespace))
-        End Sub
-
-        <WorkItem(861362)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateTypeInMemberAccessExpressionWithNamespace()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Namespace A
-    Module Program
-        Sub Main(args As String())
-            Dim s = [|$$A.B.C|]
-        End Sub
-    End Module
-End Namespace</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="B",
-expected:=<Text>Namespace A
-    Module Program
-        Sub Main(args As String())
-            Dim s = A.B.C
-        End Sub
-    End Module
-
-    Public Module B
-    End Module
-End Namespace</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Module,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.MemberAccessWithNamespace))
+assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.AllOptions))
         End Sub
 
         <WorkItem(876202)>
@@ -1560,38 +1505,6 @@ End Structure
 isNewFile:=False,
 accessibility:=Accessibility.Public,
 typeKind:=TypeKind.Structure,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Class Or TypeKindOptions.Structure))
-        End Sub
-
-        <WorkItem(861600)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateTypeWithoutEnumForGenericsInMemberAccessExpression()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = [|$$Foo(Of Bar).D|]
-    End Sub
-End Module
-
-Class Bar
-End Class</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="Foo",
-expected:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = Foo(Of Bar).D
-    End Sub
-End Module
-
-Class Bar
-End Class
-
-Public Class Foo(Of T)
-End Class
-</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
 assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Class Or TypeKindOptions.Structure))
         End Sub
 
@@ -1625,62 +1538,6 @@ isNewFile:=False,
 accessibility:=Accessibility.Public,
 typeKind:=TypeKind.Class,
 assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Class Or TypeKindOptions.Structure Or TypeKindOptions.Interface Or TypeKindOptions.Delegate))
-        End Sub
-
-        <WorkItem(861600)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateTypeInMemberAccessWithNSForModule()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = [|$$Foo.Bar|].Baz
-    End Sub
-End Module
-
-Namespace Foo
-End Namespace</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="Bar",
-expected:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = Foo.Bar.Baz
-    End Sub
-End Module
-
-Namespace Foo
-    Public Class Bar
-    End Class
-End Namespace</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.MemberAccessWithNamespace))
-        End Sub
-
-        <WorkItem(861600)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateTypeInMemberAccessWithGlobalNSForModule()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = [|$$Bar|].Baz
-    End Sub
-End Module</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="Bar",
-expected:=<Text>Module Program
-    Sub Main(args As String())
-        Dim s = Bar.Baz
-    End Sub
-End Module
-
-Public Class Bar
-End Class
-</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.MemberAccessWithNamespace))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
@@ -2184,60 +2041,6 @@ typeKind:=TypeKind.Delegate)
 #End Region
 #Region "Dev12Filtering"
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateType_Invocation_NoEnum_0()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Module Program
-    Sub Main(args As String())
-        Dim a = [|$$Baz.Foo|].Bar()
-    End Sub
-End Module
-
-Namespace Baz
-End Namespace</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="Foo",
-expected:=<Text>Module Program
-    Sub Main(args As String())
-        Dim a = Baz.Foo.Bar()
-    End Sub
-End Module
-
-Namespace Baz
-    Public Class Foo
-    End Class
-End Namespace</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
-assertTypeKindAbsent:=New TypeKindOptions() {TypeKindOptions.Enum})
-        End Sub
-
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateType_Invocation_NoEnum_1()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Module Program
-    Sub Main(args As String())
-        Dim a = [|$$Foo.Bar|]()
-    End Sub
-End Module</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="Bar",
-expected:=<Text>Module Program
-    Sub Main(args As String())
-        Dim a = Foo.Bar()
-    End Sub
-End Module
-
-Public Class Bar
-End Class
-</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
-assertTypeKindAbsent:=New TypeKindOptions() {TypeKindOptions.Enum})
-        End Sub
-
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub GenerateType_Invocation_NoEnum_2()
             TestWithMockedGenerateTypeDialog(
 initial:=<Text>Class C
@@ -2272,71 +2075,6 @@ assertTypeKindPresent:=New TypeKindOptions() {TypeKindOptions.Delegate},
 assertTypeKindAbsent:=New TypeKindOptions() {TypeKindOptions.Enum})
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateType_Invocation_NoEnum_3()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Class C
-    Custom Event E As Action
-        AddHandler(value As Action)
-        End AddHandler
-        RemoveHandler(value As [|$$Foo|])
-        End RemoveHandler
-        RaiseEvent()
-        End RaiseEvent
-    End Event
-End Class</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="Foo",
-expected:=<Text>Class C
-    Custom Event E As Action
-        AddHandler(value As Action)
-        End AddHandler
-        RemoveHandler(value As Foo)
-        End RemoveHandler
-        RaiseEvent()
-        End RaiseEvent
-    End Event
-End Class
-
-Public Delegate Sub Foo()
-</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Delegate,
-assertTypeKindPresent:=New TypeKindOptions() {TypeKindOptions.Delegate},
-assertTypeKindAbsent:=New TypeKindOptions() {TypeKindOptions.Enum})
-        End Sub
-
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
-        Public Sub GenerateType_Invocation_NoEnum_4()
-            TestWithMockedGenerateTypeDialog(
-initial:=<Text>Imports System
-Module Program
-    Sub Main(args As String())
-        Dim s As Action = AddressOf [|NS.Bar$$|].Method
-    End Sub
-End Module
-
-Namespace NS
-End Namespace</Text>.NormalizedValue,
-languageName:=LanguageNames.VisualBasic,
-typeName:="Bar",
-expected:=<Text>Imports System
-Module Program
-    Sub Main(args As String())
-        Dim s As Action = AddressOf NS.Bar.Method
-    End Sub
-End Module
-
-Namespace NS
-    Public Class Bar
-    End Class
-End Namespace</Text>.NormalizedValue,
-isNewFile:=False,
-accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
-assertTypeKindAbsent:=New TypeKindOptions() {TypeKindOptions.Enum})
-        End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub GenerateType_TypeConstraint_1()
@@ -2502,7 +2240,7 @@ Class C1
     End Event
 End Class
 
-Namespace NS
+Namespace NS.Foo
 End Namespace</Text>.NormalizedValue,
 languageName:=LanguageNames.VisualBasic,
 typeName:="Foo",
@@ -2518,14 +2256,13 @@ Class C1
     End Event
 End Class
 
-Namespace NS
-    Public Class Foo
-    End Class
+Namespace NS.Foo
+    Public Delegate Sub Foo()
 End Namespace</Text>.NormalizedValue,
 isNewFile:=False,
 accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Class Or TypeKindOptions.Structure Or TypeKindOptions.Module))
+typeKind:=TypeKind.Delegate,
+assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Delegate))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
@@ -2582,23 +2319,22 @@ Class Foo
     Public Event F As [|$$NS.Bar.MyDel|]
 End Class
 
-Namespace NS
+Namespace NS.Bar
 End Namespace</Text>.NormalizedValue,
 languageName:=LanguageNames.VisualBasic,
-typeName:="Bar",
+typeName:="MyDel",
 expected:=<Text>
 Class Foo
     Public Event F As NS.Bar.MyDel
 End Class
 
-Namespace NS
-    Public Class Bar
-    End Class
+Namespace NS.Bar
+    Public Delegate Sub MyDel()
 End Namespace</Text>.NormalizedValue,
 isNewFile:=False,
 accessibility:=Accessibility.Public,
-typeKind:=TypeKind.Class,
-assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Class Or TypeKindOptions.Structure Or TypeKindOptions.Module))
+typeKind:=TypeKind.Delegate,
+assertGenerateTypeDialogOptions:=New GenerateTypeDialogOptions(False, TypeKindOptions.Delegate))
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
@@ -2657,17 +2393,17 @@ Class Bar
     Public WithEvents G As [|$$NS.Delegate1.MyDel|]
 End Class
 
-Namespace NS
+Namespace NS.Delegate1
 End Namespace</Text>.NormalizedValue,
 languageName:=LanguageNames.VisualBasic,
-typeName:="Delegate1",
+typeName:="MyDel",
 expected:=<Text>
 Class Bar
     Public WithEvents G As NS.Delegate1.MyDel
 End Class
 
-Namespace NS
-    Public Class Delegate1
+Namespace NS.Delegate1
+    Public Class MyDel
     End Class
 End Namespace</Text>.NormalizedValue,
 isNewFile:=False,

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -101,15 +101,6 @@ NewLines("Module Program \n Friend P As Integer \n Sub Main(args As String()) \n
 index:=1)
         End Sub
 
-        <WorkItem(539848)>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
-        Public Sub TestOnLeftOfMemberAccess()
-            Test(
-NewLines("Module Program \n Sub Main(args As String()) \n [|HERE|].ToString() \n End Sub \n End Module"),
-NewLines("Module Program \n Private HERE As Object \n Sub Main(args As String()) \n HERE.ToString() \n End Sub \n End Module"),
-index:=1)
-        End Sub
-
         <WorkItem(539725)>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestMissingWhenInterfacePropertyAlreadyExists()

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -58,7 +59,26 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateType
 
         protected override SyntaxNode GetTargetNode(SyntaxNode node)
         {
-            return ((ExpressionSyntax)node).GetRightmostName();
+            var qualified = node.Parent as QualifiedNameSyntax;
+            if (qualified != null)
+            {
+                return GetRightmostNameOfAncestor(qualified);
+            }
+
+            return (node as ExpressionSyntax)?.GetRightmostName();
+        }
+
+        private SyntaxNode GetRightmostNameOfAncestor<TNameSyntax>(TNameSyntax expression) where TNameSyntax : ExpressionSyntax
+        {
+            while (true)
+            {
+                var temp = expression.Parent as TNameSyntax;
+                if (temp == null)
+                {
+                    return expression.GetRightmostName();
+                }
+                expression = temp;
+            }
         }
 
         protected override Task<IEnumerable<CodeAction>> GetCodeActionsAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeFixes.GenerateMember;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.GenerateMember.GenerateVariable;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -74,10 +74,28 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
                 var conditionalMemberAccess = identifierName.Parent.Parent as ConditionalAccessExpressionSyntax;
                 if (memberAccess?.Name == identifierName)
                 {
+                    if (!document.SemanticModel.GetSymbolInfo(memberAccess.Expression).GetBestOrAllSymbols().Any())
+                    {
+                        identifierToken = default(SyntaxToken);
+                        simpleNameOrMemberAccessExpression = null;
+                        isInExecutableBlock = false;
+                        isConditionalAccessExpression = false;
+                        return false;
+                    }
+                    
                     simpleNameOrMemberAccessExpression = memberAccess;
                 }
                 else if ((conditionalMemberAccess?.WhenNotNull as MemberBindingExpressionSyntax)?.Name == identifierName)
                 {
+                    if (!document.SemanticModel.GetSymbolInfo(conditionalMemberAccess.Expression).GetBestOrAllSymbols().Any())
+                    {
+                        identifierToken = default(SyntaxToken);
+                        simpleNameOrMemberAccessExpression = null;
+                        isInExecutableBlock = false;
+                        isConditionalAccessExpression = false;
+                        return false;
+                    }
+
                     simpleNameOrMemberAccessExpression = conditionalMemberAccess;
                 }
                 else

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                     return false;
                 }
 
-                if (!simpleName.IsLeftSideOfDot() && !simpleName.IsInsideNameOf())
+                if (!simpleName.IsLeftSideOfDot() && !simpleName.SyntaxTree.IsNameOfContext(simpleName.SpanStart, semanticModel, cancellationToken))
                 {
                     if (nameOrMemberAccessExpression == null || !nameOrMemberAccessExpression.IsKind(SyntaxKind.SimpleMemberAccessExpression) || !simpleName.IsRightSideOfDot())
                     {
@@ -231,12 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                     }
 
                     var leftSymbol = semanticModel.GetSymbolInfo(((MemberAccessExpressionSyntax)nameOrMemberAccessExpression).Expression, cancellationToken).Symbol;
-                    var token = simpleName.GetLastToken().GetNextToken();
-
-                    // We let only the Namespace to be left of the Dot
-                    if (leftSymbol == null ||
-                        !leftSymbol.IsKind(SymbolKind.Namespace) ||
-                        !token.IsKind(SyntaxKind.DotToken))
+                    if (leftSymbol != null && !leftSymbol.IsKind(SymbolKind.Namespace))
                     {
                         return false;
                     }

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
@@ -54,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
         Protected Overrides Function GetTargetNode(node As SyntaxNode) As SyntaxNode
             Dim memberAccess = TryCast(node, MemberAccessExpressionSyntax)
             If memberAccess IsNot Nothing Then
-                Return memberAccess.Name
+                Return GetRightmostNameOfAncestor(memberAccess)
             End If
 
             Dim invocationExpression = TryCast(node, InvocationExpressionSyntax)
@@ -63,6 +63,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
             End If
 
             Return node
+        End Function
+
+        Private Shared Function GetRightmostNameOfAncestor(memberAccess As MemberAccessExpressionSyntax) As SyntaxNode
+            While True
+                Dim temp = TryCast(memberAccess.Parent, MemberAccessExpressionSyntax)
+                If temp Is Nothing Then
+                    Return memberAccess.GetRightmostName()
+                Else
+                    memberAccess = temp
+                End If
+            End While
+
+            Return memberAccess.GetRightmostName()
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeFixes.GenerateMember
 Imports Microsoft.CodeAnalysis.GenerateType
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -56,7 +57,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateType
         End Function
 
         Protected Overrides Function GetTargetNode(node As SyntaxNode) As SyntaxNode
-            Return (DirectCast(node, ExpressionSyntax)).GetRightmostName()
+            Dim qualified = TryCast(node.Parent, QualifiedNameSyntax)
+            If qualified IsNot Nothing Then
+                Return GetRightmostNameOfAncestor(qualified)
+            End If
+
+            Return DirectCast(node, ExpressionSyntax).GetRightmostName
+        End Function
+
+        Private Shared Function GetRightmostNameOfAncestor(Of TNameSyntax As ExpressionSyntax)(expression As TNameSyntax) As SyntaxNode
+            While True
+                Dim temp = TryCast(expression.Parent, TNameSyntax)
+                If temp Is Nothing Then
+                    Return expression.GetRightmostName()
+                End If
+                expression = temp
+            End While
+
+            Return expression.GetRightmostName()
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2139,7 +2139,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 if (token.Parent.IsKind(SyntaxKind.SimpleMemberAccessExpression))
                 {
                     var parentMemberAccess = token.Parent;
-                    while (parentMemberAccess.IsParentKind(SyntaxKind.SimpleMemberAccessExpression))
+                    while (parentMemberAccess.IsParentKind(SyntaxKind.SimpleMemberAccessExpression) || 
+                           parentMemberAccess.IsParentKind(SyntaxKind.ConditionalAccessExpression))
                     {
                         parentMemberAccess = parentMemberAccess.Parent;
                     }

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
@@ -173,7 +173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         Public Function TryGetNameParts(expression As ExpressionSyntax, parts As List(Of String)) As Boolean
             If expression.IsKind(SyntaxKind.SimpleMemberAccessExpression) Then
                 Dim memberAccess = DirectCast(expression, MemberAccessExpressionSyntax)
-                If Not memberAccess.Name.TryGetNameParts(parts) Then
+                If Not memberAccess.Expression.TryGetNameParts(parts) Then
                     Return False
                 End If
 


### PR DESCRIPTION
Previously we would pick the second left-most name and assume the left-most name was a namespace.  Now we pick the rightmost name and assume all names to the left are a namespace.

Fixes https://github.com/dotnet/roslyn/issues/4577