### PR TITLE
Fix wrapping of single line members

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
@@ -178,6 +178,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             var firstTokenOfNode = node.GetFirstToken(includeZeroWidth: true);
 
+            var memberDeclNode = node as MemberDeclarationSyntax;
+            if (memberDeclNode != null)
+            {
+                var firstAndLastTokens = memberDeclNode.GetFirstAndLastMemberDeclarationTokensAfterAttributes();
+                firstTokenOfNode = firstAndLastTokens.Item1;
+            }
+
             if (node.IsLambdaBodyBlock())
             {
                 // include lambda itself.
@@ -203,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // this construct in the mind of the user. 
             //
             // However, say the user hits semicolon, then hits enter, then types a close curly.
-            // In this scenario we woudl actually want the get-accessor to be formatted over multiple 
+            // In this scenario we would actually want the get-accessor to be formatted over multiple 
             // lines.  The difference here is that because the user just hit close-curly here we can 
             // consider it as being part of the closest construct and we can consider its placement
             // when deciding if the construct is on a single line.

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
@@ -56,12 +56,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            var memberDeclNode = node as MemberDeclarationSyntax;
-            if (memberDeclNode != null)
-            {
-                return memberDeclNode.GetFirstAndLastMemberDeclarationTokensAfterAttributes();
-            }
-
             var switchSection = node as SwitchSectionSyntax;
             if (switchSection != null)
             {

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -1250,8 +1250,7 @@ class foo{int x = 0;}", false, changingOptions);
             AssertFormat(@"class Class5
 {
     delegate void Del(int x);
-    public int Age
-    { get { int age = 0; return age; } }
+    public int Age { get { int age = 0; return age; } }
     public int Age2
     {
         get { int age2 = 0; return age2; }
@@ -1278,8 +1277,7 @@ class foo{int x = 0;}", false, changingOptions);
         Del d = delegate (int k)
         { Console.WriteLine(); Console.WriteLine(); };
     }
-    void foo()
-    { int y = 0; int z = 0; }
+    void foo() { int y = 0; int z = 0; }
 }
 class foo
 {
@@ -6536,6 +6534,27 @@ class C
 ";
 
             AssertFormat(code, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(1711675, "https://connect.microsoft.com/VisualStudio/feedback/details/1711675/autoformatting-issues")]
+        public void SingleLinePropertiesPreservedWithLeaveStatementsAndMembersOnSingleLineFalse()
+        {
+            var changedOptionSet = new Dictionary<OptionKey, object>
+            {
+                { CSharpFormattingOptions.WrappingPreserveSingleLine, true },
+                { CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine, false},
+            };
+
+            AssertFormat(@"
+class C
+{
+    string Name { get; set; }
+}", @"
+class C
+{
+    string  Name    {    get    ;   set     ;    }
+}", changedOptionSet: changedOptionSet);
         }
     }
 }


### PR DESCRIPTION
The braces shouldn't be pushed to a newline if the "Leave block on single
line" option is checked, even if the "Leave statements and members on the
same line" option isn't checked. It may have been a bug in the old
implementation, but at least one customer like it that way based on:
https://connect.microsoft.com/VisualStudio/feedback/details/1711675/autoformatting-issues.