### PR TITLE
Collapse '#region' tags the first time a file is ever opened.

### DIFF
--- a/src/EditorFeatures/CSharp/Outlining/Outliners/RegionDirectiveOutliner.cs
+++ b/src/EditorFeatures/CSharp/Outlining/Outliners/RegionDirectiveOutliner.cs
@@ -39,7 +39,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Outlining
                 spans.Add(new OutliningSpan(
                     TextSpan.FromBounds(regionDirective.SpanStart, match.Span.End),
                     GetBannerText(regionDirective),
-                    autoCollapse: true));
+                    autoCollapse: true,
+                    isDefaultCollapsed: true));
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningSpan.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningSpan.cs
@@ -26,24 +26,30 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
         /// </summary>
         public bool AutoCollapse { get; }
 
-        public OutliningSpan(TextSpan textSpan, TextSpan hintSpan, string bannerText, bool autoCollapse)
+        /// <summary>
+        /// Whether this region should be collapsed by default when a file is opened the first time.
+        /// </summary>
+        public bool IsDefaultCollapsed { get; }
+
+        public OutliningSpan(TextSpan textSpan, TextSpan hintSpan, string bannerText, bool autoCollapse, bool isDefaultCollapsed = false)
         {
-            this.TextSpan = textSpan;
-            this.BannerText = bannerText;
-            this.HintSpan = hintSpan;
-            this.AutoCollapse = autoCollapse;
+            TextSpan = textSpan;
+            BannerText = bannerText;
+            HintSpan = hintSpan;
+            AutoCollapse = autoCollapse;
+            IsDefaultCollapsed = isDefaultCollapsed;
         }
 
-        public OutliningSpan(TextSpan textSpan, string bannerText, bool autoCollapse)
-            : this(textSpan, textSpan, bannerText, autoCollapse)
+        public OutliningSpan(TextSpan textSpan, string bannerText, bool autoCollapse, bool isDefaultCollapsed = false)
+            : this(textSpan, textSpan, bannerText, autoCollapse, isDefaultCollapsed)
         {
         }
 
         public override string ToString()
         {
             return this.TextSpan != this.HintSpan
-                ? string.Format("{{Span={0}, HintSpan={1}, BannerText=\"{2}\", AutoCollapse={3}}}", TextSpan, HintSpan, BannerText, AutoCollapse)
-                : string.Format("{{Span={0}, BannerText=\"{1}\", AutoCollapse={2}}}", TextSpan, BannerText, AutoCollapse);
+                ? $"{{Span={TextSpan}, HintSpan={HintSpan}, BannerText=\"{BannerText}\", AutoCollapse={AutoCollapse}, IsDefaultCollapsed={IsDefaultCollapsed}}}"
+                : $"{{Span={TextSpan}, BannerText=\"{BannerText}\", AutoCollapse={AutoCollapse}, IsDefaultCollapsed={IsDefaultCollapsed}}}";
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.Tag.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.Tag.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
                 string replacementString,
                 SnapshotSpan hintSpan,
                 bool isImplementation,
+                bool isDefaultCollapsed,
                 ITextEditorFactoryService textEditorFactoryService,
                 IProjectionBufferFactoryService projectionBufferFactoryService,
                 IEditorOptionsFactoryService editorOptionsFactoryService)
@@ -43,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
                 this.CollapsedForm = replacementString;
                 _hintSpan = hintSpan.Snapshot.CreateTrackingSpan(hintSpan.Span, SpanTrackingMode.EdgeExclusive);
                 this.IsImplementation = isImplementation;
-                this.IsDefaultCollapsed = false;
+                this.IsDefaultCollapsed = isDefaultCollapsed;
                 _textEditorFactoryService = textEditorFactoryService;
                 _projectionBufferFactoryService = projectionBufferFactoryService;
                 _editorOptionsFactoryService = editorOptionsFactoryService;

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.cs
@@ -123,6 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
                                                       region.BannerText,
                                                       hintSpan,
                                                       region.AutoCollapse,
+                                                      region.IsDefaultCollapsed,
                                                       _textEditorFactoryService,
                                                       _projectionBufferFactoryService,
                                                       _editorOptionsFactoryService)

--- a/src/EditorFeatures/Test/Outlining/OutliningSpanTests.cs
+++ b/src/EditorFeatures/Test/Outlining/OutliningSpanTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
             var outliningRegion = new OutliningSpan(span, hintSpan, bannerText, autoCollapse);
 
-            Assert.Equal("{Span=[0..1), HintSpan=[2..3), BannerText=\"Foo\", AutoCollapse=True}", outliningRegion.ToString());
+            Assert.Equal("{Span=[0..1), HintSpan=[2..3), BannerText=\"Foo\", AutoCollapse=True, IsDefaultCollapsed=False}", outliningRegion.ToString());
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
             var outliningRegion = new OutliningSpan(span, bannerText, autoCollapse);
 
-            Assert.Equal("{Span=[0..1), BannerText=\"Foo\", AutoCollapse=True}", outliningRegion.ToString());
+            Assert.Equal("{Span=[0..1), BannerText=\"Foo\", AutoCollapse=True, IsDefaultCollapsed=False}", outliningRegion.ToString());
         }
     }
 }

--- a/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotLineExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotLineExtensions.cs
@@ -141,5 +141,37 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         {
             return line.GetText().GetLineOffsetFromColumn(column, editorOptions.GetTabSize());
         }
+
+        /// <summary>
+        /// Checks if the given line at the given snapshot index starts with the provided value.
+        /// </summary>
+        public static bool StartsWith(this ITextSnapshotLine line, int index, string value, bool ignoreCase)
+        {
+            var snapshot = line.Snapshot;
+            if (index + value.Length >= snapshot.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                var snapshotIndex = index + i;
+                var actualCharacter = snapshot[snapshotIndex];
+                var expectedCharacter = value[i];
+
+                if (ignoreCase)
+                {
+                    actualCharacter = char.ToLowerInvariant(actualCharacter);
+                    expectedCharacter = char.ToLowerInvariant(expectedCharacter);
+                }
+
+                if (actualCharacter != expectedCharacter)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasic/Outlining/Outliners/RegionDirectiveOutliner.vb
+++ b/src/EditorFeatures/VisualBasic/Outlining/Outliners/RegionDirectiveOutliner.vb
@@ -26,7 +26,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Outlining
                     VisualBasicOutliningHelpers.CreateRegion(
                         TextSpan.FromBounds(regionDirective.SpanStart, match.Span.End),
                         GetBannerText(regionDirective),
-                        autoCollapse:=False))
+                        autoCollapse:=False,
+                        isDefaultCollapsed:=True))
             End If
         End Sub
 

--- a/src/EditorFeatures/VisualBasic/Outlining/VisualBasicOutliningHelpers.vb
+++ b/src/EditorFeatures/VisualBasic/Outlining/VisualBasicOutliningHelpers.vb
@@ -66,8 +66,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Outlining
             CollectCommentsRegions(triviaList, spans)
         End Sub
 
-        Friend Function CreateRegion(textSpan As TextSpan, bannerText As String, autoCollapse As Boolean) As OutliningSpan
-            Return New OutliningSpan(textSpan, bannerText, autoCollapse)
+        Friend Function CreateRegion(textSpan As TextSpan, bannerText As String, autoCollapse As Boolean, Optional isDefaultCollapsed As Boolean = False) As OutliningSpan
+            Return New OutliningSpan(textSpan, bannerText, autoCollapse, isDefaultCollapsed)
         End Function
 
         Friend Function CreateRegionFromBlock(node As SyntaxNode, bannerText As String, autoCollapse As Boolean) As OutliningSpan

--- a/src/EditorFeatures/VisualBasicTest/Outlining/AbstractOutlinerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/AbstractOutlinerTests.vb
@@ -11,6 +11,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
             Assert.Equal(expected.HintSpan.End, actual.HintSpan.End)
             Assert.Equal(expected.BannerText, actual.BannerText)
             Assert.Equal(expected.AutoCollapse, actual.AutoCollapse)
+            Assert.Equal(expected.IsDefaultCollapsed, actual.IsDefaultCollapsed)
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Outlining/RegionDirectiveOutlinerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/RegionDirectiveOutlinerTests.vb
@@ -45,7 +45,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
                                      textSpan:=TextSpan.FromBounds(0, 26),
                                      bannerText:="Foo",
                                      hintSpan:=TextSpan.FromBounds(0, 26),
-                                     autoCollapse:=False)
+                                     autoCollapse:=False,
+                                     isDefaultCollapsed:=True)
 
             AssertRegion(expectedRegion, actualRegion)
         End Sub
@@ -66,7 +67,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
                                      textSpan:=TextSpan.FromBounds(0, 20),
                                      bannerText:="#Region",
                                      hintSpan:=TextSpan.FromBounds(0, 20),
-                                     autoCollapse:=False)
+                                     autoCollapse:=False,
+                                     isDefaultCollapsed:=True)
 
             AssertRegion(expectedRegion, actualRegion)
         End Sub
@@ -87,7 +89,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
                                      textSpan:=TextSpan.FromBounds(0, 23),
                                      bannerText:="#Region",
                                      hintSpan:=TextSpan.FromBounds(0, 23),
-                                     autoCollapse:=False)
+                                     autoCollapse:=False,
+                                     isDefaultCollapsed:=True)
 
             AssertRegion(expectedRegion, actualRegion)
         End Sub
@@ -112,7 +115,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining
                                textSpan:=TextSpan.FromBounds(20, 40),
                                bannerText:="#Region",
                                hintSpan:=TextSpan.FromBounds(20, 40),
-                               autoCollapse:=False)
+                               autoCollapse:=False,
+                               isDefaultCollapsed:=True)
 
             AssertRegion(expectedRegion, actualRegion)
         End Sub


### PR DESCRIPTION
After that, we will persist and restore whatever outlining spans the user opens/closes.