### PR TITLE
Use the compiler initially to check if anonymous-type properties are equivalent.

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AnonymousTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AnonymousTypeSymbols.vb
@@ -120,5 +120,44 @@ End Class
             Test(input)
         End Sub
 
+        <WorkItem(3284, "https://github.com/dotnet/roslyn/issues/3284")>
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestCaseInsensitiveAnonymousType1()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class C
+    Sub M()
+        Dim x = New With {.[|$${|Definition:A|}|] = 1}
+        Dim y = New With {.[|A|] = 2}
+        Dim z = New With {.[|a|] = 3}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
+
+        <WorkItem(3284, "https://github.com/dotnet/roslyn/issues/3284")>
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Sub TestCaseInsensitiveAnonymousType2()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Class C
+    Sub M()
+        Dim x = New With {.[|A|] = 1}
+        Dim y = New With {.[|A|] = 2}
+        Dim z = New With {.[|$${|Definition:a|}|] = 3}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+            Test(input)
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -503,6 +503,18 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             private bool PropertiesAreEquivalent(IPropertySymbol x, IPropertySymbol y, Dictionary<INamedTypeSymbol, INamedTypeSymbol> equivalentTypesWithDifferingAssemblies)
             {
+                if (x.ContainingType.IsAnonymousType && y.ContainingType.IsAnonymousType)
+                {
+                    // We can short circuit here and just use the symbols themselves to determine
+                    // equality.  This will properly handle things like the VB case where two
+                    // anonymous types will be considered the same if they have properties that
+                    // differ in casing.
+                    if (x.Equals(y))
+                    {
+                        return true;
+                    }
+                }
+
                 return
                     x.IsIndexer == y.IsIndexer &&
                     x.MetadataName == y.MetadataName &&


### PR DESCRIPTION
This will ensure that if we have two anonymous type properties from the same
compilation, that they will be considered the same if the compiler thinks they
are the same.

Fixes https://github.com/dotnet/roslyn/issues/3284