### PR TITLE
Improved warning for missing analyzer dependencies

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -475,7 +475,7 @@ Use the dropdown to view and switch to other projects this file may belong to.</
     <value>MissingAnalyzerReference</value>
   </data>
   <data name="WRN_MissingAnalyzerReferenceMessage" xml:space="preserve">
-    <value>Analyzer assembly '{0}' depends on '{1}' but it was not found. Analyzers may not run correctly.</value>
+    <value>Analyzer assembly '{0}' depends on '{1}' but it was not found. Analyzers may not run correctly unless the missing assembly is added as an analyzer reference as well.</value>
   </data>
   <data name="SuppressionStateColumnHeader" xml:space="preserve">
     <value>Suppression State</value>


### PR DESCRIPTION
By design, dependencies of analyzers must be specified explicitly to ensure that builds are consistent. However, this is surprising and the warning that is generated when a dependency is missing does not give any hints as to how the problem might be solved. I updated the warning to clearly explain what must be done to resolve it.

Old warning: "Analyzer assembly '{0}' depends on '{1}' but it was not found. Analyzers may not run correctly."
New warning: "Analyzer assembly '{0}' depends on '{1}' but it was not found. Analyzers may not run correctly until you explicitly add the missing assembly as an analyzer reference as well."

Fixes #4057