### PR TITLE
only try to smart-indent a constructor initializer if there's actually a constructor initializer

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -120,8 +120,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                     return;
                 }
 
+                // only valid if the user has started to actually type a constructor initializer
                 var constructorInitializer = node as ConstructorInitializerSyntax;
-                if (constructorInitializer != null && constructorInitializer.ArgumentList.OpenParenToken.Kind() != SyntaxKind.None)
+                if (constructorInitializer != null &&
+                    constructorInitializer.ArgumentList.OpenParenToken.Kind() != SyntaxKind.None &&
+                    !constructorInitializer.ThisOrBaseKeyword.IsMissing)
                 {
                     var text = node.SyntaxTree.GetText();
 

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2551,6 +2551,25 @@ class C
                 expectedIndentation: 16);
         }
 
+        [WorkItem(5635, "https://github.com/dotnet/roslyn/issues/5635")]
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void ConstructorInitializerMissingBaseOrThisKeyword()
+        {
+            var code = @"
+class C
+{
+     C(string s)
+         :
+
+}
+";
+
+            AssertSmartIndent(
+                code,
+                indentationLine: 5,
+                expectedIndentation: 8);
+        }
+
         private static void AssertSmartIndentInProjection(string markup, int expectedIndentation, CSharpParseOptions options = null)
         {
             var optionsSet = options != null


### PR DESCRIPTION
This bug was found by examining crash dumps from internal bug 111892.

Tagging @dotnet/mlangide for review.

Fixes #5635.