### PR TITLE
Fixes binder-choosing around typeof expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -153,8 +153,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (var current = node; binder == null; current = current.ParentOrStructuredTriviaParent)
             {
                 Debug.Assert(current != null); // Why were we asked for an enclosing binder for a node outside our root?
-
                 StatementSyntax stmt = current as StatementSyntax;
+                TypeOfExpressionSyntax typeOfExpression;
                 if (stmt != null)
                 {
                     if (LookupPosition.IsInStatementScope(position, stmt))
@@ -197,9 +197,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-                else if (current.Kind() == SyntaxKind.TypeOfExpression && typeOfArgument == null)
+                else if (current.Kind() == SyntaxKind.TypeOfExpression &&
+                    typeOfArgument == null &&
+                    LookupPosition.IsBetweenTokens(
+                        position,
+                        (typeOfExpression = (TypeOfExpressionSyntax)current).OpenParenToken,
+                        typeOfExpression.CloseParenToken))
                 {
-                    typeOfArgument = ((TypeOfExpressionSyntax)current).Type;
+                    typeOfArgument = typeOfExpression.Type;
                     typeOfEncounteredBeforeUnexpectedAnonymousFunction = unexpectedAnonymousFunction == null;
                 }
                 else

--- a/src/Compilers/Core/Portable/Text/TextSpan.cs
+++ b/src/Compilers/Core/Portable/Text/TextSpan.cs
@@ -172,6 +172,9 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// Creates a new <see cref="TextSpan"/> from <paramref name="start" /> and <paramref
         /// name="end"/> positions as opposed to a position and length.
+        /// 
+        /// The returned TextSpan contains the range with <paramref name="start"/> inclusive, 
+        /// and <paramref name="end"/> exclusive.
         /// </summary>
         public static TextSpan FromBounds(int start, int end)
         {


### PR DESCRIPTION
Closes #5170

Previously, it was possible for the semantic model to think
that you were *inside* of a typeof when you were merely near it.

This commit adds an additional check that the cursor position is
actually inside of the parenthesis that make up the typeof
invocation.