### PR TITLE
Implement ITextFormattable on CustomCommitCompletion.

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Extensibility\Completion\IAsyncCompletionService.cs" />
     <Compile Include="Extensibility\Completion\ICompletionPresenterSession.cs" />
     <Compile Include="Extensibility\Completion\ICustomCommitCompletionProvider.cs" />
+    <Compile Include="Extensibility\Completion\ICustomCompletionItemFormatter.cs" />
     <Compile Include="Extensibility\Completion\SnippetCompletionProvider.cs" />
     <Compile Include="Extensibility\Completion\PredefinedCompletionPresenterNames.cs" />
     <Compile Include="Extensibility\Completion\PredefinedCompletionProviderNames.cs" />

--- a/src/EditorFeatures/Core/Extensibility/Completion/ICustomCompletionItemFormatter.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/ICustomCompletionItemFormatter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.TextFormatting;
+using Microsoft.CodeAnalysis.Completion;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    /// <summary>
+    /// Implemented by a <see cref="CompletionListProvider"/> that wants to 
+    /// customize the presentation of <see cref="CompletionItem"/>s in the
+    /// editor
+    /// </summary>
+    internal interface ICustomCompletionItemFormatter
+    {
+        /// /// <summary>
+        /// Gets a set of <see cref="TextRunProperties"/> that will override the "default" <see cref="TextRunProperties"/> used to
+        /// display this <see cref="CompletionItem"/>'s text.
+        /// </summary>
+        /// <param name="completionItem">The item to theme</param>
+        /// <param name="defaultTextRunProperties">
+        /// The set of <see cref="TextRunProperties"/> that would have been used to present this object had no overriding taken
+        /// place.
+        /// </param>
+        /// <returns>A set of <see cref="TextRunProperties"/> that should be used to display this object's text.</returns>
+        TextRunProperties GetTextRunProperties(CompletionItem completionItem, TextRunProperties defaultTextRunProperties);
+
+        /// <summary>
+        /// Gets a set of <see cref="TextRunProperties"/> that will override the "default" <see cref="TextRunProperties"/> used to
+        /// display this object's text when this object is highlighted.
+        /// </summary>
+        /// /// <param name="completionItem">The item to theme</param>
+        /// <param name="defaultHighlightedTextRunProperties">The set of <see cref="TextRunProperties"/> that would have been used to present the highlighted object had no
+        /// overriding taken place.</param>
+        /// <returns>A set of <see cref="TextRunProperties"/> that should be used to display this object's highlighted text.</returns>
+        /// <remarks>An completion item is highlighted in the default statement completion presenter when it is fully-selected.  The
+        /// <see cref="TextRunProperties"/> selected to render the highlighted text should be chosen so as to not clash with the
+        /// style of the selection rectangle.
+        /// </remarks>
+
+        TextRunProperties GetHighlightedTextRunProperties(CompletionItem completionItem, TextRunProperties defaultHighlightedTextRunProperties);
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CustomCommitCompletion.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CustomCommitCompletion.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Windows.Media;
+using System.Windows.Media.TextFormatting;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -12,7 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.Presentation
 {
-    internal sealed class CustomCommitCompletion : Microsoft.VisualStudio.Language.Intellisense.Completion3, ICustomCommit
+    internal sealed class CustomCommitCompletion : Microsoft.VisualStudio.Language.Intellisense.Completion3, ICustomCommit, ITextFormattable
     {
         private static readonly string s_glyphCompletionWarning = "GlyphCompletionWarning";
         private readonly CompletionPresenterSession _completionPresenterSession;
@@ -79,6 +80,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         public string GetDescription_TestingOnly()
         {
             return this.CompletionItem.GetDescriptionAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None).GetFullText();
+        }
+
+        public TextRunProperties GetTextRunProperties(TextRunProperties defaultTextRunProperties)
+        {
+            var item = (CompletionItem as DescriptionModifyingCompletionItem)?.CompletionItem ?? CompletionItem;
+
+            return (item.CompletionProvider as ICustomCompletionItemFormatter)?.GetTextRunProperties(item, defaultTextRunProperties) 
+                ?? defaultTextRunProperties;
+        }
+
+        public TextRunProperties GetHighlightedTextRunProperties(TextRunProperties defaultHighlightedTextRunProperties)
+        {
+            var item = (CompletionItem as DescriptionModifyingCompletionItem)?.CompletionItem ?? CompletionItem;
+
+            return (item.CompletionProvider as ICustomCompletionItemFormatter)?.GetHighlightedTextRunProperties(item, defaultHighlightedTextRunProperties) 
+                ?? defaultHighlightedTextRunProperties;
         }
 
         public override ImageMoniker IconMoniker


### PR DESCRIPTION
Add an interface, ICustomCompletionItemFormatter, that when implemented by a CompletionListProvider, is called to format the CompletionItem.

When they implement it, this will enable TypeScript to theme their CompletionItems.

Tagging @dotnet/roslyn-ide for review.

Note that this also enables scenarios like this:
![colors2](https://cloud.githubusercontent.com/assets/3751401/10373565/1ee95e88-6da3-11e5-8d14-ed5570ca6ab7.png)

