### PR TITLE
Filter out bad outlining spans.

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -270,6 +270,7 @@
     <Compile Include="Implementation\GoToImplementation\AbstractGoToImplementationService.cs" />
     <Compile Include="Implementation\GoToImplementation\IGoToImplementationService.cs" />
     <Compile Include="Implementation\Intellisense\Completion\OptionSetExtensions.cs" />
+    <Compile Include="Implementation\Outlining\InvalidOutliningRegionException.cs" />
     <Compile Include="Implementation\Suggestions\FixMultipleOccurrencesService.cs" />
     <Compile Include="Implementation\Suggestions\FixMultipleSuggestedAction.cs" />
     <Compile Include="Implementation\GoToImplementation\GoToImplementationCommandHandler.cs" />

--- a/src/EditorFeatures/Core/Implementation/Outlining/InvalidOutliningRegionException.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/InvalidOutliningRegionException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
+{
+    internal class InvalidOutliningRegionException : Exception
+    {
+        private readonly IOutliningService _service;
+        private readonly ITextSnapshot _snapshot;
+        private readonly Span _snapshotSpan;
+        private readonly Span _regionSpan;
+
+        public InvalidOutliningRegionException(IOutliningService service, ITextSnapshot snapshot, Span snapshotSpan, Span regionSpan)
+            : base(GetExceptionMessage(service, snapshot, snapshotSpan, regionSpan))
+        {
+            _service = service;
+            _snapshot = snapshot;
+            _snapshotSpan = snapshotSpan;
+            _regionSpan = regionSpan;
+        }
+
+        private static string GetExceptionMessage(IOutliningService service, ITextSnapshot snapshot, Span snapshotSpan, Span regionSpan)
+        {
+            return $"OutliningService({service.GetType()}) produced an invalid region.  ITextSnapshot span is {snapshotSpan}. OutliningSpan is {regionSpan}.";
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
                             var regions = await outliningService.GetOutliningSpansAsync(document, cancellationToken).ConfigureAwait(false);
                             if (regions != null)
                             {
-                                regions = GetMultiLineRegions(regions, snapshotSpan.Snapshot);
+                                regions = GetMultiLineRegions(outliningService, regions, snapshotSpan.Snapshot);
 
                                 // Create the outlining tags.
                                 var tagSpans =
@@ -143,7 +143,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
             }
         }
 
-        private IList<OutliningSpan> GetMultiLineRegions(IList<OutliningSpan> regions, ITextSnapshot snapshot)
+        private static bool exceptionReported = false;
+
+        private IList<OutliningSpan> GetMultiLineRegions(IOutliningService service, IList<OutliningSpan> regions, ITextSnapshot snapshot)
         {
             // Remove any spans that aren't multiline.
             var multiLineRegions = new List<OutliningSpan>(regions.Count);
@@ -151,6 +153,27 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
             {
                 if (region != null && region.TextSpan.Length > 0)
                 {
+                    // Check if any clients produced an invalid OutliningSpan.  If so, filter them
+                    // out and report a non-fatal watson so we can attempt to determine the source
+                    // of the issue.
+                    var snapshotSpan = snapshot.GetFullSpan().Span;
+                    var regionSpan = region.TextSpan.ToSpan();
+                    if (!snapshotSpan.Contains(regionSpan))
+                    {
+                        if (!exceptionReported)
+                        {
+                            exceptionReported = true;
+                            try
+                            {
+                                throw new InvalidOutliningRegionException(service, snapshot, snapshotSpan, regionSpan);
+                            }
+                            catch (InvalidOutliningRegionException e) when (FatalError.ReportWithoutCrash(e))
+                            {
+                            }
+                        }
+                        continue;
+                    }
+
                     var startLine = snapshot.GetLineNumberFromPosition(region.TextSpan.Start);
                     var endLine = snapshot.GetLineNumberFromPosition(region.TextSpan.End);
                     if (startLine != endLine)


### PR DESCRIPTION
But report a non-fatal watson so we can try to track down what outlining service caused the problem.