### PR TITLE
Don't draw line separators if they would intersect with a collapsed outlining region.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/LineSeparators/AdornmentManager.cs
+++ b/src/EditorFeatures/Core/Implementation/LineSeparators/AdornmentManager.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
 
@@ -106,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
                 var viewSnapshot = _textView.TextSnapshot;
 
                 // No need to remove tags as these spans are reformatted anyways.
-                UpdateSpans_CallOnlyOnUIThread(reformattedSpans, viewSnapshot, removeOldTags: false);
+                UpdateSpans_CallOnlyOnUIThread(reformattedSpans, removeOldTags: false);
 
                 // Compute any spans that had been invalidated but were not affected by layout.
                 List<IMappingSpan> invalidated;
@@ -123,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
                         invalidatedAndNormalized,
                         e.NewOrReformattedSpans);
 
-                    UpdateSpans_CallOnlyOnUIThread(invalidatedButNotReformatted, viewSnapshot, removeOldTags: true);
+                    UpdateSpans_CallOnlyOnUIThread(invalidatedButNotReformatted, removeOldTags: true);
                 }
             }
         }
@@ -220,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
                 {
                     var viewSnapshot = _textView.TextSnapshot;
                     var invalidatedNormalized = TranslateAndNormalize(invalidated, viewSnapshot);
-                    UpdateSpans_CallOnlyOnUIThread(invalidatedNormalized, viewSnapshot, removeOldTags: true);
+                    UpdateSpans_CallOnlyOnUIThread(invalidatedNormalized, removeOldTags: true);
                 }
             }
         }
@@ -233,15 +234,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
         /// It happens when another region of the view becomes visible or there is a change in tags.
         /// For us the end result is the same - get tags from tagger and update visuals correspondingly.
         /// </summary>        
-        private void UpdateSpans_CallOnlyOnUIThread(
-            NormalizedSnapshotSpanCollection changedSpanCollection,
-            ITextSnapshot viewSnapshot,
-            bool removeOldTags)
+        private void UpdateSpans_CallOnlyOnUIThread(NormalizedSnapshotSpanCollection changedSpanCollection, bool removeOldTags)
         {
             Contract.ThrowIfNull(changedSpanCollection);
 
             // this method should only run on UI thread as we do WPF here.
             Contract.ThrowIfFalse(_textView.VisualElement.Dispatcher.CheckAccess());
+
+            var viewSnapshot = _textView.TextSnapshot;
+            var visualSnapshot = _textView.VisualSnapshot;
 
             var viewLines = _textView.TextViewLines;
             if (viewLines == null || viewLines.Count == 0)
@@ -262,6 +263,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
                 }
             }
 
+            // We don't want to draw line separators if they would intersect a collapsed outlining
+            // region.  So we test if we can map the start of the line separator up to our visual 
+            // snapshot. If we can't, then we just skip it.
+            var projectionSnapshot = _textView.VisualSnapshot as IProjectionSnapshot;
+
             foreach (var changedSpan in changedSpanCollection)
             {
                 // is there any effect on the view?
@@ -273,6 +279,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
                 var tagSpans = _tagAggregator.GetTags(changedSpan);
                 foreach (var tagMappingSpan in tagSpans)
                 {
+                    if (projectionSnapshot != null)
+                    {
+                        var point = tagMappingSpan.Span.Start.GetPoint(changedSpan.Snapshot, PositionAffinity.Predecessor);
+                        if (point == null ||
+                            projectionSnapshot.MapFromSourceSnapshot(point.Value, PositionAffinity.Predecessor) == null)
+                        {
+                            continue;
+                        }
+                    }
+
                     SnapshotSpan span;
                     if (!TryMapToSingleSnapshotSpan(tagMappingSpan.Span, viewSnapshot, out span))
                     {
@@ -281,7 +297,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
 
                     if (!viewLines.IntersectsBufferSpan(span))
                     {
-                        // span is outside of the view so we will not get geometry for it, but may spent a lot of time trying
+                        // span is outside of the view so we will not get geometry for it, but may 
+                        // spent a lot of time trying.
                         continue;
                     }
 


### PR DESCRIPTION
This makes the UI look a lot less noisy.

Fixes https://github.com/dotnet/roslyn/issues/5007