### PR TITLE
Remove deprecated feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,7 +11,6 @@
   <packageSources>
     <clear />
     <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
-    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
     <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
     <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />


### PR DESCRIPTION
The corefx feed is deprecated.  Removing it.