### PR TITLE
Introduce Project.HasCompleteReferencesAsync

### DIFF
--- a/src/EditorFeatures/Test2/Compilation/CompilationTests.vb
+++ b/src/EditorFeatures/Test2/Compilation/CompilationTests.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Compilation.UnitTests
                 Assert.Null(project.GetCompilationAsync(CancellationToken.None).Result)
 
                 Dim solution = project.Solution
-                Assert.Null(solution.GetCompilationAsync(project, CancellationToken.None).Result)
+                Assert.Null(project.GetCompilationAsync(CancellationToken.None).Result)
                 Assert.False(solution.ContainsSymbolsWithNameAsync(project.Id, Function(dummy) True, SymbolFilter.TypeAndMember, CancellationToken.None).Result)
                 Assert.Empty(solution.GetDocumentsWithName(project.Id, Function(dummy) True, SymbolFilter.TypeAndMember, CancellationToken.None).Result)
             End Using

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -189,7 +189,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             }
 
             // Start getting the compilation so the PartialSolution will be ready when the user starts typing in the window
-            _workspace.CurrentSolution.GetCompilationAsync(document.Project, System.Threading.CancellationToken.None);
+            document.Project.GetCompilationAsync(System.Threading.CancellationToken.None);
 
             _textView.TextBuffer.ChangeContentType(_contentType, null);
 

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/TreeItems/MetadataDefinitionTreeItem.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
         private ISymbol ResolveSymbolInCurrentSolution()
         {
-            return _symbolKey.Resolve(_workspace.CurrentSolution.GetCompilationAsync(_referencingProjectId, CancellationToken.None).Result).Symbol;
+            return _symbolKey.Resolve(_workspace.CurrentSolution.GetProject(_referencingProjectId).GetCompilationAsync(CancellationToken.None).Result).Symbol;
         }
 
         internal override void SetReferenceCount(int referenceCount)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -390,6 +390,15 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Determines if the compilation returned by <see cref="GetCompilationAsync"/> has all the references it's expected to have.
+        /// </summary>
+        // TODO: make this public
+        internal Task<bool> HasCompleteReferencesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _solution.HasCompleteReferencesAsync(this, cancellationToken);
+        }
+
+        /// <summary>
         /// Gets an object that lists the added, changed and removed documents between this project and the specified project.
         /// </summary>
         public ProjectChanges GetChanges(Project oldProject)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
@@ -15,21 +15,32 @@ namespace Microsoft.CodeAnalysis
     {
         private partial class CompilationTracker
         {
-            // An empty compilation 
-            // Used as a base class to hold the SkeletonReference property used by derived types.
+            /// <summary>
+            /// The base type of all <see cref="CompilationTracker"/> states. The state of a <see cref="CompilationTracker" />
+            /// starts at <see cref="Empty"/>, and then will progress through the other states until it finally reaches
+            /// <see cref="FinalState" />.
+            /// </summary>
             private class State
             {
+                /// <summary>
+                /// The base <see cref="State"/> that starts with everything empty.
+                /// </summary>
                 public static readonly State Empty = new State();
 
-                // strong reference to declaration only compilation. 
-                // this doesn't make any expensive information such as symbols or references alive. just
-                // things like declaration table alive.
+                /// <summary>
+                /// A strong reference to the declaration-only compilation. This compilation isn't used to produce symbols,
+                /// nor does it have any references. It just holds the declaration table alive.
+                /// </summary>
                 public Compilation DeclarationOnlyCompilation { get; }
 
-                // The compilation available.  May be an InProgress, Full Declaration, or Final compilation
+                /// <summary>
+                /// The best compilation that is available.  May be an in-progress, full declaration, or a final compilation.
+                /// </summary>
                 public ValueSource<Compilation> Compilation { get; }
 
-                // The Final compilation if available, otherwise an empty IValueSource
+                /// <summary>
+                /// The final compilation if available, otherwise an empty <see cref="ValueSource{Compilation}"/>.
+                /// </summary>
                 public virtual ValueSource<Compilation> FinalCompilation
                 {
                     get { return ConstantValueSource<Compilation>.Empty; }
@@ -80,8 +91,10 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // A previously built compilation that we can incrementally build a 
-            // DeclarationCompilation from by iteratively processing IntermediateProjects
+            /// <summary>
+            /// A state where we are holding onto a previously built compilation, and have a known set of transformations
+            /// that could get us to a more final state.
+            /// </summary>
             private sealed class InProgressState : State
             {
                 public ImmutableArray<ValueTuple<ProjectState, CompilationTranslationAction>> IntermediateProjects { get; }
@@ -99,7 +112,9 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // declaration only state that has no associated references or symbols. just declaration table only.
+            /// <summary>
+            /// Declaration-only state that has no associated references or symbols. just declaration table only.
+            /// </summary>
             private sealed class LightDeclarationState : State
             {
                 public LightDeclarationState(Compilation declarationOnlyCompilation)
@@ -108,8 +123,10 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // A built compilation for the tracker that contains the fully built DeclarationTable,
-            // but may not have references initialized
+            /// <summary>
+            /// A built compilation for the tracker that contains the fully built DeclarationTable,
+            /// but may not have references initialized
+            /// </summary>
             private sealed class FullDeclarationState : State
             {
                 public FullDeclarationState(Compilation declarationCompilation)
@@ -118,7 +135,10 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // The final built compilation for the tracker containing the DeclarationTable and references
+            /// <summary>
+            /// The final state a compilation tracker reaches. The <see cref="State.DeclarationOnlyCompilation"/> is available,
+            /// as well as the real <see cref="State.FinalCompilation"/>.
+            /// </summary>
             private sealed class FinalState : State
             {
                 public override ValueSource<Compilation> FinalCompilation

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis
                 /// <summary>
                 /// The base <see cref="State"/> that starts with everything empty.
                 /// </summary>
-                public static readonly State Empty = new State();
+                public static readonly State Empty = new State(compilation: ConstantValueSource<Compilation>.Empty, declarationOnlyCompilation: null);
 
                 /// <summary>
                 /// A strong reference to the declaration-only compilation. This compilation isn't used to produce symbols,
@@ -46,20 +46,6 @@ namespace Microsoft.CodeAnalysis
                     get { return ConstantValueSource<Compilation>.Empty; }
                 }
 
-                private State()
-                    : this(ConstantValueSource<Compilation>.Empty, null)
-                {
-                }
-
-                protected State(ValueSource<Compilation> compilation)
-                    : this(compilation, null)
-                {
-                }
-
-                protected State(Compilation declarationOnlyCompilation)
-                    : this(ConstantValueSource<Compilation>.Empty, declarationOnlyCompilation)
-                {
-                }
 
                 protected State(ValueSource<Compilation> compilation, Compilation declarationOnlyCompilation)
                 {
@@ -102,7 +88,7 @@ namespace Microsoft.CodeAnalysis
                 public InProgressState(
                     Compilation inProgressCompilation,
                     ImmutableArray<ValueTuple<ProjectState, CompilationTranslationAction>> intermediateProjects)
-                    : base(new ConstantValueSource<Compilation>(inProgressCompilation))
+                    : base(compilation: new ConstantValueSource<Compilation>(inProgressCompilation), declarationOnlyCompilation: null)
                 {
                     Contract.ThrowIfNull(inProgressCompilation);
                     Contract.ThrowIfTrue(intermediateProjects.IsDefault);
@@ -118,7 +104,7 @@ namespace Microsoft.CodeAnalysis
             private sealed class LightDeclarationState : State
             {
                 public LightDeclarationState(Compilation declarationOnlyCompilation)
-                    : base(declarationOnlyCompilation)
+                    : base(compilation: ConstantValueSource<Compilation>.Empty, declarationOnlyCompilation: declarationOnlyCompilation)
                 {
                 }
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
@@ -39,13 +39,18 @@ namespace Microsoft.CodeAnalysis
                 public ValueSource<Compilation> Compilation { get; }
 
                 /// <summary>
+                /// Specifies if there are references that got dropped in the production of <see cref="FinalCompilation"/>. This can return
+                /// null if the state isn't at the point where it would know, and it's necessary to transition to <see cref="FinalState"/> to figure that out.
+                /// </summary>
+                public virtual bool? HasCompleteReferences => null;
+
+                /// <summary>
                 /// The final compilation if available, otherwise an empty <see cref="ValueSource{Compilation}"/>.
                 /// </summary>
                 public virtual ValueSource<Compilation> FinalCompilation
                 {
                     get { return ConstantValueSource<Compilation>.Empty; }
                 }
-
 
                 protected State(ValueSource<Compilation> compilation, Compilation declarationOnlyCompilation)
                 {
@@ -130,14 +135,19 @@ namespace Microsoft.CodeAnalysis
             /// </summary>
             private sealed class FinalState : State
             {
+                private readonly bool hasCompleteReferences;
+
                 public override ValueSource<Compilation> FinalCompilation
                 {
                     get { return this.Compilation; }
                 }
 
-                public FinalState(ValueSource<Compilation> finalCompilationSource)
+                public override bool? HasCompleteReferences => hasCompleteReferences;
+
+                public FinalState(ValueSource<Compilation> finalCompilationSource, bool hasCompleteReferences)
                     : base(finalCompilationSource, finalCompilationSource.GetValue().Clone().RemoveAllReferences())
                 {
+                    this.hasCompleteReferences = hasCompleteReferences;
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
@@ -51,6 +51,9 @@ namespace Microsoft.CodeAnalysis
                 {
                     this.Compilation = compilation;
                     this.DeclarationOnlyCompilation = declarationOnlyCompilation;
+
+                    // Declaration-only compilations should never have any references
+                    Contract.ThrowIfTrue(declarationOnlyCompilation != null && declarationOnlyCompilation.ExternalReferences.Any());
                 }
 
                 public static State Create(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// Tries to get the latest snapshot of the compilation without waiting for it to be
             /// fully built. This method takes advantage of the progress side-effect produced during
-            /// BuildCompilation. It will either return the already built compilation, any
+            /// <see cref="BuildCompilationAsync(Solution, CancellationToken)"/>. It will either return the already built compilation, any
             /// in-progress compilation or any known old compilation in that order of preference.
             /// The compilation state that is returned will have a compilation that is retained so
             /// that it cannot disappear.
@@ -562,8 +562,10 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            // Add all appropriate references to the compilation and set it as our final compilation
-            // state.
+            /// <summary>
+            /// Add all appropriate references to the compilation and set it as our final compilation
+            /// state.
+            /// </summary>
             private async Task<Compilation> FinalizeCompilationAsync(
                 Solution solution,
                 Compilation compilation,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
@@ -178,15 +178,16 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 // The user is asking for an in progress snap.  We don't want to create it and then a
-                // have the compilation immediately disappear.  So we force it to stay around with a ConstantValueSource
+                // have the compilation immediately disappear.  So we force it to stay around with a ConstantValueSource.
+                // As a policy, all partial-state projects are said to have incomplete references, since the state has no guarantees.
                 return new CompilationTracker(inProgressProject,
-                    new FinalState(new ConstantValueSource<Compilation>(inProgressCompilation)));
+                    new FinalState(new ConstantValueSource<Compilation>(inProgressCompilation), hasCompleteReferences: false));
             }
 
             /// <summary>
             /// Tries to get the latest snapshot of the compilation without waiting for it to be
             /// fully built. This method takes advantage of the progress side-effect produced during
-            /// <see cref="BuildCompilationAsync(Solution, CancellationToken)"/>. It will either return the already built compilation, any
+            /// <see cref="BuildCompilationInfoAsync(Solution, CancellationToken)"/>. It will either return the already built compilation, any
             /// in-progress compilation or any known old compilation in that order of preference.
             /// The compilation state that is returned will have a compilation that is retained so
             /// that it cannot disappear.
@@ -307,7 +308,23 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    return GetOrBuildCompilationAsync(solution, lockGate: true, cancellationToken: cancellationToken);
+                    return GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken)
+                        .ContinueWith(t => t.Result.Compilation, cancellationToken, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+                }
+            }
+
+            public Task<bool> HasCompleteReferencesAsync(Solution solution, CancellationToken cancellationToken)
+            {
+                var state = this.ReadState();
+
+                if (state.HasCompleteReferences.HasValue)
+                {
+                    return Task.FromResult(state.HasCompleteReferences.Value);
+                }
+                else
+                {
+                    return GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken)
+                        .ContinueWith(t => t.Result.HasCompleteReferences, cancellationToken, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
                 }
             }
 
@@ -371,7 +388,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private async Task<Compilation> GetOrBuildCompilationAsync(
+            private async Task<CompilationInfo> GetOrBuildCompilationInfoAsync(
                 Solution solution,
                 bool lockGate,
                 CancellationToken cancellationToken)
@@ -389,7 +406,7 @@ namespace Microsoft.CodeAnalysis
                         var finalCompilation = state.FinalCompilation.GetValue(cancellationToken);
                         if (finalCompilation != null)
                         {
-                            return finalCompilation;
+                            return new CompilationInfo(finalCompilation, hasCompleteReferences: state.HasCompleteReferences.Value);
                         }
 
                         // Otherwise, we actually have to build it.  Ensure that only one thread is trying to
@@ -398,12 +415,12 @@ namespace Microsoft.CodeAnalysis
                         {
                             using (await _buildLock.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                             {
-                                return await BuildCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
+                                return await BuildCompilationInfoAsync(solution, cancellationToken).ConfigureAwait(false);
                             }
                         }
                         else
                         {
-                            return await BuildCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
+                            return await BuildCompilationInfoAsync(solution, cancellationToken).ConfigureAwait(false);
                         }
                     }
                 }
@@ -417,7 +434,7 @@ namespace Microsoft.CodeAnalysis
             /// Builds the compilation matching the project state. In the process of building, also
             /// produce in progress snapshots that can be accessed from other threads.
             /// </summary>
-            private Task<Compilation> BuildCompilationAsync(
+            private Task<CompilationInfo> BuildCompilationInfoAsync(
                 Solution solution,
                 CancellationToken cancellationToken)
             {
@@ -430,7 +447,7 @@ namespace Microsoft.CodeAnalysis
                 var compilation = state.FinalCompilation.GetValue(cancellationToken);
                 if (compilation != null)
                 {
-                    return SpecializedTasks.FromResult(compilation);
+                    return Task.FromResult(new CompilationInfo(compilation, state.HasCompleteReferences.Value));
                 }
 
                 compilation = state.Compilation.GetValue(cancellationToken);
@@ -445,7 +462,7 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     // We've got nothing.  Build it from scratch :(
-                    return BuildCompilationFromScratchAsync(solution, state, cancellationToken);
+                    return BuildCompilationInfoFromScratchAsync(solution, state, cancellationToken);
                 }
                 else if (state is FullDeclarationState)
                 {
@@ -463,7 +480,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private async Task<Compilation> BuildCompilationFromScratchAsync(
+            private async Task<CompilationInfo> BuildCompilationInfoFromScratchAsync(
                 Solution solution, State state, CancellationToken cancellationToken)
             {
                 try
@@ -518,7 +535,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private async Task<Compilation> BuildFinalStateFromInProgressStateAsync(
+            private async Task<CompilationInfo> BuildFinalStateFromInProgressStateAsync(
                 Solution solution, InProgressState state, Compilation inProgressCompilation, CancellationToken cancellationToken)
             {
                 try
@@ -562,17 +579,30 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
+            private struct CompilationInfo
+            {
+                public Compilation Compilation { get; }
+                public bool HasCompleteReferences { get; }
+
+                public CompilationInfo(Compilation compilation, bool hasCompleteReferences)
+                {
+                    this.Compilation = compilation;
+                    this.HasCompleteReferences = hasCompleteReferences;
+                }
+            }
+
             /// <summary>
             /// Add all appropriate references to the compilation and set it as our final compilation
             /// state.
             /// </summary>
-            private async Task<Compilation> FinalizeCompilationAsync(
+            private async Task<CompilationInfo> FinalizeCompilationAsync(
                 Solution solution,
                 Compilation compilation,
                 CancellationToken cancellationToken)
             {
                 try
                 {
+                    bool hasCompleteReferences = true;
                     var newReferences = new List<MetadataReference>();
                     newReferences.AddRange(this.ProjectState.MetadataReferences);
 
@@ -600,12 +630,14 @@ namespace Microsoft.CodeAnalysis
                                 var metadataReference = await solution.GetMetadataReferenceAsync(
                                     projectReference, this.ProjectState, cancellationToken).ConfigureAwait(false);
 
-                                // The compilation doesn't want to receive a null entry in the set
-                                // of references it is constructed with. A reference can fail to be
-                                // created if a skeleton assembly could not be constructed.
+                                // A reference can fail to be created if a skeleton assembly could not be constructed.
                                 if (metadataReference != null)
                                 {
                                     newReferences.Add(metadataReference);
+                                }
+                                else
+                                {
+                                    hasCompleteReferences = false;
                                 }
                             }
                         }
@@ -616,9 +648,9 @@ namespace Microsoft.CodeAnalysis
                         compilation = compilation.WithReferences(newReferences);
                     }
 
-                    this.WriteState(new FinalState(State.CreateValueSource(compilation, solution.Services)), solution);
+                    this.WriteState(new FinalState(State.CreateValueSource(compilation, solution.Services), hasCompleteReferences), solution);
 
-                    return compilation;
+                    return new CompilationInfo(compilation, hasCompleteReferences);
                 }
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
                 {
@@ -713,8 +745,8 @@ namespace Microsoft.CodeAnalysis
                             using (await _buildLock.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                             {
                                 // okay, we still don't have one. bring the compilation to final state since we are going to use it to create skeleton assembly
-                                var compilation = await this.GetOrBuildCompilationAsync(solution, lockGate: false, cancellationToken: cancellationToken).ConfigureAwait(false);
-                                reference = MetadataOnlyReference.GetOrBuildReference(solution, projectReference, compilation, version, cancellationToken);
+                                var compilationInfo = await this.GetOrBuildCompilationInfoAsync(solution, lockGate: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                                reference = MetadataOnlyReference.GetOrBuildReference(solution, projectReference, compilationInfo.Compilation, version, cancellationToken);
                             }
                         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis
                 // we can use current state as it is since we will replace the document with latest document anyway.
                 if (inProgressState != null &&
                     inProgressCompilation != null &&
-                    inProgressState.IntermediateProjects.All(t => TouchDocumentActionForDocument(t, id)))
+                    inProgressState.IntermediateProjects.All(t => IsTouchDocumentActionForDocument(t, id)))
                 {
                     inProgressProject = this.ProjectState;
                     return;
@@ -279,8 +279,8 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private bool TouchDocumentActionForDocument(ValueTuple<ProjectState, CompilationTranslationAction> tuple, DocumentId id)
-            {
+            private static bool IsTouchDocumentActionForDocument(ValueTuple<ProjectState, CompilationTranslationAction> tuple, DocumentId id)
+            { 
                 var touchDocumentAction = tuple.Item2 as CompilationTranslationAction.TouchDocumentAction;
                 return touchDocumentAction != null && touchDocumentAction.DocumentId == id;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTranslationAction.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTranslationAction.cs
@@ -50,20 +50,6 @@ namespace Microsoft.CodeAnalysis
             }
 
             #endregion
-
-            public static void CheckKnownActions(CompilationTranslationAction translate)
-            {
-                if (translate != null)
-                {
-                    Contract.ThrowIfFalse(translate is ProjectAssemblyNameAction ||
-                                          translate is ProjectCompilationOptionsAction ||
-                                          translate is ProjectParseOptionsAction ||
-                                          translate is AddDocumentAction ||
-                                          translate is RemoveDocumentAction ||
-                                          translate is RemoveAllDocumentsAction ||
-                                          translate is TouchDocumentAction);
-                }
-            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1754,9 +1754,6 @@ namespace Microsoft.CodeAnalysis
             ImmutableDictionary<string, ImmutableArray<DocumentId>> newLinkedFilesMap = null,
             bool forkTracker = true)
         {
-            // make sure we are getting only known translate actions
-            CompilationTranslationAction.CheckKnownActions(translate);
-
             var projectId = newProjectState.Id;
 
             var newStateMap = _projectIdToProjectStateMap.SetItem(projectId, newProjectState);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -2015,6 +2015,13 @@ namespace Microsoft.CodeAnalysis
                 : SpecializedTasks.Default<Compilation>();
         }
 
+        internal Task<bool> HasCompleteReferencesAsync(Project project, CancellationToken cancellationToken)
+        {
+            return project.SupportsCompilation
+                ? this.GetCompilationTracker(project.Id).HasCompleteReferencesAsync(this, cancellationToken)
+                : SpecializedTasks.False;
+        }
+
         private static readonly ConditionalWeakTable<MetadataReference, ProjectId> s_metadataReferenceToProjectMap =
             new ConditionalWeakTable<MetadataReference, ProjectId>();
 

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -309,8 +309,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var solution = CreateSolutionWithProjectDependencyChain(projectCount);
             ProjectId[] projectIds = solution.ProjectIds.ToArray();
 
-            var compilation0 = solution.GetCompilationAsync(projectIds[0], CancellationToken.None).Result;
-            var compilation2 = solution.GetCompilationAsync(projectIds[2], CancellationToken.None).Result;
+            var compilation0 = solution.GetProject(projectIds[0]).GetCompilationAsync(CancellationToken.None).Result;
+            var compilation2 = solution.GetProject(projectIds[2]).GetCompilationAsync(CancellationToken.None).Result;
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]


### PR DESCRIPTION
When you get a compilation from a project in a workspace, it's possible that the compilation doesn't have all the references you expect. If the project has references to other languages, we have to produce reference assemblies, a process that might fail. If it fails, your compilation just doesn't get references you thought it'd get. Now with this API, you can ask if the compilation is going to have such missing references, and act accordingly.

**NB:** This pull request also includes a number of other small teaks that I noticed while trying to understand how `CompilationTracker` works. The commits are broken up, so feel free to look at them and understand which is which. I'm happy to discuss those as well and elide any changes people don't like.

**Still Coming:** An API to explicitly state that projects are missing references outside the purview of the workspaces API.

**Reviewers:** @mattwar, @heejaechang, @mavasani, @dotnet/roslyn-ide