### PR TITLE
Guarding rename to check if a node is a type that can be expanded.

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1372,5 +1372,36 @@ End Module
                 VerifyTagsAreCorrect(workspace, "qp")
             End Using
         End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(2445, "https://github.com/dotnet/roslyn/issues/2445")>
+        Public Sub InvalidExpansionTarget()
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+                                int x;
+                                x = 2;
+                                void [|$$M|]() { }
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim session = StartSession(workspace)
+
+                ' Type a bit in the file
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().TextBuffer
+
+                textBuffer.Delete(New Span(caretPosition, 1))
+                textBuffer.Insert(caretPosition, "x")
+
+                session.Commit()
+
+                VerifyTagsAreCorrect(workspace, "x")
+            End Using
+        End Sub
+
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -147,11 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                     }
                 }
 
-                var shouldComplexifyNode =
-                    !isInConflictLambdaBody &&
-                    _skipRenameForComplexification == 0 &&
-                    !_isProcessingComplexifiedSpans &&
-                    _conflictLocations.Contains(node.Span);
+                var shouldComplexifyNode = ShouldComplexifyNode(node, isInConflictLambdaBody);
 
                 SyntaxNode result;
 
@@ -170,6 +166,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                 }
 
                 return result;
+            }
+
+            private bool ShouldComplexifyNode(SyntaxNode node, bool isInConflictLambdaBody)
+            {
+                return !isInConflictLambdaBody &&
+                       _skipRenameForComplexification == 0 &&
+                       !_isProcessingComplexifiedSpans &&
+                       _conflictLocations.Contains(node.Span) &&
+                       (node is AttributeSyntax ||
+                        node is AttributeArgumentSyntax ||
+                        node is ConstructorInitializerSyntax ||
+                        node is ExpressionSyntax ||
+                        node is FieldDeclarationSyntax ||
+                        node is StatementSyntax ||
+                        node is CrefSyntax ||
+                        node is XmlNameAttributeSyntax ||
+                        node is TypeConstraintSyntax ||
+                        node is BaseTypeSyntax);
             }
 
             public override SyntaxToken VisitToken(SyntaxToken token)

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -128,11 +128,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                     Next
                 End If
 
-                Dim shouldComplexifyNode =
-                    Not isInConflictLambdaBody AndAlso
-                    Me._skipRenameForComplexification = 0 AndAlso
-                    Not Me._isProcessingComplexifiedSpans AndAlso
-                    Me._conflictLocations.Contains(node.Span)
+                Dim shouldComplexifyNode = Me.ShouldComplexifyNode(node, isInConflictLambdaBody)
 
                 Dim result As SyntaxNode
                 If shouldComplexifyNode Then
@@ -145,6 +141,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                 End If
 
                 Return result
+            End Function
+
+            Private Function ShouldComplexifyNode(node As SyntaxNode, isInConflictLambdaBody As Boolean) As Boolean
+                Return Not isInConflictLambdaBody AndAlso
+                       _skipRenameForComplexification = 0 AndAlso
+                       Not _isProcessingComplexifiedSpans AndAlso
+                       _conflictLocations.Contains(node.Span) AndAlso
+                       (TypeOf node Is ExpressionSyntax OrElse
+                        TypeOf node Is StatementSyntax OrElse
+                        TypeOf node Is AttributeSyntax OrElse
+                        TypeOf node Is SimpleArgumentSyntax OrElse
+                        TypeOf node Is CrefReferenceSyntax OrElse
+                        TypeOf node Is TypeConstraintSyntax)
             End Function
 
             Private Function Complexify(originalNode As SyntaxNode, newNode As SyntaxNode) As SyntaxNode


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/5035
Fixes https://github.com/dotnet/roslyn/issues/2445

Tagging @dotnet/mlangideTeam members are private 