### PR TITLE
Cascade rename locations between all symbol kinds

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -313,6 +313,25 @@ public partial class C { }
 
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(3623, "https://github.com/dotnet/roslyn/issues/3623")>
+        Public Sub RenameTypeInLinkedFiles()
+            Dim workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" AssemblyName="CSProj">
+                            <Document FilePath="C.cs"><![CDATA[
+public class [|$$C|] { }
+]]></Document>
+                        </Project>
+                        <Project Language="C#" CommonReferences="true" AssemblyName="Proj2">
+                            <Document IsLinkFile="true" LinkAssemblyName="CSProj" LinkFilePath="C.cs"/>
+                        </Project>
+                    </Workspace>)
+
+            VerifyRenameOptionChangedSessionCommit(workspace, "C", "AB")
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(700923), WorkItem(700925), WorkItem(1486, "https://github.com/dotnet/roslyn/issues/1486")>
         Public Sub RenameInCommentsAndStringsCSharp()
             Dim workspace = CreateWorkspaceWithWaiter(

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -148,18 +148,11 @@ namespace Microsoft.CodeAnalysis.Rename
                 // where the names might be different is explicit interface implementations in
                 // Visual Basic and VB's identifiers are case insensitive. 
                 // Do not cascade to symbols that are defined only in metadata.
-                if (referencedSymbol.Kind == SymbolKind.Method ||
-                    referencedSymbol.Kind == SymbolKind.Property ||
-                    referencedSymbol.Kind == SymbolKind.Event ||
-                    referencedSymbol.Kind == SymbolKind.TypeParameter ||
-                    referencedSymbol.Kind == SymbolKind.Field)
+                if (referencedSymbol.Kind == originalSymbol.Kind &&
+                    string.Compare(TrimNameToAfterLastDot(referencedSymbol.Name), TrimNameToAfterLastDot(originalSymbol.Name), StringComparison.OrdinalIgnoreCase) == 0 &&
+                    referencedSymbol.Locations.Any(loc => loc.IsInSource))
                 {
-                    if (referencedSymbol.Kind == originalSymbol.Kind &&
-                        string.Compare(TrimNameToAfterLastDot(referencedSymbol.Name), TrimNameToAfterLastDot(originalSymbol.Name), StringComparison.OrdinalIgnoreCase) == 0 &&
-                        referencedSymbol.Locations.Any(loc => loc.IsInSource))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
 
                 // If the original symbol is an alias, then the referenced symbol will be where we


### PR DESCRIPTION
Cascade rename locations between all symbol kinds
Fixes #3623

The LinkedFileReferenceFinder cascades to all linked declarations, but the rename engine threw out cascaded symbols of certain types. I don't believe that restriction was necessary, so it is removed here.