### PR TITLE
Fix bug that async and await keywords are not recommended in interactive window

### DIFF
--- a/src/EditorFeatures/CSharpTest/Recommendations/AsyncKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/AsyncKeywordRecommenderTests.cs
@@ -35,6 +35,22 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void MethodDeclarationInGlobalStatement1()
+        {
+            const string text = @"$$";
+            VerifyKeyword(SourceCodeKind.Interactive, text);
+            VerifyKeyword(SourceCodeKind.Script, text);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void MethodDeclarationInGlobalStatement2()
+        {
+            const string text = @"public $$";
+            VerifyKeyword(SourceCodeKind.Interactive, text);
+            VerifyKeyword(SourceCodeKind.Script, text);
+        }  
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public void ExpressionContext()
         {
             VerifyKeyword(@"class C

--- a/src/EditorFeatures/CSharpTest/Recommendations/AwaitKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/AwaitKeywordRecommenderTests.cs
@@ -137,5 +137,13 @@ class Program
     {
         lock($$");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public void InGlobalStatement()
+        {
+            const string text = @"$$";
+            VerifyKeyword(SourceCodeKind.Interactive, text);
+            VerifyKeyword(SourceCodeKind.Script, text);
+        } 
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsyncKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsyncKeywordRecommender.cs
@@ -27,7 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         private static bool InMemberDeclarationContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
-            return context.SyntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken)
+            return context.IsGlobalStatementContext
+                || context.SyntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken)
                 || context.IsMemberDeclarationContext(
                     validModifiers: SyntaxKindSet.AllMemberModifiers,
                     validTypeDeclarations: SyntaxKindSet.ClassStructTypeDeclarations,

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AwaitKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AwaitKeywordRecommender.cs
@@ -17,6 +17,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
+            if (context.IsGlobalStatementContext)
+            {
+                return true;
+            }
+
             if (context.IsAnyExpressionContext || context.IsStatementContext)
             {
                 foreach (var node in context.LeftToken.GetAncestors<SyntaxNode>())


### PR DESCRIPTION
This fixes https://github.com/dotnet/roslyn/issues/5593, and `AwaitKeywordRecommender` is fixed as a bonus :)

Question: Do we want to add integration tests for this now?

@dotnet/interactive 