### PR TITLE
Smartly handle Shift+Enter better... 

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -41,6 +41,38 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             editorOperation.InsertNewLine();
         }
 
+        protected override bool TreatAsReturn(Document document, int position, CancellationToken cancellationToken)
+        {
+            var root = document.GetSyntaxRootAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+
+            var endToken = root.FindToken(position);
+            if (endToken.IsMissing)
+            {
+                return false;
+            }
+
+            var startToken = endToken.GetPreviousToken();
+
+            // case 1:
+            //      Consider code like so: try {|}
+            //      With auto brace completion on, user types `{` and `Return` in a hurry.
+            //      During typing, it is possible that shift was still down and not released after typing `{`.
+            //      So we've got an unintentional `shift + enter` and also we have nothing to complete this, 
+            //      so we put in a newline,
+            //      which generates code like so : try { } 
+            //                                     |
+            //      which is not useful as : try {
+            //                                  |
+            //                               }
+            //      To support this, we treat `shift + enter` like `enter` here.
+            var afterOpenBrace = startToken.Kind() == SyntaxKind.OpenBraceToken
+                              && endToken.Kind() == SyntaxKind.CloseBraceToken
+                              && endToken.Parent.IsKind(SyntaxKind.Block)
+                              && FormattingRangeHelper.AreTwoTokensOnSameLine(startToken, endToken);
+
+            return afterOpenBrace;
+        }
+
         protected override void FormatAndApply(Document document, int position, CancellationToken cancellationToken)
         {
             var root = document.GetSyntaxRootAsync(cancellationToken).WaitAndGetResult(cancellationToken);

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -51,6 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                 return false;
             }
 
+            var tokenToLeft = root.FindTokenOnLeftOfPosition(position);
             var startToken = endToken.GetPreviousToken();
 
             // case 1:
@@ -67,6 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             //      To support this, we treat `shift + enter` like `enter` here.
             var afterOpenBrace = startToken.Kind() == SyntaxKind.OpenBraceToken
                               && endToken.Kind() == SyntaxKind.CloseBraceToken
+                              && tokenToLeft == startToken
                               && endToken.Parent.IsKind(SyntaxKind.Block)
                               && FormattingRangeHelper.AreTwoTokensOnSameLine(startToken, endToken);
 

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -50,12 +50,11 @@ $$", "class {$$}");
         {
             Test(@"class C
 {
-    void Method() { }
-    $$
+    void Method() {$$}
 }", @"class C
 {
     void Method() {$$}
-}");
+}", assertNextHandlerInvoked: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
@@ -700,6 +699,144 @@ $$
 }", @"class TestClass
 {
     public int A { get; set; }$$
+}");
+        }
+
+        [WorkItem(150480)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void DelegatedInEmptyBlock()
+        {
+            Test(@"class TestClass
+{
+    void Method()
+    {
+        try { $$}
+    }
+}", @"class TestClass
+{
+    void Method()
+    {
+        try { $$}
+    }
+}", assertNextHandlerInvoked: true);
+        }
+
+        [WorkItem(150480)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void DelegatedInEmptyBlock2()
+        {
+            Test(@"class TestClass
+{
+    void Method()
+    {
+        if (true) { $$}
+    }
+}", @"class TestClass
+{
+    void Method()
+    {
+        if (true) { $$}
+    }
+}", assertNextHandlerInvoked: true);
+        }
+
+        [WorkItem(150480)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotDelegatedOutsideEmptyBlock()
+        {
+            Test(@"class TestClass
+{
+    void Method()
+    {
+        try { }
+        $$
+    }
+}", @"class TestClass
+{
+    void Method()
+    {
+        try { }$$
+    }
+}");
+        }
+
+        [WorkItem(150480)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotDelegatedAfterOpenBraceAndMissingCloseBrace()
+        {
+            Test(@"class TestClass
+{
+    void Method()
+    {
+        try {
+            $$
+    }
+}", @"class TestClass
+{
+    void Method()
+    {
+        try {$$
+    }
+}");
+        }
+
+        [WorkItem(150480)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotDelegatedInNonEmptyBlock()
+        {
+            Test(@"class TestClass
+{
+    void Method()
+    {
+        try { x }
+        $$
+    }
+}", @"class TestClass
+{
+    void Method()
+    {
+        try { x$$ }
+    }
+}");
+        }
+
+        [WorkItem(150480)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotDelegatedAfterOpenBraceInAnonymousObjectCreationExpression()
+        {
+            Test(@"class TestClass
+{
+    void Method()
+    {
+        var pet = new { };
+        $$
+    }
+}", @"class TestClass
+{
+    void Method()
+    {
+        var pet = new { $$}
+    }
+}");
+        }
+
+        [WorkItem(150480)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        public void NotDelegatedAfterOpenBraceObjectCreationExpression()
+        {
+            Test(@"class TestClass
+{
+    void Method()
+    {
+        var pet = new List<int> { };
+        $$
+    }
+}", @"class TestClass
+{
+    void Method()
+    {
+        var pet = new List<int> { $$}
+    }
 }");
         }
 

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
@@ -51,6 +51,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
         /// </summary>
         protected abstract void FormatAndApply(Document document, int position, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// special cases where we do not want to do line completion but just fall back to line break and formatting.
+        /// </summary>
+        protected abstract bool TreatAsReturn(Document document, int position, CancellationToken cancellationToken);
+
         public CommandState GetCommandState(AutomaticLineEnderCommandArgs args, Func<CommandState> nextHandler)
         {
             return CommandState.Available;
@@ -93,10 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
                         return;
                     }
 
-                    // try to move the caret to the end of the line on which the caret is
                     var subjectLineWhereCaretIsOn = position.Value.GetContainingLine();
-                    args.TextView.TryMoveCaretToAndEnsureVisible(subjectLineWhereCaretIsOn.End);
-
                     var insertionPoint = GetInsertionPoint(document, subjectLineWhereCaretIsOn, w.CancellationToken);
                     if (!insertionPoint.HasValue)
                     {
@@ -104,8 +106,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
                         return;
                     }
 
+                    // special cases where we treat this command simply as Return.
+                    if (TreatAsReturn(document, position.Value.Position, w.CancellationToken))
+                    {
+                        // leave it to the VS editor to handle this command.
+                        // VS editor's default implementation of SmartBreakLine is simply BreakLine, which inserts
+                        // a new line and positions the caret with smart indent.
+                        nextHandler();
+                        return;
+                    }
+
                     using (var transaction = args.TextView.CreateEditTransaction(EditorFeaturesResources.AutomaticLineEnder, _undoRegistry, _editorOperationsFactoryService))
                     {
+                        // try to move the caret to the end of the line on which the caret is
+                        args.TextView.TryMoveCaretToAndEnsureVisible(subjectLineWhereCaretIsOn.End);
+
                         // okay, now insert ending if we need to
                         var newDocument = InsertEndingIfRequired(document, insertionPoint.Value, position.Value, w.CancellationToken);
 

--- a/src/EditorFeatures/VisualBasic/AutomaticCompletion/AutomaticLineEnderCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticCompletion/AutomaticLineEnderCommandHandler.vb
@@ -31,6 +31,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
             nextAction()
         End Sub
 
+        Protected Overrides Function TreatAsReturn(document As Document, position As Integer, cancellationToken As CancellationToken) As Boolean
+            ' No special handling in VB.
+            Return False
+        End Function
+
         Protected Overrides Sub FormatAndApply(document As Document, position As Integer, cancellationToken As CancellationToken)
             ' vb does automatic line commit
             ' no need to do explicit formatting

--- a/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             return previousToken.Kind() == SyntaxKind.None ? token : previousToken;
         }
 
-        private static bool AreTwoTokensOnSameLine(SyntaxToken token1, SyntaxToken token2)
+        public static bool AreTwoTokensOnSameLine(SyntaxToken token1, SyntaxToken token2)
         {
             var tree = token1.SyntaxTree;
             var text = default(SourceText);


### PR DESCRIPTION
...by treating it as Enter where user can unintentionally have
Shift key pressed while hitting Enter.

In cases of pressing shift+enter after typing open parenthesis to open a block, assuming brace completion is on, we produced code like this:

initial:
```C#
try { |}
```
final:
```C#
try { }
|
```
basically, in such a case, we didn't have anything to complete the line (like a semicolon that we need to insert), yet we handled it anyway and inserted a Newline after the block and positioned caret on the next line.

a better output here could be what we produce on enter:

```C#
try
{
    |
}
```

the implementation is simple: detect cases like this and delegate the command to the editor whose default implementation is exactly what we need.

Fixes internal bug 150480. 
Also this: http://stackoverflow.com/questions/32259287/visual-studio-2015-brackets-not-automatically-formatting-when-pressing-shift