### PR TITLE
Replace the conditional weak table in the analyzer driver with a weak…

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1137,7 +1137,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Debug.Assert(analysisState != null);
 
             CompilationData compilationData;
-            if (!s_compilationDataCache.TryGetValue(compilation, out compilationData) ||
+            if (!TryGetCachedCompilationData(compilation, out compilationData) ||
                 !analysisState.IsDeclarationComplete(node))
             {
                 return;


### PR DESCRIPTION
… reference to the cached data.

Analyzer driver needs to cache some per-compilation data across analyzer diagnostic requests from the IDE. Currently we cache this data using a conditional weak table keyed by the compilation. However, we don't really need the old data once we move to analyzing a new compilation, so we can just use a weak reference.