### PR TITLE
Work around issue with ISymUnmanagedConstant.GetSignature...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -519,6 +519,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     Debug.Assert(!info.IsByRef);
                     Debug.Assert(!info.IsPinned);
                     var type = info.Type;
+                    if (type.IsErrorType())
+                    {
+                        continue;
+                    }
 
                     var constantValue = PdbHelpers.GetConstantValue(type.EnumUnderlyingType(), rawValue);
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Debugger.Clr;
+using Microsoft.DiaSymReader;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
@@ -3009,11 +3010,80 @@ class C
             testData.GetMethodData("<>x.<>m0").VerifyIL(tIL);
         }
 
+        [WorkItem(955, "https://github.com/aspnet/Home/issues/955")]
+        [Fact]
+        public void ConstantWithErrorType()
+        { 
+            const string source = @"
+class Program
+{
+    static void Main()
+    {
+        const int a = 1;
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
+            var runtime = CreateRuntimeInstance(comp);
+            var badConst = new MockSymUnmanagedConstant(
+                "a",
+                1,
+                (int bufferLength, out int count, byte[] name) =>
+                {
+                    count = 0;
+                    return DiaSymReader.SymUnmanagedReaderExtensions.E_NOTIMPL;
+                });
+            var debugInfo = new MethodDebugInfoBytes.Builder(constants: new[] {badConst}).Build();
+            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+
+            GetLocals(runtime, "Program.Main", debugInfo, locals, count: 0);
+
+            locals.Free();
+        }
+
         private static void GetLocals(RuntimeInstance runtime, string methodName, bool argumentsOnly, ArrayBuilder<LocalAndMethod> locals, int count, out string typeName, out CompilationTestData testData)
         {
             var context = CreateMethodContext(runtime, methodName);
             testData = new CompilationTestData();
             var assembly = context.CompileGetLocals(locals, argumentsOnly, out typeName, testData);
+            Assert.NotNull(assembly);
+            if (count == 0)
+            {
+                Assert.Equal(0, assembly.Count);
+            }
+            else
+            {
+                Assert.InRange(assembly.Count, 0, int.MaxValue);
+            }
+            Assert.Equal(count, locals.Count);
+        }
+
+        private static void GetLocals(RuntimeInstance runtime, string methodName, MethodDebugInfoBytes debugInfo, ArrayBuilder<LocalAndMethod> locals, int count)
+        {
+            ImmutableArray<MetadataBlock> blocks;
+            Guid moduleVersionId;
+            ISymUnmanagedReader unused;
+            int methodToken;
+            int localSignatureToken;
+            GetContextState(runtime, methodName, out blocks, out moduleVersionId, out unused, out methodToken, out localSignatureToken);
+
+            var symReader = new MockSymUnmanagedReader(
+                new Dictionary<int, MethodDebugInfoBytes>()
+                {
+                    {methodToken, debugInfo}
+                }.ToImmutableDictionary());
+            var context = EvaluationContext.CreateMethodContext(
+                default(CSharpMetadataContext),
+                blocks,
+                symReader,
+                moduleVersionId,
+                methodToken,
+                methodVersion: 1,
+                ilOffset: 0,
+                localSignatureToken: localSignatureToken);
+
+            string typeName;
+            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: null);
+
             Assert.NotNull(assembly);
             if (count == 0)
             {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MethodDebugInfo.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MethodDebugInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             private ArrayBuilder<byte> _bytesBuilder;
             private int _recordCount;
 
-            public Builder(string[][] importStringGroups = null, bool suppressUsingInfo = false)
+            public Builder(string[][] importStringGroups = null, bool suppressUsingInfo = false, ISymUnmanagedConstant[] constants = null)
             {
                 _bytesBuilder = ArrayBuilder<byte>.GetInstance();
                 if (importStringGroups != null && !suppressUsingInfo)
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 var namespaces = importStringGroups == null
                     ? default(ImmutableArray<ISymUnmanagedNamespace>)
                     : importStringGroups.SelectMany(names => names.Select(name => (ISymUnmanagedNamespace)new MockSymUnmanagedNamespace(name))).ToImmutableArray();
-                var childScope = new MockSymUnmanagedScope(default(ImmutableArray<ISymUnmanagedScope>), namespaces);
+                var childScope = new MockSymUnmanagedScope(default(ImmutableArray<ISymUnmanagedScope>), namespaces, constants);
                 var rootScope = new MockSymUnmanagedScope(ImmutableArray.Create<ISymUnmanagedScope>(childScope), default(ImmutableArray<ISymUnmanagedNamespace>));
                 _method = new MockSymUnmanagedMethod(rootScope);
             }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -603,6 +603,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     Debug.Assert(Not info.IsByRef)
                     Debug.Assert(Not info.IsPinned)
                     Dim type As TypeSymbol = info.Type
+                    If type.IsErrorType() Then
+                        Continue For
+                    End If
 
                     Dim constantValue = PdbHelpers.GetConstantValue(type.GetEnumUnderlyingTypeOrSelf(), rawValue)
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -1,12 +1,11 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
-Imports System.Collections.ObjectModel
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.VisualStudio.Debugger.Clr
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
@@ -3194,10 +3193,72 @@ End Class
             testData.GetMethodData("<>x.<>m0").VerifyIL(xIL)
         End Sub
 
+        <WorkItem(955, "https://github.com/aspnet/Home/issues/955")>
+        <Fact>
+        Public Sub ConstantWithErrorType()
+            Const source = "
+Module Module1
+    Sub Main()
+        Const a = 1
+    End Sub
+End Module"
+            Dim comp = CreateCompilationWithMscorlib({source}, {MsvbRef}, options:=TestOptions.DebugExe)
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim badConst = New MockSymUnmanagedConstant(
+                "a",
+                1,
+                Function(bufferLength As Integer, ByRef count As Integer, name() As Byte)
+                    count = 0
+                    Return DiaSymReader.SymUnmanagedReaderExtensions.E_NOTIMPL
+                End Function)
+            Dim debugInfo = New MethodDebugInfoBytes.Builder(constants:={badConst}).Build()
+            Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
+
+            GetLocals(runtime, "Module1.Main", debugInfo, locals, count:=0)
+
+            locals.Free()
+        End Sub
+
         Private Shared Sub GetLocals(runtime As RuntimeInstance, methodName As String, argumentsOnly As Boolean, locals As ArrayBuilder(Of LocalAndMethod), count As Integer, ByRef typeName As String, ByRef testData As CompilationTestData)
             Dim context = CreateMethodContext(runtime, methodName)
+
             testData = New CompilationTestData()
             Dim assembly = context.CompileGetLocals(locals, argumentsOnly, typeName, testData)
+
+            Assert.NotNull(assembly)
+            If count = 0 Then
+                Assert.Equal(0, assembly.Count)
+            Else
+                Assert.InRange(assembly.Count, 0, Integer.MaxValue)
+            End If
+            Assert.Equal(count, locals.Count)
+        End Sub
+
+        Private Shared Sub GetLocals(runtime As RuntimeInstance, methodName As String, debugInfo As MethodDebugInfoBytes, locals As ArrayBuilder(Of LocalAndMethod), count As Integer)
+            Dim blocks As ImmutableArray(Of MetadataBlock) = Nothing
+            Dim moduleVersionId As Guid = Nothing
+            Dim methodToken = 0
+            Dim localSignatureToken = 0
+            GetContextState(runtime, methodName, blocks, moduleVersionId, symReader:=Nothing, methodOrTypeToken:=methodToken, localSignatureToken:=localSignatureToken)
+
+            Dim symReader = New MockSymUnmanagedReader(
+                New Dictionary(Of Integer, MethodDebugInfoBytes)() From
+                {
+                    {methodToken, debugInfo}
+                }.ToImmutableDictionary())
+            Dim context = EvaluationContext.CreateMethodContext(
+                Nothing,
+                blocks,
+                MakeDummyLazyAssemblyReaders(),
+                symReader,
+                moduleVersionId,
+                methodToken,
+                methodVersion:=1,
+                ilOffset:=0,
+                localSignatureToken:=localSignatureToken)
+
+            Dim assembly = context.CompileGetLocals(locals, argumentsOnly:=False, typeName:=Nothing, testData:=Nothing)
+
             Assert.NotNull(assembly)
             If count = 0 Then
                 Assert.Equal(0, assembly.Count)


### PR DESCRIPTION
This method seems to be returning E_NOTIMPL in some cases.  When that
happens, the decoded type of the local will be ErrorType.  We should
drop these locals so that we can still Emit.