### PR TITLE
Add null check for appconfig

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.CSharpProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.CSharpProjectFile.cs
@@ -301,7 +301,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 public bool SetApplicationConfiguration(string applicationConfiguration)
                 {
-                    this.CommandLineArgs.Add("/appconfig:" + applicationConfiguration);
+                    if (!string.IsNullOrWhiteSpace(applicationConfiguration))
+                    {
+                        this.CommandLineArgs.Add("/appconfig:" + applicationConfiguration);
+                    }
+
                     return true;
                 }
 


### PR DESCRIPTION
Fixes #5767 

Adds simple check to avoid generating the appconfig command line argument when the configuration is null.

@rchande @dpoeschl @Pilchie  please review