### PR TITLE
Don't explicitly focus the editor when our ICompletionSession is dismissed

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
@@ -164,17 +164,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 return;
             }
 
-            // Slimy bit of nastiness: When we dismiss the presenter session, that will
-            // inadvertantly trigger a LostAggregateFocus event for the view. The reason for this
-            // is long and ugly, but essentially when the completion presenter gets keyboard
-            // focus, it posts a message to surrender focus to the view. However, if the we're
-            // stopping the model computation because the presenter was double-clicked, that
-            // message is still sitting in the queue. Then, when the session is dimissed below
-            // a LostAggregateFocus event gets triggered when the presenter's space reservation
-            // manager is popped off the stack. To work around this, we set focus back to the
-            // view here.
-            Keyboard.Focus(((IWpfTextView)_textView).VisualElement);
-
             _editorSessionOpt.Dismiss();
             _editorSessionOpt = null;
         }


### PR DESCRIPTION
Years ago, we added a line of code to explicitly focus the editor when our ICompletionSession is dismissed, to handle a specific problem with VB completion. Essentially, through a subtle confluence of focus issues and events firing, VB line commit would run when double-clicking an item in the completion list to commit it. However, this line is causing numerous other problems in Visual Studio. (There's a particularly bad one when clicking VS toolbar item when the completion list is up.) After removing this line, I can no longer reproduce the original problem. So, I'm removing this to address the other problems. If it turns out that the original problem still occurs in certain circumstances, we'll work with the VS editor team to add a proper fix.

Tagging @dotnet/roslyn-ide 