### PR TITLE
Disable CTRL+SHIFT+V in interactive window

### DIFF
--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -180,6 +180,18 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                         return VSConstants.S_OK;
                 }
             }
+            else if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97)
+            {
+                switch ((VSConstants.VSStd97CmdID)prgCmds[0].cmdID)
+                {
+                    // TODO: Add support of rotating clipboard ring 
+                    // https://github.com/dotnet/roslyn/issues/5651
+                    case VSConstants.VSStd97CmdID.PasteNextTBXCBItem:
+                        prgCmds[0].cmdf = CommandDisabled;
+                        prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
+                        return VSConstants.S_OK;
+                }
+            }
 
             return _editorCommandFilter.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
         }
@@ -272,7 +284,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                     // TODO: Add support of rotating clipboard ring 
                     // https://github.com/dotnet/roslyn/issues/5651
                     case VSConstants.VSStd97CmdID.PasteNextTBXCBItem:
-                        return VSConstants.S_OK;
+                        return VSConstants.E_FAIL;
 
                     case VSConstants.VSStd97CmdID.Paste:
                         _window.Operations.Paste();

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -269,6 +269,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
             {
                 switch ((VSConstants.VSStd97CmdID)nCmdID)
                 {
+                    // TODO: Add support of rotating clipboard ring 
+                    // https://github.com/dotnet/roslyn/issues/5651
+                    case VSConstants.VSStd97CmdID.PasteNextTBXCBItem:
+                        return VSConstants.S_OK;
+
                     case VSConstants.VSStd97CmdID.Paste:
                         _window.Operations.Paste();
                         return VSConstants.S_OK;

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -188,7 +188,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                     // https://github.com/dotnet/roslyn/issues/5651
                     case VSConstants.VSStd97CmdID.PasteNextTBXCBItem:
                         prgCmds[0].cmdf = CommandDisabled;
-                        prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
                         return VSConstants.S_OK;
                 }
             }
@@ -284,7 +283,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                     // TODO: Add support of rotating clipboard ring 
                     // https://github.com/dotnet/roslyn/issues/5651
                     case VSConstants.VSStd97CmdID.PasteNextTBXCBItem:
-                        return VSConstants.E_FAIL;
+                        return (int)OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED;
 
                     case VSConstants.VSStd97CmdID.Paste:
                         _window.Operations.Paste();


### PR DESCRIPTION
Address https://github.com/dotnet/roslyn/issues/5563. 

https://github.com/dotnet/roslyn/issues/5651 is filed to track the task of adding clipboard ring feature to interactive window.

@ManishJayaswal @cston @KevinH-MS @amcasey @tmat 
