### PR TITLE
Add support for attributes on accessors in SyntaxGenerator

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1065,6 +1065,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return ((EventDeclarationSyntax)declaration).AttributeLists;
                 case SyntaxKind.Parameter:
                     return ((ParameterSyntax)declaration).AttributeLists;
+                case SyntaxKind.AddAccessorDeclaration:
+                case SyntaxKind.GetAccessorDeclaration:
+                case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.RemoveAccessorDeclaration:
+                    return ((AccessorDeclarationSyntax)declaration).AttributeLists;
                 case SyntaxKind.CompilationUnit:
                     return ((CompilationUnitSyntax)declaration).AttributeLists;
                 default:
@@ -1108,6 +1113,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return ((EventDeclarationSyntax)declaration).WithAttributeLists(attributeLists);
                 case SyntaxKind.Parameter:
                     return ((ParameterSyntax)declaration).WithAttributeLists(attributeLists);
+                case SyntaxKind.AddAccessorDeclaration:
+                case SyntaxKind.GetAccessorDeclaration:
+                case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.RemoveAccessorDeclaration:
+                    return ((AccessorDeclarationSyntax)declaration).WithAttributeLists(attributeLists);
                 case SyntaxKind.CompilationUnit:
                     return ((CompilationUnitSyntax)declaration).WithAttributeLists(AsAssemblyAttributes(attributeLists));
                 default:

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1336,6 +1336,32 @@ public interface IFace
         }
 
         [Fact]
+        [WorkItem(5066, "https://github.com/dotnet/roslyn/issues/5066")]
+        public void TestAddAttributesToAccessors()
+        {
+            var prop = _g.PropertyDeclaration("P", _g.IdentifierName("T"));
+            var evnt = _g.CustomEventDeclaration("E", _g.IdentifierName("T"));
+            CheckAddRemoveAttribute(_g.GetAccessor(prop, DeclarationKind.GetAccessor));
+            CheckAddRemoveAttribute(_g.GetAccessor(prop, DeclarationKind.SetAccessor));
+            CheckAddRemoveAttribute(_g.GetAccessor(evnt, DeclarationKind.AddAccessor));
+            CheckAddRemoveAttribute(_g.GetAccessor(evnt, DeclarationKind.RemoveAccessor));
+        }
+
+        private void CheckAddRemoveAttribute(SyntaxNode declaration)
+        {
+            var initialAttributes = _g.GetAttributes(declaration);
+            Assert.Equal(0, initialAttributes.Count);
+
+            var withAttribute = _g.AddAttributes(declaration, _g.Attribute("a"));
+            var attrsAdded = _g.GetAttributes(withAttribute);
+            Assert.Equal(1, attrsAdded.Count);
+
+            var withoutAttribute = _g.RemoveNode(withAttribute, attrsAdded[0]);
+            var attrsRemoved = _g.GetAttributes(withoutAttribute);
+            Assert.Equal(0, attrsRemoved.Count);
+        }
+
+        [Fact]
         public void TestAddRemoveAttributesPerservesTrivia()
         {
             var cls = SyntaxFactory.ParseCompilationUnit(@"// comment

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -1461,6 +1461,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     Return DirectCast(node, EventBlockSyntax).EventStatement.AttributeLists
                 Case SyntaxKind.EventStatement
                     Return DirectCast(node, EventStatementSyntax).AttributeLists
+                Case SyntaxKind.GetAccessorBlock,
+                    SyntaxKind.SetAccessorBlock,
+                    SyntaxKind.AddHandlerAccessorBlock,
+                    SyntaxKind.RemoveHandlerAccessorBlock,
+                    SyntaxKind.RaiseEventAccessorBlock
+                    Return DirectCast(node, AccessorBlockSyntax).AccessorStatement.AttributeLists
+                Case SyntaxKind.GetAccessorStatement,
+                    SyntaxKind.SetAccessorStatement,
+                    SyntaxKind.AddHandlerAccessorStatement,
+                    SyntaxKind.RemoveHandlerAccessorStatement,
+                    SyntaxKind.RaiseEventAccessorStatement
+                    Return DirectCast(node, AccessorStatementSyntax).AttributeLists
                 Case Else
                     Return Nothing
             End Select
@@ -1522,6 +1534,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     Return DirectCast(node, EventBlockSyntax).WithEventStatement(DirectCast(node, EventBlockSyntax).EventStatement.WithAttributeLists(arg))
                 Case SyntaxKind.EventStatement
                     Return DirectCast(node, EventStatementSyntax).WithAttributeLists(arg)
+                Case SyntaxKind.GetAccessorBlock,
+                    SyntaxKind.SetAccessorBlock,
+                    SyntaxKind.AddHandlerAccessorBlock,
+                    SyntaxKind.RemoveHandlerAccessorBlock,
+                    SyntaxKind.RaiseEventAccessorBlock
+                    Return DirectCast(node, AccessorBlockSyntax).WithAccessorStatement(DirectCast(node, AccessorBlockSyntax).AccessorStatement.WithAttributeLists(arg))
+                Case SyntaxKind.GetAccessorStatement,
+                    SyntaxKind.SetAccessorStatement,
+                    SyntaxKind.AddHandlerAccessorStatement,
+                    SyntaxKind.RemoveHandlerAccessorStatement,
+                    SyntaxKind.RaiseEventAccessorStatement
+                    Return DirectCast(node, AccessorStatementSyntax).WithAttributeLists(arg)
                 Case Else
                     Return node
             End Select

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Editting
         Private Sub VerifySyntax(Of TSyntax As SyntaxNode)(type As SyntaxNode, expectedText As String)
             Assert.IsAssignableFrom(GetType(TSyntax), type)
             Dim normalized = type.NormalizeWhitespace().ToFullString()
-            Dim fixedExpectations = expectedText.Replace(vbLf, vbCrLf)
+            Dim fixedExpectations = expectedText.Replace(vbCrLf, vbLf).Replace(vbLf, vbCrLf)
             Assert.Equal(fixedExpectations, normalized)
         End Sub
 
@@ -1858,6 +1858,30 @@ End Namespace
 <x>&lt;a&gt;
 Delegate Sub d()</x>.Value)
 
+        End Sub
+
+        <Fact>
+        <WorkItem(5066, "https://github.com/dotnet/roslyn/issues/5066")>
+        Public Sub TestAddAttributesOnAccessors()
+            Dim prop = _g.PropertyDeclaration("P", _g.IdentifierName("T"))
+            Dim evnt = _g.CustomEventDeclaration("E", _g.IdentifierName("T"))
+            CheckAddRemoveAttribute(_g.GetAccessor(prop, DeclarationKind.GetAccessor))
+            CheckAddRemoveAttribute(_g.GetAccessor(prop, DeclarationKind.SetAccessor))
+            CheckAddRemoveAttribute(_g.GetAccessor(evnt, DeclarationKind.AddAccessor))
+            CheckAddRemoveAttribute(_g.GetAccessor(evnt, DeclarationKind.RemoveAccessor))
+        End Sub
+
+        Private Sub CheckAddRemoveAttribute(declaration As SyntaxNode)
+            Dim initialAttributes = _g.GetAttributes(declaration)
+            Assert.Equal(0, initialAttributes.Count)
+
+            Dim withAttribute = _g.AddAttributes(declaration, _g.Attribute("a"))
+            Dim attrsAdded = _g.GetAttributes(withAttribute)
+            Assert.Equal(1, attrsAdded.Count)
+
+            Dim withoutAttribute = _g.RemoveNode(withAttribute, attrsAdded(0))
+            Dim attrsRemoved = _g.GetAttributes(withoutAttribute)
+            Assert.Equal(0, attrsRemoved.Count)
         End Sub
 
         <Fact>

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -1864,11 +1864,27 @@ Delegate Sub d()</x>.Value)
         <WorkItem(5066, "https://github.com/dotnet/roslyn/issues/5066")>
         Public Sub TestAddAttributesOnAccessors()
             Dim prop = _g.PropertyDeclaration("P", _g.IdentifierName("T"))
-            Dim evnt = _g.CustomEventDeclaration("E", _g.IdentifierName("T"))
+
+            Dim evnt = DirectCast(SyntaxFactory.ParseCompilationUnit("
+Class C
+  Custom Event MyEvent As MyDelegate
+      AddHandler(ByVal value As MyDelegate)
+      End AddHandler
+ 
+      RemoveHandler(ByVal value As MyDelegate)
+      End RemoveHandler
+ 
+      RaiseEvent(ByVal message As String)
+      End RaiseEvent
+  End Event
+End Class
+").Members(0), ClassBlockSyntax).Members(0)
+
             CheckAddRemoveAttribute(_g.GetAccessor(prop, DeclarationKind.GetAccessor))
             CheckAddRemoveAttribute(_g.GetAccessor(prop, DeclarationKind.SetAccessor))
             CheckAddRemoveAttribute(_g.GetAccessor(evnt, DeclarationKind.AddAccessor))
             CheckAddRemoveAttribute(_g.GetAccessor(evnt, DeclarationKind.RemoveAccessor))
+            CheckAddRemoveAttribute(_g.GetAccessor(evnt, DeclarationKind.RaiseAccessor))
         End Sub
 
         Private Sub CheckAddRemoveAttribute(declaration As SyntaxNode)


### PR DESCRIPTION
Fixes #5066

Adds support in SyntaxGenerator API for adding/removing attributes on accessors.

@rchande @dpoeschl @Pilchie @DustinCampbell  please review