### PR TITLE
Disable more flaky tests in InteractiveWindowTests

### DIFF
--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -372,13 +372,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Task.Run(() => Window.Operations.SelectAll()).PumpingWait();
         }
 
-        [Fact]
+        [Fact(Skip = "5544"), WorkItem(5544, "https://github.com/dotnet/roslyn/issues/5544")]
         public void CallPasteOnNonUIThread()
         {
             Task.Run(() => Window.Operations.Paste()).PumpingWait();
         }
 
-        [Fact]
+        [Fact(Skip = "5544"), WorkItem(5544, "https://github.com/dotnet/roslyn/issues/5544")]
         public void CallCutOnNonUIThread()
         {
             Task.Run(() => Window.Operations.Cut()).PumpingWait();


### PR DESCRIPTION
These tests access the clipboard directly in the unit tests and hence
have flaky behavior across machines. Disabling.

See https://github.com/dotnet/roslyn/issues/5544