### PR TITLE
Improve GTD & simplification of anonymous type properties

### DIFF
--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -1772,5 +1772,121 @@ End Namespace
         End Sub
 #End Region
 
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        Public Sub GoToDefinitionToAnonymousTypeImplicitlyNamedProperty_CSharp()
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+public class MyClass
+{
+    public string Prop1 { get; set; }
+}
+class Program
+{
+    static void Main(string[] args)
+    {
+        var instance = new MyClass();
+
+        var x = new
+        {
+            instance.[|Prop1|]
+        };
+
+        var z = x.Prop$$1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        Public Sub GoToDefinitionFromAnonymousTypeImplicitlyNamedProperty_CSharp()
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+public class MyClass
+{
+    public string [|Prop1|] { get; set; }
+}
+class Program
+{
+    static void Main(string[] args)
+    {
+        var instance = new MyClass();
+
+        var x = new
+        {
+            instance.Pro$$p1
+        };
+
+        var z = x.Prop1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        Public Sub GoToDefinitionToAnonymousTypeImplicitlyNamedProperty_VB()
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Public Class C
+    Public Prop1 = String.Empty
+End Class
+Class Program
+    Shared Sub Main(args As String())
+        Dim instance = New C()
+
+        Dim x = New With {instance.[|Prop1|]}
+
+        Dim z = x.Pr$$op1
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        Public Sub GoToDefinitionFromAnonymousTypeImplicitlyNamedProperty_VB()
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Public Class C
+    Public [|Prop1|] = String.Empty
+End Class
+Class Program
+    Shared Sub Main(args As String())
+        Dim instance = New C()
+
+        Dim x = New With {instance.Pro$$p1}
+
+        Dim z = x.Prop1
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -4180,5 +4180,161 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WorkItem(540186)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Sub InlineConstantToAnonymousTypeExplicitlyNamedProperty()
+            Dim initial =
+"Class C
+    Sub M()
+        Dim [||]x = 123
+        Dim y = New With {.x = x}
+    End Sub
+End Class"
+
+            Dim expected =
+"Class C
+    Sub M()
+        Dim y = New With {.x = 123}
+    End Sub
+End Class"
+
+            Test(initial, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WorkItem(540186)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Sub InlineConstantToAnonymousTypeImplicitlyNamedProperty()
+            Dim initial =
+"Class C
+    Sub M()
+        Dim [||]x = 123
+        Dim y = New With {x}
+    End Sub
+End Class"
+
+            Dim expected =
+"Class C
+    Sub M()
+        Dim y = New With {.x = 123}
+    End Sub
+End Class"
+
+            Test(initial, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Sub InlineMemberAccessToAnonymousTypeImplicitlyNamedProperty_ExplicitNameNotNeeded()
+            Dim initial =
+"Class D
+    Public Shared x As Integer
+End Class
+Class C
+    Sub M()
+        Dim [||]x = D.x
+        Dim y = New With {x}
+    End Sub
+End Class"
+
+            Dim expected =
+"Class D
+    Public Shared x As Integer
+End Class
+Class C
+    Sub M()
+        Dim y = New With {D.x}
+    End Sub
+End Class"
+
+            Test(initial, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Sub InlineMemberAccessToAnonymousTypeImplicitlyNamedProperty_ExplicitNameNeeded()
+            Dim initial =
+"Class D
+    Public Shared z As Integer
+End Class
+Class C
+    Sub M()
+        Dim [||]x = D.z
+        Dim y = New With {x}
+    End Sub
+End Class"
+
+            Dim expected =
+"Class D
+    Public Shared z As Integer
+End Class
+Class C
+    Sub M()
+        Dim y = New With {.x = D.z}
+    End Sub
+End Class"
+
+            Test(initial, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Sub InlineMemberAccessToAnonymousTypeExplicitlyNamedPropertyWithSameName_KeepsExplicitName()
+            Dim initial =
+"Class D
+    Public Shared x As Integer
+End Class
+Class C
+    Sub M()
+        Dim [||]x = D.x
+        Dim y = New With {.x = x}
+    End Sub
+End Class"
+
+            Dim expected =
+"Class D
+    Public Shared x As Integer
+End Class
+Class C
+    Sub M()
+        Dim y = New With {.x = D.x}
+    End Sub
+End Class"
+
+            Test(initial, expected, index:=0, compareTokens:=False)
+        End Sub
+
+        <WorkItem(3589, "https://github.com/dotnet/roslyn/issues/3589")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Sub InlineMemberAccessToAnonymousTypeImplicitlyNamedProperty_ExpressionNotReduced()
+            Dim initial =
+"Namespace N
+    Class D
+        Public Shared x As Integer
+    End Class
+    Class C
+        Sub M()
+            Dim [||]x = N.D.x
+            Dim y = New With {x}
+        End Sub
+    End Class
+End Namespace"
+
+            Dim expected =
+"Namespace N
+    Class D
+        Public Shared x As Integer
+    End Class
+    Class C
+        Sub M()
+            Dim y = New With {N.D.x}
+        End Sub
+    End Class
+End Namespace"
+
+            Test(initial, expected, index:=0, compareTokens:=False)
+        End Sub
+
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.ReferenceRewriter.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.ReferenceRewriter.cs
@@ -65,30 +65,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                 return base.VisitIdentifierName(node);
             }
 
-            public override SyntaxNode VisitAnonymousObjectMemberDeclarator(AnonymousObjectMemberDeclaratorSyntax node)
-            {
-                var nameEquals = node.NameEquals;
-                var expression = node.Expression;
-                var identifier = expression as IdentifierNameSyntax;
-
-                if (nameEquals != null || identifier == null || !IsReference(identifier) || HasConflict(identifier, _variableDeclarator))
-                {
-                    return base.VisitAnonymousObjectMemberDeclarator(node);
-                }
-
-                // Special case inlining into anonymous types to ensure that we keep property names:
-                //
-                // E.g.
-                //     int x = 42;
-                //     var a = new { x; };
-                //
-                // Should become:
-                //     var a = new { x = 42; };
-                nameEquals = SyntaxFactory.NameEquals(identifier);
-                expression = (ExpressionSyntax)this.Visit(expression);
-                return node.Update(nameEquals, expression).WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
-            }
-
             public static SyntaxNode Visit(
                 SemanticModel semanticModel,
                 SyntaxNode scope,

--- a/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
+++ b/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Simplification\AbstractCSharpReducer.AbstractExpressionRewriter.cs" />
     <Compile Include="Simplification\AbstractCSharpReducer.cs" />
     <Compile Include="Simplification\CSharpCastReducer.cs" />
+    <Compile Include="Simplification\CSharpAnonymousTypePropertyReducer.Rewriter.cs" />
     <Compile Include="Simplification\CSharpCastReducer.Rewriter.cs" />
     <Compile Include="Simplification\CSharpEscapingReducer.cs" />
     <Compile Include="Simplification\CSharpEscapingReducer.Rewriter.cs" />
@@ -208,6 +209,7 @@
     <Compile Include="Simplification\CSharpSimplificationService.cs" />
     <Compile Include="Simplification\CSharpSimplificationService.Expander.cs" />
     <Compile Include="Simplification\CSharpSimplificationService.NodesAndTokensToReduceComputer.cs" />
+    <Compile Include="Simplification\CSharpAnonymousTypePropertyReducer.cs" />
     <Compile Include="Utilities\CompilationOptionsConversion.cs" />
     <Compile Include="Utilities\FormattingRangeHelper.cs" />
     <Compile Include="Utilities\NameSyntaxComparer.cs" />

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpAnonymousTypePropertyReducer.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpAnonymousTypePropertyReducer.Rewriter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.CSharp.Simplification
+{
+    internal partial class CSharpAnonymousTypePropertyReducer
+    {
+        private class Rewriter : AbstractExpressionRewriter
+        {
+            public Rewriter(OptionSet optionSet, CancellationToken cancellationToken)
+                : base(optionSet, cancellationToken)
+            {
+            }
+
+            public override SyntaxNode VisitNameEquals(NameEqualsSyntax node)
+            {
+                return SimplifyNode(node, base.VisitNameEquals(node), node.Parent, SimplifyNameEquals);
+            }
+        }
+    }
+}

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpAnonymousTypePropertyReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpAnonymousTypePropertyReducer.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.Simplification
+{
+    internal partial class CSharpAnonymousTypePropertyReducer : AbstractCSharpReducer
+    {
+        public override IExpressionRewriter CreateExpressionRewriter(OptionSet optionSet, CancellationToken cancellationToken)
+        {
+            return new Rewriter(optionSet, cancellationToken);
+        }
+
+        private static SyntaxNode SimplifyNameEquals(NameEqualsSyntax node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
+        {
+            // Reduces "var a = new { C = A.B.C }" to "var a = new { A.B.C }" when possible
+
+            var declarator = node.Parent as AnonymousObjectMemberDeclaratorSyntax;
+            if (declarator == null)
+            {
+                return node;
+            }
+
+            var explicitPropertyName = node.Name?.Identifier.Text;
+            string implicitPropertyName = null;
+
+            var identifier = declarator.Expression as IdentifierNameSyntax;
+            var memberAccess = declarator.Expression as MemberAccessExpressionSyntax;
+            if (identifier != null)
+            {
+                implicitPropertyName = identifier.Identifier.Text;
+            }
+            else if (memberAccess != null)
+            {
+                implicitPropertyName = memberAccess.Name?.Identifier.Text;
+            }
+
+            if (implicitPropertyName == null || implicitPropertyName != explicitPropertyName)
+            {
+                return node;
+            }
+
+            // The NameEquals is removable
+            return null;
+        }
+    }
+}

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             yield return new CSharpParenthesesReducer();
             yield return new CSharpExtensionMethodReducer();
             yield return new CSharpEscapingReducer();
+            yield return new CSharpAnonymousTypePropertyReducer();
             yield return new CSharpMiscellaneousReducer();
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -15,7 +15,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     public static partial class SymbolFinder
     {
         /// <summary>
-        /// Finds the symbol that is associated with a position in the text of a document.
+        /// Finds the symbol that is associated with a position in the text of a document. If 
+        /// multiple symbols are associated with the token (e.g. implicitly named anonymous type
+        /// properties), then referenced symbols are preferred over the defined symbol. If the
+        /// defined symbol is required in this case, use <see cref="ModelExtensions.GetDeclaredSymbol(SemanticModel, SyntaxNode, CancellationToken)"/>
+        /// with the corresponding <see cref="SyntaxNode"/>.
         /// </summary>
         /// <param name="semanticModel">The semantic model associated with the document.</param>
         /// <param name="position">The character position within the document.</param>

--- a/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
+++ b/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
@@ -194,6 +194,8 @@
     <Compile Include="Rename\VisualBasicRenameRewriterLanguageServiceFactory.vb" />
     <Compile Include="Simplification\AbstractVisualBasicReducer.vb" />
     <Compile Include="Simplification\AbstractVisualBasicSimplifier.AbstractExpressionRewriter.vb" />
+    <Compile Include="Simplification\VisualBasicNamedFieldInitializerReducer.Rewriter.vb" />
+    <Compile Include="Simplification\VisualBasicNamedFieldInitializerReducer.vb" />
     <Compile Include="Simplification\VisualBasicCallReducer.Rewriter.vb" />
     <Compile Include="Simplification\VisualBasicCallReducer.vb" />
     <Compile Include="Simplification\VisualBasicCastReducer.Rewriter.vb" />

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicNamedFieldInitializerReducer.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicNamedFieldInitializerReducer.Rewriter.vb
@@ -1,0 +1,21 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
+    Partial Friend Class VisualBasicNamedFieldInitializerReducer
+        Private Class Rewriter
+            Inherits AbstractExpressionRewriter
+
+            Public Sub New(optionSet As OptionSet, cancellationToken As CancellationToken)
+                MyBase.New(optionSet, cancellationToken)
+            End Sub
+
+            Public Overrides Function VisitNamedFieldInitializer(node As NamedFieldInitializerSyntax) As SyntaxNode
+                Return SimplifyNode(node, MyBase.VisitNamedFieldInitializer(node), node.Parent, AddressOf SimplifyNamedFieldInitializer)
+            End Function
+        End Class
+    End Class
+End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicNamedFieldInitializerReducer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicNamedFieldInitializerReducer.vb
@@ -1,0 +1,42 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
+    Partial Friend Class VisualBasicNamedFieldInitializerReducer
+        Inherits AbstractVisualBasicReducer
+
+        Public Overrides Function CreateExpressionRewriter(optionSet As OptionSet, cancellationToken As CancellationToken) As IExpressionRewriter
+            Return New Rewriter(optionSet, cancellationToken)
+        End Function
+
+        Private Shared Function SimplifyNamedFieldInitializer(
+            node As NamedFieldInitializerSyntax,
+            semanticModel As SemanticModel,
+            optionSet As OptionSet,
+            cancellationToken As CancellationToken
+        ) As SyntaxNode
+
+            ' Reduces "New With {.X = X}" (NamedFieldInitializer) to "New With {X}" (InferredFieldInitializer)
+
+            Dim implicitName As String = Nothing
+
+            Dim identifier = TryCast(node.Expression, IdentifierNameSyntax)
+            Dim memberAccess = TryCast(node.Expression, MemberAccessExpressionSyntax)
+
+            If identifier IsNot Nothing Then
+                implicitName = identifier.Identifier.Text
+            ElseIf memberAccess IsNot Nothing Then
+                implicitName = memberAccess.Name?.Identifier.Text
+            End If
+
+            Dim explicitName = node.Name?.Identifier.Text
+
+            Return If(implicitName IsNot Nothing AndAlso implicitName = explicitName,
+                SyntaxFactory.InferredFieldInitializer(node.Expression),
+                DirectCast(node, SyntaxNode))
+        End Function
+    End Class
+End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
@@ -23,6 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 New VisualBasicNameReducer(),
                 New VisualBasicParenthesesReducer(),
                 New VisualBasicCallReducer(),
+                New VisualBasicNamedFieldInitializerReducer(),
                 New VisualBasicEscapingReducer(), ' order before VisualBasicMiscellaneousReducer, see RenameNewOverload test
                 New VisualBasicMiscellaneousReducer(),
                 New VisualBasicCastReducer(),


### PR DESCRIPTION
Fixes #3589

Consider the anonymous type defined here:

``` C#
var x = new { A.z }
```

There are two main changes:
- SymbolFinder.FindSymbolAtPosition now prefers "A.z" over "<anonymous type>.z" when looking up symbols at "z" in the above code. Consumers of this API will now get a consistent result between the case of "z" in "{ A.z }" and the case of "z" in "{ t = A.z }". **Note**: This is a behavioral change of a public API.
- Add simplifier expansion and reduction handling of implicitly named anonymous type property declarators. A declarator such as that in "new { A.z }" is expanded to "new { A = A.z }", any relevant code fixes are performed, and then the "A = " is removed if the expression on the right is of the right kind (identifier or member access) and would cause the property to be named "A".
