### PR TITLE
Calculate exception regions when an active statement is deleted

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -5088,6 +5088,169 @@ class C
             edits.VerifyRudeDiagnostics(active);
         }
 
+        [Fact]
+        public void TryFinally_DeleteStatement_Inner()
+        {
+            string src1 = @"
+class C
+{
+    static void Main()
+    {
+        <AS:0>Console.WriteLine(0);</AS:0>
+
+        try
+        {
+            <AS:1>Console.WriteLine(1);</AS:1>
+        }
+        <ER:1.0>finally
+        {
+            Console.WriteLine(2);
+        }</ER:1.0>
+    }
+}";
+            string src2 = @"
+class C
+{
+    static void Main()
+    {
+        <AS:0>Console.WriteLine(0);</AS:0>
+     
+        try
+        {
+        <AS:1>}</AS:1>
+        finally
+        {
+            Console.WriteLine(2);
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "{"));
+        }
+
+        [Fact]
+        public void TryFinally_DeleteStatement_Leaf()
+        {
+            string src1 = @"
+class C
+{
+    static void Main(string[] args)
+    {
+        <ER:0.0>try
+        {
+            Console.WriteLine(0);
+        }
+        finally
+        {
+            <AS:0>Console.WriteLine(1);</AS:0>
+        }</ER:0.0>
+    }
+}";
+            string src2 = @"
+class C
+{
+    static void Main(string[] args)
+    {
+        try
+        {
+            Console.WriteLine(0);
+        }
+        finally
+        {
+        <AS:0>}</AS:0>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "finally", CSharpFeaturesResources.FinallyClause));
+        }
+
+        [Fact]
+        public void Try_DeleteStatement_Inner()
+        {
+            string src1 = @"
+class C
+{
+    static void Main()
+    {
+        <AS:0>Console.WriteLine(0);</AS:0>
+        
+        try
+        {
+            <AS:1>Console.WriteLine(1);</AS:1>
+        }
+        finally
+        {
+            Console.WriteLine(2);
+        }
+    }
+}";
+            string src2 = @"
+class C
+{
+    static void Main()
+    {
+        <AS:0>Console.WriteLine(0);</AS:0>
+        
+        try
+        {
+        <AS:1>}</AS:1>
+        finally
+        {
+            Console.WriteLine(2);
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "{"));
+        }
+
+        [Fact]
+        public void Try_DeleteStatement_Leaf()
+        {
+            string src1 = @"
+class C
+{
+    static void Main()
+    {
+        try
+        {
+            <AS:0>Console.WriteLine(1);</AS:0>
+        }
+        finally
+        {
+            Console.WriteLine(2);
+        }
+    }
+}";
+            string src2 = @"
+class C
+{
+    static void Main()
+    {
+        try
+        {
+        <AS:0>}</AS:0>
+        finally
+        {
+            Console.WriteLine(2);
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
         #endregion
 
         #region Catch

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -3448,6 +3448,135 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub TryFinally_DeleteStatement_Inner()
+            Dim src1 = "
+Class C
+    Sub Main()
+        <AS:0>Console.WriteLine(0)</AS:0>
+
+        Try
+            <AS:1>Console.WriteLine(1)</AS:1>
+        <ER:1.0>Finally
+            Console.WriteLine(2)
+        End Try</ER:1.0>
+    End Sub
+End Class
+"
+            Dim src2 = "
+Class C
+    Sub Main()
+        <AS:0>Console.WriteLine(0)</AS:0>
+
+        <AS:1>Try</AS:1>
+        Finally
+            Console.WriteLine(2)
+        End Try
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Try"))
+        End Sub
+
+        <Fact>
+        Public Sub TryFinally_DeleteStatement_Leaf()
+            Dim src1 = "
+Class C
+    Sub Main()
+        <ER:0.0>Try
+            Console.WriteLine(0)
+        Finally
+            <AS:0>Console.WriteLine(1)</AS:0>
+        End Try</ER:0.0>
+    End Sub
+End Class
+"
+            Dim src2 = "
+Class C
+    Sub Main()
+        Try
+            Console.WriteLine(0)
+        <AS:0>Finally</AS:0>
+        End Try
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "Finally", VBFeaturesResources.FinallyClause))
+        End Sub
+
+        <Fact>
+        Public Sub Try_DeleteStatement_Inner()
+            Dim src1 = "
+Class C
+    Sub Main()
+        <AS:0>Console.WriteLine(0)</AS:0>
+
+        Try
+            <AS:1>Console.WriteLine(1)</AS:1>
+        Finally
+            Console.WriteLine(2)
+        End Try
+    End Sub
+End Class
+"
+            Dim src2 = "
+Class C
+    Sub Main()
+        <AS:0>Console.WriteLine(0)</AS:0>
+
+        <AS:1>Try</AS:1>
+        Finally
+            Console.WriteLine(2)
+        End Try
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Try"))
+        End Sub
+
+        <Fact>
+        Public Sub Try_DeleteStatement_Leaf()
+            Dim src1 = "
+Class C
+    Sub Main()
+
+        Try
+            <AS:0>Console.WriteLine(1)</AS:0>
+        Finally
+            Console.WriteLine(2)
+        End Try
+    End Sub
+End Class
+"
+            Dim src2 = "
+Class C
+    Sub Main()
+
+        <AS:0>Try</AS:0>
+        Finally
+            Console.WriteLine(2)
+        End Try
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
         Public Sub Catch_Add_Inner()
             Dim src1 = "
 Class C

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -2780,7 +2780,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             List<RudeEditDiagnostic> diagnostics,
             IEnumerable<Edit<SyntaxNode>> exceptionHandlingEdits,
             SyntaxNode oldStatement,
-            SyntaxNode newStatement)
+            TextSpan newStatementSpan)
         {
             foreach (var edit in exceptionHandlingEdits)
             {
@@ -2789,7 +2789,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 if (edit.Kind != EditKind.Update || !AreExceptionClausesEquivalent(edit.OldNode, edit.NewNode))
                 {
-                    AddRudeDiagnostic(diagnostics, edit.OldNode, edit.NewNode, newStatement);
+                    AddRudeDiagnostic(diagnostics, edit.OldNode, edit.NewNode, newStatementSpan);
                 }
             }
         }
@@ -3053,7 +3053,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             if (isRude)
             {
-                AddRudeDiagnostic(diagnostics, oldCheckedStatement, newCheckedStatement, newActiveStatement);
+                AddRudeDiagnostic(diagnostics, oldCheckedStatement, newCheckedStatement, newActiveStatement.Span);
             }
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -64,6 +64,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private readonly Dictionary<DocumentId, Analysis> _analyses;
 
         // A document id is added whenever any analysis reports rude edits.
+        // We collect a set of document ids that contained a rude edit
+        // at some point in time during the lifespan of an edit session.
+        // At the end of the session we aks the diagnostic analyzer to reanalyze 
+        // the documents to clean up the diagnostics.
+        // An id may be present in this set even if the document doesn't have a rude edit anymore.
         private readonly object _documentsWithReportedRudeEditsGuard = new object();
         private readonly HashSet<DocumentId> _documentsWithReportedRudeEdits;
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -2912,12 +2912,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         Friend Overrides Sub ReportEnclosingExceptionHandlingRudeEdits(diagnostics As List(Of RudeEditDiagnostic),
                                                                        exceptionHandlingEdits As IEnumerable(Of Edit(Of SyntaxNode)),
                                                                        oldStatement As SyntaxNode,
-                                                                       newStatement As SyntaxNode)
+                                                                       newStatementSpan As TextSpan)
             For Each edit In exceptionHandlingEdits
                 Debug.Assert(edit.Kind <> EditKind.Update OrElse edit.OldNode.RawKind = edit.NewNode.RawKind)
 
                 If edit.Kind <> EditKind.Update OrElse Not AreExceptionHandlingPartsEquivalent(edit.OldNode, edit.NewNode) Then
-                    AddRudeDiagnostic(diagnostics, edit.OldNode, edit.NewNode, newStatement)
+                    AddRudeDiagnostic(diagnostics, edit.OldNode, edit.NewNode, newStatementSpan)
                 End If
             Next
         End Sub
@@ -3112,7 +3112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
             Dim onErrorOrResumeStatement = FindOnErrorOrResumeStatement(match.NewRoot)
             If onErrorOrResumeStatement IsNot Nothing Then
-                AddRudeDiagnostic(diagnostics, oldActiveStatement, onErrorOrResumeStatement, newActiveStatement)
+                AddRudeDiagnostic(diagnostics, oldActiveStatement, onErrorOrResumeStatement, newActiveStatement.Span)
             End If
 
             ReportRudeEditsForAncestorsDeclaringInterStatementTemps(diagnostics, match, oldActiveStatement, newActiveStatement, isLeaf)

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -1118,7 +1118,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
         /// <summary>
         /// Called when changes are being applied.
         /// </summary>
-        public int GetCurrentExceptionSpanPosition(uint id, VsTextSpan[] ptsNewPosition)
+        /// <param name="exceptionRegionId">
+        /// The value of <see cref="ShellInterop.ENC_EXCEPTION_SPAN.id"/>. 
+        /// Set by <see cref="GetExceptionSpans(uint, ShellInterop.ENC_EXCEPTION_SPAN[], ref uint)"/> to the index into <see cref="_exceptionRegions"/>. 
+        /// </param>
+        /// <param name="ptsNewPosition">Output value holder.</param>
+        public int GetCurrentExceptionSpanPosition(uint exceptionRegionId, VsTextSpan[] ptsNewPosition)
         {
             try
             {
@@ -1129,7 +1134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     Debug.Assert(!_encService.EditSession.StoppedAtException);
                     Debug.Assert(ptsNewPosition.Length == 1);
 
-                    var exceptionRegion = _exceptionRegions[(int)id];
+                    var exceptionRegion = _exceptionRegions[(int)exceptionRegionId];
 
                     var session = _encService.EditSession;
                     var asid = _activeStatementIds[exceptionRegion.ActiveStatementId];
@@ -1142,7 +1147,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     Debug.Assert(!analysis.HasChangesAndErrors);
                     Debug.Assert(!regions.IsDefault);
 
-                    // Absence of rude edits guarantees that the exception regions around AS hasn't semantically changed.
+                    // Absence of rude edits guarantees that the exception regions around AS haven't semantically changed.
                     // Only their spans might have changed.
                     ptsNewPosition[0] = regions[asid.Ordinal][exceptionRegion.Ordinal].ToVsTextSpan();
                 }


### PR DESCRIPTION
Fixes internal bug 131449: VS crashed when active statement in catch or finally clause was deleted or commented out.