### PR TITLE
VB Remove Unnecessary Cast should not remove necessary casts from Nothing to T?

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -8086,6 +8086,126 @@ End Class
             Test(input, expected)
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(5685, "https://github.com/dotnet/roslyn/issues/5685")>
+        Public Sub VisualBasic_DontRemove_NecessaryCastToNullable1()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = If(True, {|Simplify:DirectCast(Nothing, Date?)|}, CDate(""))
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = If(True, DirectCast(Nothing, Date?), CDate(""))
+    End Sub
+End Class
+]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(5685, "https://github.com/dotnet/roslyn/issues/5685")>
+        Public Sub VisualBasic_Remove_UnnecessaryCastToNullable1()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = If(True, {|Simplify:DirectCast(Nothing, Date?)|}, CType(#10/6/2015#, Date?))
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = If(True, Nothing, CType(#10/6/2015#, Date?))
+    End Sub
+End Class
+]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(5685, "https://github.com/dotnet/roslyn/issues/5685")>
+        Public Sub VisualBasic_Remove_UnnecessaryCastToNullable2()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = If(True, DirectCast(Nothing, Date?), {|Simplify:CType(#10/6/2015#, Date?)|})
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = If(True, DirectCast(Nothing, Date?), #10/6/2015#)
+    End Sub
+End Class
+]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(5685, "https://github.com/dotnet/roslyn/issues/5685")>
+        Public Sub VisualBasic_Remove_UnnecessaryCastToNullable3()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = {|Simplify:DirectCast(Nothing, Date?)|}
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Class C
+    Sub M()
+        Dim d As Date? = Nothing
+    End Sub
+End Class
+]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
 #End Region
 
     End Class

--- a/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
@@ -3,8 +3,6 @@
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
@@ -58,9 +56,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         Private Shared Function GetOuterCastType(expression As ExpressionSyntax, expressionTypeInfo As TypeInfo, semanticModel As SemanticModel, cancellationToken As CancellationToken) As ITypeSymbol
-            Dim nodeWalkUpParenthesesParent = expression.WalkUpParentheses().Parent
+            expression = expression.WalkUpParentheses()
+            Dim parent = expression.Parent
 
-            Dim parentExpression = TryCast(nodeWalkUpParenthesesParent, ExpressionSyntax)
+            Dim parentExpression = TryCast(parent, ExpressionSyntax)
             If parentExpression IsNot Nothing Then
                 If TypeOf parentExpression Is CastExpressionSyntax OrElse
                TypeOf parentExpression Is PredefinedCastExpressionSyntax Then
@@ -72,27 +71,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return expressionTypeInfo.ConvertedType
             End If
 
-            Dim parentExpressionasEqualClause = TryCast(nodeWalkUpParenthesesParent, EqualsValueSyntax)
-            If parentExpressionasEqualClause IsNot Nothing Then
-
-                Dim returnedType = AsTypeInVariableDeclarator(parentExpressionasEqualClause.Parent, semanticModel)
-
-                If returnedType IsNot Nothing Then
-                    Return returnedType
-                End If
-            End If
-
-            Dim parentExpressionForeach = TryCast(nodeWalkUpParenthesesParent, ForEachStatementSyntax)
-            If parentExpressionForeach IsNot Nothing Then
-                Dim returnedType = AsTypeInVariableDeclarator(parentExpressionForeach.ControlVariable, semanticModel)
+            Dim parentEqualsValue = TryCast(parent, EqualsValueSyntax)
+            If parentEqualsValue IsNot Nothing Then
+                Dim returnedType = AsTypeInVariableDeclarator(parentEqualsValue.Parent, semanticModel)
 
                 If returnedType IsNot Nothing Then
                     Return returnedType
                 End If
             End If
 
-            Dim parentAssignmentStatement = TryCast(nodeWalkUpParenthesesParent, AssignmentStatementSyntax)
-            If parentAssignmentStatement IsNot Nothing AndAlso nodeWalkUpParenthesesParent.Kind = SyntaxKind.SimpleAssignmentStatement Then
+            Dim parentForEach = TryCast(parent, ForEachStatementSyntax)
+            If parentForEach IsNot Nothing Then
+                Dim returnedType = AsTypeInVariableDeclarator(parentForEach.ControlVariable, semanticModel)
+
+                If returnedType IsNot Nothing Then
+                    Return returnedType
+                End If
+            End If
+
+            Dim parentAssignmentStatement = TryCast(parent, AssignmentStatementSyntax)
+            If parentAssignmentStatement IsNot Nothing AndAlso parent.Kind = SyntaxKind.SimpleAssignmentStatement Then
                 Return semanticModel.GetTypeInfo(parentAssignmentStatement.Left).Type
             End If
 
@@ -100,6 +98,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             If parentUnaryExpression IsNot Nothing AndAlso Not semanticModel.GetConversion(expression).IsUserDefined Then
                 Dim parentTypeInfo = semanticModel.GetTypeInfo(parentUnaryExpression, cancellationToken)
                 Return GetOuterCastType(parentUnaryExpression, parentTypeInfo, semanticModel, cancellationToken)
+            End If
+
+            Dim parentTernaryConditional = TryCast(parent, TernaryConditionalExpressionSyntax)
+            If parentTernaryConditional IsNot Nothing AndAlso
+               parentTernaryConditional.Condition IsNot expression Then
+
+                Dim otherExpression = If(parentTernaryConditional.WhenTrue Is expression,
+                                         parentTernaryConditional.WhenFalse,
+                                         parentTernaryConditional.WhenTrue)
+
+                Return semanticModel.GetTypeInfo(otherExpression).Type
             End If
 
             Return expressionTypeInfo.ConvertedType
@@ -373,16 +382,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         Private Shared Function CastRemovalChangesDefaultValue(castType As ITypeSymbol, outerType As ITypeSymbol) As Boolean
             If castType.IsNumericType Then
                 Return Not outerType.IsNumericType
-            Else
-                Select Case castType.SpecialType
-                    Case SpecialType.System_DateTime
-                        Return Not outerType.SpecialType = SpecialType.System_DateTime
-                    Case SpecialType.System_Boolean
-                        Return Not (outerType.IsNumericType OrElse outerType.SpecialType = SpecialType.System_Boolean)
-                    Case Else
-                        Return False
-                End Select
             End If
+
+            If castType.OriginalDefinition?.SpecialType = SpecialType.System_Nullable_T Then
+                ' Don't allow casts of Nothing to T? to be removed unless the outer type is T? or Object.
+                ' Otherwise, Nothing will lose its "nullness" and get the default value of T.
+                '
+                ' So, this is OK:
+                '
+                '   Dim x As Object = DirectCast(Nothing, Integer?)
+                '
+                ' But this is not:
+                '
+                '   Dim x As Integer = DirectCast(Nothing, Integer?)
+
+                If castType.Equals(outerType) OrElse outerType.SpecialType = SpecialType.System_Object Then
+                    Return False
+                End If
+
+                Return True
+            End If
+
+            Select Case castType.SpecialType
+                Case SpecialType.System_DateTime
+                    Return Not outerType.SpecialType = SpecialType.System_DateTime
+                Case SpecialType.System_Boolean
+                    Return Not (outerType.IsNumericType OrElse outerType.SpecialType = SpecialType.System_Boolean)
+                Case Else
+                    Return False
+            End Select
         End Function
 
         Public Shared Function IsUnnecessary(

--- a/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
@@ -380,8 +380,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         Private Shared Function CastRemovalChangesDefaultValue(castType As ITypeSymbol, outerType As ITypeSymbol) As Boolean
-            If castType.IsNumericType Then
-                Return Not outerType.IsNumericType
+            If castType.IsNumericType() Then
+                Return Not outerType.IsNumericType()
+            ElseIf castType.SpecialType = SpecialType.System_DateTime
+                Return Not outerType.SpecialType = SpecialType.System_DateTime
+            ElseIf castType.SpecialType = SpecialType.System_Boolean
+                Return Not (outerType.IsNumericType OrElse outerType.SpecialType = SpecialType.System_Boolean)
             End If
 
             If castType.OriginalDefinition?.SpecialType = SpecialType.System_Nullable_T Then
@@ -403,14 +407,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return True
             End If
 
-            Select Case castType.SpecialType
-                Case SpecialType.System_DateTime
-                    Return Not outerType.SpecialType = SpecialType.System_DateTime
-                Case SpecialType.System_Boolean
-                    Return Not (outerType.IsNumericType OrElse outerType.SpecialType = SpecialType.System_Boolean)
-                Case Else
-                    Return False
-            End Select
+            Return False
         End Function
 
         Public Shared Function IsUnnecessary(


### PR DESCRIPTION
Fixes #5685

There are several scenarios where removing a cast from Nothing to T? can result in the value of Nothing changing. Essentially, the value uses its "nullness" and gets the default value of T. For example:

```VB
Dim x As Integer? = If(True, DirectCast(Nothing, Integer?), 42)
Console.Write(x)
```

In the code above, ```Write``` won't print anything to the console because the argument passed in is null. However, if the cast is removed, the program changes because ```Nothing``` gets the default value of Integer, which is 0.

This change adds logic for the Nothing to T? case. Additionally, there is now code to compute the outer type for checking casts as the "other side" (i.e. the when-true and when-false) branches of a ternary conditional expression.

Tagging @dotnet/mlangide 