### PR TITLE
Remove dependency on csc2 / vbc2

### DIFF
--- a/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Core/VBCSCompilerTests/CompilerServerTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     public class CompilerServerUnitTests : TestBase
     {
         private const string CompilerServerExeName = "VBCSCompiler.exe";
-        private const string CSharpClientExeName = "csc2.exe";
-        private const string BasicClientExeName = "vbc2.exe";
+        private const string CSharpClientExeName = "csc.exe";
+        private const string BasicClientExeName = "vbc.exe";
         private const string BuildTaskDllName = "Microsoft.Build.Tasks.CodeAnalysis.dll";
 
         private static string s_msbuildDirectory;
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
         private static readonly string s_compilerServerExecutableSrc = ResolveAssemblyPath(CompilerServerExeName);
         private static readonly string s_buildTaskDllSrc = ResolveAssemblyPath(BuildTaskDllName);
-        private static readonly string s_CSharpCompilerExecutableSrc = ResolveAssemblyPath("csc.exe");
+        private static readonly string s_csharpCompilerExecutableSrc = ResolveAssemblyPath("csc.exe");
         private static readonly string s_basicCompilerExecutableSrc = ResolveAssemblyPath("vbc.exe");
         private static readonly string s_microsoftCodeAnalysisDllSrc = ResolveAssemblyPath("Microsoft.CodeAnalysis.dll");
         private static readonly string s_systemCollectionsImmutableDllSrc = ResolveAssemblyPath("System.Collections.Immutable.dll");
@@ -84,8 +84,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         // The native client executables can't be loaded via Assembly.Load, so we just use the
         // compiler server resolved path
         private static readonly string s_clientExecutableBasePath = Path.GetDirectoryName(s_compilerServerExecutableSrc);
-        private static readonly string s_CSharpCompilerClientSrcPath = Path.Combine(s_clientExecutableBasePath, CSharpClientExeName);
-        private static readonly string s_basicCompilerClientSrcPath = Path.Combine(s_clientExecutableBasePath, BasicClientExeName);
 
         private static readonly KeyValuePair<string, string>[] s_helloWorldSrcCs =
         {
@@ -117,12 +115,10 @@ End Module")
 
         private static readonly string[] s_allCompilerFiles =
         {
-            s_CSharpCompilerExecutableSrc,
+            s_csharpCompilerExecutableSrc,
             s_basicCompilerExecutableSrc,
             s_compilerServerExecutableSrc,
             s_microsoftCodeAnalysisDllSrc,
-            s_CSharpCompilerClientSrcPath,
-            s_basicCompilerClientSrcPath,
             s_systemCollectionsImmutableDllSrc,
             s_buildTaskDllSrc,
             ResolveAssemblyPath("System.Reflection.Metadata.dll"),
@@ -333,9 +329,9 @@ End Module")
         [Fact]
         public void FallbackToCsc()
         {
-            // Delete VBCSCompiler.exe so csc2 is forced to fall back to csc.exe
+            // Delete VBCSCompiler.exe so /shared is forced to fall back to csc.exe
             File.Delete(_compilerServerExecutable);
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
             VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
         }
 
@@ -344,9 +340,9 @@ End Module")
         {
             var files = new Dictionary<string, string> { { "hello.cs", "♕" } };
 
-            // Delete VBCSCompiler.exe so csc2 is forced to fall back to csc.exe
+            // Delete VBCSCompiler.exe so /shared is forced to fall back to csc.exe
             File.Delete(_compilerServerExecutable);
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /nologo hello.cs", _tempDirectory, files);
             Assert.Equal(result.ExitCode, 1);
             Assert.True(result.ContainsErrors);
             Assert.Equal("hello.cs(1,1): error CS1056: Unexpected character '?'", result.Output.Trim());
@@ -358,11 +354,11 @@ End Module")
             var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
-            // Delete VBCSCompiler.exe so csc2 is forced to fall back to csc.exe
+            // Delete VBCSCompiler.exe so /shared is forced to fall back to csc.exe
             File.Delete(_compilerServerExecutable);
 
             var result = ProcessUtilities.Run("cmd",
-                string.Format("/C {0} /utf8output /nologo /t:library {1} > {2}",
+                string.Format("/C {0} /shared /utf8output /nologo /t:library {1} > {2}",
                 _csharpCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
@@ -377,12 +373,12 @@ End Module")
         {
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText("♕").Path;
 
-            // Delete VBCSCompiler.exe so csc2 is forced to fall back to csc.exe
+            // Delete VBCSCompiler.exe so /shared is forced to fall back to csc.exe
             File.Delete(_compilerServerExecutable);
 
             var result = ProcessUtilities.Run(
                 _basicCompilerClientExecutable,
-                "/nologo test.vb",
+                "/shared /nologo test.vb",
                 _tempDirectory.Path);
 
             Assert.Equal(result.ExitCode, 1);
@@ -399,11 +395,11 @@ End Module")
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText("♕").Path;
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
-            // Delete VBCSCompiler.exe so csc2 is forced to fall back to csc.exe
+            // Delete VBCSCompiler.exe so /shared is forced to fall back to csc.exe
             File.Delete(_compilerServerExecutable);
 
             var result = ProcessUtilities.Run("cmd",
-                string.Format("/C {0} /utf8output /nologo /t:library {1} > {2}",
+                string.Format("/C {0} /shared /utf8output /nologo /t:library {1} > {2}",
                 _basicCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
@@ -418,9 +414,9 @@ End Module")
         [Fact]
         public void FallbackToVbc()
         {
-            // Delete VBCSCompiler.exe so vbc2 is forced to fall back to vbc.exe
+            // Delete VBCSCompiler.exe so /shared is forced to fall back to vbc.exe
             File.Delete(_compilerServerExecutable);
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/nologo hello.vb", _tempDirectory, s_helloWorldSrcVb);
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/shared /nologo hello.vb", _tempDirectory, s_helloWorldSrcVb);
             VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
         }
 
@@ -428,7 +424,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void HelloWorldCS()
         {
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
             VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
         }
 
@@ -453,7 +449,7 @@ End Module")
         {
             var files = new Dictionary<string, string> { { "c.cs", "class C {}" } };
             var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
-                                                "/nologo /t:library /platform:x86 c.cs",
+                                                "/shared /nologo /t:library /platform:x86 c.cs",
                                                 _tempDirectory,
                                                 files);
             VerifyResult(result);
@@ -465,7 +461,7 @@ End Module")
         {
             var files = new Dictionary<string, string> { { "c.vb", "Class C\nEnd Class" } };
             var result = RunCommandLineCompiler(_basicCompilerClientExecutable,
-                                                "/nologo /t:library /platform:x86 c.vb",
+                                                "/shared /nologo /t:library /platform:x86 c.vb",
                                                 _tempDirectory,
                                                 files);
             VerifyResult(result);
@@ -476,7 +472,7 @@ End Module")
         public void ExtraMSCorLibCS()
         {
             var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
-                                                "/nologo /r:mscorlib.dll hello.cs",
+                                                "/shared /nologo /r:mscorlib.dll hello.cs",
                                                 _tempDirectory,
                                                 s_helloWorldSrcCs);
             VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
@@ -487,7 +483,7 @@ End Module")
         public void HelloWorldVB()
         {
             var result = RunCommandLineCompiler(_basicCompilerClientExecutable,
-                                                "/nologo /r:Microsoft.VisualBasic.dll hello.vb",
+                                                "/shared /nologo /r:Microsoft.VisualBasic.dll hello.vb",
                                                 _tempDirectory,
                                                 s_helloWorldSrcVb);
             VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
@@ -498,7 +494,7 @@ End Module")
         public void ExtraMSCorLibVB()
         {
             var result = RunCommandLineCompiler(_basicCompilerClientExecutable,
-                "/nologo /r:mscorlib.dll /r:Microsoft.VisualBasic.dll hello.vb",
+                "/shared /nologo /r:mscorlib.dll /r:Microsoft.VisualBasic.dll hello.vb",
                 _tempDirectory,
                 s_helloWorldSrcVb);
             VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
@@ -518,7 +514,7 @@ class Hello
     { Console.WriteLine(""Hello, world."") }
 }"}};
 
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared hello.cs", _tempDirectory, files);
 
             // Should output errors, but not create output file.
             Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
@@ -543,7 +539,7 @@ Module Module1
     End Sub
 End Class"}};
 
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/r:Microsoft.VisualBasic.dll hellovb.vb", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/shared /r:Microsoft.VisualBasic.dll hellovb.vb", _tempDirectory, files);
 
             // Should output errors, but not create output file.
             Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
@@ -558,7 +554,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void MissingFileErrorCS()
         {
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "missingfile.cs", _tempDirectory, new Dictionary<string, string>());
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared missingfile.cs", _tempDirectory, new Dictionary<string, string>());
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -572,7 +568,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void MissingReferenceErrorCS()
         {
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/r:missing.dll hello.cs", _tempDirectory, s_helloWorldSrcCs);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /r:missing.dll hello.cs", _tempDirectory, s_helloWorldSrcCs);
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -593,7 +589,7 @@ End Class"}};
                                                { "app.cs", "class Test { static void Main() {} }"},
                                            };
 
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/r:Lib.cs app.cs", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /r:Lib.cs app.cs", _tempDirectory, files);
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -607,7 +603,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public void MissingFileErrorVB()
         {
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "missingfile.vb", _tempDirectory, new Dictionary<string, string>());
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/shared missingfile.vb", _tempDirectory, new Dictionary<string, string>());
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -633,7 +629,7 @@ Module Module1
     End Sub
 End Module"}};
 
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/nologo /r:Microsoft.VisualBasic.dll /r:missing.dll hellovb.vb", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/shared /nologo /r:Microsoft.VisualBasic.dll /r:missing.dll hellovb.vb", _tempDirectory, files);
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -658,7 +654,7 @@ End Class" },
     End Sub
 End Module"}};
 
-            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/r:Lib.vb app.vb", _tempDirectory, files);
+            var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "/shared /r:Lib.vb app.vb", _tempDirectory, files);
 
             // Should output errors, but not create output file.
             Assert.Equal("", result.Errors);
@@ -689,7 +685,7 @@ End Class
 
             using (var tmpFile = GetResultFile(rootDirectory, "lib.dll"))
             {
-                var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "src1.vb /nologo /t:library /out:lib.dll", rootDirectory, files);
+                var result = RunCommandLineCompiler(_basicCompilerClientExecutable, "src1.vb /shared /nologo /t:library /out:lib.dll", rootDirectory, files);
                 Assert.Equal("", result.Output);
                 Assert.Equal("", result.Errors);
                 Assert.Equal(0, result.ExitCode);
@@ -706,7 +702,7 @@ Module Module1
     End Sub
 End Module
 "}};
-                    result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello1.vb /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", rootDirectory, files);
+                    result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello1.vb /shared /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", rootDirectory, files);
                     Assert.Equal("", result.Output);
                     Assert.Equal("", result.Errors);
                     Assert.Equal(0, result.ExitCode);
@@ -727,7 +723,7 @@ Public Sub Main()
 End Sub
 End Module
 "}};
-                        result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello2.vb /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello2.exe", rootDirectory, files);
+                        result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello2.vb /shared /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello2.exe", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -751,7 +747,7 @@ Public Class Library
 End Class
 "}};
 
-                        result = RunCommandLineCompiler(_basicCompilerClientExecutable, "src2.vb /nologo /t:library /out:lib.dll", rootDirectory, files);
+                        result = RunCommandLineCompiler(_basicCompilerClientExecutable, "src2.vb /shared /nologo /t:library /out:lib.dll", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -768,7 +764,7 @@ Module Module1
     End Sub
 End Module
 "}};
-                            result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello3.vb /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello3.exe", rootDirectory, files);
+                            result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello3.vb /shared /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello3.exe", rootDirectory, files);
                             Assert.Equal("", result.Output);
                             Assert.Equal("", result.Errors);
                             Assert.Equal(0, result.ExitCode);
@@ -808,7 +804,7 @@ public class Library
     { return ""library1""; }
 }"}};
 
-                var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "src1.cs /nologo /t:library /out:lib.dll", rootDirectory, files);
+                var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "src1.cs /shared /nologo /t:library /out:lib.dll", rootDirectory, files);
                 Assert.Equal("", result.Output);
                 Assert.Equal("", result.Errors);
                 Assert.Equal(0, result.ExitCode);
@@ -824,7 +820,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello1 from {0}"", Library.GetString()); }
 }"}};
-                    result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello1.cs /nologo /r:lib.dll /out:hello1.exe", rootDirectory, files);
+                    result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello1.cs /shared /nologo /r:lib.dll /out:hello1.exe", rootDirectory, files);
                     Assert.Equal("", result.Output);
                     Assert.Equal("", result.Errors);
                     Assert.Equal(0, result.ExitCode);
@@ -846,7 +842,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello2 from {0}"", Library.GetString()); }
 }"}};
-                        result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello2.cs /nologo /r:lib.dll /out:hello2.exe", rootDirectory, files);
+                        result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello2.cs /shared /nologo /r:lib.dll /out:hello2.exe", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -869,7 +865,7 @@ public class Library
     { return ""library3""; }
 }"}};
 
-                        result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "src2.cs /nologo /t:library /out:lib.dll", rootDirectory, files);
+                        result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "src2.cs /shared /nologo /t:library /out:lib.dll", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -885,7 +881,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello3 from {0}"", Library.GetString2()); }
 }"}};
-                            result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello3.cs /nologo /r:lib.dll /out:hello3.exe", rootDirectory, files);
+                            result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello3.cs /shared /nologo /r:lib.dll /out:hello3.exe", rootDirectory, files);
                             Assert.Equal("", result.Output);
                             Assert.Equal("", result.Errors);
                             Assert.Equal(0, result.ExitCode);
@@ -933,13 +929,13 @@ End Module", i));
         // Run compiler in directory set up by SetupDirectory
         private Process RunCompilerCS(TempDirectory dir, int i)
         {
-            return ProcessUtilities.StartProcess(_csharpCompilerClientExecutable, string.Format("/nologo hello{0}.cs /out:hellocs{0}.exe", i), dir.Path);
+            return ProcessUtilities.StartProcess(_csharpCompilerClientExecutable, string.Format("/shared /nologo hello{0}.cs /out:hellocs{0}.exe", i), dir.Path);
         }
 
         // Run compiler in directory set up by SetupDirectory
         private Process RunCompilerVB(TempDirectory dir, int i)
         {
-            return ProcessUtilities.StartProcess(_basicCompilerClientExecutable, string.Format("/nologo hello{0}.vb /r:Microsoft.VisualBasic.dll /out:hellovb{0}.exe", i), dir.Path);
+            return ProcessUtilities.StartProcess(_basicCompilerClientExecutable, string.Format("/shared /nologo hello{0}.vb /r:Microsoft.VisualBasic.dll /out:hellovb{0}.exe", i), dir.Path);
         }
 
         // Run output in directory set up by SetupDirectory
@@ -1566,7 +1562,7 @@ public class Library
 }"}};
 
             var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
-                                                "src1.cs /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
+                                                "src1.cs /shared /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
                                                 _tempDirectory, files);
 
             Assert.Equal("", result.Output);
@@ -1584,7 +1580,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello1 from {0}"", Library.GetString()); }
 }"}};
-            result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello1.cs /nologo /r:lib.dll /out:hello1.exe", _tempDirectory, files,
+            result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "hello1.cs /shared /nologo /r:lib.dll /out:hello1.exe", _tempDirectory, files,
                                             additionalEnvironmentVars: new Dictionary<string, string>() { { "LIB", libDirectory.Path } });
 
             Assert.Equal("", result.Output);
@@ -1614,7 +1610,7 @@ End Class
 "}};
 
             var result = RunCommandLineCompiler(_basicCompilerClientExecutable,
-                                                "src1.vb /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
+                                                "src1.vb /shared /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
                                                 _tempDirectory, files);
 
             Assert.Equal("", result.Output);
@@ -1633,7 +1629,7 @@ Module Module1
     End Sub
 End Module
 "}};
-            result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello1.vb /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", _tempDirectory, files,
+            result = RunCommandLineCompiler(_basicCompilerClientExecutable, "hello1.vb /shared /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", _tempDirectory, files,
                                             additionalEnvironmentVars: new Dictionary<string, string>() { { "LIB", libDirectory.Path } });
 
             Assert.Equal("", result.Output);
@@ -1646,13 +1642,13 @@ End Module
         [WorkItem(545446, "DevDiv")]
         [Fact()]
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
-        public void Utf8Output_WithRedirecting_Off_csc2()
+        public void Utf8Output_WithRedirecting_Off_Shared()
         {
             var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
             var result = ProcessUtilities.Run("cmd",
-                string.Format("/C {0} /nologo /t:library {1} > {2}",
+                string.Format("/C {0} /shared /nologo /t:library {1} > {2}",
                 _csharpCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
@@ -1665,12 +1661,12 @@ End Module
         [WorkItem(545446, "DevDiv")]
         [Fact()]
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
-        public void Utf8Output_WithRedirecting_Off_vbc2()
+        public void Utf8Output_WithRedirecting_Off_Share()
         {
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText(@"♕").Path;
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
-            var result = ProcessUtilities.Run("cmd", string.Format("/C {0} /nologo /t:library {1} > {2}",
+            var result = ProcessUtilities.Run("cmd", string.Format("/C {0} /nologo /shared /t:library {1} > {2}",
                 _basicCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
@@ -1687,12 +1683,12 @@ End Module
         [WorkItem(545446, "DevDiv")]
         [Fact()]
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
-        public void Utf8Output_WithRedirecting_On_csc2()
+        public void Utf8Output_WithRedirecting_On_Shared()
         {
             var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
-            var result = ProcessUtilities.Run("cmd", string.Format("/C {0} /utf8output /nologo /t:library {1} > {2}",
+            var result = ProcessUtilities.Run("cmd", string.Format("/C {0} /shared /utf8output /nologo /t:library {1} > {2}",
                 _csharpCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
@@ -1705,12 +1701,12 @@ End Module
         [WorkItem(545446, "DevDiv")]
         [Fact()]
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
-        public void Utf8Output_WithRedirecting_On_vbc2()
+        public void Utf8Output_WithRedirecting_On_Shared()
         {
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText(@"♕").Path;
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
-            var result = ProcessUtilities.Run("cmd", string.Format("/C {0} /utf8output /nologo /t:library {1} > {2}",
+            var result = ProcessUtilities.Run("cmd", string.Format("/C {0} /utf8output /nologo /shared /t:library {1} > {2}",
                 _basicCompilerClientExecutable,
                 srcFile, tempOut.Path));
 
@@ -1746,7 +1742,7 @@ End Module
 "}};
 
             var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
-                                                "ref_mscorlib2.cs /nologo /nostdlib /noconfig /t:library /r:mscorlib20.dll",
+                                                "ref_mscorlib2.cs /shared /nologo /nostdlib /noconfig /t:library /r:mscorlib20.dll",
                                                 _tempDirectory, files);
 
             Assert.Equal("", result.Output);
@@ -1770,7 +1766,7 @@ class Program
 }
 "}};
             result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
-                                            "main.cs /nologo /nostdlib /noconfig /r:mscorlib40.dll /r:ref_mscorlib2.dll",
+                                            "main.cs /shared /nologo /nostdlib /noconfig /r:mscorlib40.dll /r:ref_mscorlib2.dll",
                                             _tempDirectory, files);
 
             Assert.Equal("", result.Output);
@@ -1789,7 +1785,7 @@ class Program
 
             var result = ProcessUtilities.Run("cmd",
                 string.Format(
-                    "/C {0} /noconfig @{1} > {2}",
+                    "/C {0} /shared /noconfig @{1} > {2}",
                     _csharpCompilerClientExecutable,
                     rspFile,
                     tempOut));
@@ -1811,7 +1807,7 @@ class Program
 
             var result = ProcessUtilities.Run("cmd",
                 string.Format(
-                    "/C {0} /noconfig @{1} > {2}",
+                    "/C {0} /shared /noconfig @{1} > {2}",
                     _basicCompilerClientExecutable,
                     rspFile,
                     tempOut));
@@ -1852,7 +1848,7 @@ class Program
         [Fact]
         public void BadKeepAlive1()
         {
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /keepalive", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1863,7 +1859,7 @@ class Program
         [Fact]
         public void BadKeepAlive2()
         {
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive:foo", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /keepalive:foo", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1874,7 +1870,7 @@ class Program
         [Fact]
         public void BadKeepAlive3()
         {
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive:-100", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /keepalive:-100", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1885,7 +1881,7 @@ class Program
         [Fact]
         public void BadKeepAlive4()
         {
-            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/keepalive:9999999999", _tempDirectory.Path);
+            var result = RunCommandLineCompiler(_csharpCompilerClientExecutable, "/shared /keepalive:9999999999", _tempDirectory.Path);
 
             Assert.True(result.ContainsErrors);
             Assert.Equal(1, result.ExitCode);
@@ -1897,7 +1893,7 @@ class Program
         public void SimpleKeepAlive()
         {
             var result = RunCommandLineCompiler(_csharpCompilerClientExecutable,
-                                                $"/nologo /keepalive:1 hello.cs",
+                                                $"/nologo /shared /keepalive:1 hello.cs",
                                                 _tempDirectory,
                                                 s_helloWorldSrcCs);
             VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
@@ -1912,7 +1908,7 @@ class Program
             var tmp = Path.Combine(_tempDirectory.Path, "Temp");
 
             var result = ProcessUtilities.Run("cmd",
-                string.Format("/C \"SET TMP={2} && {0} /nologo /t:library {1}\"",
+                string.Format("/C \"SET TMP={2} && {0} /shared /nologo /t:library {1}\"",
                 _csharpCompilerClientExecutable,
                 srcFile, tmp));
 
@@ -1938,7 +1934,7 @@ class Program
             var tmp = Path.Combine(_tempDirectory.Path, "Temp");
 
             var result = ProcessUtilities.Run("cmd",
-                string.Format("/C \"SET TMP={2} && {0} /nologo /t:library {1}\"",
+                string.Format("/C \"SET TMP={2} && {0} /shared /nologo /t:library {1}\"",
                 _basicCompilerClientExecutable,
                 srcFile, tmp));
 
@@ -1947,7 +1943,7 @@ class Program
             Directory.Delete(tmp);
 
             result = ProcessUtilities.Run("cmd",
-                string.Format("/C {0} /nologo /t:library {1}",
+                string.Format("/C {0} /shared /nologo /t:library {1}",
                 _basicCompilerClientExecutable,
                 srcFile));
 
@@ -2025,10 +2021,10 @@ class Program
         [Fact]
         public void OnlyStartsOneServer()
         {
-            var result = ProcessUtilities.Run(_csharpCompilerClientExecutable, "");
+            var result = ProcessUtilities.Run(_csharpCompilerClientExecutable, "/shared");
             Assert.Equal(1, GetProcessesByFullPath(_compilerServerExecutable).Count);
 
-            result = ProcessUtilities.Run(_csharpCompilerClientExecutable, "");
+            result = ProcessUtilities.Run(_csharpCompilerClientExecutable, "/shared");
             Assert.Equal(1, GetProcessesByFullPath(_compilerServerExecutable).Count);
         }
 


### PR DESCRIPTION
This change removes the compiler server test dependency on csc2 and
vbc2.  These binaries don't exist in all environments where we run these
unit tests as they are no longer a part of the shipping product.
Instead I replaced all uses with csc / vbc and explicitly passed the
shared flag to the compiler.

closes #5550