### PR TITLE
Unify default completion commit characters between C# and VB

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionRules.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionRules.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion
 {
@@ -11,19 +10,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
         public CSharpCompletionRules(AbstractCompletionService completionService)
             : base(completionService)
         {
-        }
-
-        protected override bool IsCommitCharacterCore(CompletionItem completionItem, char ch, string textTypedSoFar)
-        {
-            // TODO(cyrusn): Don't hardcode this in.  Suck this out of the user options.
-            var commitCharacters = new[]
-            {
-                ' ', '{', '}', '[', ']', '(', ')', '.', ',', ':',
-                ';', '+', '-', '*', '/', '%', '&', '|', '^', '!',
-                '~', '=', '<', '>', '?', '@', '#', '\'', '\"', '\\'
-            };
-
-            return commitCharacters.Contains(ch);
         }
 
         protected override bool SendEnterThroughToEditorCore(CompletionItem completionItem, string textTypedSoFar, OptionSet options)

--- a/src/Features/Core/Portable/Completion/CompletionRules.cs
+++ b/src/Features/Core/Portable/Completion/CompletionRules.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 
@@ -9,6 +10,13 @@ namespace Microsoft.CodeAnalysis.Completion
 {
     internal class CompletionRules
     {
+        private readonly static char[] s_defaultCommitCharacters = new[]
+            {
+                ' ', '{', '}', '[', ']', '(', ')', '.', ',', ':',
+                ';', '+', '-', '*', '/', '%', '&', '|', '^', '!',
+                '~', '=', '<', '>', '?', '@', '#', '\'', '\"', '\\'
+            };
+
         private readonly object _gate = new object();
         private readonly AbstractCompletionService _completionService;
         private readonly Dictionary<string, PatternMatcher> _patternMatcherMap = new Dictionary<string, PatternMatcher>();
@@ -180,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
         protected virtual bool IsCommitCharacterCore(CompletionItem completionItem, char ch, string textTypedSoFar)
         {
-            return false;
+            return s_defaultCommitCharacters.Contains(ch);
         }
 
         /// <summary>

--- a/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionRules.vb
+++ b/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionRules.vb
@@ -3,15 +3,12 @@
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.Options
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
     Partial Friend Class VisualBasicCompletionService
         Private NotInheritable Class VisualBasicCompletionRules
             Inherits CompletionRules
-
-            Private ReadOnly s_commitChars As Char() = {" "c, ";"c, "("c, ")"c, "["c, "]"c, "{"c, "}"c, "."c, ","c, ":"c, "+"c, "-"c, "*"c, "/"c, "\"c, "^"c, "<"c, ">"c, "'"c, "="c, "?"c}
 
             Public Sub New(service As AbstractCompletionService)
                 MyBase.New(service)
@@ -136,10 +133,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
 
                 Return (item1.Glyph IsNot Nothing AndAlso item2.Glyph IsNot Nothing) AndAlso
                        (item1.Glyph.Value = item2.Glyph.Value)
-            End Function
-
-            Protected Overrides Function IsCommitCharacterCore(completionItem As CompletionItem, ch As Char, textTypedSoFar As String) As Boolean
-                Return s_commitChars.Contains(ch)
             End Function
 
             Protected Overrides Function SendEnterThroughToEditorCore(completionItem As CompletionItem, textTypedSoFar As String, options As OptionSet) As Boolean


### PR DESCRIPTION
Fixes #4010

VB's default commit characters (which were originally gathered from the old VB language service), are a pure subset of C#'s default commit characters. However, the characters missing from VB's set are completely reasonable commit characters from VB. So, this change unifies them. In addition, TypeScript uses the same commit characters as C#. So, TS could stop defining their own copy of those commit characters and just rely on the defaults at some point.

tagging @dotnet/mlangide 