### PR TITLE
Fix nested path check in FilePathUtilities

### DIFF
--- a/src/Workspaces/Core/Desktop/InternalUtilities/FilePathUtilities.cs
+++ b/src/Workspaces/Core/Desktop/InternalUtilities/FilePathUtilities.cs
@@ -10,7 +10,10 @@ namespace Roslyn.Utilities
     {
         public static bool IsNestedPath(string basePath, string fullPath)
         {
-            return fullPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase);
+            return basePath.Length > 0
+                && fullPath.Length > basePath.Length
+                && fullPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase)
+                && (PathUtilities.IsDirectorySeparator(basePath[basePath.Length - 1]) || PathUtilities.IsDirectorySeparator(fullPath[basePath.Length]));
         }
 
         public static string GetNestedPath(string baseDirectory, string fullPath)

--- a/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/FilePathUtilitiesTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -95,6 +96,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
             string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
 
             Assert.Equal(expected: @"D:\Alpha\Beta\Gamma\Doc.txt", actual: result);
+        }
+
+        [Fact]
+        [WorkItem(4660, "https://github.com/dotnet/roslyn/issues/4660")]
+        public void GetRelativePath_WithBaseDirectoryMatchingIncompletePortionOfFullPath()
+        {
+            string baseDirectory = @"C:\Alpha\Beta";
+            string fullPath = @"C:\Alpha\Beta2\Gamma";
+
+            string result = FilePathUtilities.GetRelativePath(baseDirectory, fullPath);
+
+            Assert.Equal(expected: @"..\Beta2\Gamma", actual: result);
         }
     }
 }


### PR DESCRIPTION
Fixes #4660

Change IsNestedPath to only match complete directory names.

@pilchie @rchande @dpoeschl  please review