### PR TITLE
Final set of spelling corrections in strings and comments.

### DIFF
--- a/src/Compilers/Core/Portable/FileSystem/RelativePathResolver.cs
+++ b/src/Compilers/Core/Portable/FileSystem/RelativePathResolver.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#pragma warning disable 436 // The type 'RelativePathResolver' comflicts with imported type
+#pragma warning disable 436 // The type 'RelativePathResolver' conflicts with imported type
 
 using System;
 using System.Collections.Immutable;

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/DocumentMap.cs
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/DocumentMap.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         private readonly MetadataReader _reader;
 
-        // { last part of document name -> one or many document handles that have the part in commmon }
+        // { last part of document name -> one or many document handles that have the part in common }
         private readonly IReadOnlyDictionary<string, KeyValuePair<DocumentNameAndHandle, ImmutableArray<DocumentNameAndHandle>>> _map;
 
         public DocumentMap(MetadataReader reader)

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/SymDocument.cs
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/SymDocument.cs
@@ -30,14 +30,14 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         public int FindClosestLine(int line, out int closestLine)
         {
-            // Find a minimal sequence point start line in this docuemnt 
+            // Find a minimal sequence point start line in this document 
             // that is greater than or equal to the given line.
 
             int result = int.MaxValue;
             var map = SymReader.GetMethodMap();
             var mdReader = SymReader.MetadataReader;
 
-            // Note DiaSymReader searches accross all documents with the same file name in CDiaWrapper::FindClosestLineAcrossFileIDs. We don't.
+            // Note DiaSymReader searches across all documents with the same file name in CDiaWrapper::FindClosestLineAcrossFileIDs. We don't.
             foreach (var extent in map.EnumerateContainingOrClosestFollowingMethodExtents(Handle, line))
             {
                 Debug.Assert(extent.MaxLine >= line);

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/SymMethod.cs
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/SymMethod.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
         public int GetNamespace([MarshalAs(UnmanagedType.Interface)]out ISymUnmanagedNamespace @namespace)
         {
-            // SymReader doesn't support namspaces
+            // SymReader doesn't support namespaces
             @namespace = null;
             return HResult.E_NOTIMPL;
         }
@@ -82,7 +82,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
                 return HResult.E_INVALIDARG;
             }
 
-            // DiaSymReader uses DiaSession::findLinesByLinenum, which results in bad results for lines shared accross multiple methods
+            // DiaSymReader uses DiaSession::findLinesByLinenum, which results in bad results for lines shared across multiple methods
             // and for lines outside of the current method.
 
             var spReader = GetSequencePointsReader();
@@ -139,7 +139,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
                 return HResult.E_INVALIDARG;
             }
 
-            // DiaSymReader uses DiaSession::findLinesByLinenum, which results in bad results for lines shared accross multiple methods.
+            // DiaSymReader uses DiaSession::findLinesByLinenum, which results in bad results for lines shared across multiple methods.
 
             var spReader = GetSequencePointsReader();
             var documentHandle = symDocument.Handle;
@@ -455,7 +455,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
         #region ISymEncUnmanagedMethod
 
         /// <summary>
-        /// Get the file name for the line associated with speficied offset.
+        /// Get the file name for the line associated with specified offset.
         /// </summary>
         public int GetFileNameFromOffset(
             int offset,

--- a/src/EditorFeatures/CSharp/DocumentationComments/XmlTagCompletionCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/DocumentationComments/XmlTagCompletionCommandHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments
 
                 // Slightly special case: <blah><blah$$</blah>
                 // If we already have a matching end tag and we're parented by 
-                // an xml element with the same start tag and a missing/nonmatching end tag, 
+                // an xml element with the same start tag and a missing/non-matching end tag, 
                 // do completion anyway. Generally, if this is the case, we have to walk
                 // up the parent elements until we find an unmatched start tag.
 

--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 
             var options = document.Project.Solution.Workspace.Options;
 
-            // dont attempt to format on close brace if autoformat on close brace feature is off, instead just smart indent
+            // don't attempt to format on close brace if autoformat on close brace feature is off, instead just smart indent
             bool smartIndentOnly =
                 token.IsKind(SyntaxKind.CloseBraceToken) &&
                 !options.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace, document.Project.Language);

--- a/src/EditorFeatures/CSharp/LineSeparators/CSharpLineSeparatorService.cs
+++ b/src/EditorFeatures/CSharp/LineSeparators/CSharpLineSeparatorService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LineSeparator
     {
         /// <summary>
         /// Given a tree returns line separator spans.
-        /// The operation may take fairly long time on a big tree so it is cancelable.
+        /// The operation may take fairly long time on a big tree so it is cancellable.
         /// </summary>
         public async Task<IEnumerable<TextSpan>> GetLineSeparatorsAsync(
             Document document,

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -3080,7 +3080,7 @@ class Program
         }
 
         // After @ both X and XAttribute are legal. We think this is an edge case in the language and
-        // are not fixing the bug 11931. This test captures that XAttribute doesnt show up indeed.
+        // are not fixing the bug 11931. This test captures that XAttribute doesn't show up indeed.
         [WorkItem(11931, "DevDiv_Projects/Roslyn")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public void VerbatimAttributes()

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2102,7 +2102,7 @@ $$
             }
         }";
 
-            // In this case we alsign with the "if", - the base indentation we pass in doesn't matter.
+            // In this case we align with the "if", - the base indentation we pass in doesn't matter.
             AssertSmartIndentInProjection(markup,
                 expectedIndentation: BaseIndentationOfNugget + 4);
         }

--- a/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/InvalidIdentifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Outlining/MetadataAsSource/InvalidIdentifierTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Outlining.MetadataAsSou
 {
     /// <summary>
     /// Identifiers coming from IL can be just about any valid string and since C# doesn't have a way to escape all possible
-    /// IL identifiers, we have to account for the possibility that an item's metadata name could lead to unparsable code.
+    /// IL identifiers, we have to account for the possibility that an item's metadata name could lead to unparseable code.
     /// </summary>
     public class InvalidIdentifierTests : AbstractOutlinerTests
     {

--- a/src/EditorFeatures/Core/Implementation/Classification/IEditorClassificationService.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/IEditorClassificationService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor
         /// Important: The classification should not consider the context the text exists in, and how
         /// that may affect the final classifications.  This may result in incorrect classification
         /// (i.e. identifiers being classified as keywords).  These incorrect results will be patched
-        /// up when the lexical results are superceded by the calls to AddSyntacticClassifications.
+        /// up when the lexical results are superseded by the calls to AddSyntacticClassifications.
         /// </summary>
         void AddLexicalClassifications(SourceText text, TextSpan textSpan, List<ClassifiedSpan> result, CancellationToken cancellationToken);
 
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor
         /// but a character was added that would make it into a keyword, then indicate that here.
         /// 
         /// This allows the classified to quickly fix up old classifications as the user types.  These
-        /// adjustments are allowed to be incorrect as they will be superceded by calls to get the
+        /// adjustments are allowed to be incorrect as they will be superseded by calls to get the
         /// syntactic and semantic classifications for this version later.
         /// </summary>
         ClassifiedSpan AdjustStaleClassification(SourceText text, ClassifiedSpan classifiedSpan);

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationTaggerProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
         protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {
-            // Note: we don't listen for OnTextChanged.  Text changes to this this buffer will get
+            // Note: we don't listen for OnTextChanged.  Text changes to this buffer will get
             // reported by OnSemanticChanged.
             return TaggerEventSources.Compose(
                 TaggerEventSources.OnSemanticChanged(subjectBuffer, TaggerDelay.Short, _semanticChangeNotificationService),
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             var subTextSpan = service.GetMemberBodySpanForSpeculativeBinding(member);
             if (subTextSpan.IsEmpty)
             {
-                // Wasn't a member we could reclassify indepdently.
+                // Wasn't a member we could reclassify independently.
                 return false;
             }
 

--- a/src/EditorFeatures/Core/Implementation/Debugging/ILanguageDebugInfoService.cs
+++ b/src/EditorFeatures/Core/Implementation/Debugging/ILanguageDebugInfoService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Debugging
         /// Find an appropriate span to pass the debugger given a point in a snapshot.  Optionally
         /// pass back a string to pass to the debugger instead if no good span can be found.  For
         /// example, if the user hovers on "var" then we actually want to pass the fully qualified
-        /// name of the type that 'var' binds to to the debugger.
+        /// name of the type that 'var' binds to, to the debugger.
         /// </summary>
         Task<DebugDataTipInfo> GetDataTipInfoAsync(Document document, int position, CancellationToken cancellationToken);
     }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                 // Register to hear about diagnostics changing.  When we're notified about new
                 // diagnostics (and those diagnostics are for our buffer), we'll ensure that
-                // we have an underlying tagger responsible for asynchrounously handling diagnostics
+                // we have an underlying tagger responsible for asynchronously handling diagnostics
                 // from the owner of that diagnostic update.
                 _owner._diagnosticService.DiagnosticsUpdated += OnDiagnosticsUpdated;
 
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     tagger.TagsChanged += OnUnderlyingTaggerTagsChanged;
                 }
 
-                // Let the provier know that there are new diagnostics.  It will then
+                // Let the provider know that there are new diagnostics.  It will then
                 // handle all the async processing of those diagnostics.
                 providerAndTagger.Item1.OnDiagnosticsUpdated(e, sourceText, editorSnapshot);
             }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
         /// we create an instance of this async tagger provider for each diagnostic source
         /// we hear about for a particular buffer.  Each async tagger is then responsible
         /// for asynchronous producing tags for that diagnostic source.  This allows each 
-        /// individual async tagger to collect diagnostics, diff them against hte last set
+        /// individual async tagger to collect diagnostics, diff them against the last set
         /// produced by that diagnostic source, and then notify any interested parties about
         /// what changed.
         /// </summary>

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         // This ensures that we have an 'invisible' squiggle (which will in turn
                         // display Quick Info on mouse hover) for the hidden diagnostics that we
                         // report for 'Remove Unnecessary Usings' and 'Simplify Type Name'. The
-                        // presence of Quick Info pane for such squiggles allows allows platform
+                        // presence of Quick Info pane for such squiggles allows platform
                         // to display Light Bulb for the corresponding fixes (per their current
                         // design platform can only display light bulb if Quick Info pane is present).
                         return PredefinedErrorTypeNames.Suggestion;

--- a/src/EditorFeatures/Core/Implementation/FindReferences/AbstractFindReferencesService.cs
+++ b/src/EditorFeatures/Core/Implementation/FindReferences/AbstractFindReferencesService.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.FindReferences
                     select NavigableItemFactory.GetItemFromSymbolLocation(searchSolution, r.Definition, loc.Location);
 
             // realize the list here so that the consumer await'ing the result doesn't lazily cause
-            // them to be created on an inapropriate thread.
+            // them to be created on an inappropriate thread.
             return q.ToList();
         }
 

--- a/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
+++ b/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification
 
                     processedCount++;
 
-                    // there is input to process, or we've exceeded a timeslice, postpone the remaining work
+                    // there is input to process, or we've exceeded a time slice, postpone the remaining work
                     if (IsInputPending() || Environment.TickCount - startProcessingTime > DefaultTimeSliceInMS)
                     {
                         return;
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification
             private void Enqueue_NoLock(LinkedListNode<PendingWork> entry)
             {
                 // TODO: if this cost shows up in the trace, either use tree based implementation
-                // or just have separate lists for each delay (shart, medium, long)
+                // or just have separate lists for each delay (short, medium, long)
                 if (_list.Count == 0)
                 {
                     _list.AddLast(entry);

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             if (syntaxFactsService.IsTypeNamedVarInVariableOrFieldDeclaration(triggerToken, triggerToken.Parent))
             {
-                // To check if va in this context is a real type, or the keyword, we need to 
+                // To check if var in this context is a real type, or the keyword, we need to 
                 // speculatively bind the identifier "var". If it returns a symbol, it's a real type,
                 // if not, it's the keyword.
                 // see bugs 659683 (compiler API) and 659705 (rename/workspace api) for examples

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 AssertIsForeground();
 
                 // Detach from the buffer; it is important that this is done before we start
-                // undoing transactions, since the undo's will cause buffer changes.
+                // undoing transactions, since the undo actions will cause buffer changes.
                 _subjectBuffer.ChangedLowPriority -= OnTextBufferChanged;
 
                 foreach (var view in _textViews)

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -269,8 +269,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 AssertIsForeground();
 
-                // Detatch from the buffer; it is important that this is done before we start
-                // undoing transactions, since the undos will cause buffer changes.
+                // Detach from the buffer; it is important that this is done before we start
+                // undoing transactions, since the undo's will cause buffer changes.
                 _subjectBuffer.ChangedLowPriority -= OnTextBufferChanged;
 
                 foreach (var view in _textViews)
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                                 }
                                 else
                                 {
-                                    // We might not have a renamable span if an alias conflict completely changed the text
+                                    // We might not have a renameable span if an alias conflict completely changed the text
                                     _referenceSpanToLinkedRenameSpanMap[replacement.OriginalSpan] = new RenameTrackingSpan(
                                         _referenceSpanToLinkedRenameSpanMap[replacement.OriginalSpan].TrackingSpan,
                                         RenameSpanKind.None);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AbstractController.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AbstractController.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             // have even shown ui yet.
             var handledCommand = sessionOpt.InitialUnfilteredModel != null;
 
-            // In the presense of an escape, we always stop what we're doing.
+            // In the presence of an escape, we always stop what we're doing.
             this.StopModelComputation();
 
             return handledCommand;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             private readonly CompletionRules _completionRules;
 
             // When we issue filter tasks, provide them with a (monotonically increasing) id.  That
-            // way, when they run we can bail on computation if they've been superceded by another
+            // way, when they run we can bail on computation if they've been superseded by another
             // filter task.  
             private int _filterId;
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 var selectedItem = bestFilterMatch ?? allFilteredItems.First();
 
                 // If we have a best item, then we want to hard select it.  Otherwise we want
-                // softselection.  However, no hard selection if there's a builder.
+                // soft selection.  However, no hard selection if there's a builder.
                 var hardSelection = IsHardSelection(model, bestFilterMatch, textSnapshot, completionRules, model.TriggerInfo, filterReason);
 
                 var result = model.WithFilteredItems(allFilteredItems)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             // Note: Dev10 behavior seems to be that if there is no unique item that filtering is
             // turned off.  However, i do not know if this is desirable behavior, or merely a bug
-            // with how that convoluted code worked.  So i'm not maintaining that behavior here.  If
+            // with how that convoluted code worked.  So I'm not maintaining that behavior here.  If
             // we do want it through, it would be easy to get again simply by asking the model
             // computation to remove all filtering.
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             // sig help in this case.
             if (this.TextView.TypeCharWasHandledStrangely(this.SubjectBuffer, args.TypedChar))
             {
-                // If we we were computing anything, we stop.  We only want to process a typechar
+                // If we were computing anything, we stop.  We only want to process a typechar
                 // if it was a normal character.
                 DismissSessionIfActive();
                 return;

--- a/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Outlining/OutliningTaggerProvider.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Outlining
     /// Shared implementation of the outliner tagger provider.
     /// 
     /// Note: the outliner tagger is a normal buffer tagger provider and not a view tagger provider.
-    /// This is important for two reason.  The first is that if it were view based then we would lose
+    /// This is important for two reasons.  The first is that if it were view-based then we would lose
     /// the state of the collapsed/open regions when they scrolled in and out of view.  Also, if the
-    /// editor doesn't know about all the regions in the file, then it wouldn't be able to to
+    /// editor doesn't know about all the regions in the file, then it wouldn't be able to
     /// persist them to the SUO file to persist this data across sessions.
     /// </summary>
     [Export(typeof(ITaggerProvider))]

--- a/src/EditorFeatures/Core/Implementation/Preview/PreviewFactoryService.cs
+++ b/src/EditorFeatures/Core/Implementation/Preview/PreviewFactoryService.cs
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
             if (!(originalSpans.Any() && changedSpans.Any()))
             {
                 // Both line spans must be non-empty. Otherwise, below projection buffer factory API call will throw.
-                // So if either is empty (signalling that there are no changes to preview in the document), then we bail out.
+                // So if either is empty (signaling that there are no changes to preview in the document), then we bail out.
                 // This can happen in cases where the user has already applied the fix and light bulb has already been dismissed,
                 // but platform hasn't cancelled the preview operation yet. Since the light bulb has already been dismissed at
                 // this point, the preview that we return will never be displayed to the user. So returning null here is harmless.

--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
 
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {
-            // Note: we don't listen for OnTextChanged.  Text changes to this this buffer will get
+            // Note: we don't listen for OnTextChanged.  Text changes to this buffer will get
             // reported by OnSemanticChanged.
             return TaggerEventSources.Compose(
                 TaggerEventSources.OnCaretPositionChanged(textView, textView.TextBuffer, TaggerDelay.Short),

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     //    continue that session.
                     // 3. Otherwise, we're starting a new tracking session. Find and track the span of
                     //    the relevant word in the foreground, and use a task to figure out whether the
-                    //    original word was a renamable identifier or not.
+                    //    original word was a renameable identifier or not.
 
                     if (e.Changes.Count != 1 || ShouldClearTrackingSession(e.Changes.Single()))
                     {

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
         }
 
         /// <summary>
-        /// Determines whether the original token was a renamable identifier on a background thread
+        /// Determines whether the original token was a renameable identifier on a background thread
         /// </summary>
         private class TrackingSession : ForegroundThreadAffinitizedObject
         {
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 {
                     // If the snapshotSpan is nonempty, then the session began with a change that
                     // was touching a word. Asynchronously determine whether that word was a
-                    // renamable identifier. If it is, alert the state machine so it can trigger
+                    // renameable identifier. If it is, alert the state machine so it can trigger
                     // tagging.
 
                     _originalName = snapshotSpan.GetText();

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                     }
 
                     // This line is inside an inactive region. Examine the 
-                    // first preceeding line not in an inactive region.
+                    // first preceding line not in an inactive region.
                     var disabledSpan = syntaxFacts.GetInactiveRegionSpanAroundPosition(this.Tree, actualLine.Extent.Start, CancellationToken);
                     if (disabledSpan != default(TextSpan))
                     {

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor
     /// <summary>
     /// An indentation result represents where the indent should be placed.  It conveys this through
     /// a pair of values.  A position in the existing document where the indent should be relative,
-    /// and the number of columns after that that the indent should be placed at.  
+    /// and the number of columns after that the indent should be placed at.  
     /// 
     /// This pairing provides flexibility to the implementor to compute the indentation results in
     /// a variety of ways.  For example, one implementation may wish to express indentation of a 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.CaretPositionRestorer.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.CaretPositionRestorer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             // Bug 5535: By default the standard editor caret is set to have positive affinity.  This
             // means that if text is added right at the caret then the caret moves to the right and
             // is placed after the added text.  However, we don't want that.  Instead, we want the
-            // caret to stay where it started at. So we store the caret position here and and
+            // caret to stay where it started at. So we store the caret position here and
             // restore it afterwards.
             private readonly EventHandler<CaretPositionChangedEventArgs> _caretPositionChangedHandler;
             private readonly IList<Tuple<IWpfTextView, IMappingPoint>> _caretPositions;

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             {
                 IEnumerable<CodeActionOperation> operations = null;
 
-                // NOTE: As mentoned above, we want to avoid computing the operations on the UI thread.
+                // NOTE: As mentioned above, we want to avoid computing the operations on the UI thread.
                 // However, for CodeActionWithOptions, GetOptions() might involve spinning up a dialog
                 // to compute the options and must be done on the UI thread.
                 var actionWithOptions = this.CodeAction as CodeActionWithOptions;

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -629,7 +629,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             private void OnWorkspaceChanged(object sender, EventArgs e)
             {
                 // REVIEW: this event should give both old and new workspace as argument so that
-                // one doesnt need to hold onto workspace in field.
+                // one doesn't need to hold onto workspace in field.
 
                 // remove existing event registration
                 if (_workspace != null)

--- a/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
                 return ImmutableArray<TodoItem>.Empty;
             }
 
-            // TODO let's think about what to do here. for now, let call it synchronously. also, there is no actual asynch-ness for the
+            // TODO let's think about what to do here. for now, let call it synchronously. also, there is no actual async-ness for the
             // TryGetExistingDataAsync, API just happen to be async since our persistent API is async API. but both caller and implementor are
             // actually not async.
             var existingData = _state.TryGetExistingDataAsync(document, cancellationToken).WaitAndGetResult(cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 
             foreach (var projectId in _activeCaches.Keys)
             {
-                // this should be cheap. graph is cached everytime project reference is updated.
+                // this should be cheap. graph is cached every time project reference is updated.
                 var p2pReferences = (ImmutableHashSet<ProjectId>)graph.GetProjectsThatThisProjectTransitivelyDependsOn(projectId);
                 if (p2pReferences.Contains(key))
                 {

--- a/src/EditorFeatures/Core/Shared/Extensions/IEditorOptionsFactoryServiceExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IEditorOptionsFactoryServiceExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
             return editorOptionsFactory.GlobalOptions;
         }
 
-        // This particular section is commented for future reference if there arises a need to implement a option serilizer in the editor layer
+        // This particular section is commented for future reference if there arises a need to implement a option serializer in the editor layer
         // public static IOptionService GetFormattingOptions(this IEditorOptionsFactoryService editorOptionsFactory, Document document)
         // {
         //     return CreateOptions(editorOptionsFactory.GetEditorOptions(document));

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
             private void OnSubjectBufferChanged(object sender, TextContentChangedEventArgs e)
             {
-                // Whenever this subject buffer has chnaged, we always consider that to be a 
+                // Whenever this subject buffer has changed, we always consider that to be a 
                 // semantic change.
                 this.RaiseChanged();
             }
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
                 //
                 // Note: although we're passing CancellationToken.None here, this should never actually
                 // block.  This is because we would have only gotten this notification if this value
-                // was already compted.  In which case retrieving it again should happen immediately.
+                // was already computed.  In which case retrieving it again should happen immediately.
                 var documentVersion = document.GetTopLevelChangeTextVersionAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
                 var projectVersion = document.Project.GetDependentSemanticVersionAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
 

--- a/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
+++ b/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Threading
     //
     // 1) Background actions are run serially.  This allows you to enqueue a whole host of background
     // work to do, without having to worry about those same background tasks running simultaneously 
-    // and munging each other inappropriately.
+    // and colliding with each other.
     //
     // 2) You can start a 'chain' of actions starting with an action that fires after a delay. After
     // that point you can continue adding actions to that chain.  You can then ask to wait until that

--- a/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
+++ b/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Threading
     //
     // 1) Background actions are run serially.  This allows you to enqueue a whole host of background
     // work to do, without having to worry about those same background tasks running simultaneously 
-    // and mungeing each other inappropriately.
+    // and munging each other inappropriately.
     //
     // 2) You can start a 'chain' of actions starting with an action that fires after a delay. After
     // that point you can continue adding actions to that chain.  You can then ask to wait until that

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             // When we do,  we diminish performance by choking the UI thread with lots of update
             // operations. To help alleviate that, we don't immediately report changes to the UI.  We
             // instead create a timer that will report the changes and we enqueue any pending updates to
-            // a list that will be updated all at once once the timer actually runs.
+            // a list that will be updated all at once the timer actually runs.
             private bool _notificationRequestEnqueued;
             private readonly SortedDictionary<int, NormalizedSnapshotSpanCollection> _snapshotVersionToSpansMap =
                 new SortedDictionary<int, NormalizedSnapshotSpanCollection>();

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 Connect();
 
-                // Kick off a task to compte the initial set of tags.
+                // Kick off a task to complete the initial set of tags.
                 RecalculateTagsOnChanged(new TaggerEventArgs(TaggerDelay.Short));
             }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 Connect();
 
-                // Kick off a task to complete the initial set of tags.
+                // Kick off a task to compute the initial set of tags.
                 RecalculateTagsOnChanged(new TaggerEventArgs(TaggerDelay.Short));
             }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                         return null;
                     }
 
-                    // If we don't have any old tags then we just need to reutrn the new tags.
+                    // If we don't have any old tags then we just need to return the new tags.
                     return new TagSpanIntervalTree<TTag>(textBuffer, _dataSource.SpanTrackingMode, newTags);
                 }
 
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 // If we're examining a text buffer other than the one we tagged.
                 if (textBuffer != spanToInvalidate.Snapshot.TextBuffer)
                 {
-                    // If we have no new tags produced for it, we can just use the olg tags for is.
+                    // If we have no new tags produced for it, we can just use the old tags for it.
                     if (newTags.IsEmpty())
                     {
                         return oldTagTree;
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 // example, say that another change happened between the time when we 
                 // registered for UpdateStateAndReportChanges and now.  If we processed that
                 // notification (on the UI thread) first, then our cancellation token would 
-                // have been been triggered, and the foreground notification service would not 
+                // have been triggered, and the foreground notification service would not 
                 // call into this method. 
                 // 
                 // If, instead, we did get called into, then we will update our instance state.
@@ -667,7 +667,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 // Note: we're raising changes here on the UI thread.  However, this doesn't actually
                 // mean we'll be notifying the editor.  Instead, these will be batched up in the 
                 // AsynchronousTagger's BatchChangeNotifier.  If we tell it about enough changes
-                // to a file, it will colaesce them into one large change to keep chattyness with
+                // to a file, it will coalesce them into one large change to keep chattyness with
                 // the editor down.
                 RaiseTagsChanged(bufferToChanges);
             }
@@ -706,14 +706,14 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 if (!this.UpToDate)
                 {
-                    // We're not up to date.  That means we have an outstandanding update that we're 
+                    // We're not up to date.  That means we have an outstanding update that we're 
                     // currently processing.  Unfortunately we have no way to track the progress of
                     // that update (i.e. a Task).  Also, even if we did, we'd have the problem that 
                     // we have delays coded into the normal tagging process.  So waiting on that Task
                     // could take a long time.
                     //
                     // So, instead, we just cancel whatever work we're currently doing, and we just
-                    // compute the the results synchronously in this call.
+                    // compute the results synchronously in this call.
 
                     // We can cancel any background computations currently happening
                     this._workQueue.CancelCurrentWork();

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -667,7 +667,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 // Note: we're raising changes here on the UI thread.  However, this doesn't actually
                 // mean we'll be notifying the editor.  Instead, these will be batched up in the 
                 // AsynchronousTagger's BatchChangeNotifier.  If we tell it about enough changes
-                // to a file, it will coalesce them into one large change to keep chattyness with
+                // to a file, it will coalesce them into one large change to keep chattiness with
                 // the editor down.
                 RaiseTagsChanged(bufferToChanges);
             }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         protected virtual TaggerTextChangeBehavior TextChangeBehavior => TaggerTextChangeBehavior.None;
 
         /// <summary>
-        /// The bahavior the tagger will have when changes happen to the caret.
+        /// The behavior the tagger will have when changes happen to the caret.
         /// </summary>
         protected virtual TaggerCaretChangeBehavior CaretChangeBehavior => TaggerCaretChangeBehavior.None;
 
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// notifications from the <see cref="ITaggerEventSource"/> that something has changed, and
         /// will only be called from the UI thread.  The tagger infrastructure will then determine
         /// the <see cref="DocumentSnapshotSpan"/>s associated with these <see cref="SnapshotSpan"/>s
-        /// and will asycnhronously call into <see cref="ProduceTagsAsync(TaggerContext{TTag})"/> at some point in
+        /// and will asynchronously call into <see cref="ProduceTagsAsync(TaggerContext{TTag})"/> at some point in
         /// the future to produce tags for these spans.
         /// </summary>
         protected virtual IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textViewOpt, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
@@ -5,7 +5,7 @@ using System;
 namespace Microsoft.CodeAnalysis.Editor.Tagging
 {
     /// <summary>
-    /// The events that the <see cref="AbstractAsynchronousTaggerProvider{TTag}"/> listens to to know when 
+    /// The events that the <see cref="AbstractAsynchronousTaggerProvider{TTag}"/> listens to, to know when 
     /// to request more tags.  For example, an <see cref="ITaggerEventSource"/> may listen to text 
     /// buffer changes, and can tell the <see cref="AbstractAsynchronousTaggerProvider{TTag}"/> that it needs
     /// to recompute tags.

--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         public SnapshotPoint? CaretPosition { get; }
 
         /// <summary>
-        /// The text that has changed between the last successfull tagging and this new request to
+        /// The text that has changed between the last successful tagging and this new request to
         /// produce tags.  In order to be passed this value, <see cref="TaggerTextChangeBehavior.TrackTextChanges"/> 
         /// must be specified in <see cref="AbstractAsynchronousTaggerProvider{TTag}.TextChangeBehavior"/>.
         /// </summary>

--- a/src/EditorFeatures/Test/CodeAnalysisResources.cs
+++ b/src/EditorFeatures/Test/CodeAnalysisResources.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis
     // InternalsVisibleTo(this-assembly) because there are numerous shared (linked) files common to both
     // Microsoft.CodeAnalysis and Microsoft.CodeAnalysis.Workspaces and that gives us major issues with duplicate 
     // internal types that suddenly become visible (e.g., SpecializedCollections) and that leads down a rabbit hole
-    // of requiring assembly aliasing that would make many tests in this project unreadable.  The descision was made to
+    // of requiring assembly aliasing that would make many tests in this project unreadable.  The decision was made to
     // manually load the few resources we need from the CodeAnalysis assembly at the cost of Find All References and
     // Rename not working as expected.
     internal static class CodeAnalysisResources

--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             }
             else
             {
-                // nothing was commited, but we should insert the commit character.
+                // nothing was committed, but we should insert the commit character.
                 var textChange = new TextChange(new TextSpan(firstItem.FilterSpan.End, 0), commitChar.ToString());
                 text = text.WithChanges(textChange);
             }

--- a/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         /// The internal method <see cref="AnalyzerExecutor.IsAnalyzerExceptionDiagnostic(Diagnostic)"/> does
         /// essentially this, but due to linked files between projects, this project cannot have internals visible
         /// access to the Microsoft.CodeAnalysis project without the cascading effect of many extern aliases, so it
-        /// is re-implemented here in a way that is potentially overly agressive with the knowledge that if this method
+        /// is re-implemented here in a way that is potentially overly aggressive with the knowledge that if this method
         /// starts failing on non-analyzer exception diagnostics, it can be appropriately tuned or re-evaluated.
         /// </summary>
         private void AssertNoAnalyzerExceptionDiagnostics(IEnumerable<Diagnostic> diagnostics)

--- a/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 workspace.OnProjectRemoved(project2.Id);
             }
 
-            // make sure p2p reference doesnt go to implicit cache
+            // make sure p2p reference doesn't go to implicit cache
             CollectGarbage();
             Assert.False(weak.IsAlive);
         }

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -500,7 +500,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim expected = Diagnostic.Create("test", "test", "test", DiagnosticSeverity.Error, DiagnosticSeverity.Error, True, 0)
                 Dim exceptionDiagnosticsSource = New TestHostDiagnosticUpdateSource(workspace)
 
-                ' check reporting diagnostic to a project that doesnt exist
+                ' check reporting diagnostic to a project that doesn't exist
                 exceptionDiagnosticsSource.ReportAnalyzerDiagnostic(analyzer, expected, workspace, New ProjectId(Guid.NewGuid(), "dummy"))
                 Dim diagnostics = exceptionDiagnosticsSource.TestOnly_GetReportedDiagnostics(analyzer)
                 Assert.Equal(0, diagnostics.Count())

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -93,7 +93,7 @@ class c { $$
             End Using
         End Function
 
-        ' NOTE(cyrusn): This should just be a unit test for SymbolCompletionProvider.  However, i'm
+        ' NOTE(cyrusn): This should just be a unit test for SymbolCompletionProvider.  However, I'm
         ' just porting the integration tests to here for now.
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestMultipleTypes() As Task
@@ -108,7 +108,7 @@ class C { $$ } struct S { } enum E { } interface I { } delegate void D();
             End Using
         End Function
 
-        ' NOTE(cyrusn): This should just be a unit test for KeywordCompletionProvider.  However, i'm
+        ' NOTE(cyrusn): This should just be a unit test for KeywordCompletionProvider.  However, I'm
         ' just porting the integration tests to here for now.
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestInEmptyFile() As Task

--- a/src/EditorFeatures/VisualBasic/AutomaticEndConstructCorrection/AutomaticEndConstructCorrector.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticEndConstructCorrection/AutomaticEndConstructCorrector.vb
@@ -121,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticEndConstructCorrect
                 Return False
             End If
 
-            ' we only start session if one edit happens not multiedits
+            ' we only start session if one edit happens, not multi-edits
             If changes.Count <> 1 Then
                 Return False
             End If

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
             ' For block but we want to highlight the outermost matching For block. 
 
             If TypeOf node Is NextStatementSyntax Then
-                ' If there is no For block the correctnumber of levels out (consider 2 nested For 
+                ' If there is no For block the correct number of levels out (consider 2 nested For 
                 ' blocks terminated by "Next c, b, a"), then choose the outermost even if it's not 
                 ' the exact match.
                 Return GetForBlocksMatchingNextStatement(DirectCast(node, NextStatementSyntax)).FirstOrDefault()

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
@@ -146,7 +146,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 
                         bufferManager.CommitDirty(isExplicitFormat:=False, cancellationToken:=_cancellationToken)
 
-                        ' We may have reindented the surrounding block, so let's recompute
+                        ' We may have re-indented the surrounding block, so let's recompute
                         ' where we should end up
                         Dim newCaretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer)
 

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 
                 Dim textSpanToFormat = spanToFormat.Span.ToTextSpan()
 
-                ' create commit formatting cleaup provider that has line commit specific behavior
+                ' create commit formatting cleanup provider that has line commit specific behavior
                 Dim commitFormattingCleanup = GetCommitFormattingCleanupProvider(
                                                 document,
                                                 spanToFormat,

--- a/src/EditorFeatures/VisualBasic/LineSeparators/VisualBasicLineSeparatorService.vb
+++ b/src/EditorFeatures/VisualBasic/LineSeparators/VisualBasicLineSeparatorService.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineSeparators
 
         ''' <summary>
         ''' Given a syntaxTree returns line separator spans. The operation may take fairly long time
-        ''' on a big syntaxTree so it is cancelable.
+        ''' on a big syntaxTree so it is cancellable.
         ''' </summary>
         Public Async Function GetLineSeparatorsAsync(document As Document,
                                           textSpan As TextSpan,

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
 
         Protected Overrides Sub RegisterIneligibleFieldsAction(context As CompilationStartAnalysisContext, ineligibleFields As ConcurrentBag(Of IFieldSymbol))
             ' There are no syntactic constructs that make a field ineligible to be replaced with 
-            ' a property.  In C# you can't use a property in a ref/out positoin.  But that restriction
+            ' a property.  In C# you can't use a property in a ref/out position.  But that restriction
             ' doesn't apply to VB.
         End Sub
 
@@ -111,8 +111,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
 
             ' the property doesn't have a setter currently. check all the types the field is 
             ' declared in.  If the field is written to outside of a constructor, then this 
-            ' field Is Not elegible for replacement with an auto prop.  We'd have to make 
-            ' the autoprop read/write, And that could be opening up the propert widely 
+            ' field Is Not eligible for replacement with an auto prop.  We'd have to make 
+            ' the autoprop read/write, And that could be opening up the property widely 
             ' (in accessibility terms) in a way the user would not want.
             Dim containingType = field.ContainingType
             For Each ref In containingType.DeclaringSyntaxReferences

--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -2976,12 +2976,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
         Public Sub TestBug927678()
             Dim val = StringFromLines(
                 "'This is not usually a ",
-                "'collapsable comment block",
+                "'collapsible comment block",
                 "x = 2")
 
             TestInMethod(val,
                          Comment("'This is not usually a "),
-                         Comment("'collapsable comment block"),
+                         Comment("'collapsible comment block"),
                          Identifier("x"),
                          Operators.Equals,
                          Number("2"))

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
         Protected Overrides Sub VerifyWorker(code As String, position As Integer, expectedItemOrNull As String, expectedDescriptionOrNull As String, sourceCodeKind As SourceCodeKind, usePreviousCharAsTrigger As Boolean, checkForAbsence As Boolean, experimental As Boolean, glyph As Integer?)
             ' Script/interactive support removed for now.
-            ' TODO: Reenable these when interactive is back in the product.
+            ' TODO: Re-enable these when interactive is back in the product.
             If sourceCodeKind <> Microsoft.CodeAnalysis.SourceCodeKind.Regular Then
                 Return
             End If
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
         Protected Overrides Sub VerifyCustomCommitProviderWorker(codeBeforeCommit As String, position As Integer, itemToCommit As String, expectedCodeAfterCommit As String, sourceCodeKind As SourceCodeKind, Optional commitChar As Char? = Nothing)
             ' Script/interactive support removed for now.
-            ' TODO: Reenable these when interactive is back in the product.
+            ' TODO: Re-enable these when interactive is back in the product.
             If sourceCodeKind <> Microsoft.CodeAnalysis.SourceCodeKind.Regular Then
                 Return
             End If

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
         Protected Overrides Sub VerifyWorker(code As String, position As Integer, expectedItemOrNull As String, expectedDescriptionOrNull As String, sourceCodeKind As SourceCodeKind, usePreviousCharAsTrigger As Boolean, checkForAbsence As Boolean, experimental As Boolean, glyph As Integer?)
             ' Script/interactive support removed for now.
-            ' TODO: Reenable these when interactive is back in the product.
+            ' TODO: Re-enable these when interactive is back in the product.
             If sourceCodeKind <> SourceCodeKind.Regular Then
                 Return
             End If

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.vb
@@ -146,7 +146,7 @@ NewLines("Class A \n Sub Main(args As String()) \n Color.Green \n End Sub \n End
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateWithImplicitValues()
-            ' Red is implicitly assigned to 0, Green is implicitely Red + 1, So Blue must be 2.
+            ' Red is implicitly assigned to 0, Green is implicitly Red + 1, So Blue must be 2.
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Module \n Enum Color \n Red \n Green \n Yellow = -1 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Module \n Enum Color \n Red \n Green \n Yellow = -1 \n Blue = 2 \n End Enum"))

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
@@ -324,13 +324,13 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-    &lt;[|Assembly:|] Reflection.AssemblyCultureAttribute("de")&gt; 'Bomment
+    &lt;[|Assembly:|] Reflection.AssemblyCultureAttribute("de")&gt; 'Comment
 End Module 
 </File>
 
             Dim expected = <File>
 &lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Comment
-&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Bomment
+&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Comment
 Module Program
     Sub Main(args As String())
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
@@ -324,13 +324,13 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-    &lt;[|Assembly:|] Reflection.AssemblyCultureAttribute("de")&gt; 'Comment
+    &lt;[|Assembly:|] Reflection.AssemblyCultureAttribute("de")&gt; 'Another Comment
 End Module 
 </File>
 
             Dim expected = <File>
 &lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Comment
-&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Comment
+&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Another Comment
 Module Program
     Sub Main(args As String())
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
@@ -790,7 +790,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
 
-            ' to make it simpler, we recompiler the constructor (by reporting a field as a node update)
+            ' to make it simpler, we recompile the constructor (by reporting a field as a node update)
             edits.VerifyLineEdits({New LineChange(2, 3)}, {"Foo"})
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
@@ -145,7 +145,7 @@ End Class
                 TestExtractMethod(code, expected)
             End Sub
 
-            ' C# disallows this. since vbc supports "Don’t Copy Back ByRef" VB extract method allows this
+            ' C# disallows this. since vbc supports "Don't Copy Back ByRef" VB extract method allows this
             ' Note that we have to expand Extract Method's selection here to avoid breaking semantics since
             ' this ByRef will not perform copy back to i after Extract Method occurs.
             ' http://blogs.msdn.com/b/jaredpar/archive/2010/01/21/the-many-cases-of-byref.aspx

--- a/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/InvalidIdentifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Outlining/MetadataAsSource/InvalidIdentifierTests.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Outlining.MetadataAsSource
     ''' <summary>
     ''' Identifiers coming from IL can be just about any valid string and since VB doesn't have a way to escape all possible
-    ''' IL identifiers, we have to account for the possibility that an item's metadata name could lead to unparsable code.
+    ''' IL identifiers, we have to account for the possibility that an item's metadata name could lead to unparseable code.
     ''' </summary>
     Public Class InvalidIdentifierTests
         Inherits AbstractOutlinerTests

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LanguageInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/LanguageInstructionDecoder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 // DkmVariableInfoFlags.FullNames was accepted by the old GetMethodName implementation,
                 // but it was ignored.  Furthermore, it's not clear what FullNames would mean with respect
                 // to argument names in C# or Visual Basic.  For consistency with the old behavior, we'll
-                // just ignore the the flag as well.
+                // just ignore the flag as well.
                 Debug.Assert((argumentFlags & (DkmVariableInfoFlags.FullNames | DkmVariableInfoFlags.Names | DkmVariableInfoFlags.Types)) == argumentFlags,
                     $"Unexpected argumentFlags '{argumentFlags}'");
 

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmException.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmException.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Debugger
         //
         // Summary:
         //     Create a new exception instance. To enable native-interop scenarios, this exception
-        //     system is error code based, so there is no excepion string.
+        //     system is error code based, so there is no exception string.
         //
         // Parameters:
         //   code:

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmExceptionCode.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmExceptionCode.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Debugger
         E_LAUNCH_NO_INTEROP = -2147221499,
         //
         // Summary:
-        //     Debugging isn't possible due to an incompatability within the CLR implementation.
+        //     Debugging isn't possible due to an incompatibility within the CLR implementation.
         E_LAUNCH_DEBUGGING_NOT_POSSIBLE = -2147221498,
         //
         // Summary:
@@ -1011,8 +1011,8 @@ namespace Microsoft.VisualStudio.Debugger
         E_THREAD_NOT_FOUND = -2147218175,
         //
         // Summary:
-        //     Cannot autoattach to the SQL Server, possibly because the firewall is configured
-        //     incorrectly or autoattach is forbidden by the operating system.
+        //     Cannot auto-attach to the SQL Server, possibly because the firewall is configured
+        //     incorrectly or auto-attach is forbidden by the operating system.
         E_CANNOT_AUTOATTACH_TO_SQLSERVER = -2147218174,
         E_OBJECT_OUT_OF_SYNC = -2147218173,
         E_PROCESS_ALREADY_CONTINUED = -2147218172,
@@ -1232,13 +1232,13 @@ namespace Microsoft.VisualStudio.Debugger
         E_XAPI_MANAGED_DISPATCHER_SIGNATURE_ERROR = -1898053600,
         //
         // Summary:
-        //     Method may only be called by components which load in the IDE process (copmonent
+        //     Method may only be called by components which load in the IDE process (component
         //     level > 100000).
         E_XAPI_CLIENT_ONLY_METHOD = -1898053599,
         //
         // Summary:
         //     Method may only be called by components which load in the remote debugger process
-        //     (copmonent level < 100000).
+        //     (component level < 100000).
         E_XAPI_SERVER_ONLY_METHOD = -1898053598,
         //
         // Summary:
@@ -1307,7 +1307,7 @@ namespace Microsoft.VisualStudio.Debugger
         E_WRONG_COMPONENT = -1842151410,
         //
         // Summary:
-        //     Operation is only permitted on the latest version of an editted method.
+        //     Operation is only permitted on the latest version of an edited method.
         E_WRONG_METHOD_VERSION = -1842151409,
         //
         // Summary:
@@ -1418,7 +1418,7 @@ namespace Microsoft.VisualStudio.Debugger
         E_UNKNOWN_CPU_INSTRUCTION = -1842151373,
         //
         // Summary:
-        //     An invliad runtime was specified for this operation.
+        //     An invalid runtime was specified for this operation.
         E_INVALID_RUNTIME = -1842151372,
         //
         // Summary:

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             // We're exclusive if this context could only be an object initializer and not also a
             // collection initializer. If we're initializing something that could be initialized as
             // an object or as a collection, say we're not exclusive. That way the rest of
-            // intellisense can be used in the collection intializer.
+            // intellisense can be used in the collection initializer.
             // 
             // Consider this case:
 

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.SwitchStatement:
                     // Note: Any nested statements in the switch will already have been hit on the
                     // way up.  Similarly, hitting a 'case' label will already have been taken care
-                    // of.  So i nthis case, we just set the bp on the "switch(expr)" itself.
+                    // of.  So in this case, we just set the bp on the "switch(expr)" itself.
                     var switchStatement = (SwitchStatementSyntax)statement;
                     return CreateSpan(switchStatement, switchStatement.CloseParenToken);
 
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     // Note: if the user was in the body of the 'try', then we would have hit its nested
                     // statement on the way up.  This means we must be on the "try" part.  In this case,
                     // just set the BP on the start of the block.  Note: if they were in a catch or
-                    // finally section, then then that will already have been taken care of above.
+                    // finally section, then that will already have been taken care of above.
                     var tryStatement = (TryStatementSyntax)statement;
                     return TryCreateSpanForStatement(tryStatement.Block, position);
 

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -611,7 +611,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.PropertyDeclaration:
                     // The active span corresponding to a property declaration is the span corresponding to its initializer (if any),
-                    // not the span correspoding to the accessor.
+                    // not the span corresponding to the accessor.
                     // int P { [|get;|] } = [|<initializer>|];
                     var propertyDeclaration = (PropertyDeclarationSyntax)node;
 
@@ -669,7 +669,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     {
                         // We enumerated all members and none of them has an initializer.
                         // We don't have any better place where to place the span than the initial field.
-                        // Consider: in nonpartial classes we could find a single constructor. 
+                        // Consider: in non-partial classes we could find a single constructor. 
                         // Otherwise, it would be confusing to select one arbitrarily.
                         yield return KeyValuePair.Create(statement, -1);
                     }

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -739,7 +739,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
 
             while (node != null)
             {
-                // Types in BaseList, Type Constraint or Member Types cannot be of restricter accessibility than the declaring type
+                // Types in BaseList, Type Constraint or Member Types cannot be of more restricted accessibility than the declaring type
                 if ((node is BaseListSyntax || node is TypeParameterConstraintClauseSyntax) &&
                     node.Parent != null &&
                     node.Parent is TypeDeclarationSyntax)

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
                 }
 
                 // We use the callback form if "ReplaceNode" here because we want to see the
-                // invocation expressoin after any rewrites we already did when rewriting the
+                // invocation expression after any rewrites we already did when rewriting the
                 // 'get' references.
                 editor.ReplaceNode(invocation, (i, g) =>
                 {

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/IFixMultipleOccurrencesService.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/IFixMultipleOccurrencesService.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     internal interface IFixMultipleOccurrencesService : IWorkspaceService
     {
         /// <summary>
-        /// Computes the fix muliple occurrences code fix for the given diagnostics with source locations, brings up the preview changes dialog for the fix and
+        /// Computes the fix multiple occurrences code fix for the given diagnostics with source locations, brings up the preview changes dialog for the fix and
         /// apply the code action operations corresponding to the fix.
         /// </summary>
         void ComputeAndApplyFix(
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Get the fix muliple occurrences code fix for the given diagnostics with source locations.
+        /// Get the fix multiple occurrences code fix for the given diagnostics with source locations.
         /// NOTE: This method does not apply the fix to the workspace.
         /// </summary>
         Solution GetFix(
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Computes the fix muliple occurrences code fix for the given diagnostics without any source location, brings up the preview changes dialog for the fix and
+        /// Computes the fix multiple occurrences code fix for the given diagnostics without any source location, brings up the preview changes dialog for the fix and
         /// apply the code action operations corresponding to the fix.
         /// </summary>
         void ComputeAndApplyFix(
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Get the fix muliple occurrences code fix for the given diagnostics with source locations.
+        /// Get the fix multiple occurrences code fix for the given diagnostics with source locations.
         /// NOTE: This method does not apply the fix to the workspace.
         /// </summary>
         Solution GetFix(

--- a/src/Features/Core/Portable/Completion/CompletionRules.cs
+++ b/src/Features/Core/Portable/Completion/CompletionRules.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Completion
             }
 
             // If they both seemed just as good, but they differ on preselection, then
-            // item1 is better if it is preselected, otherwise it it worse.
+            // item1 is better if it is preselected, otherwise it is worse.
             if (item1.Preselect != item2.Preselect)
             {
                 return item1.Preselect;

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private static async Task PersistProjectData(Project project, DiagnosticState state, AnalysisData data)
         {
             // TODO: Cancellation is not allowed here to prevent data inconsistency. But there is still a possibility of data inconsistency due to
-            //       things like exception. For now, I am letting it go and let v2 engine take care of it properly. If v2 doesnt come online soon enough
+            //       things like exception. For now, I am letting it go and let v2 engine take care of it properly. If v2 doesn't come online soon enough
             //       more refactoring is required on project state.
 
             // clear all existing data
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
         private bool ShouldRunAnalyzerForClosedFile(CompilationOptions options, bool openedDocument, DiagnosticAnalyzer analyzer)
         {
-            // we have opened document, doesnt matter
+            // we have opened document, doesn't matter
             if (openedDocument || analyzer.IsCompilerAnalyzer())
             {
                 return true;

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 // make sure we don't report same id to multiple different analyzers
                 if (!seen.Add(descriptor.Id))
                 {
-                    // TODO: once we have information where diagnostic came from, we probably doesnt need this.
+                    // TODO: once we have information where diagnostic came from, we probably don't need this.
                     continue;
                 }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/MemberRangeMap.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/MemberRangeMap.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 var versionsInTrackingMap = data.VersionTrackingMap.Keys;
                 var versionsInRangeMap = data.MemberRangeMap.Keys;
 
-                // there shoudn't be any version that is not in the version map
+                // there shouldn't be any version that is not in the version map
                 foreach (var version in versionsInRangeMap)
                 {
                     Contract.Requires(versionsInVersionMap.Contains(version));

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private ImmutableDictionary<DiagnosticAnalyzer, HashSet<string>> _compilerDiagnosticAnalyzerDescriptorMap;
 
         /// <summary>
-        /// Cache from <see cref="DiagnosticAnalyzer"/> instance to its supported desciptors.
+        /// Cache from <see cref="DiagnosticAnalyzer"/> instance to its supported descriptors.
         /// </summary>
         private readonly ConditionalWeakTable<DiagnosticAnalyzer, IReadOnlyCollection<DiagnosticDescriptor>> _descriptorCache;
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2774,7 +2774,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         Debug.Assert(newDeclaration.SyntaxTree == topMatch.NewRoot.SyntaxTree);
 
                         // Constructor that doesn't contain initializers had a corresponding semantic edit produced previously 
-                        // or was not not edited. In either case we should not produce a semantic edit for it.
+                        // or was not edited. In either case we should not produce a semantic edit for it.
                         if (!IsConstructorWithMemberInitializers(newDeclaration))
                         {
                             continue;
@@ -3066,7 +3066,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             // Report rude edits for lambdas added to the method.
-            // We already checked that no new captures are introduced opr removed. 
+            // We already checked that no new captures are introduced or removed. 
             // We also need to make sure that no new parent frame links are introduced.
             // 
             // We could implement the same analysis as the compiler does when rewriting lambdas - 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         private readonly Solution _baseSolution;
 
-        // signalled when the session is terminated:
+        // signaled when the session is terminated:
         private readonly CancellationTokenSource _cancellation;
 
         // document id -> [active statements ordered by position]

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 //
                 // Note: if we get either of these cases, we ensure that we can at least convert 
                 // the parameter types we have to the constructor parameter types.  This way we
-                // don't accidently think we delegate to a constructor in an abstract base class
+                // don't accidentally think we delegate to a constructor in an abstract base class
                 // when the parameter types don't match.
                 if (symbolInfo.CandidateReason == CandidateReason.Inaccessible ||
                     (symbolInfo.CandidateReason == CandidateReason.NotCreatable && containingType.IsAbstract))

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             {
                 // See if we can find a possible base type for the type being generated.
                 // NOTE(cyrusn): I currently limit this to when we have an object creation node.
-                // That's because that's when we would have an expression that could be coverted to
+                // That's because that's when we would have an expression that could be converted to
                 // something else.  i.e. if the user writes "IList<int> list = new Foo()" then we can
                 // infer a base interface for 'Foo'.  However, if they write "IList<int> list = Foo"
                 // then we don't really want to infer a base type for 'Foo'.

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 // LValue location.  i.e. if you have: "a[1] = b" then you don't want to change that to
                 // "var c = a[1]; c = b", as that write is no longer happening into the right LValue.
                 //
-                // In essence, this says "i can be replaced with an expression as long as i'm not being
+                // In essence, this says "i can be replaced with an expression as long as I'm not being
                 // written to".
                 var semanticFacts = this.Document.Project.LanguageServices.GetService<ISemanticFactsService>();
                 return semanticFacts.CanReplaceWithRValue(this.Document.SemanticModel, this.Expression, cancellationToken);

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private Task RaiseEvent(string eventName)
             {
-                // this method name doesnt have Async since it should work as async void.
+                // this method name doesn't have Async since it should work as async void.
                 var ev = _eventMap.GetEventHandlers<EventHandler>(eventName);
                 if (ev.HasHandlers)
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     // explicitly iterate so that we can use struct enumerator.
                     // Return the first normal priority work item we find.  If we don't
-                    // find any, then just return the first low pri item we saw.
+                    // find any, then just return the first low prio item we saw.
                     DocumentId lowPriorityDocumentId = null;
                     foreach (var pair in documentMap)
                     {

--- a/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Async
     Friend Class VisualBasicConvertToAsyncFunctionCodeFixProvider
         Inherits AbstractChangeToAsyncCodeFixProvider
 
-        Friend Const BC37001 As String = "BC37001" ' error BC37001: 'Blah' Does not return a Task and is not awaited consider changing to and Aync Function.
+        Friend Const BC37001 As String = "BC37001" ' error BC37001: 'Blah' Does not return a Task and is not awaited consider changing to an Async Function.
 
         Friend ReadOnly Ids As ImmutableArray(Of String) = ImmutableArray.Create(Of String)(BC37001)
 

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
@@ -391,7 +391,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
         End Function
 
         Private Shared Async Function CreateExpressionToInlineAsync(document As Document, cancellationToken As CancellationToken) As Task(Of ExpressionSyntax)
-            ' TODO: We should be using a speculative semantic model in the method rather than forking new semantic model everytime.
+            ' TODO: We should be using a speculative semantic model in the method rather than forking new semantic model every time.
 
             Dim semanticModel = Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False)
 

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InvertIf/InvertIfCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InvertIf/InvertIfCodeRefactoringProvider.vb
@@ -241,7 +241,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InvertIf
 
 #If False Then
         ' If we have a : following the outermost SingleLineIf, we'll want to remove it and use a statementterminator token instead.
-        ' This ensures that the following statement will stand alone instead of becoming part of the if, as dicussed in Bug 14259.
+        ' This ensures that the following statement will stand alone instead of becoming part of the if, as discussed in Bug 14259.
         Private Function UpdateStatementList(invertedIfNode As SingleLineIfStatementSyntax, originalIfNode As SingleLineIfStatementSyntax, cancellationToken As CancellationToken) As SyntaxList(Of StatementSyntax)
             Dim parentMultiLine = originalIfNode.GetContainingMultiLineExecutableBlocks().FirstOrDefault
             Dim statements = parentMultiLine.GetExecutableBlockStatements()

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectInitializerCompletionProvider.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 Return Nothing
             End If
 
-            ' We have the right tokens. Get the containing object intializer. Will we be able to walk
+            ' We have the right tokens. Get the containing object initializer. Will we be able to walk
             ' up and determine the type?
             Dim containingInitializer = commaOrBrace.Parent
             If containingInitializer Is Nothing OrElse

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -1702,7 +1702,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
 #End Region
 
-#Region "Top-level Syntatic Rude Edits"
+#Region "Top-level Syntactic Rude Edits"
         Private Structure EditClassifier
 
             Private ReadOnly _analyzer As VisualBasicEditAndContinueAnalyzer

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.TriviaResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.TriviaResult.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 token1 As SyntaxToken, list As IEnumerable(Of SyntaxTrivia), token2 As SyntaxToken) As IEnumerable(Of SyntaxTrivia)
 
                 ' special case for skipped token trivia
-                ' formatter doesn't touch tokens that have skipped tokens inbetween. so, we need to take care of such case ourselves
+                ' formatter doesn't touch tokens that have skipped tokens in-between. so, we need to take care of such case ourselves
                 If list.Any(Function(t) t.RawKind = SyntaxKind.SkippedTokensTrivia) Then
                     Return RemoveElasticAfterColon(
                         token1.TrailingTrivia.Concat(list).Concat(ReplaceElasticToEndOfLine(token2.LeadingTrivia)))

--- a/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
@@ -569,7 +569,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateType
 
             Dim node As SyntaxNode = expression
             While node IsNot Nothing
-                ' Types in BaseList, Type Constraint or Member Types cannot be of restricter accessibility than the declaring type
+                ' Types in BaseList, Type Constraint or Member Types cannot be of more restricted accessibility than the declaring type
                 If TypeOf node Is InheritsOrImplementsStatementSyntax AndAlso
                     node.Parent IsNot Nothing AndAlso
                     TypeOf node.Parent Is TypeBlockSyntax Then

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/CSharpVBInteractiveCommandContentTypes.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/CSharpVBInteractiveCommandContentTypes.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.VisualStudio.Editor.Interactive
 {
     /// <summary>
-    /// Repesents the content type for specialized interactive commands for C# and VB
+    /// Represents the content type for specialized interactive commands for C# and VB
     /// interactive window which override the implementation of these commands in underlying
     /// interactive window.
     /// </summary>

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             public readonly Service Service;
             private readonly int _processId;
 
-            // output pumping threads (stream output from stdout/stderror of the host process to the output/errorOutput writers)
+            // output pumping threads (stream output from stdout/stderr of the host process to the output/errorOutput writers)
             private Thread _readOutputThread;           // nulled on dispose
             private Thread _readErrorOutputThread;      // nulled on dispose
             private InteractiveHost _host;       // nulled on dispose

--- a/src/InteractiveWindow/Editor/InteractiveWindow.EditResolver.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.EditResolver.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             // <prompt span><lang span 2>
             // 
             // In the case where the prompts are in the margin we have an insertion conflict between the two language spans.  But because
-            // lang span 1 includes the new line in order to be oun the boundary we need to be on lang span 2's line.
+            // lang span 1 includes the new line in order to be on the boundary we need to be on lang span 2's line.
             // 
             // This works the same way w/ our input buffer where the input buffer present instead of <lang span 2>.
 

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             _operations.HistoryNext();
             AssertCurrentSubmission(inputString2);
 
-            //Next should again do nothing as it is the last item, bufer should have the same value
+            //Next should again do nothing as it is the last item, buffer should have the same value
             _operations.HistoryNext();
             AssertCurrentSubmission(inputString2);
 

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -956,7 +956,7 @@ System.Console.WriteLine();",
             Assert.Equal("> 1\r\n1\r\n> int x\r\n> ;", GetTextFromCurrentSnapshot());
 
             // Backspace() with caret in 2nd active prompt, move caret to 
-            // closest editable buffer then delete prvious characer (breakline)        
+            // closest editable buffer then delete previous character (breakline)        
             caret.MoveToNextCaretPosition();
             Window.Operations.End(false);
             caret.MoveToNextCaretPosition();

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#pragma warning disable 436 // The type 'RelativePathResolver' comflicts with imported type
+#pragma warning disable 436 // The type 'RelativePathResolver' conflicts with imported type
 
 using System;
 using System.Collections.Generic;

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#pragma warning disable 436 // The type 'RelativePathResolver' comflicts with imported type
+#pragma warning disable 436 // The type 'RelativePathResolver' conflicts with imported type
 
 using System;
 using System.Collections.Immutable;

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// <exception cref="ArgumentException">The type of <paramref name="globals"/> doesn't match <see cref="Script.GlobalsType"/>.</exception>
         public new Task<ScriptState<T>> RunAsync(object globals = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // The following validation and executor contruction may throw;
+            // The following validation and executor construction may throw;
             // do so synchronously so that the exception is not wrapped in the task.
 
             ValidateGlobals(globals, GlobalsType);
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// <exception cref="ArgumentException"><paramref name="previousState"/> is not a previous execution state of this script.</exception>
         public new Task<ScriptState<T>> ContinueAsync(ScriptState previousState, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // The following validation and executor contruction may throw;
+            // The following validation and executor construction may throw;
             // do so synchronously so that the exception is not wrapped in the task.
 
             if (previousState == null)

--- a/src/Scripting/Core/ScriptState.cs
+++ b/src/Scripting/Core/ScriptState.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// </summary> 
         /// <remarks>
         /// If multiple script variables are defined in the script (in distinct submissions) returns the last one.
-        /// Namve lookup is case sensitive in C# scripts and case insensitive in VB scripts.
+        /// Name lookup is case sensitive in C# scripts and case insensitive in VB scripts.
         /// </remarks>
         /// <returns><see cref="ScriptVariable"/> or null, if no variable of the specified <paramref name="name"/> is defined in the script.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>

--- a/src/Scripting/CoreTest.Desktop/MetadataShadowCopyProviderTests.cs
+++ b/src/Scripting/CoreTest.Desktop/MetadataShadowCopyProviderTests.cs
@@ -220,13 +220,13 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting.UnitTests
             Assert.Equal(Path.Combine(Path.GetDirectoryName(sc.PrimaryModule.FullPath), @"a.xml"), sc.DocumentationFile.FullPath); 
             Assert.Equal("Invariant", File.ReadAllText(sc.DocumentationFile.FullPath));
 
-            // greek culture
+            // Greek culture
             provider = CreateProvider(elGR);
             sc = provider.GetMetadataShadowCopy(dll.Path, MetadataImageKind.Assembly);
             Assert.Equal(Path.Combine(Path.GetDirectoryName(sc.PrimaryModule.FullPath), @"el-GR\a.xml"), sc.DocumentationFile.FullPath);
             Assert.Equal("Greek", File.ReadAllText(sc.DocumentationFile.FullPath));
 
-            // arabic culture (culture specific docs not found, use invariant)
+            // Arabic culture (culture specific docs not found, use invariant)
             provider = CreateProvider(arMA);
             sc = provider.GetMetadataShadowCopy(dll.Path, MetadataImageKind.Assembly);
             Assert.Equal(Path.Combine(Path.GetDirectoryName(sc.PrimaryModule.FullPath), @"a.xml"), sc.DocumentationFile.FullPath);

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -1806,7 +1806,7 @@ namespace CSharpSyntaxGenerator
             }
             else
             {
-                // otherwise, if there there is a single optional node, use that..
+                // otherwise, if there is a single optional node, use that..
                 int nodeCount = nd.Fields.Count(f => IsNode(f.Type) && f.Type != "SyntaxToken");
                 if (nodeCount == 1)
                 {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VBSyntaxModelSchema.xsd
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VBSyntaxModelSchema.xsd
@@ -81,7 +81,7 @@ the definition of VB parse tree nodes. -->
                       <!-- A spec-section element defines the cross-reference to the language spec. -->
                       <xs:element minOccurs="0" maxOccurs="unbounded" name="spec-section" type="xs:string" />
 
-                      <!-- A grammar element defins the grammar non-terminal -->
+                      <!-- A grammar element defines the grammar non-terminal -->
                       <xs:element minOccurs="0" maxOccurs="unbounded" name="grammar" type="xs:string" />
 
                       <!-- A node-kind defines an element of the NodeKind enumeration that refers to this node.
@@ -242,7 +242,7 @@ the definition of VB parse tree nodes. -->
                       <xs:element name="enumerators">
                         <xs:complexType>
                           <xs:sequence>
-                            <!-- enumerator defins one enumeration in an enumeration
+                            <!-- enumerator defines one enumeration in an enumeration
                             Attributes:
                               name - name of the enumerator [required]
                               hexvalue - hex value of the enumerator [optional]

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -412,7 +412,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
         /// </summary>
         /// <param name="container">The <see cref="SyntaxNode"/> from which to retrieve members.</param>
         /// <param name="includeSelf">If true, the container is returned as well.</param>
-        /// <param name="recursive">If true, members are recursed to return descendent members as well
+        /// <param name="recursive">If true, members are recursed to return descendant members as well
         /// as immediate children. For example, a namespace would return the namespaces and types within.
         /// However, if <paramref name="recursive"/> is true, members with the namespaces and types would
         /// also be returned.</param>

--- a/src/VisualStudio/CSharp/Impl/Debugging/CSharpProximityExpressionsService.ExpressionType.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/CSharpProximityExpressionsService.ExpressionType.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
         // For example, consider the expression a[b+c].  The analysis of this expression starts at
         // the ElementAccessExpression.  The rules for an ElementAccessExpression say that the
         // expression is a ValidTerm if and only if both the LHS('a' in this case) and the
-        // RHS('b+c') are valid ValidExpressions. The LHS is a ValidTerm, and the RHS is a binary o
-        // perator-- this time AddExpression. The rules for AddExpression state that the expression
+        // RHS('b+c') are valid ValidExpressions. The LHS is a ValidTerm, and the RHS is a binary
+        // operator-- this time AddExpression. The rules for AddExpression state that the expression
         // is never a ValidTerm, but is a ValidExpression if both the LHS and the RHS are
         // ValidExpressions. In this case, both 'b' and 'c' are ValidTerms (thus valid expressions),
         // so 'a+b' is a ValidExpression (but not a ValidTerm), and finally 'a[b+c]' is considered a

--- a/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
                 return new DebugDataTipInfo(TextSpan.FromBounds(curr.SpanStart, expression.Span.End), text: null);
             }
 
-            // NOTE(cyrusn): This behavior is to mimic what we did in Dev10, i'm not sure if it's
+            // NOTE(cyrusn): This behavior is to mimic what we did in Dev10, I'm not sure if it's
             // necessary or not.
             if (expression.IsKind(SyntaxKind.InvocationExpression))
             {

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.IVsEditorFactoryNotify.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.IVsEditorFactoryNotify.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 {
     // The native project system requires that project sites implement IVsEditorFactoryNotify, and
     // the project system stores an internal list of the interface pointers to them. The old editor
-    // factory would then call each implementaion from it's own IVsEditorFactoryNotify methods.
+    // factory would then call each implementation from it's own IVsEditorFactoryNotify methods.
     // Since we now supply our own editor factory that doesn't do this, these methods will never be
     // called. Still, we must implement the interface or we'll never load at all.
     internal partial class CSharpProjectShim : IVsEditorFactoryNotify

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/Interop/ICSharpProjectSite.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/Interop/ICSharpProjectSite.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Inter
         [PreserveSig]
         int OnResourceFileRemoved([MarshalAs(UnmanagedType.LPWStr)] string filename);
 
-        // NOTICE: OnImportAdded is superceded by OnImportAddedEx.
+        // NOTICE: OnImportAdded is superseded by OnImportAddedEx.
         // The function has not been removed due to the hard-dependency on this particular signature in Venus' 
         // templates
         [PreserveSig]

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/Interop/ICSharpVenusProjectSite.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/Interop/ICSharpVenusProjectSite.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Inter
     internal interface ICSharpVenusProjectSite
     {
         /// <summary>
-        /// This function should not be used by any new code; it is now superceded by AddReferenceToCodeDirectoryEx. The
+        /// This function should not be used by any new code; it is now superseded by AddReferenceToCodeDirectoryEx. The
         /// function has not been removed due to the hard-dependency on this particular signature in Venus' templates.
         /// </summary>
         [Obsolete]

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
         private static string GetContentLocation(string shellFolder, string rootFolder, string installPath, string relativePath)
         {
-            // extension manager should expose an API that doesnt require this.
+            // extension manager should expose an API that doesn't require this.
             const string ShellFolderToken = "$ShellFolder$";
             const string RootFolderToken = "$RootFolder$";
 

--- a/src/VisualStudio/Core/Def/Implementation/Interop/WrapperPolicy.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interop/WrapperPolicy.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
             var ptr = Marshal.GetIUnknownForObject(managedObject);
             try
             {
-                // This asks the CLR to return the RCW correspoding to the
+                // This asks the CLR to return the RCW corresponding to the
                 // aggregator object.
                 object wrapper = Marshal.GetObjectForIUnknown(ptr);
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -1083,7 +1083,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // For 'Shared' projects, IVSHierarchy returns a hierarchy item with < character in its name (i.e. <SharedProjectName>)
                 // as a child of the root item. There is no such item in the 'visual' hierarchy in solution explorer and no such folder
                 // is present on disk either. Since this is not a real 'folder', we exclude it from the contents of Document.Folders.
-                // Note: The parent of the hierarchy item that contains < characher in its name is VSITEMID.Root. So we don't need to
+                // Note: The parent of the hierarchy item that contains < character in its name is VSITEMID.Root. So we don't need to
                 // worry about accidental propagation out of the Shared project to any containing 'Solution' folders - the check for
                 // VSITEMID.Root below already takes care of that.
                 var name = (string)nameObj;
@@ -1319,7 +1319,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         [Conditional("DEBUG")]
         private void ValidateReferences()
         {
-            // can happen when project is unloaded and reloaded or in venus (aspx) case
+            // can happen when project is unloaded and reloaded or in Venus (aspx) case
             if (_filePathOpt == null || _binOutputPathOpt == null || _objOutputPathOpt == null)
             {
                 return;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IIntPtrReturningVsInvisibleEditorManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IIntPtrReturningVsInvisibleEditorManager.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.I
 {
     /// <remarks>
     /// A redefinition of Microsoft.VisualStudio.Shell.Interop.IVsInvisibleEditorManager. One critical difference
-    /// here is is we declare the ppEditor retval argument as IntPtr instead of IVsInvisibleEditor. Since the
+    /// here is we declare the ppEditor retval argument as IntPtr instead of IVsInvisibleEditor. Since the
     /// invisible editor is saved and closed when the last reference is Released(), it's critical we have precise
     /// control when the COM object goes away. By default, the COM marshaller will return a non-unique RCW, which
     /// means we have no control over when the RCW will call Release(). To have control, we need a unique RCW, but

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -705,7 +705,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var itemId = document.GetItemId();
             if (itemId == (uint)VSConstants.VSITEMID.Nil)
             {
-                // If the ItemId is Nil, then then IVsProject would not be able to open the 
+                // If the ItemId is Nil, then IVsProject would not be able to open the 
                 // document using its ItemId. Thus, we must use OpenDocumentViaProject, which only 
                 // depends on the file path.
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/SharedInfoCache.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/SharedInfoCache.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         {
             if (_cache == null)
             {
-                // make sure this is deterministric
+                // make sure this is deterministic
                 var orderedItems = _documentIds.Select(d => d.ProjectId).Distinct().OrderBy(p => p.Id);
                 _cache = ProjectInfoCache.GetOrAdd(GetHashCode(workspace, orderedItems), orderedItems, c => new ProjectInfoCache(orderedItems.ToImmutableArray()));
             }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableEntriesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableEntriesFactory.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return _sources.Primary.GetItems();
                 }
 
-                // flatten items from multiple soures and group them by deduplication identity
+                // flatten items from multiple sources and group them by deduplication identity
                 // merge duplicated items into de-duplicated item list
                 var items = _sources.GetSources()
                                     .SelectMany(s => s.GetItems())

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
             public override AbstractTableEntriesSnapshot<DiagnosticData> CreateSnapshot(AbstractTableEntriesSource<DiagnosticData> source, int version, ImmutableArray<TableItem<DiagnosticData>> items, ImmutableArray<ITrackingPoint> trackingPoints)
             {
-                // Build doens't support tracking point.
+                // Build doesn't support tracking point.
                 return new TableEntriesSnapshot((DiagnosticTableEntriesSource)source, version, items);
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -209,7 +209,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             if (id != null)
             {
                 // save error line/column (surface buffer location) as mapped line/column so that we can display
-                // right location on closed venus file.
+                // right location on closed Venus file.
                 return GetDiagnosticData(
                     id, GetErrorId(error), error.bstrText, GetDiagnosticSeverity(error),
                     null, error.iLine, error.iCol, error.iLine, error.iCol, error.bstrFileName, line, column, line, column);

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonErrorReport.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonErrorReport.cs
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Watson
         /// <returns>true on success and false on failure</returns>
         private unsafe bool InitializeHandlesForSnapshot()
         {
-            // Grab the pointer the the exception
+            // Grab the pointer to the exception
             _exceptionPointersPointer = Marshal.GetExceptionPointers();
 
             NativeWin32Stubs.SECURITY_ATTRIBUTES secAttrib = new NativeWin32Stubs.SECURITY_ATTRIBUTES();

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     return changes;
                 }
 
-                // in case of a venus, when format document command is issued, venus will call format API with each script block spans.
+                // in case of a Venus, when format document command is issued, Venus will call format API with each script block spans.
                 // in that case, we need to make sure formatter doesn't overstep other script blocks content. in actual format selection case,
                 // we need to format more than given selection otherwise, we will not adjust indentation of first token of the given selection.
                 foreach (var visibleSpan in containedDocument.GetEditorVisibleSpans())

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         /// </summary>
         /// <param name="container">The <see cref="SyntaxNode"/> from which to retrieve members.</param>
         /// <param name="includeSelf">If true, the container is returned as well.</param>
-        /// <param name="recursive">If true, members are recursed to return descendent members as well
+        /// <param name="recursive">If true, members are recursed to return descendant members as well
         /// as immediate children. For example, a namespace would return the namespaces and types within.
         /// However, if <paramref name="recursive"/> is true, members with the namespaces and types would
         /// also be returned.</param>
@@ -1361,28 +1361,28 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         public virtual IList<string> GetHandledEventNames(SyntaxNode method, SemanticModel semanticModel)
         {
-            // descendents may override (particularly VB).
+            // descendants may override (particularly VB).
 
             return SpecializedCollections.EmptyList<string>();
         }
 
         public virtual bool HandlesEvent(string eventName, SyntaxNode method, SemanticModel semanticModel)
         {
-            // descendents may override (particularly VB).
+            // descendants may override (particularly VB).
 
             return false;
         }
 
         public virtual Document AddHandlesClause(Document document, string eventName, SyntaxNode method, CancellationToken cancellationToken)
         {
-            // descendents may override (particularly VB).
+            // descendants may override (particularly VB).
 
             return document;
         }
 
         public virtual Document RemoveHandlesClause(Document document, string eventName, SyntaxNode method, CancellationToken cancellationToken)
         {
-            // descendents may override (particularly VB).
+            // descendants may override (particularly VB).
 
             return document;
         }

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/OverloadsCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/OverloadsCollection.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             // Retrieving the overloads is potentially very expensive because it can force multiple FileCodeModels to be instantiated.
             // Here, we cache the result to avoid having to perform these calculations each time GetOverloads() is called.
             // This *could* be an issue because it means that an OverloadsCollection will not necessarily reflect the
-            // current state of the user's code. However, because a new OverloadsCollection is created everytime the Overloads
+            // current state of the user's code. However, because a new OverloadsCollection is created every time the Overloads
             // property is accessed on CodeFunction, consumers would hit this behavior rarely.
             if (_overloads == null)
             {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/PartialTypeCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/PartialTypeCollection.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             // Retrieving the parts is potentially very expensive because it can force multiple FileCodeModels to be instantiated.
             // Here, we cache the result to avoid having to perform these calculations each time GetParts() is called.
             // This *could* be an issue because it means that a PartialTypeCollection will not necessarily reflect the
-            // current state of the user's code. However, because a new PartialTypeCollection is created everytime the Parts
+            // current state of the user's code. However, because a new PartialTypeCollection is created every time the Parts
             // property is accessed on CodeClass, CodeStruct or CodeInterface, consumers would hit this behavior rarely.
             if (_parts == null)
             {

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         /// </summary>
         /// <param name="container">The <see cref="SyntaxNode"/> from which to retrieve members.</param>
         /// <param name="includeSelf">If true, the container is returned as well.</param>
-        /// <param name="recursive">If true, members are recursed to return descendent members as well
+        /// <param name="recursive">If true, members are recursed to return descendant members as well
         /// as immediate children. For example, a namespace would return the namespaces and types within.
         /// However, if <paramref name="recursive"/> is true, members with the namespaces and types would
         /// also be returned.</param>

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPage.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPage.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             //
             // This second one is tricky, because we don't actually want to update our controls
             // right then, because they'd be wrong the next time the page opens -- it's possible
-            // they may have been changed programatically. Therefore, we'll set a flag so we load
+            // they may have been changed programmatically. Therefore, we'll set a flag so we load
             // next time
             _needsLoadOnNextActivate = true;
         }
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             _pageControl.SaveSettings();
 
             // Make sure we load the next time the page is activated, in case if options changed
-            // programatically between now and the next time the page is activated
+            // programmatically between now and the next time the page is activated
             _needsLoadOnNextActivate = true;
         }
 

--- a/src/VisualStudio/Core/SolutionExplorerShim/ISolutionExplorerWorkspaceProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/ISolutionExplorerWorkspaceProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     /// this is a workaround to get different workspace per host without text buffer
     /// 
     /// currently, any feature that doesn't work on top of a buffer imports specific type of workspace explicitly. there is
-    /// no broker inbetween - unlike features that work on top of text buffers. so these components end up tightly coupled with specific
+    /// no broker in-between - unlike features that work on top of text buffers. so these components end up tightly coupled with specific
     /// kind of host, and can't be re-used in other host even if code itself could be.
     /// 
     /// this is a workaround interface for that limitation. 

--- a/src/VisualStudio/Core/Test/Preview/PreviewChangesTests.vb
+++ b/src/VisualStudio/Core/Test/Preview/PreviewChangesTests.vb
@@ -197,7 +197,7 @@ Class C
                 Dim addedDocumentId2 = DocumentId.CreateNewId(docId.ProjectId)
                 Dim addedDocumentText = "// This file will be added!"
                 newSolution = newSolution.AddDocument(addedDocumentId1, "test4.cs", addedDocumentText)
-                newSolution = newSolution.AddDocument(addedDocumentId2, "test5.cs", "// This file will be be unchecked and not added!")
+                newSolution = newSolution.AddDocument(addedDocumentId2, "test5.cs", "// This file will be unchecked and not added!")
 
                 Dim previewEngine = New PreviewEngine(
                     "Title", "helpString", "description", "topLevelItemName", CodeAnalysis.Glyph.Assembly,

--- a/src/VisualStudio/Core/Test/Venus/CSharpContainedLanguageSupportTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/CSharpContainedLanguageSupportTests.vb
@@ -501,7 +501,7 @@ public class _Default
 
 #Region "EnsureEventHandler"
 
-        ' To Do : log a bug, kevin doesnt use uint itemidInsertionPoint thats sent in.
+        ' TODO: log a bug, Kevin doesn't use uint itemidInsertionPoint thats sent in.
         <WpfFact(), Trait(Traits.Feature, Traits.Features.Venus)>
         Public Sub EnsureEventHandler_HandlerExists()
             Dim code As String = <text>
@@ -837,7 +837,7 @@ public partial class _Default
             End Using
         End Sub
 
-        ' To Do: Who tests the fully qualified names and their absence?
+        ' TODO: Who tests the fully qualified names and their absence?
         <WpfFact(), Trait(Traits.Feature, Traits.Features.Venus)>
         Public Sub TryRenameElement_UnresolvableMembers()
             Dim code As String = <text>

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/MethodXML/MethodXmlBuilder.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/MethodXML/MethodXmlBuilder.vb
@@ -363,7 +363,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel.MethodXm
                     End If
 
                     ' This can occur if a module member is referenced without the module name. In that case,
-                    ' we'll go ahead and try to use the module name name.
+                    ' we'll go ahead and try to use the module namespace name.
                     If leftHandSymbol.Kind = SymbolKind.Namespace AndAlso
                        symbolOpt?.ContainingType?.TypeKind = TypeKind.Module Then
 

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -456,7 +456,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
         ''' </summary>
         ''' <param name="container">The <see cref="SyntaxNode"/> from which to retrieve members.</param>
         ''' <param name="includeSelf">If true, the container Is returned as well.</param>
-        ''' <param name="recursive">If true, members are recursed to return descendent members as well
+        ''' <param name="recursive">If true, members are recursed to return descendant members as well
         ''' as immediate children. For example, a namespace would return the namespaces And types within.
         ''' However, if <paramref name="recursive"/> Is true, members with the namespaces And types would
         ''' also be returned.</param>
@@ -2873,7 +2873,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
             If typeSymbol Is Nothing Then
                 ' If no type is specified (e.g. CodeElement.Type = Nothing), we just convert to a Sub
-                ' it it isn't one already.
+                ' if it isn't one already.
                 If delegateStatement.IsKind(SyntaxKind.DelegateFunctionStatement) Then
                     delegateStatement = SyntaxFactory.DelegateSubStatement(
                         attributeLists:=delegateStatement.AttributeLists,
@@ -3037,7 +3037,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
             If typeSymbol Is Nothing Then
                 ' If no type is specified (e.g. CodeElement.Type = Nothing), we just convert to a Sub
-                ' it it isn't one already.
+                ' if it isn't one already.
                 If declareStatement.IsKind(SyntaxKind.DeclareFunctionStatement) Then
                     declareStatement = SyntaxFactory.DeclareSubStatement(
                         attributeLists:=declareStatement.AttributeLists,
@@ -3093,7 +3093,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
             If typeSymbol Is Nothing Then
                 ' If no type is specified (e.g. CodeElement.Type = Nothing), we just convert to a Sub
-                ' it it isn't one already.
+                ' if it isn't one already.
                 If methodStatement.IsKind(SyntaxKind.FunctionStatement) Then
                     methodStatement = SyntaxFactory.SubStatement(
                         attributeLists:=methodStatement.AttributeLists,

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -129,7 +129,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
             Public Shared Shadows Instance As IFormattingRule = New VisualBasicHelperFormattingRule()
 
             Public Overrides Sub AddIndentBlockOperations(list As List(Of IndentBlockOperation), node As SyntaxNode, optionSet As OptionSet, nextOperation As NextAction(Of IndentBlockOperation))
-                ' we need special behavior for VB due to @Helper code generation wierd-ness.
+                ' we need special behavior for VB due to @Helper code generation weird-ness.
                 ' this will looking for code gen specific style to make it not so expansive
                 If IsEndHelperPattern(node) Then
                     Return

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -1466,7 +1466,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             if (InsideNameOfExpression(name, semanticModel))
             {
-                // Nullable<T> can't be simplified to T? in nameof expresions.
+                // Nullable<T> can't be simplified to T? in nameof expressions.
                 return false;
             }
 

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -658,7 +658,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             if (ppIndex != -1)
             {
-                // We have a pp directive.  it (and all all previous trivia) must be stripped.
+                // We have a pp directive.  it (and all previous trivia) must be stripped.
                 leadingTriviaToStrip = new List<SyntaxTrivia>(leadingTrivia.Take(ppIndex + 1));
                 leadingTriviaToKeep = new List<SyntaxTrivia>(leadingTrivia.Skip(ppIndex + 1));
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     SyntaxFactory.TriviaList(CreateTriviaListFromTo(triviaList, index + 1, triviaList.Count - 1)));
             }
 
-            // whitespace trivia case such as spaces/tabes/new lines
+            // whitespace trivia case such as spaces/tabs/new lines
             // these will always have a single text change
             var text = pair.Value.GetTextChanges(GetTextSpan(pair.Key)).Single().NewText;
             var trailingTrivia = SyntaxFactory.ParseTrailingTrivia(text);
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return SyntaxFactory.TriviaList(csharpTriviaData.GetTriviaList(cancellationToken));
             }
 
-            // whitespace trivia case such as spaces/tabes/new lines
+            // whitespace trivia case such as spaces/tabs/new lines
             // these will always have single text changes
             var text = triviaData.GetTextChanges(GetTextSpan(pair)).Single().NewText;
             return SyntaxFactory.ParseLeadingTrivia(text);

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             if (lastToken.IsMissing)
             {
-                // embedded statement is not done, consider following as part of embeded statement
+                // embedded statement is not done, consider following as part of embedded statement
                 AddIndentBlockOperation(list, firstToken, lastToken);
             }
             else

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -924,7 +924,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case SyntaxKind.AmpersandEqualsToken:
                         // NOTE(cyrusn): |= and &= can be used for both ints and bools  However, in the
                         // case where there isn't enough information to determine which the user wanted,
-                        // i'm just defaulting to bool based on personal preference.
+                        // I'm just defaulting to bool based on personal preference.
                         return SpecializedCollections.SingletonEnumerable(this.Compilation.GetSpecialType(SpecialType.System_Boolean));
                 }
 

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -889,7 +889,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                     }
                 }
 
-                // if the renamed symbol is a type member, it's name should not coflict with a type parameter
+                // if the renamed symbol is a type member, it's name should not conflict with a type parameter
                 if (renamedSymbol.ContainingType != null && renamedSymbol.ContainingType.GetMembers(renamedSymbol.Name).Contains(renamedSymbol))
                 {
                     foreach (var typeParameter in renamedSymbol.ContainingType.TypeParameters)

--- a/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
         private void VisitQueryInternal(FromClauseSyntax fromClause, QueryBodySyntax body)
         {
             // This is somewhat ornery: we need to collect all the locals being introduced
-            // since they're all in scope throught all parts of the query.
+            // since they're all in scope through all parts of the query.
             var tokens = new List<SyntaxToken>();
 
             if (fromClause != null)

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpEscapingReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpEscapingReducer.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             var result = token.Kind() == SyntaxKind.IdentifierToken ? CreateNewIdentifierTokenFromToken(token, escape: false) : token;
 
             // we can't remove the escaping if this would change the semantic. This can happen in cases
-            // where there are two attribute declarations one with and and one without the attribute
+            // where there are two attribute declarations: one with and one without the attribute
             // suffix.
             if (SyntaxFacts.IsAttributeName(parent))
             {

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -547,7 +547,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                         {
                             ExpressionSyntax left;
 
-                            // Assumption here is, if the enclosing and containing types are different then there is Inheritence relationship
+                            // Assumption here is, if the enclosing and containing types are different then there is inheritance relationship
                             if (_semanticModel.GetEnclosingNamedType(originalSimpleName.SpanStart, _cancellationToken) != symbol.ContainingType)
                             {
                                 left = SyntaxFactory.BaseExpression();

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/ProjectBlock.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/ProjectBlock.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             var projectTypeGuid = Guid.Parse(scanner.ReadUpToAndEat("\")"));
 
-            // Read chars upto next quote, must contain "=" with optional leading/trailing whitespaces.
+            // Read chars up to next quote, must contain "=" with optional leading/trailing whitespaces.
             if (scanner.ReadUpToAndEat("\"").Trim() != "=")
             {
                 throw new Exception(WorkspacesResources.InvalidProjectBlockInSolutionFile);
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             var projectName = scanner.ReadUpToAndEat("\"");
 
-            // Read chars upto next quote, must contain "," with optional leading/trailing whitespaces.
+            // Read chars up to next quote, must contain "," with optional leading/trailing whitespaces.
             if (scanner.ReadUpToAndEat("\"").Trim() != ",")
             {
                 throw new Exception(WorkspacesResources.InvalidProjectBlockInSolutionFile2);
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             var projectPath = scanner.ReadUpToAndEat("\"");
 
-            // Read chars upto next quote, must contain "," with optional leading/trailing whitespaces.
+            // Read chars up to next quote, must contain "," with optional leading/trailing whitespaces.
             if (scanner.ReadUpToAndEat("\"").Trim() != ",")
             {
                 throw new Exception(WorkspacesResources.InvalidProjectBlockInSolutionFile3);

--- a/src/Workspaces/Core/Portable/CodeActions/Annotations/ConflictAnnotation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Annotations/ConflictAnnotation.cs
@@ -5,7 +5,7 @@ using System;
 namespace Microsoft.CodeAnalysis.CodeActions
 {
     /// <summary>
-    /// Apply this annotation to a SyntaxNode to indicate a conflict may exist that requires user understanding and acknowledgement before taking action.
+    /// Apply this annotation to a SyntaxNode to indicate a conflict may exist that requires user understanding and acknowledgment before taking action.
     /// </summary>
     public static class ConflictAnnotation
     {

--- a/src/Workspaces/Core/Portable/Differencing/EditScript.cs
+++ b/src/Workspaces/Core/Portable/Differencing/EditScript.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             }
 
             // Step 1
-            //  Make all children of w and and all children x "out of order"
+            //  Make all children of w and all children x "out of order"
             //  NOTE: We don't need to mark nodes "in order".
 
             // Step 2

--- a/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Editing
         public delegate Task AsyncDeclarationEditAction(DocumentEditor editor, SyntaxNode declaration, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Enables editting the definition of one of the symbol's declarations.
+        /// Enables editing the definition of one of the symbol's declarations.
         /// Partial types and methods may have more than one declaration.
         /// </summary>
         /// <param name="symbol">The symbol to edit.</param>
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Enables editting the definition of one of the symbol's declarations.
+        /// Enables editing the definition of one of the symbol's declarations.
         /// Partial types and methods may have more than one declaration.
         /// </summary>
         /// <param name="symbol">The symbol to edit.</param>
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Enables editting the definition of one of the symbol's declarations.
+        /// Enables editing the definition of one of the symbol's declarations.
         /// Partial types and methods may have more than one declaration.
         /// </summary>
         /// <param name="symbol">The symbol to edit.</param>
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Enables editting the definition of one of the symbol's declarations.
+        /// Enables editing the definition of one of the symbol's declarations.
         /// Partial types and methods may have more than one declaration.
         /// </summary>
         /// <param name="symbol">The symbol to edit.</param>
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Enables editting the symbol's declaration where the member is also declared.
+        /// Enables editing the symbol's declaration where the member is also declared.
         /// Partial types and methods may have more than one declaration.
         /// </summary>
         /// <param name="symbol">The symbol to edit.</param>
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Enables editting the symbol's declaration where the member is also declared.
+        /// Enables editing the symbol's declaration where the member is also declared.
         /// Partial types and methods may have more than one declaration.
         /// </summary>
         /// <param name="symbol">The symbol to edit.</param>
@@ -454,10 +454,10 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Enables editting all the symbol's declarations. 
+        /// Enables editing all the symbol's declarations. 
         /// Partial types and methods may have more than one declaration.
         /// </summary>
-        /// <param name="symbol">The symbol to be editted.</param>
+        /// <param name="symbol">The symbol to be edited.</param>
         /// <param name="editAction">The action that makes edits to the declaration.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/>.</param>
         /// <returns>The new symbol including the changes.</returns>
@@ -512,10 +512,10 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Enables editting all the symbol's declarations. 
+        /// Enables editing all the symbol's declarations. 
         /// Partial types and methods may have more than one declaration.
         /// </summary>
-        /// <param name="symbol">The symbol to be editted.</param>
+        /// <param name="symbol">The symbol to be edited.</param>
         /// <param name="editAction">The action that makes edits to the declaration.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/>.</param>
         /// <returns>The new symbol including the changes.</returns>

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/AbstractSyntaxTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/AbstractSyntaxTreeInfo.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return info;
             }
 
-            // check whether we can get it from peristence service
+            // check whether we can get it from persistence service
             info = await LoadAsync(document, persistenceName, serializationFormat, reader, cancellationToken).ConfigureAwait(false);
             if (info != null)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeContextInfo.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return info;
             }
 
-            // check whether we can get it from peristence service
+            // check whether we can get it from persistence service
             info = await LoadAsync(document, PersistenceName, SerializationFormat, ReadFrom, cancellationToken).ConfigureAwait(false);
             if (info != null)
             {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return true;
                 }
 
-                // delegate to normal singleline space applier
+                // delegate to normal single-line space applier
                 return ApplySpaceIfSingleLine(operation, pairIndex);
             }
 
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 Dictionary<SyntaxToken, int> previousChangesMap,
                 CancellationToken cancellationToken)
             {
-                // if baseToken is not in the stream, then it is guaranteeded to be not moved.
+                // if baseToken is not in the stream, then it is guaranteed to be not moved.
                 var tokenWithIndex = baseToken;
                 if (tokenWithIndex.IndexInStream < 0)
                 {

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.Rename
             }
 
             /// <summary>
-            /// Given a ISymbol, returns the renamable locations for a given symbol.
+            /// Given a ISymbol, returns the renameable locations for a given symbol.
             /// </summary>
             public static async Task<IEnumerable<RenameLocation>> GetRenamableDefinitionLocationsAsync(ISymbol referencedSymbol, ISymbol originalSymbol, Solution solution, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var interfacesToImplement = new List<INamedTypeSymbol>(
                 interfaces.SelectMany(i => i.GetAllInterfacesIncludingThis()).Distinct());
 
-            // However, there's no need to reimplement any interfaces that our base types already
+            // However, there's no need to re-implement any interfaces that our base types already
             // implement.  By definition they must contain all the necessary methods.
             var baseType = classOrStructType.BaseType;
             var alreadyImplementedInterfaces = baseType == null || allowReimplementation

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxNodeExtensions.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         /// <summary>
-        /// Returns true if is a given token is a child token of of a certain type of parent node.
+        /// Returns true if is a given token is a child token of a certain type of parent node.
         /// </summary>
         /// <typeparam name="TParent">The type of the parent node.</typeparam>
         /// <param name="node">The node that we are testing.</param>

--- a/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         public ImmutableArray<string> ExceptionTypes { get; private set; }
 
         /// <summary>
-        /// The item named named in the &lt;completionlist&gt; tag's cref attribute.
+        /// The item named in the &lt;completionlist&gt; tag's cref attribute.
         /// Null if the tag or cref attribute didn't exist.
         /// </summary>
         public string CompletionListCref { get; private set; }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -354,7 +354,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     return false;
                 }
 
-                // Above check makes sure that the containing assemblies are considered the same by the the assembly comparer being used.
+                // Above check makes sure that the containing assemblies are considered the same by the assembly comparer being used.
                 // If they are in fact not the same (have different name) and the caller requested to know about such types add {x, y} 
                 // to equivalentTypesWithDifferingAssemblies map.
                 if (equivalentTypesWithDifferingAssemblies != null &&

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
         /// <summary>
         /// Determines whether performing the given syntax replacement will change the semantics of any parenting expressions
-        /// by performing a bottom up walk from the <see cref="OriginalExpression"/> upto <see cref="SemanticRootOfOriginalExpression"/>
+        /// by performing a bottom up walk from the <see cref="OriginalExpression"/> up to <see cref="SemanticRootOfOriginalExpression"/>
         /// in the original tree and simultaneously walking bottom up from <see cref="ReplacedExpression"/> up to <see cref="SemanticRootOfReplacedExpression"/>
         /// in the speculated syntax tree and performing appropriate semantic comparisons.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
@@ -217,7 +217,7 @@ namespace Roslyn.Utilities
                 request.RegisterForCancellation(OnAsynchronousRequestCancelled, cancellationToken);
 
                 // Since we already registered for cancellation, it's possible that the registration has
-                // cancelled this new computation if we were the only requestor.
+                // cancelled this new computation if we were the only requester.
                 if (newAsynchronousComputation != null)
                 {
                     StartAsynchronousComputation(newAsynchronousComputation.Value, requestToCompleteSynchronously: request, callerCancellationToken: cancellationToken);
@@ -409,7 +409,7 @@ namespace Roslyn.Utilities
 
                 // We can only be here if the computation was cancelled, which means all requests for the value
                 // must have been cancelled. Therefore, the ThrowIfCancellationRequested above must have thrown
-                // because that token from the requestor was cancelled.
+                // because that token from the requester was cancelled.
                 throw ExceptionUtilities.Unreachable;
             }
         }

--- a/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
@@ -150,7 +150,7 @@ namespace Roslyn.Utilities
 
                         if (char.ToLower(oldString[column - 1]) == char.ToLower(newString[row - 1]))
                         {
-                            // Both chars are the same, so increate the length
+                            // Both chars are the same, so increment the length
                             currentLength = rowBefore1[column - 1] + 1;
                         }
                         else
@@ -181,8 +181,8 @@ namespace Roslyn.Utilities
         }
 
         /// <summary>
-        /// Returns true if 'value1' and 'value2' are likely a mispelling of each other.
-        /// Returns false otherwlse.  If it is a likely mispelling a matchCost is provided
+        /// Returns true if 'value1' and 'value2' are likely a misspelling of each other.
+        /// Returns false otherwise.  If it is a likely misspelling a matchCost is provided
         /// to help rank the match.  Lower costs mean it was a better match.
         /// </summary>
         public static bool IsCloseMatch(string originalText, string candidateText, out double matchCost)
@@ -196,8 +196,8 @@ namespace Roslyn.Utilities
         }
 
         /// <summary>
-        /// Returns true if 'value1' and 'value2' are likely a mispelling of each other.
-        /// Returns false otherwlse.  If it is a likely mispelling a matchCost is provided
+        /// Returns true if 'value1' and 'value2' are likely a misspelling of each other.
+        /// Returns false otherwise.  If it is a likely misspelling a matchCost is provided
         /// to help rank the match.  Lower costs mean it was a better match.
         /// </summary>
         public static bool IsCloseMatch(string originalText, string candidateText, int costThreshold, out double matchCost)

--- a/src/Workspaces/Core/Portable/Utilities/ExceptionHelpers.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ExceptionHelpers.cs
@@ -8,7 +8,7 @@ namespace Roslyn.Utilities
     {
         public static FailFastReset SuppressFailFast()
         {
-            // TODO: reimplement this mechanism in a portable way
+            // TODO: re-implement this mechanism in a portable way
             // CallContext.LogicalSetData(SuppressFailFastKey, boxedTrue);
             return new FailFastReset();
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -2120,7 +2120,7 @@ namespace Microsoft.CodeAnalysis
                 return result.Value;
             }
 
-            // it looks like declaration compilation doesnt exist yet. we have to build full compilation
+            // it looks like declaration compilation doesn't exist yet. we have to build full compilation
             var compilation = await GetCompilationAsync(id, cancellationToken).ConfigureAwait(false);
             if (compilation == null)
             {
@@ -2140,7 +2140,7 @@ namespace Microsoft.CodeAnalysis
                 return ConvertTreesToDocuments(id, trees);
             }
 
-            // it looks like declaration compilation doesnt exist yet. we have to build full compilation
+            // it looks like declaration compilation doesn't exist yet. we have to build full compilation
             var compilation = await GetCompilationAsync(id, cancellationToken).ConfigureAwait(false);
             if (compilation == null)
             {

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -212,14 +212,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // Verify we can get compilations for both projects
             var projects = solution.Projects.ToArray();
 
-            // Exactly one of them should have a reference to the other. Which one it is is unspecced
+            // Exactly one of them should have a reference to the other. Which one it is, is unspecced
             Assert.True(projects[0].ProjectReferences.Any(r => r.ProjectId == projects[1].Id) ||
                         projects[1].ProjectReferences.Any(r => r.ProjectId == projects[0].Id));
 
             var compilation1 = projects[0].GetCompilationAsync().Result;
             var compilation2 = projects[1].GetCompilationAsync().Result;
 
-            // Exactly one of them should have a compilation to the other. Which one it is is unspecced
+            // Exactly one of them should have a compilation to the other. Which one it is, is unspecced
             Assert.True(compilation1.References.OfType<CompilationReference>().Any(c => c.Compilation == compilation2) ||
                         compilation2.References.OfType<CompilationReference>().Any(c => c.Compilation == compilation1));
         }
@@ -1040,7 +1040,7 @@ class C1
         [WorkItem(3931, "https://github.com/dotnet/roslyn/issues/3931")]
         public void TestOpenSolution_WithMissingLanguageLibraries_WithSkipFalse_Throws()
         {
-            // proves that if the language libaries are missing then the appropriate error occurs
+            // proves that if the language libraries are missing then the appropriate error occurs
             CreateFiles(GetSimpleCSharpSolutionFiles());
 
             AssertThrows<InvalidOperationException>(() =>
@@ -1059,7 +1059,7 @@ class C1
         [WorkItem(3931, "https://github.com/dotnet/roslyn/issues/3931")]
         public void TestOpenSolution_WithMissingLanguageLibraries_WithSkipTrue_SucceedsWithDiagnostic()
         {
-            // proves that if the language libaries are missing then the appropriate error occurs
+            // proves that if the language libraries are missing then the appropriate error occurs
             CreateFiles(GetSimpleCSharpSolutionFiles());
 
             var ws = MSBuildWorkspace.Create(hostServicesWithoutCSharp);
@@ -1081,7 +1081,7 @@ class C1
         [WorkItem(3931, "https://github.com/dotnet/roslyn/issues/3931")]
         public void TestOpenProject_WithMissingLanguageLibraries_Throws()
         {
-            // proves that if the language libaries are missing then the appropriate error occurs
+            // proves that if the language libraries are missing then the appropriate error occurs
             CreateFiles(GetSimpleCSharpSolutionFiles());
 
             AssertThrows<InvalidOperationException>(() =>

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/RemoveUnnecessaryLineContinuationCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/RemoveUnnecessaryLineContinuationCodeCleanupProvider.vb
@@ -204,7 +204,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                     Return
                 End If
 
-                ' check whether colon is for statements inside of singleline statement
+                ' check whether colon is for statements inside of single-line statement
                 If (colonInTrailing AndAlso PartOfSinglelineConstruct(token1)) OrElse
                    (colonInLeading AndAlso PartOfSinglelineConstruct(token2)) Then
                     Return

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
@@ -655,7 +655,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             ' We don't want to allow a variable to be introduced if the expression contains an
             ' implicit member access.  i.e. ".Blah.ToString()" as that .Blah refers to the containing
             ' object creation or anonymous type and we can't make a local for it.  So we get all the
-            ' descendents and we suppress ourselves. 
+            ' descendants and we suppress ourselves. 
 
             ' Note: if we hit a with block or an anonymous type, then we do not look deeper.  Any
             ' implicit member accesses will refer to that thing and we *can* introduce a variable
@@ -1386,7 +1386,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             End If
 
             If InsideNameOfExpression(name) Then
-                ' Nullable(Of T) can't be simplified to T? in nameof expresions.
+                ' Nullable(Of T) can't be simplified to T? in nameof expressions.
                 Return False
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
@@ -507,10 +507,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
             ' Rules for stripping trivia: 
             ' 1) If there is a pp directive, then it (and all preceding trivia) *must* be stripped.
-            '    This rule supercedes all other rules.
+            '    This rule supersedes all other rules.
             ' 2) If there is a doc comment, it cannot be stripped.  Even if there is a doc comment,
             '    followed by 5 new lines, then the doc comment still must stay with the node.  This
-            '    rule does *not* supercede rule 1.
+            '    rule does *not* supersede rule 1.
             ' 3) Single line comments in a group (i.e. with no blank lines between them) belong to
             '    the node *iff* there is no blank line between it and the following trivia.
 
@@ -525,7 +525,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Next
 
             If ppIndex <> -1 Then
-                ' We have a pp directive.  it (and all all previous trivia) must be stripped.
+                ' We have a pp directive.  it (and all previous trivia) must be stripped.
                 leadingTriviaToStrip = New List(Of SyntaxTrivia)(leadingTrivia.Take(ppIndex + 1))
                 leadingTriviaToKeep = New List(Of SyntaxTrivia)(leadingTrivia.Skip(ppIndex + 1))
             Else

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTokenExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTokenExtensions.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         ''' <summary>
-        ''' Returns true if is a given token is a child token of of a certain type of parent node.
+        ''' Returns true if is a given token is a child token of a certain type of parent node.
         ''' </summary>
         ''' <typeparam name="TParent">The type of the parent node.</typeparam>
         ''' <param name="token">The token that we are testing.</param>

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/NodeBasedFormattingRule.vb
@@ -499,7 +499,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 Return node.GetLastToken(includeZeroWidth:=True)
             End If
 
-            ' get all enclosing forblock statements
+            ' get all enclosing for block statements
             Dim forBlocks = nextStatement.GetAncestors(Of ForOrForEachBlockSyntax)()
 
             ' get count of the for blocks

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -455,7 +455,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function GetRefKindOfArgument(node As Microsoft.CodeAnalysis.SyntaxNode) As Microsoft.CodeAnalysis.RefKind Implements ISyntaxFactsService.GetRefKindOfArgument
-            ' TODO(cyrusn): Consider the method this argument is passed to to determine this.
+            ' TODO(cyrusn): Consider the method this argument is passed to, to determine this.
             Return RefKind.None
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
@@ -615,7 +615,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Private Function InferTypeInForStepClause(forStepClause As ForStepClauseSyntax, Optional previousToken As SyntaxToken = Nothing) As IEnumerable(Of ITypeSymbol)
                 ' TODO(cyrusn): Potentially infer a different type based on the type of the variable
-                ' being foreached over.
+                ' being foreach-ed over.
                 Return SpecializedCollections.SingletonEnumerable(Me.Compilation.GetSpecialType(SpecialType.System_Int32))
             End Function
 
@@ -645,7 +645,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
                 End If
 
-                ' If we're in a lambda, then use the return tpe of the lambda to figure out what to
+                ' If we're in a lambda, then use the return type of the lambda to figure out what to
                 ' infer.  i.e.   Func<int,string> f = i => { return Foo(); }
                 Dim lambda = returnStatement.GetAncestorsOrThis(Of ExpressionSyntax)().FirstOrDefault(
                     Function(e) TypeOf e Is MultiLineLambdaExpressionSyntax OrElse
@@ -753,7 +753,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Function
 
             Private Function InferTypeInThrowStatement(Optional previousToken As SyntaxToken = Nothing) As IEnumerable(Of ITypeSymbol)
-                ' If we're not the Throw token, there's nothing to to
+                ' If we're not the Throw token, there's nothing to do
                 If previousToken <> Nothing AndAlso previousToken.Kind <> SyntaxKind.ThrowKeyword Then
                     Return SpecializedCollections.EmptyEnumerable(Of ITypeSymbol)()
                 End If

--- a/src/Workspaces/VisualBasic/Portable/Rename/LocalConflictVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/LocalConflictVisitor.vb
@@ -141,7 +141,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
             End If
 
             If controlVariable.Kind = SyntaxKind.VariableDeclarator Then
-                ' it's only legal to have one name in the variable declarator for for and for each loops.
+                ' it's only legal to have one name in the variable declarator for for and foreach loops.
                 tokens.Add(DirectCast(controlVariable, VariableDeclaratorSyntax).Names.First().Identifier)
             Else
                 Dim semanticModel = _newSolution.GetDocument(controlVariable.SyntaxTree).GetSemanticModelAsync(_cancellationToken).Result

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -721,7 +721,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                 Next
             End If
 
-            ' if the renamed symbol is a type member, it's name should not coflict with a type parameter
+            ' if the renamed symbol is a type member, it's name should not conflict with a type parameter
             If renamedSymbol.ContainingType IsNot Nothing AndAlso renamedSymbol.ContainingType.GetMembers(renamedSymbol.Name).Contains(renamedSymbol) Then
                 For Each typeParameter In renamedSymbol.ContainingType.TypeParameters
                     If CaseInsensitiveComparison.Equals(typeParameter.Name, renamedSymbol.Name) Then


### PR DESCRIPTION
This completes my pass over all code in roslyn.sln, scanning for spelling errors in comments and string literals.

CC @dotnet/roslyn-compiler