### PR TITLE
Ignore constant expressions in CapturedVariableRewriter

### DIFF
--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
@@ -31,6 +31,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             _diagnostics = diagnostics
         End Sub
 
+        Public Overrides Function Visit(node As BoundNode) As BoundNode
+            ' Ignore nodes that will be rewritten to literals in the LocalRewriter.
+            If TryCast(node, BoundExpression)?.ConstantValueOpt IsNot Nothing Then
+                Return node
+            End If
+
+            Return MyBase.Visit(node)
+        End Function
+
         Public Overrides Function VisitBlock(node As BoundBlock) As BoundNode
             Dim rewrittenLocals = node.Locals.WhereAsArray(AddressOf IncludeLocal)
             Dim rewrittenStatements = VisitList(node.Statements)


### PR DESCRIPTION
The VB EE runs ```CapturedVariableRewriter```, so it ends up looking
inside constants that will be rewritten into literal expressions in
```LocalRewriter```.  This can result in spurious errors - e.g. when
accessing an instance member in a ```nameof``` expression in a
```shared``` context.

C# is unaffected since it runs ```CapturedVariableRewriter``` after ```LocalRewriter```.

Fixes #3939