### PR TITLE
Fix issue where comments on a Collapse '#end region' tag were not being classified properly.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Classification/AbstractVisualBasicClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/AbstractVisualBasicClassifierTests.vb
@@ -87,7 +87,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
             Dim length = code.Length
             Dim span = New TextSpan(start, length)
             Test(code, allCode, span, expected)
+        End Sub
 
+        Protected Sub Test(
+            code As String,
+            span As TextSpan,
+            ParamArray expected As Tuple(Of String, String)())
+            Test(code, code, span, expected)
         End Sub
 
         Protected Sub Test(

--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -3841,5 +3841,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
                          Comment("' Comment"))
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Classification)>
+        <WorkItem(3291, "https://github.com/dotnet/roslyn/issues/3291")>
+        Public Sub TestCommentOnCollapsedEndRegion()
+            Test(
+"#Region ""Stuff""
+End Region ' Stuff",
+TextSpan.FromBounds(28, 36),
+Comment("' Stuff"))
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Classification/Worker.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/Worker.vb
@@ -1,9 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Classification
-Imports Microsoft.CodeAnalysis.Shared.Collections
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -79,10 +77,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
             End If
         End Sub
 
-        Friend Sub ClassifyToken(token As SyntaxToken)
+        Friend Sub ClassifyToken(token As SyntaxToken, Optional type As String = Nothing)
             Dim span = token.Span
             If span.Length <> 0 AndAlso _textSpan.OverlapsWith(span) Then
-                Dim type = ClassificationHelpers.GetClassification(token)
+                type = If(type, ClassificationHelpers.GetClassification(token))
 
                 If type IsNot Nothing Then
                     AddClassification(token.Span, type)
@@ -151,7 +149,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
         End Sub
 
         Private Sub ClassifyDirectiveSyntax(directiveSyntax As SyntaxNode)
-            If Not _textSpan.OverlapsWith(directiveSyntax.Span) Then
+            If Not _textSpan.OverlapsWith(directiveSyntax.FullSpan) Then
                 Return
             End If
 
@@ -172,10 +170,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                              SyntaxKind.WarningKeyword,
                              SyntaxKind.DisableKeyword
 
-                            Dim token = child.AsToken()
-
-                            AddClassification(token, ClassificationTypeNames.PreprocessorKeyword)
-                            ClassifyTrivia(token)
+                            ClassifyToken(child.AsToken(), ClassificationTypeNames.PreprocessorKeyword)
                         Case Else
                             ClassifyToken(child.AsToken())
                     End Select
@@ -184,6 +179,5 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 End If
             Next
         End Sub
-
     End Class
 End Namespace


### PR DESCRIPTION
This was happening because the editor was asking us specifically about the span after what
was collapsed.  Due to a small logic bug (where we compared a PP-Directive's Span instead
of FullSpan), we didn't even bother diving into the comment to classify it.

Fixes https://github.com/dotnet/roslyn/issues/3291