### PR TITLE
Unbreak End Construct around an broken code scenario

### DIFF
--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructStatementVisitor_Properties.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructStatementVisitor_Properties.vb
@@ -41,6 +41,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 lines.AddRange(GenerateSetAccessor(node, _subjectBuffer.CurrentSnapshot))
             End If
 
+            ' If we didn't need any accessors, that already means there's some accessor after us. Spitting
+            ' End Property (if we have to) after that point would just make more broken code, so just bail
+            If lines.Count = 0 Then
+                Return Nothing
+            End If
+
             ' If we are missing a End Property, then spit it
             If propertyBlock Is Nothing OrElse propertyBlock.EndPropertyStatement.IsMissing Then
                 Dim aligningWhitespace = _subjectBuffer.CurrentSnapshot.GetAligningWhitespace(node.SpanStart)

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
@@ -147,6 +147,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
+        Public Sub DontApplyForReadOnlyPropertyIfEndPropertyMissingWhenInvokedAfterProperty()
+            VerifyStatementEndConstructNotApplied(
+                text:={"Class c1",
+                       "    ReadOnly Property foo As Integer",
+                       "        Get",
+                       "End Class"},
+                caret:={1, -1})
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Sub TestApplyOnGetForRegularPropertyWithSetPresent()
             VerifyStatementEndConstructApplied(
                 before:={"Class c1",


### PR DESCRIPTION
If you hit enter after a Property statement that already had accessors,
but was missing an End Property, we'd get confused of what to do and
not let you do anything at all. That's bad, so now we just do nothing
special and pass it through as an enter. In this case spitting anything
just makes more broken code for the user, so we're best off avoiding
any fanciness.

Fixes #5208.

Reviewers: @dotnet/mlangide