### PR TITLE
Script.<Main> should block until <Initialize> has completed

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2827,7 +2827,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var scriptInitializer = new SynthesizedInteractiveInitializerMethod(this, diagnostics);
                 members.Add(scriptInitializer);
-                var scriptEntryPoint = SynthesizedEntryPointSymbol.Create(this, scriptInitializer.ReturnType, diagnostics);
+                var scriptEntryPoint = SynthesizedEntryPointSymbol.Create(scriptInitializer, diagnostics);
                 members.Add(scriptEntryPoint);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -18,22 +19,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly NamedTypeSymbol _containingType;
         private readonly TypeSymbol _returnType;
 
-        internal static SynthesizedEntryPointSymbol Create(NamedTypeSymbol containingType, TypeSymbol returnType, DiagnosticBag diagnostics)
+        internal static SynthesizedEntryPointSymbol Create(SynthesizedInteractiveInitializerMethod initializerMethod, DiagnosticBag diagnostics)
         {
+            var containingType = initializerMethod.ContainingType;
             var compilation = containingType.DeclaringCompilation;
-            if (containingType.ContainingAssembly.IsInteractive)
+            if (compilation.IsSubmission)
             {
                 var submissionArrayType = compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Object));
-                var useSiteDiagnostic = submissionArrayType.GetUseSiteDiagnostic();
-                if (useSiteDiagnostic != null)
-                {
-                    ReportUseSiteDiagnostic(useSiteDiagnostic, diagnostics, NoLocation.Singleton);
-                }
-                return new SubmissionEntryPoint(containingType, returnType, submissionArrayType);
+                ReportUseSiteDiagnostics(submissionArrayType, diagnostics);
+                return new SubmissionEntryPoint(
+                    containingType,
+                    initializerMethod.ReturnType,
+                    submissionArrayType);
             }
             else
             {
-                return new ScriptEntryPoint(containingType, returnType);
+                var taskType = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+#if DEBUG
+                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                Debug.Assert(taskType.IsErrorType() || initializerMethod.ReturnType.IsDerivedFrom(taskType, ignoreDynamic: true, useSiteDiagnostics: ref useSiteDiagnostics));
+#endif
+                ReportUseSiteDiagnostics(taskType, diagnostics);
+                var getAwaiterMethod = taskType.IsErrorType() ?
+                    null :
+                    GetRequiredMethod(taskType, WellKnownMemberNames.GetAwaiter, diagnostics);
+                var getResultMethod = ((object)getAwaiterMethod == null) ?
+                    null :
+                    GetRequiredMethod(getAwaiterMethod.ReturnType, WellKnownMemberNames.GetResult, diagnostics);
+                return new ScriptEntryPoint(
+                    containingType,
+                    compilation.GetSpecialType(SpecialType.System_Void),
+                    getAwaiterMethod,
+                    getResultMethod);
             }
         }
 
@@ -265,13 +282,56 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (CSharpSyntaxNode)syntaxTree.GetRoot();
         }
 
+        private static void ReportUseSiteDiagnostics(Symbol symbol, DiagnosticBag diagnostics)
+        {
+            var useSiteDiagnostic = symbol.GetUseSiteDiagnostic();
+            if (useSiteDiagnostic != null)
+            {
+                ReportUseSiteDiagnostic(useSiteDiagnostic, diagnostics, NoLocation.Singleton);
+            }
+        }
+
+        private static MethodSymbol GetRequiredMethod(TypeSymbol type, string methodName, DiagnosticBag diagnostics)
+        {
+            var method = type.GetMembers(methodName).SingleOrDefault() as MethodSymbol;
+            if ((object)method == null)
+            {
+                diagnostics.Add(ErrorCode.ERR_MissingPredefinedMember, NoLocation.Singleton, type, methodName);
+            }
+            return method;
+        }
+
+        private static BoundCall CreateParameterlessCall(CSharpSyntaxNode syntax, BoundExpression receiver, MethodSymbol method)
+        {
+            return new BoundCall(
+                syntax,
+                receiver,
+                method,
+                ImmutableArray<BoundExpression>.Empty,
+                default(ImmutableArray<string>),
+                default(ImmutableArray<RefKind>),
+                isDelegateCall: false,
+                expanded: false,
+                invokedAsExtensionMethod: false,
+                argsToParamsOpt: default(ImmutableArray<int>),
+                resultKind: LookupResultKind.Viable,
+                type: method.ReturnType)
+            { WasCompilerGenerated = true };
+        }
+
         private sealed class ScriptEntryPoint : SynthesizedEntryPointSymbol
         {
-            internal ScriptEntryPoint(NamedTypeSymbol containingType, TypeSymbol returnType) :
+            private readonly MethodSymbol _getAwaiterMethod;
+            private readonly MethodSymbol _getResultMethod;
+
+            internal ScriptEntryPoint(NamedTypeSymbol containingType, TypeSymbol returnType, MethodSymbol getAwaiterMethod, MethodSymbol getResultMethod) :
                 base(containingType, returnType)
             {
                 Debug.Assert(containingType.IsScriptClass);
                 Debug.Assert(returnType.SpecialType == SpecialType.System_Void);
+
+                _getAwaiterMethod = getAwaiterMethod;
+                _getResultMethod = getResultMethod;
             }
 
             public override string Name
@@ -287,10 +347,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // private static void <Main>()
             // {
             //     var script = new Script();
-            //     script.<Initialize>();
+            //     script.<Initialize>().GetAwaiter().GetResult();
             // }
             internal override BoundBlock CreateBody()
             {
+                // CreateBody should only be called if no errors.
+                Debug.Assert((object)_getAwaiterMethod != null);
+                Debug.Assert((object)_getResultMethod != null);
+
                 var syntax = this.GetSyntax();
 
                 var ctor = _containingType.GetScriptConstructor();
@@ -322,23 +386,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 _containingType)
                             { WasCompilerGenerated = true })
                         { WasCompilerGenerated = true },
-                        // script.<Initialize>();
+                        // script.<Initialize>().GetAwaiter().GetResult();
                         new BoundExpressionStatement(
                             syntax,
-                            new BoundCall(
+                            CreateParameterlessCall(
                                 syntax,
-                                scriptLocal,
-                                initializer,
-                                ImmutableArray<BoundExpression>.Empty,
-                                default(ImmutableArray<string>),
-                                default(ImmutableArray<RefKind>),
-                                isDelegateCall: false,
-                                expanded: false,
-                                invokedAsExtensionMethod: false,
-                                argsToParamsOpt: default(ImmutableArray<int>),
-                                resultKind: LookupResultKind.Viable,
-                                type: initializer.ReturnType)
-                            { WasCompilerGenerated = true })
+                                CreateParameterlessCall(
+                                    syntax,
+                                    CreateParameterlessCall(
+                                        syntax,
+                                        scriptLocal,
+                                        initializer),
+                                    _getAwaiterMethod),
+                                _getResultMethod))
                         { WasCompilerGenerated = true },
                         // return;
                         new BoundReturnStatement(
@@ -357,6 +417,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 base(containingType, returnType)
             {
                 Debug.Assert(containingType.IsSubmissionClass);
+                Debug.Assert(returnType.SpecialType != SpecialType.System_Void);
                 _parameters = ImmutableArray.Create<ParameterSymbol>(new SynthesizedParameterSymbol(this, submissionArrayType, 0, RefKind.None, "submissionArray"));
             }
 
@@ -416,20 +477,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 { WasCompilerGenerated = true };
 
                 // return submission.<Initialize>();
-                var initializeResult = new BoundCall(
+                var initializeResult = CreateParameterlessCall(
                     syntax,
                     submissionLocal,
-                    initializer,
-                    ImmutableArray<BoundExpression>.Empty,
-                    default(ImmutableArray<string>),
-                    default(ImmutableArray<RefKind>),
-                    isDelegateCall: false,
-                    expanded: false,
-                    invokedAsExtensionMethod: false,
-                    argsToParamsOpt: default(ImmutableArray<int>),
-                    resultKind: LookupResultKind.Viable,
-                    type: initializer.ReturnType)
-                { WasCompilerGenerated = true };
+                    initializer);
                 Debug.Assert(initializeResult.Type == _returnType);
                 var returnStatement = new BoundReturnStatement(
                     syntax,

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -230,23 +230,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             out TypeSymbol resultType,
             out TypeSymbol returnType)
         {
-            var submissionReturnType = compilation.SubmissionReturnType;
-            if (submissionReturnType == null)
+            var submissionReturnType = compilation.SubmissionReturnType ?? typeof(object);
+            var taskT = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+            var useSiteDiagnostic = taskT.GetUseSiteDiagnostic();
+            if (useSiteDiagnostic != null)
             {
-                resultType = null;
-                returnType = compilation.GetSpecialType(SpecialType.System_Void);
+                diagnostics.Add(useSiteDiagnostic, NoLocation.Singleton);
             }
-            else
-            {
-                var taskT = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
-                var useSiteDiagnostic = taskT.GetUseSiteDiagnostic();
-                if (useSiteDiagnostic != null)
-                {
-                    diagnostics.Add(useSiteDiagnostic, NoLocation.Singleton);
-                }
-                resultType = compilation.GetTypeByReflectionType(submissionReturnType, diagnostics);
-                returnType = taskT.Construct(resultType);
-            }
+            resultType = compilation.GetTypeByReflectionType(submissionReturnType, diagnostics);
+            returnType = taskT.Construct(resultType);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -3,12 +3,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -815,7 +811,9 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "dynamic").WithArguments("System.Runtime.CompilerServices.DynamicAttribute"));
         }
 
-        private static readonly string s_noCS1980String = @"
+        private static string GetNoCS1980String(string typeName)
+        {
+            const string noCS1980String = @"
 [Attr(typeof(%TYPENAME%))]            // No CS1980
 public class Gen<T>
 {
@@ -835,9 +833,7 @@ class Attr: System.Attribute
   public Attr(object x) {}
 }
 ";
-        private static string GetNoCS1980String(string typeName)
-        {
-            return s_noCS1980String.Replace("%TYPENAME%", typeName);
+            return noCS1980String.Replace("%TYPENAME%", typeName);
         }
 
         [Fact]
@@ -856,7 +852,7 @@ class Attr: System.Attribute
         private void TestNoCS1980WhenNotInContextWhichNeedsDynamicAttributeHelper(CSharpParseOptions parseOptions)
         {
             var source = GetNoCS1980String(typeName: @"dynamic");
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: parseOptions);
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: parseOptions);
             comp.VerifyDiagnostics(
                 // (4,7): error CS1962: The typeof operator cannot be used on the dynamic type
                 // [Attr(typeof(dynamic))]            // No CS1980
@@ -917,7 +913,7 @@ public class Gen2<T> : X    // CS1980
     set {}
   }
 }";
-            comp = CreateCompilationWithMscorlib(source2, parseOptions: parseOptions);
+            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
             comp.VerifyDiagnostics(
                 // (21,24): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
                 // public class Gen2<T> : X    // CS1980
@@ -955,19 +951,19 @@ public class Gen2<T> : X    // CS1980
         private void TestDynamicAttributeForSubmissionFieldHelper(CSharpParseOptions parseOptions)
         {
             string source = GetNoCS1980String(typeName: @"Gen<dynamic>");
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: parseOptions);
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: parseOptions);
             comp.VerifyDiagnostics();
 
             // Dynamic type field
             string source2 = @"
 dynamic x = 0;";
-            comp = CreateCompilationWithMscorlibAndSystemCore(source2, parseOptions: parseOptions);
+            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions, references: new[] { SystemCoreRef });
             comp.VerifyDiagnostics();
             var implicitField = comp.ScriptClass.GetMember<FieldSymbol>("x");
             DynamicAttributeValidator.ValidateDynamicAttribute(implicitField, comp, expectedDynamicAttribute: true);
 
             // No reference to System.Core, generates CS1980
-            comp = CreateCompilationWithMscorlib(source2, parseOptions: parseOptions);
+            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
             comp.VerifyDiagnostics(
                 // (2,1): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
                 // dynamic x = 0;
@@ -977,14 +973,14 @@ dynamic x = 0;";
             // Field type is constructed generic type with dynamic type argument
             source2 = source + @"
 Gen<dynamic> x = null;";
-            comp = CreateCompilationWithMscorlibAndSystemCore(source2, parseOptions: parseOptions);
+            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions, references: new[] { SystemCoreRef });
             comp.VerifyDiagnostics();
             implicitField = comp.ScriptClass.GetMember<FieldSymbol>("x");
             var expectedTransformsFlags = new bool[] { false, true };
             DynamicAttributeValidator.ValidateDynamicAttribute(implicitField, comp, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformsFlags);
 
             // No reference to System.Core, generates CS1980
-            comp = CreateCompilationWithMscorlib(source2, parseOptions: parseOptions);
+            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
             comp.VerifyDiagnostics(
                 // (20,5): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
                 // Gen<dynamic> x = null;
@@ -995,13 +991,13 @@ Gen<dynamic> x = null;";
             string aliasDecl = @"using X = Gen<dynamic>;     // No CS1980";
             source2 = aliasDecl + source + @"
 X x = null;";
-            comp = CreateCompilationWithMscorlibAndSystemCore(source2, parseOptions: parseOptions);
+            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions, references: new[] { SystemCoreRef });
             comp.VerifyDiagnostics();
             implicitField = comp.ScriptClass.GetMember<FieldSymbol>("x");
             DynamicAttributeValidator.ValidateDynamicAttribute(implicitField, comp, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformsFlags);
 
             // No reference to System.Core, generates CS1980
-            comp = CreateCompilationWithMscorlib(source2, parseOptions: parseOptions);
+            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
             comp.VerifyDiagnostics(
                 // (20,1): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
                 // X x = null;
@@ -1027,7 +1023,7 @@ X x = null;";
 System.Console.WriteLine(typeof(dynamic));
 System.Console.WriteLine(typeof(Gen<dynamic>));
 System.Console.WriteLine(typeof(X));";
-            var comp = CreateCompilationWithMscorlib(source2, parseOptions: parseOptions);
+            var comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
             comp.VerifyDiagnostics(
                 // (20,26): error CS1962: The typeof operator cannot be used on the dynamic type
                 // System.Console.WriteLine(typeof(dynamic));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -7198,9 +7198,10 @@ dynamic x = Color.F((dynamic)1);
             var verifier = CompileAndVerify(script);
             verifier.VerifyIL("<<Initialize>>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
 @"{
-  // Code size      158 (0x9e)
+  // Code size      161 (0xa1)
   .maxstack  10
-  .locals init (System.Exception V_0)
+  .locals init (object V_0,
+                System.Exception V_1)
   .try
   {
     IL_0000:  ldarg.0
@@ -7239,27 +7240,30 @@ dynamic x = Color.F((dynamic)1);
     IL_0062:  box        ""int""
     IL_0067:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, Color, object)""
     IL_006c:  stfld      ""dynamic Script.x""
-    IL_0071:  leave.s    IL_008a
+    IL_0071:  ldnull
+    IL_0072:  stloc.0
+    IL_0073:  leave.s    IL_008c
   }
   catch System.Exception
   {
-    IL_0073:  stloc.0
-    IL_0074:  ldarg.0
-    IL_0075:  ldc.i4.s   -2
-    IL_0077:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
-    IL_007c:  ldarg.0
-    IL_007d:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Script.<<Initialize>>d__0.<>t__builder""
-    IL_0082:  ldloc.0
-    IL_0083:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_0088:  leave.s    IL_009d
+    IL_0075:  stloc.1
+    IL_0076:  ldarg.0
+    IL_0077:  ldc.i4.s   -2
+    IL_0079:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
+    IL_007e:  ldarg.0
+    IL_007f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> Script.<<Initialize>>d__0.<>t__builder""
+    IL_0084:  ldloc.1
+    IL_0085:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_008a:  leave.s    IL_00a0
   }
-  IL_008a:  ldarg.0
-  IL_008b:  ldc.i4.s   -2
-  IL_008d:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
-  IL_0092:  ldarg.0
-  IL_0093:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Script.<<Initialize>>d__0.<>t__builder""
-  IL_0098:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_009d:  ret
+  IL_008c:  ldarg.0
+  IL_008d:  ldc.i4.s   -2
+  IL_008f:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
+  IL_0094:  ldarg.0
+  IL_0095:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> Script.<<Initialize>>d__0.<>t__builder""
+  IL_009a:  ldloc.0
+  IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_00a0:  ret
 }", realIL: true);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
@@ -20,11 +20,10 @@ Console.WriteLine(o.ToString());
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CSharpCompilation.Create(
-                    assemblyName: "Test",
+                CreateCompilationWithMscorlib45(
+                    new[] { tree },
                     options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef },
-                    syntaxTrees: new[] { tree }),
+                    references: new[] { SystemCoreRef }),
                 expectedOutput: "{ a = 1 }"
             );
         }
@@ -40,11 +39,10 @@ Console.WriteLine(o.ToString());
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CSharpCompilation.Create(
-                    assemblyName: "Test",
+                CreateCompilationWithMscorlib45(
+                    new[] { tree },
                     options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef },
-                    syntaxTrees: new[] { tree }),
+                    references: new[] { SystemCoreRef }),
                 expectedOutput: "{ a = 1 }"
             );
         }
@@ -59,11 +57,10 @@ Console.WriteLine(new { a = 1 }.ToString());
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CSharpCompilation.Create(
-                    assemblyName: "Test",
+                CreateCompilationWithMscorlib45(
+                    new[] { tree },
                     options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef },
-                    syntaxTrees: new[] { tree }),
+                    references: new[] { SystemCoreRef }),
                 expectedOutput: "{ a = 1 }"
             );
         }
@@ -86,11 +83,10 @@ new CLS().M();
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             CompileAndVerify(
-                CSharpCompilation.Create(
-                    assemblyName: "Test",
+                CreateCompilationWithMscorlib45(
+                    new[] { tree },
                     options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                    references: new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef },
-                    syntaxTrees: new[] { tree }),
+                    references: new[] { SystemCoreRef }),
                 expectedOutput: "{ a = 1 }"
             );
         }
@@ -111,11 +107,9 @@ new CLS().M();
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
-            var compilation = CSharpCompilation.Create(
-                                assemblyName: "Test",
-                                options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                                references: new[] { MscorlibRef },
-                                syntaxTrees: new[] { tree });
+            var compilation = CreateCompilationWithMscorlib45(
+                new[] { tree },
+                options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             compilation.VerifyDiagnostics(
                 // (5,30): error CS1736: Default parameter value for 'p' must be a compile-time constant
@@ -138,11 +132,9 @@ M();
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
-            var compilation = CSharpCompilation.Create(
-                                assemblyName: "Test",
-                                options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                                references: new[] { MscorlibRef },
-                                syntaxTrees: new[] { tree });
+            var compilation = CreateCompilationWithMscorlib45(
+                new[] { tree },
+                options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             compilation.VerifyDiagnostics(
                 // (4,26): error CS1736: Default parameter value for 'p' must be a compile-time constant
@@ -171,11 +163,9 @@ M();
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
-            var compilation = CSharpCompilation.Create(
-                                assemblyName: "Test",
-                                options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                                references: new[] { MscorlibRef },
-                                syntaxTrees: new[] { tree });
+            var compilation = CreateCompilationWithMscorlib45(
+                new[] { tree },
+                options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             compilation.VerifyDiagnostics(
                 // (9,8): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
@@ -201,11 +191,9 @@ class CLS
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
-            var compilation = CSharpCompilation.Create(
-                                assemblyName: "Test",
-                                options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                                references: new[] { MscorlibRef },
-                                syntaxTrees: new[] { tree });
+            var compilation = CreateCompilationWithMscorlib45(
+                new[] { tree },
+                options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             compilation.VerifyDiagnostics(
                 // (9,8): error CS0836: Cannot use anonymous type in a constant expression

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -121,7 +119,7 @@ public class C
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib(
+            var compilation = CreateCompilationWithMscorlib45(
                 new[]
                 {
                     Parse(csx, options: TestOptions.Script),
@@ -768,7 +766,7 @@ class C
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib(
+            var compilation = CreateCompilationWithMscorlib45(
                 new[]
                 {
                     SyntaxFactory.ParseSyntaxTree(csx, options: TestOptions.Script),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitlyTypedLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitlyTypedLocalsTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -50,7 +48,7 @@ class C
             string text = @"
 var array = { 1, 2 };
 ";
-            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Script).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (2,5): error CS0820: Cannot initialize an implicitly-typed variable with an array initializer
                 // var array = { 1, 2 };
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedArrayInitializer, "array = { 1, 2 }"));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string test = @"
 this[1]
 ";
-            var compilation = CreateCompilationWithMscorlib(test, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlib45(test, parseOptions: TestOptions.Interactive);
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
 
@@ -53,7 +53,7 @@ this[1]
 
             var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Script);
 
-            var compilation = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree }, options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             compilation.VerifyDiagnostics(
                 // (1,13): warning CS7022: The entry point of the program is global script code; ignoring 'Main()' entry point.
@@ -76,7 +76,7 @@ this[1]
 
             var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Script);
 
-            var compilation = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree }, options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             compilation.VerifyDiagnostics(
                 // (1,13): warning CS7022: The entry point of the program is global script code; ignoring 'Main()' entry point.
@@ -230,10 +230,9 @@ delegate void G();
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
-            var compilation = CSharpCompilation.Create(
-                assemblyName: "Test",
-                options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                syntaxTrees: new[] { tree });
+            var compilation = CreateCompilationWithMscorlib45(
+                new[] { tree },
+                options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             var global = compilation.GlobalNamespace;
             ImmutableArray<NamedTypeSymbol> members;
@@ -273,11 +272,9 @@ WriteLine(""hello"");
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp6));
 
-            var compilation = CSharpCompilation.Create(
-                assemblyName: "Test",
-                options: TestOptions.ReleaseExe.WithScriptClassName("Script"),
-                syntaxTrees: new[] { tree },
-                references: new[] { MscorlibRef });
+            var compilation = CreateCompilationWithMscorlib45(
+                new[] { tree },
+                options: TestOptions.ReleaseExe.WithScriptClassName("Script"));
 
             var expr = (((tree.
                 GetCompilationUnitRoot() as CompilationUnitSyntax).
@@ -383,7 +380,7 @@ this[1]
 decimal d = checked(2M + 1M);
 ";
 
-            var compilation = CreateCompilationWithMscorlib(Parse(source, options: TestOptions.Script));
+            var compilation = CreateCompilationWithMscorlib45(new[] { Parse(source, options: TestOptions.Script) });
             compilation.VerifyDiagnostics();
         }
 
@@ -396,7 +393,7 @@ using System.IO;
 FileAccess fa = checked(FileAccess.Read + 1);
 ";
 
-            var compilation = CreateCompilationWithMscorlib(Parse(source, options: TestOptions.Script));
+            var compilation = CreateCompilationWithMscorlib45(new[] { Parse(source, options: TestOptions.Script) });
             compilation.VerifyDiagnostics();
         }
 
@@ -408,7 +405,7 @@ FileAccess fa = checked(FileAccess.Read + 1);
 System.Action a = null;
 a += null;
 ";
-            var compilation = CreateCompilationWithMscorlib(Parse(source, options: TestOptions.Script));
+            var compilation = CreateCompilationWithMscorlib45(new[] { Parse(source, options: TestOptions.Script) });
             compilation.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -1354,12 +1354,8 @@ class C
         this.foo();
     }
 }";
-
-            var comp = CSharpCompilation.Create(
-                "Test",
-                new[] { SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Script) },
-                new[] { MscorlibRef });
-
+            var comp = CreateCompilationWithMscorlib45(
+                new[] { SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Script) });
             comp.VerifyDiagnostics(
                 // (4,9): error CS0027: Keyword 'this' is not available in the current context
                 Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
@@ -10681,7 +10677,7 @@ class C
         [Fact]
         public void CS0670ERR_FieldCantHaveVoidType_Var()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 var x = default(void); 
 ", parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (2,17): error CS1547: Keyword 'void' cannot be used in this context
@@ -10835,7 +10831,7 @@ public class Test
         [Fact]
         public void CS0723ERR_VarDeclIsStaticClass_Fields()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 static class SC {} 
 
 var sc2 = new SC();
@@ -11065,7 +11061,7 @@ class Test
         [Fact]
         public void CS0815ERR_ImplicitlyTypedVariableAssignedBadValue_Field()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 static void M() {}
 
 var m = M;       
@@ -11115,7 +11111,7 @@ class A
         [Fact]
         public void CS0818ERR_ImplicitlyTypedVariableWithNoInitializer_Fields()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 var a; // CS0818
 ", parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (1,5): error CS0818: Implicitly-typed variables must be initialized
@@ -11150,7 +11146,7 @@ class A
         [Fact]
         public void CS0819ERR_ImplicitlyTypedVariableMultipleDeclarator_Fields()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 var foo = 4, bar = 4.5;
 ", parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (2,1): error CS0819: Implicitly-typed fields cannot have multiple declarators
@@ -11182,7 +11178,7 @@ class G
         [Fact]
         public void CS0820ERR_ImplicitlyTypedVariableAssignedArrayInitializer_Fields()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 var y = { 1, 2, 3 };
 ", parseOptions: TestOptions.Script).VerifyDiagnostics(
             // (1,5): error CS0820: Cannot initialize an implicitly-typed variable with an array initializer
@@ -11247,7 +11243,7 @@ Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableCannotBeConst, "const var y = (i
         [Fact]
         public void CS0822ERR_ImplicitlyTypedVariableCannotBeConst_Fields()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 const var x = 0; // CS0822.cs
 ", parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (2,7): error CS0822: Implicitly-typed variables cannot be constant
@@ -11257,20 +11253,20 @@ const var x = 0; // CS0822.cs
         [Fact]
         public void CS0825ERR_ImplicitlyTypedVariableCannotBeUsedAsTheTypeOfAParameter_Fields()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 void foo(var arg) { }
 var foo(int arg) { return 2; }
 ", parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (1,10): error CS0825: The contextual keyword 'var' may only appear within a local variable declaration or in script code
-                // (2,1): error CS0825: The contextual keyword 'var' may only appear within a local variable declaration or in script code
                 Diagnostic(ErrorCode.ERR_TypeVarNotFound, "var"),
+                // (2,1): error CS0825: The contextual keyword 'var' may only appear within a local variable declaration or in script code
                 Diagnostic(ErrorCode.ERR_TypeVarNotFound, "var"));
         }
 
         [Fact]
         public void CS0825ERR_ImplicitlyTypedVariableCannotBeUsedAsTheTypeOfAParameter_Fields2()
         {
-            CreateCompilationWithMscorlib(@"
+            CreateCompilationWithMscorlib45(@"
 T foo<T>() { return default(T); }
 foo<var>();
 ", parseOptions: TestOptions.Script).VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -2126,7 +2126,7 @@ switch (1)
     case 2:
         Console.WriteLine(2);
 }";
-            var compilation = CreateCompilationWithMscorlib(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script);
             compilation.VerifyDiagnostics(
                 // (4,5): error CS0163: Control cannot fall through from one case label ('default:') to another
                 //     default:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -7592,7 +7592,7 @@ unsafe class C
             var text = @"
 unsafe int* p = stackalloc int[1];
 ";
-            CreateCompilationWithMscorlib(text, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Script).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (4,14): error CS1525: Invalid expression term 'stackalloc'
                 //     int* p = stackalloc int[1];
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc"));

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -10,13 +10,10 @@ using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Threading;
-using System.Xml.Linq;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -1345,7 +1342,7 @@ class A
         public void GetEntryPoint_Script()
         {
             var source = @"System.Console.WriteLine(1);";
-            var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Script);
             compilation.VerifyDiagnostics();
 
             var scriptMethod = compilation.GetMember<MethodSymbol>("Script.<Main>");
@@ -1366,7 +1363,7 @@ class A
     static void Main() { }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script);
             compilation.VerifyDiagnostics(
                 // (4,17): warning CS7022: The entry point of the program is global script code; ignoring 'A.Main()' entry point.
                 //     static void Main() { }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
@@ -34,7 +34,6 @@ class C
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;"));
         }
 
-
         [WorkItem(865627, "DevDiv")]
         [Fact]
         public void TestUnusedExtensionMarksImportsAsUsed()
@@ -68,7 +67,6 @@ namespace ClassLibrary2
     }
 }";
             var classLib2 = CreateCompilationWithMscorlib(text: class2Source, assemblyName: "ClassLibrary2", references: new[] { SystemRef, SystemCoreRef, classLib1.ToMetadataReference() });
-
 
             string consoleApplicationSource = @"using ClassLibrary2;
 using ClassLibrary1;
@@ -140,7 +138,6 @@ class Program
                 // using System.Threading.Tasks;
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Threading.Tasks;")
                 );
-
 
             comp = comp.WithReferences(comp.References.Concat(SystemCoreRef));
             comp.VerifyDiagnostics(
@@ -372,7 +369,7 @@ using System;
         public void UnusedUsingScript()
         {
             var tree = Parse("using System;", options: TestOptions.Script);
-            var comp = CreateCompilationWithMscorlib(tree);
+            var comp = CreateCompilationWithMscorlib45(new[] { tree });
 
             comp.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -10,38 +10,41 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class LoadDirectiveTests : CSharpTestBase
     {
         [Fact]
-        void EmptyFile()
+        public void EmptyFile()
         {
             var code = "#load \"\"";
-            var compilation = CreateCompilation(code);
-                
+            var options = TestOptions.DebugDll.WithSourceReferenceResolver(TestSourceReferenceResolver.Default);
+            var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Interactive);
+
             Assert.Single(compilation.SyntaxTrees);
-            compilation.GetDiagnostics().Verify(
+            compilation.VerifyDiagnostics(
                 // error CS1504: Source file '' could not be opened -- Could not find file.
                 Diagnostic(ErrorCode.ERR_NoSourceFile, "\"\"").WithArguments("", CSharpResources.CouldNotFindFile).WithLocation(1, 7));
         }
 
         [Fact]
-        void MissingFile()
+        public void MissingFile()
         {
             var code = "#load \"missing\"";
-            var compilation = CreateCompilation(code);
-                
+            var options = TestOptions.DebugDll.WithSourceReferenceResolver(TestSourceReferenceResolver.Default);
+            var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Interactive);
+
             Assert.Single(compilation.SyntaxTrees);
-            compilation.GetDiagnostics().Verify(
+            compilation.VerifyDiagnostics(
                 // error CS1504: Source file 'missing' could not be opened -- Could not find file.
                 Diagnostic(ErrorCode.ERR_NoSourceFile, "\"missing\"").WithArguments("missing", CSharpResources.CouldNotFindFile).WithLocation(1, 7));
         }
 
         [Fact]
-        void FileWithErrors()
+        public void FileWithErrors()
         {
             var code = "#load \"a.csx\"";
             var resolver = CreateResolver(
                 Script("a.csx", @"
                     #load ""b.csx""
                     asdf();"));
-            var compilation = CreateCompilation(code, resolver);
+            var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
+            var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Script);
 
             Assert.Equal(2, compilation.SyntaxTrees.Length);
             compilation.GetParseDiagnostics().Verify(
@@ -58,25 +61,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        void NoSourceReferenceResolver()
+        public void NoSourceReferenceResolver()
         {
             var code = "#load \"test\"";
-            var compilation = CreateCompilationWithMscorlib(code, parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(code, parseOptions: TestOptions.Script);
 
             Assert.Single(compilation.SyntaxTrees);
-            compilation.GetDiagnostics().Verify(
+            compilation.VerifyDiagnostics(
                 // (1,1): error CS8099: Source file references are not supported.
                 // #load "test"
                 Diagnostic(ErrorCode.ERR_SourceFileReferencesNotSupported, @"#load ""test""").WithLocation(1, 1));
-        }
-
-        private static CSharpCompilation CreateCompilation(string code, SourceReferenceResolver sourceReferenceResolver = null)
-        {
-            var options = new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                sourceReferenceResolver: sourceReferenceResolver ?? TestSourceReferenceResolver.Default);
-            var parseOptions = new CSharpParseOptions(kind: SourceCodeKind.Interactive);
-            return CreateCompilationWithMscorlib(code, options: options, parseOptions: parseOptions);
         }
 
         private static SourceReferenceResolver CreateResolver(params KeyValuePair<string, string>[] scripts)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -867,7 +867,7 @@ public class E : bar::C { }
                     t2 = Parse($"#r \"{p3}\"", options: TestOptions.Script),
                     t3 = Parse("#r \"Lib\"", options: TestOptions.Script),
                 },
-                references: new MetadataReference[] { MscorlibRef, r1, r2 },
+                references: new MetadataReference[] { MscorlibRef_v4_0_30316_17626, r1, r2 },
                 options: TestOptions.ReleaseDll.WithMetadataReferenceResolver(
                     new TestMetadataReferenceResolver(
                         assemblyNames: new Dictionary<string, PortableExecutableReference> { { "Lib", r3 } },
@@ -879,7 +879,7 @@ public class E : bar::C { }
 
             var refs = compilation.ExternalReferences;
             Assert.Equal(3, refs.Length);
-            Assert.Equal(MscorlibRef, refs[0]);
+            Assert.Equal(MscorlibRef_v4_0_30316_17626, refs[0]);
             Assert.Equal(r1, refs[1]);
             Assert.Equal(r2, refs[2]);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
@@ -2684,9 +2684,8 @@ System.Diagnostics.Process.GetCurrentProcess();
 ", options: TestOptions.Script)
             };
 
-            var compilation = CSharpCompilation.Create("foo",
-                syntaxTrees: trees,
-                references: new[] { MscorlibRef },
+            var compilation = CreateCompilationWithMscorlib45(
+                trees,
                 options: TestOptions.ReleaseDll.WithMetadataReferenceResolver(new Resolver(data, core, system)));
 
             compilation.VerifyDiagnostics();
@@ -2721,9 +2720,8 @@ System.Diagnostics.Process.GetCurrentProcess();
 ")
                 };
 
-            var compilation = CSharpCompilation.Create("foo",
-                syntaxTrees: trees,
-                references: new[] { MscorlibRef },
+            var compilation = CreateCompilationWithMscorlib45(
+                trees,
                 options: TestOptions.ReleaseDll.WithMetadataReferenceResolver(new Resolver(data, core, system)));
 
             compilation.VerifyDiagnostics(
@@ -2768,11 +2766,8 @@ System.Diagnostics.Process.GetCurrentProcess();
 #r """ + csInterfaces01 + @"""
 class C : Metadata.ICSPropImpl { }";
 
-            var compilation = CSharpCompilation.Create("foo",
-                syntaxTrees: new[]
-                    {
-                        Parse(source, options: TestOptions.Script)
-                    },
+            var compilation = CreateCompilationWithMscorlib45(
+                new[] { Parse(source, options: TestOptions.Script) },
                 options: TestOptions.ReleaseDll.WithMetadataReferenceResolver(new DummyReferenceResolver(csClasses01)));
 
             compilation.VerifyDiagnostics();
@@ -2781,10 +2776,9 @@ class C : Metadata.ICSPropImpl { }";
         [Fact]
         public void CompilationWithReferenceDirective_NoResolver()
         {
-            var compilation = CSharpCompilation.Create("foo",
+            var compilation = CreateCompilationWithMscorlib45(
                 new[] { SyntaxFactory.ParseSyntaxTree(@"#r ""bar""", TestOptions.Script, "a.csx", Encoding.UTF8) },
-                new[] { MscorlibRef },
-                TestOptions.ReleaseDll.WithMetadataReferenceResolver(null));
+                options: TestOptions.ReleaseDll.WithMetadataReferenceResolver(null));
 
             compilation.VerifyDiagnostics(
                 // a.csx(1,1): error CS7099: Metadata references not supported.
@@ -2809,11 +2803,9 @@ class C
 ")
             };
 
-            var compilation = CSharpCompilation.Create(
-                "foo",
-                options: TestOptions.ReleaseDll.WithUsings(ImmutableArray.Create("System.Console", "System")),
-                syntaxTrees: trees,
-                references: new[] { MscorlibRef });
+            var compilation = CreateCompilationWithMscorlib45(
+                trees,
+                options: TestOptions.ReleaseDll.WithUsings(ImmutableArray.Create("System.Console", "System")));
 
             var diagnostics = compilation.GetDiagnostics().ToArray();
 
@@ -2833,11 +2825,9 @@ Console.WriteLine(2);
 ", options: TestOptions.Script)
             };
 
-            var compilation = CSharpCompilation.Create(
-                "foo",
-                options: TestOptions.ReleaseDll.WithUsings("System.Console!", "Blah"),
-                syntaxTrees: trees,
-                references: new[] { MscorlibRef });
+            var compilation = CreateCompilationWithMscorlib45(
+                trees,
+                options: TestOptions.ReleaseDll.WithUsings("System.Console!", "Blah"));
 
             compilation.VerifyDiagnostics(
                 // error CS0234: The type or namespace name 'Console!' does not exist in the namespace 'System' (are you missing an assembly reference?)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -3682,7 +3682,7 @@ class C
 }
 var o = new object();
 o.F();";
-            var compilation = CreateCompilationWithMscorlib(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script);
+            var compilation = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script);
             compilation.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -58,7 +57,7 @@ void Foo()
         [Fact, WorkItem(531535, "DevDiv")]
         public void Events()
         {
-            var c = CreateCompilationWithMscorlib(@"
+            var c = CreateCompilationWithMscorlib45(@"
 event System.Action e;
 ", parseOptions: TestOptions.Script);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExternAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExternAliasTests.cs
@@ -93,7 +93,7 @@ class Maine
 extern alias Bar;
 Bar::NS.Foo d = new Bar::NS.Foo();
 ";
-            var comp = CreateCompilationWithMscorlib(src, options: new CSharpCompilationOptions(OutputKind.ConsoleApplication), parseOptions: TestOptions.Script);
+            var comp = CreateCompilationWithMscorlib45(src, options: new CSharpCompilationOptions(OutputKind.ConsoleApplication), parseOptions: TestOptions.Script);
             comp = comp.AddReferences(Foo1, Foo2);
             comp.VerifyDiagnostics();
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
 using Xunit;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -106,7 +103,7 @@ static void M12() { }
 ";
             foreach (var options in new[] { TestOptions.Script, TestOptions.Interactive })
             {
-                var comp = CreateCompilationWithMscorlib(text, parseOptions: options);
+                var comp = CreateCompilationWithMscorlib45(text, parseOptions: options);
                 var script = comp.ScriptClass;
                 var m1 = script.GetMembers("M1").Single() as MethodSymbol;
                 Assert.Equal(Accessibility.Private, m1.DeclaredAccessibility);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -15627,8 +15627,8 @@ namespace N1
                 Diagnostic(ErrorCode.ERR_NamespaceNotAllowedInScript, "namespace").WithLocation(2, 1)
             };
 
-            CreateCompilationWithMscorlib(Parse(text, options: TestOptions.Script)).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilationWithMscorlib(Parse(text, options: TestOptions.Interactive)).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilationWithMscorlib45(new[] { Parse(text, options: TestOptions.Script) }).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilationWithMscorlib45(new[] { Parse(text, options: TestOptions.Interactive) }).VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -2772,7 +2772,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim syntaxRef = SyntaxReferences.Single()
                 Dim scriptInitializer = New SynthesizedInteractiveInitializerMethod(syntaxRef, Me, diagnostics)
                 AddSymbolToMembers(scriptInitializer, members.Members)
-                Dim scriptEntryPoint = SynthesizedEntryPointSymbol.Create(Me, scriptInitializer.ReturnType, diagnostics)
+                Dim scriptEntryPoint = SynthesizedEntryPointSymbol.Create(scriptInitializer, diagnostics)
                 AddSymbolToMembers(scriptEntryPoint, members.Members)
             End If
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
@@ -59,19 +59,16 @@ System.Console.WriteLine(1+1)
                 Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "System.Console.WriteLine(1+1)"))
         End Sub
 
-
         <Fact>
         Public Sub ReturnStatement()
             Dim source = <text>
-Return Foo
+Return 1
 </text>.Value
 
             Dim tree = VisualBasicSyntaxTree.ParseText(source, options:=TestOptions.Script)
-            Dim c = VisualBasicCompilation.Create("Test", {tree}, LatestVbReferences)
+            Dim c = CreateCompilationWithMscorlib45({tree})
 
-            c.VerifyDiagnostics(
-                Diagnostic(ERRID.ERR_ReturnFromNonFunction, "Return Foo").WithLocation(2, 1),
-                Diagnostic(ERRID.ERR_NameNotDeclared1, "Foo").WithArguments("Foo").WithLocation(2, 8))
+            c.VerifyDiagnostics()
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
@@ -285,6 +285,122 @@ Imports Unknown
             submission.GetDiagnostics().AssertTheseDiagnostics(expectedErrors)
         End Sub
 
+        ''' <summary>
+        ''' The script entry point should complete synchronously.
+        ''' </summary>
+        <WorkItem(4495)>
+        <Fact>
+        Public Sub ScriptEntryPoint()
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(
+                <compilation>
+                    <file name="a.vbx"><![CDATA[
+System.Threading.Tasks.Task.Delay(100)
+System.Console.Write("complete")
+]]></file>
+                </compilation>,
+                parseOptions:=TestOptions.Script,
+                options:=TestOptions.DebugExe,
+                additionalRefs:={SystemCoreRef})
+            Dim verifier = CompileAndVerify(comp, expectedOutput:="complete")
+            Dim methodData = verifier.TestData.GetMethodData("Script.<Initialize>")
+            Assert.Equal("System.Threading.Tasks.Task(Of Object)", methodData.Method.ReturnType.ToDisplayString())
+            methodData.VerifyIL(
+"{
+  // Code size       57 (0x39)
+  .maxstack  2
+  .locals init (Script.VB$StateMachine_1_<Initialize> V_0)
+  IL_0000:  newobj     ""Sub Script.VB$StateMachine_1_<Initialize>..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  stfld      ""Script.VB$StateMachine_1_<Initialize>.$VB$Me As Script""
+  IL_000d:  ldloc.0
+  IL_000e:  ldc.i4.m1
+  IL_000f:  stfld      ""Script.VB$StateMachine_1_<Initialize>.$State As Integer""
+  IL_0014:  ldloc.0
+  IL_0015:  call       ""Function System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).Create() As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_001a:  stfld      ""Script.VB$StateMachine_1_<Initialize>.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_001f:  ldloc.0
+  IL_0020:  ldflda     ""Script.VB$StateMachine_1_<Initialize>.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).Start(Of Script.VB$StateMachine_1_<Initialize>)(ByRef Script.VB$StateMachine_1_<Initialize>)""
+  IL_002c:  nop
+  IL_002d:  ldloc.0
+  IL_002e:  ldflda     ""Script.VB$StateMachine_1_<Initialize>.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_0033:  call       ""Function System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).get_Task() As System.Threading.Tasks.Task(Of Object)""
+  IL_0038:  ret
+}")
+            methodData = verifier.TestData.GetMethodData("Script.<Main>")
+            Assert.True(methodData.Method.ReturnsVoid)
+            methodData.VerifyIL(
+"{
+  // Code size       24 (0x18)
+  .maxstack  1
+  .locals init (System.Runtime.CompilerServices.TaskAwaiter V_0)
+  IL_0000:  newobj     ""Sub Script..ctor()""
+  IL_0005:  callvirt   ""Function Script.<Initialize>() As System.Threading.Tasks.Task(Of Object)""
+  IL_000a:  callvirt   ""Function System.Threading.Tasks.Task.GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter""
+  IL_000f:  stloc.0
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  call       ""Sub System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+  IL_0017:  ret
+}")
+        End Sub
+
+        <Fact>
+        Public Sub InteractiveEntryPoint()
+            Dim parseOptions = TestOptions.Interactive
+            Dim references = {MscorlibRef_v4_0_30316_17626, SystemCoreRef, MsvbRef}
+            Dim source0 = <![CDATA[
+System.Threading.Tasks.Task.Delay(100)
+System.Console.Write("complete")
+]]>
+            Dim s0 = VisualBasicCompilation.CreateSubmission(
+                "s0.dll",
+                syntaxTree:=Parse(source0.Value, parseOptions),
+                references:=references)
+            Dim verifier = CompileAndVerify(s0, verify:=False)
+            Dim methodData = verifier.TestData.GetMethodData("Script.<Initialize>")
+            Assert.Equal("System.Threading.Tasks.Task(Of Object)", methodData.Method.ReturnType.ToDisplayString())
+            methodData.VerifyIL(
+"{
+  // Code size       57 (0x39)
+  .maxstack  2
+  .locals init (Script.VB$StateMachine_1_<Initialize> V_0)
+  IL_0000:  newobj     ""Sub Script.VB$StateMachine_1_<Initialize>..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  stfld      ""Script.VB$StateMachine_1_<Initialize>.$VB$Me As Script""
+  IL_000d:  ldloc.0
+  IL_000e:  ldc.i4.m1
+  IL_000f:  stfld      ""Script.VB$StateMachine_1_<Initialize>.$State As Integer""
+  IL_0014:  ldloc.0
+  IL_0015:  call       ""Function System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).Create() As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_001a:  stfld      ""Script.VB$StateMachine_1_<Initialize>.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_001f:  ldloc.0
+  IL_0020:  ldflda     ""Script.VB$StateMachine_1_<Initialize>.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).Start(Of Script.VB$StateMachine_1_<Initialize>)(ByRef Script.VB$StateMachine_1_<Initialize>)""
+  IL_002c:  nop
+  IL_002d:  ldloc.0
+  IL_002e:  ldflda     ""Script.VB$StateMachine_1_<Initialize>.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object)""
+  IL_0033:  call       ""Function System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Object).get_Task() As System.Threading.Tasks.Task(Of Object)""
+  IL_0038:  ret
+}")
+            methodData = verifier.TestData.GetMethodData("Script.<Factory>")
+            Assert.Equal("System.Threading.Tasks.Task(Of Object)", methodData.Method.ReturnType.ToDisplayString())
+            methodData.VerifyIL(
+"{
+  // Code size       12 (0xc)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  newobj     ""Sub Script..ctor(Object())""
+  IL_0006:  callvirt   ""Function Script.<Initialize>() As System.Threading.Tasks.Task(Of Object)""
+  IL_000b:  ret
+}")
+        End Sub
+
     End Class
 End Namespace
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -1288,7 +1288,7 @@ End Class
         <Fact()>
         Public Sub GetEntryPoint_Script()
             Dim source = <![CDATA[System.Console.WriteLine(1)]]>
-            Dim compilation = CreateCompilationWithMscorlib({VisualBasicSyntaxTree.ParseText(source.Value, options:=TestOptions.Script)}, options:=TestOptions.ReleaseDll)
+            Dim compilation = CreateCompilationWithMscorlib45({VisualBasicSyntaxTree.ParseText(source.Value, options:=TestOptions.Script)}, options:=TestOptions.ReleaseDll)
             compilation.VerifyDiagnostics()
 
             Dim scriptMethod = compilation.GetMember("Script.<Main>")
@@ -1308,7 +1308,7 @@ End Class
         End Sub
     End Class
     ]]>
-            Dim compilation = CreateCompilationWithMscorlib({VisualBasicSyntaxTree.ParseText(source.Value, options:=TestOptions.Script)}, options:=TestOptions.ReleaseDll)
+            Dim compilation = CreateCompilationWithMscorlib45({VisualBasicSyntaxTree.ParseText(source.Value, options:=TestOptions.Script)}, options:=TestOptions.ReleaseDll)
             compilation.VerifyDiagnostics(Diagnostic(ERRID.WRN_MainIgnored, "Main").WithArguments("Public Shared Sub Main()").WithLocation(3, 20))
 
             Dim scriptMethod = compilation.GetMember("Script.<Main>")

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
@@ -1,12 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
@@ -311,7 +306,7 @@ Imports System
         <Fact()>
         Public Sub UnusedImportScript()
             Dim tree = Parse("Imports System", options:=TestOptions.Script)
-            Dim compilation = CreateCompilationWithMscorlib(tree)
+            Dim compilation = CreateCompilationWithMscorlib45({tree})
             compilation.AssertTheseDiagnostics(
                 <errors>
 BC50001: Unused import statement.

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -2463,6 +2463,7 @@ End Function
 Dim o As New Object()
 ? o.F()]]>
             Dim source1 = <![CDATA[
+Imports System.Runtime.CompilerServices
 <Extension>
 Shared Function G(o As Object) As Object
     Return 1
@@ -2477,7 +2478,7 @@ Dim o As New Object()
             Assert.True(s0.SourceAssembly.MightContainExtensionMethods)
             Dim s1 = VisualBasicCompilation.CreateSubmission(
                 "s1.dll",
-                syntaxTree:=Parse(source0.Value, parseOptions),
+                syntaxTree:=Parse(source1.Value, parseOptions),
                 previousSubmission:=s0,
                 references:=references)
             s1.VerifyDiagnostics()

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -2433,19 +2433,16 @@ End Module
 
         <Fact>
         Public Sub ScriptExtensionMethods()
-            Dim comp = CreateCompilationWithMscorlib(
-                <compilation>
-                    <file name="a.vbx"><![CDATA[
+            Dim source = <![CDATA[
 Imports System.Runtime.CompilerServices
 <Extension>
 Shared Function F(o As Object) As Object
     Return Nothing
 End Function
 Dim o As New Object()
-o.F()]]></file>
-                </compilation>,
-                parseOptions:=TestOptions.Script,
-                references:={MscorlibRef, SystemCoreRef})
+o.F()]]>
+            Dim comp = CreateCompilationWithMscorlib45(
+                {VisualBasicSyntaxTree.ParseText(source.Value, TestOptions.Script)})
             comp.VerifyDiagnostics()
             Assert.True(comp.SourceAssembly.MightContainExtensionMethods)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -23675,15 +23675,13 @@ Imports GlobEnumsClass
 
         <Fact>
         Public Sub MustOverrideInScript()
-            Dim comp = CreateCompilationWithMscorlib(
-                <compilation>
-                    <file name="a.vbx"><![CDATA[
+            Dim source = <![CDATA[
 Friend MustOverride Function F() As Object
 Friend MustOverride ReadOnly Property P
-]]></file>
-                </compilation>,
-                parseOptions:=TestOptions.Script,
-                references:={MscorlibRef, SystemCoreRef})
+]]>
+            Dim comp = CreateCompilationWithMscorlib45(
+                {VisualBasicSyntaxTree.ParseText(source.Value, TestOptions.Script)},
+                references:={SystemCoreRef})
             comp.AssertTheseDiagnostics(<expected>
 BC30607: 'NotInheritable' classes cannot have members declared 'MustOverride'.
 Friend MustOverride Function F() As Object


### PR DESCRIPTION
```Script.<Main>``` is now defined as ```(new Script()).<Initialize>().GetAwaiter().GetResult();```