### PR TITLE
Fix a NullReferenceException in the syntax visualizer

### DIFF
--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml.cs
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml.cs
@@ -778,7 +778,7 @@ namespace Roslyn.SyntaxVisualizer.Control
                 else
                 {
                     typeTextLabel.Visibility = Visibility.Visible;
-                    typeValueLabel.Content = value.Value.GetType().Name;
+                    typeValueLabel.Content = value.Value?.GetType().Name ?? "<null>";
                     _propertyGrid.SelectedObject = value;
                 }
             }


### PR DESCRIPTION
The syntax visualizer crashed Visual Studio when observing the constant value of `null`. This was because the syntax visualizer was not expecting GetConstantValue().Value to be null with .HasValue set to true.