### PR TITLE
Allowing insertion of /// or ''' within an XML doc comment on ENTER, even if the option isn't set

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -503,6 +503,26 @@ class C
             VerifyPressingEnter(code, expected);
         }
 
+        [WorkItem(4817, "https://github.com/dotnet/roslyn/issues/4817")]
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void PressingEnter_InsertComment_Class1_AutoGenerateXmlDocCommentsOff()
+        {
+            var code =
+@"///$$
+class C
+{
+}";
+
+            var expected =
+@"///
+$$
+class C
+{
+}";
+
+            VerifyPressingEnter(code, expected, autoGenerateXmlDocComments: false);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void PressingEnter_InsertComment_Class2()
         {
@@ -1040,6 +1060,29 @@ class C
             VerifyPressingEnter(code, expected);
         }
 
+        [WorkItem(4817, "https://github.com/dotnet/roslyn/issues/4817")]
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void PressingEnter_InsertSlashes12_AutoGenerateXmlDocCommentsOff()
+        {
+            var code =
+@"///$$
+/// <summary></summary>
+class C
+{
+}";
+
+            var expected =
+@"///
+/// $$
+/// <summary></summary>
+class C
+{
+}";
+
+            VerifyPressingEnter(code, expected, autoGenerateXmlDocComments: false);
+        }
+
+
         [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void PressingEnter_DontInsertSlashes1()
         {
@@ -1345,6 +1388,26 @@ class C
 }";
 
             VerifyInsertCommentCommand(code, expected);
+        }
+
+        [WorkItem(4817, "https://github.com/dotnet/roslyn/issues/4817")]
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void Command_Class_AutoGenerateXmlDocCommentsOff()
+        {
+            var code =
+@"class C
+{$$
+}";
+
+            var expected =
+@"/// <summary>
+/// $$
+/// </summary>
+class C
+{
+}";
+
+            VerifyInsertCommentCommand(code, expected, autoGenerateXmlDocComments: false);
         }
 
         [WorkItem(538714)]

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -33,6 +33,24 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void TypingCharacter_Class_AutoGenerateXmlDocCommentsOff()
+        {
+            var code =
+@"//$$
+class C
+{
+}";
+
+            var expected =
+@"///$$
+class C
+{
+}";
+
+            VerifyTypingCharacter(code, expected, autoGenerateXmlDocComments: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void TypingCharacter_Method()
         {
             var code =

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Host;
@@ -220,14 +219,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             ITextView textView,
             CancellationToken cancellationToken)
         {
-            if (!subjectBuffer.GetOption(FeatureOnOffOptions.AutoXmlDocCommentGeneration))
-            {
-                return false;
-            }
+            // Don't attempt to generate a new XML doc comment on ENTER if the option to auto-generate
+            // them isn't set. Regardless of the option, we should generate exterior trivia (i.e. /// or ''')
+            // on ENTER inside an existing XML doc comment.
 
-            if (TryGenerateDocumentationCommentAfterEnter(syntaxTree, text, position, originalPosition, subjectBuffer, textView, cancellationToken))
+            if (subjectBuffer.GetOption(FeatureOnOffOptions.AutoXmlDocCommentGeneration))
             {
-                return true;
+                if (TryGenerateDocumentationCommentAfterEnter(syntaxTree, text, position, originalPosition, subjectBuffer, textView, cancellationToken))
+                {
+                    return true;
+                }
             }
 
             if (TryGenerateExteriorTriviaAfterEnter(syntaxTree, text, position, originalPosition, subjectBuffer, textView, cancellationToken))

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -262,6 +262,22 @@ End Class
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        Public Sub PressingEnter_Class1_AutoGenerateXmlDocCommentsOff()
+            Const code = "
+'''$$
+Class C
+End Class
+"
+            Const expected = "
+'''
+$$
+Class C
+End Class
+"
+            VerifyPressingEnter(code, expected, autoGenerateXmlDocComments:=False)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
         Public Sub PressingEnter_Class2()
             Const code = "
 '''$$Class C
@@ -510,6 +526,23 @@ Class C
 End Class
 "
             VerifyPressingEnter(code, expected)
+        End Sub
+
+        <WorkItem(4817, "https://github.com/dotnet/roslyn/issues/4817")>
+        <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        Public Sub PressingEnter_InsertApostrophes9_AutoGenerateXmlDocCommentsOff()
+            Const code = "
+''' <summary></summary>$$
+Class C
+End Class
+"
+            Const expected = "
+''' <summary></summary>
+''' $$
+Class C
+End Class
+"
+            VerifyPressingEnter(code, expected, autoGenerateXmlDocComments:=False)
         End Sub
 
         <WorkItem(540017)>
@@ -809,6 +842,25 @@ Class C
 End Class
 "
             VerifyInsertCommentCommand(code, expected)
+        End Sub
+
+        <WorkItem(4817, "https://github.com/dotnet/roslyn/issues/4817")>
+        <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        Public Sub Command_Class_AutoGenerateXmlDocCommentsOff()
+            Const code = "
+Class C
+    $$
+End Class
+"
+            Const expected = "
+''' <summary>
+''' $$
+''' </summary>
+Class C
+
+End Class
+"
+            VerifyInsertCommentCommand(code, expected, autoGenerateXmlDocComments:=False)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -11,6 +11,21 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.DocumentationComme
         Inherits AbstractDocumentationCommentTests
 
         <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        Public Sub TypingCharacter_Class_AutoGenerateXmlDocCommentsOff()
+            Const code = "
+''$$
+Class C
+End Class
+"
+            Const expected = "
+'''$$
+Class C
+End Class
+"
+            VerifyTypingCharacter(code, expected, autoGenerateXmlDocComments:=False)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
         Public Sub TypingCharacter_Class()
             Const code = "
 ''$$


### PR DESCRIPTION
Fixes #4817

In an XML doc comment, we should insert exterior trivia (i.e. /// or ''') even when the 'Generate XML documentation comments for ///' isn't set.

Unit tests have been added to ensure that we don't regress the following behavior:
* Don't generate XML doc comments when typing the last / or ' of exterior trivia.
* Don't generate XML doc comments when pressing ENTER after /// or ''' where there isn't an existing XML doc comment.
* Always let the Insert Comment command work, regardless of the option.

Tagging @dotnet/mlangide 