### PR TITLE
Provide a better exception message.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -677,7 +677,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (!foregroundObject.IsForeground())
             {
-                throw new NotSupportedException(ServicesVSResources.ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread);
+                throw new InvalidOperationException(ServicesVSResources.ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread);
             }
 
             var document = this.GetHostDocument(documentId);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -8,6 +8,7 @@ using System.Text;
 using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Notification;
@@ -46,6 +47,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         // document worker coordinator
         private ISolutionCrawlerRegistrationService _registrationService;
+
+        private readonly ForegroundThreadAffinitizedObject foregroundObject = new ForegroundThreadAffinitizedObject();
 
         public VisualStudioWorkspaceImpl(
             SVsServiceProvider serviceProvider,
@@ -670,6 +673,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (documentId == null)
             {
                 throw new ArgumentNullException(nameof(documentId));
+            }
+
+            if (!foregroundObject.IsForeground())
+            {
+                throw new NotSupportedException(ServicesVSResources.ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread);
             }
 
             var document = this.GetHostDocument(documentId);

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1084,6 +1084,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This workspace only supports opening documents on the UI thread..
+        /// </summary>
+        internal static string ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread {
+            get {
+                return ResourceManager.GetString("ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to C#/VB Todo List Table Data Source.
         /// </summary>
         internal static string TodoTableSourceName {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -501,8 +501,10 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   <data name="ComputingRemoveSuppressionFix" xml:space="preserve">
     <value>Computing remove suppressions fix...</value>
   </data>
-<data name="ApplyingRemoveSuppressionFix" xml:space="preserve">
+  <data name="ApplyingRemoveSuppressionFix" xml:space="preserve">
     <value>Applying remove suppressions fix...</value>
   </data>
-  
+  <data name="ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread" xml:space="preserve">
+    <value>This workspace only supports opening documents on the UI thread.</value>
+  </data>
 </root>


### PR DESCRIPTION
You cannot call VSWorkspace.OpenDocument on a background thread.   We now give an up front exception to make the issue clear to the caller as to what the issue is (instead of a cryptic 'Assert-False' error further on down the line).

Fixes https://github.com/dotnet/roslyn/issues/4613

(well, doesn't actually fix.  just improves the API experience for people).