### PR TITLE
Fix indentation when pressing ENTER in a partially completed from clause of a query expression

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Formatting.Rules;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -2529,6 +2526,29 @@ namespace ConsoleApplication1
                 code,
                 indentationLine: 13,
                 expectedIndentation: 25);
+        }
+
+        [WorkItem(5495, "https://github.com/dotnet/roslyn/issues/5495")]
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void AfterPartialFromClause()
+        {
+            var code = @"
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        var q = from x
+
+    }
+}
+";
+
+            AssertSmartIndent(
+                code,
+                indentationLine: 8,
+                expectedIndentation: 16);
         }
 
         private static void AssertSmartIndentInProjection(string markup, int expectedIndentation, CSharpParseOptions options = null)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/QueryExpressionFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/QueryExpressionFormattingRule.cs
@@ -26,6 +26,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
         }
 
+        private void AddIndentBlockOperationsForFromClause(List<IndentBlockOperation> list, FromClauseSyntax fromClause)
+        {
+            // Only add the indent block operation if the 'in' keyword is present. Otherwise, we'll get the following:
+            //
+            //     from x
+            //         in args
+            //
+            // Rather than:
+            //
+            //     from x
+            //     in args
+            //
+            // However, we want to get the following result if the 'in' keyword is present to allow nested queries
+            // to be formatted properly.
+            //
+            //     from x in
+            //         args
+
+            if (fromClause.InKeyword.IsMissing)
+            {
+                return;
+            }
+
+            var baseToken = fromClause.FromKeyword;
+            var startToken = fromClause.Expression.GetFirstToken(includeZeroWidth: true);
+            var endToken = fromClause.Expression.GetLastToken(includeZeroWidth: true);
+
+            AddIndentBlockOperation(list, baseToken, startToken, endToken);
+        }
+
         public override void AddIndentBlockOperations(List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet, NextAction<IndentBlockOperation> nextOperation)
         {
             nextOperation.Invoke(list);
@@ -33,19 +63,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var queryExpression = node as QueryExpressionSyntax;
             if (queryExpression != null)
             {
-                var firstToken = queryExpression.FromClause.Expression.GetFirstToken(includeZeroWidth: true);
-                var lastToken = queryExpression.FromClause.Expression.GetLastToken(includeZeroWidth: true);
-                AddIndentBlockOperation(list, queryExpression.FromClause.FromKeyword, firstToken, lastToken);
+                AddIndentBlockOperationsForFromClause(list, queryExpression.FromClause);
 
-                for (int i = 0; i < queryExpression.Body.Clauses.Count; i++)
+                foreach (var queryClause in queryExpression.Body.Clauses)
                 {
                     // if it is nested query expression
-                    var fromClause = queryExpression.Body.Clauses[i] as FromClauseSyntax;
+                    var fromClause = queryClause as FromClauseSyntax;
                     if (fromClause != null)
                     {
-                        firstToken = fromClause.Expression.GetFirstToken(includeZeroWidth: true);
-                        lastToken = fromClause.Expression.GetLastToken(includeZeroWidth: true);
-                        AddIndentBlockOperation(list, fromClause.FromKeyword, firstToken, lastToken);
+                        AddIndentBlockOperationsForFromClause(list, fromClause);
                     }
                 }
 


### PR DESCRIPTION
Fixes #2638 

In Visual Studio 2013, we would always indent to the start of the 'from' keyword when pressing ENTER inside of a from clause. For example:

```C#
var q = from x
        |
```

Unfortunately, we regressed that behavior in Visual Studio 2015. It now does this:

```C#
var q = from x
			|
```

This change restores the VS 2013 behavior by adding a special indent block operation specifically for ```FromClauseSyntax```. However, it also continues to support nested query formatting (which we improved in VS 2015) by adding the indent block operation only when the 'in' keyword is present:

```C#
var q = from x in
		    from y in args
		    select y
		select x;
```

Tagging @dotnet/mlangide and @heejaechang for review.