### PR TITLE
Fix couple of bugs in the analyzer driver

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var declaringReferenceSyntax = declaration.GetSyntax(cancellationToken);
             var topmostNodeForAnalysis = semanticModel.GetTopmostNodeForDiagnosticAnalysis(symbol, declaringReferenceSyntax);
-            ComputeDeclarationsInNode(semanticModel, declaringReferenceSyntax, topmostNodeForAnalysis, builder, cancellationToken);
+            ComputeDeclarationsInNode(semanticModel, symbol, declaringReferenceSyntax, topmostNodeForAnalysis, builder, cancellationToken);
             var isPartialDeclAnalysis = analysisScope.FilterSpanOpt.HasValue && !analysisScope.ContainsSpan(topmostNodeForAnalysis.FullSpan);
             var nodesToAnalyze = shouldExecuteSyntaxNodeActions ?
                     GetSyntaxNodesToAnalyze(topmostNodeForAnalysis, symbol, builder, analysisScope, isPartialDeclAnalysis, semanticModel, analyzerExecutor) :
@@ -1188,11 +1188,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return declarationAnalysisData;
         }
 
-        private static void ComputeDeclarationsInNode(SemanticModel semanticModel, SyntaxNode declaringReferenceSyntax, SyntaxNode topmostNodeForAnalysis, List<DeclarationInfo> builder, CancellationToken cancellationToken)
+        private static void ComputeDeclarationsInNode(SemanticModel semanticModel, ISymbol declaredSymbol, SyntaxNode declaringReferenceSyntax, SyntaxNode topmostNodeForAnalysis, List<DeclarationInfo> builder, CancellationToken cancellationToken)
         {
             // We only care about the top level symbol declaration and its immediate member declarations.
             int? levelsToCompute = 2;
-            var getSymbol = topmostNodeForAnalysis != declaringReferenceSyntax;
+            var getSymbol = topmostNodeForAnalysis != declaringReferenceSyntax || declaredSymbol.Kind == SymbolKind.Namespace;
             semanticModel.ComputeDeclarationsInNode(topmostNodeForAnalysis, getSymbol, builder, cancellationToken, levelsToCompute);
         }
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -599,6 +599,62 @@ End Class
                     Diagnostic("FieldDeclarationDiagnostic", <![CDATA[Dim z2 = 0]]>))
         End Sub
 
+        <Fact, WorkItem(4745, "https://github.com/dotnet/roslyn/issues/4745")>
+        Public Sub TestNamespaceDeclarationAnalyzer()
+            Dim analyzer = New VisualBasicNamespaceDeclarationAnalyzer()
+            Dim sources = <compilation>
+                              <file name="c.vb">
+                                  <![CDATA[
+Namespace Foo.Bar.FooBar
+End Namespace
+]]>
+                              </file>
+                          </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlibAndReferences(sources,
+                    references:={SystemCoreRef, MsvbRef},
+                    options:=TestOptions.ReleaseDll)
+
+            compilation.VerifyDiagnostics()
+            compilation.VerifyAnalyzerDiagnostics({analyzer}, Nothing, Nothing, False,
+                    Diagnostic(VisualBasicNamespaceDeclarationAnalyzer.DiagnosticId, <![CDATA[Namespace Foo.Bar.FooBar]]>))
+        End Sub
+
+        <Fact, WorkItem(5463, "https://github.com/dotnet/roslyn/issues/5463")>
+        Public Sub TestObjectCreationInCodeBlockAnalyzer()
+            Dim analyzer = New VisualBasicCodeBlockObjectCreationAnalyzer()
+            Dim sources = <compilation>
+                              <file name="c.vb">
+                                  <![CDATA[
+Public Class C1
+End Class
+
+Public Class C2
+End Class
+
+Public Class C3
+End Class
+
+Public Class D
+    Dim x As C1 = New C1()
+    Dim y As New C2()
+    Public ReadOnly Property Z As New C3()
+End Class
+]]>
+                              </file>
+                          </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlibAndReferences(sources,
+                    references:={SystemCoreRef, MsvbRef},
+                    options:=TestOptions.ReleaseDll)
+
+            compilation.VerifyDiagnostics()
+            compilation.VerifyAnalyzerDiagnostics({analyzer}, Nothing, Nothing, False,
+                    Diagnostic(VisualBasicCodeBlockObjectCreationAnalyzer.DiagnosticDescriptor.Id, <![CDATA[New C1()]]>),
+                    Diagnostic(VisualBasicCodeBlockObjectCreationAnalyzer.DiagnosticDescriptor.Id, <![CDATA[New C2()]]>),
+                    Diagnostic(VisualBasicCodeBlockObjectCreationAnalyzer.DiagnosticDescriptor.Id, <![CDATA[New C3()]]>))
+        End Sub
+
         <Fact, WorkItem(1473, "https://github.com/dotnet/roslyn/issues/1473")>
         Public Sub TestReportingNotConfigurableDiagnostic()
             Dim analyzer = New NotConfigurableDiagnosticAnalyzer()


### PR DESCRIPTION
1. Fixes #5463: VB field and property declarations don't include the "AsClauseSyntax" node in the node's "Initializer" field, which caused us to miss executing the syntax node actions for AsNewClauseSyntax nodes within code blocks. Now we explicitly account for these initializer nodes.

2. Fixes #4745: C# namespace symbols defined by a qualified name such as "X.Y.Z" within "namespace X.Y.Z {}", all have the same declaring syntax reference. So we need to ensure that we don't make duplicate syntax node callbacks for such namespace declaration nodes.