### PR TITLE
Remove SourceCodeKind.Interactive

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return _syntaxTree.Options.Kind == SourceCodeKind.Interactive || _syntaxTree.Options.Kind == SourceCodeKind.Script;
+                return _syntaxTree.Options.Kind == SourceCodeKind.Script;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -567,13 +567,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // A submission may be empty or comprised of a single script file.
             var tree = _syntaxAndDeclarations.ExternalSyntaxTrees.SingleOrDefault();
-            if (tree == null || tree.Options.Kind != SourceCodeKind.Interactive)
+            if (tree == null)
             {
                 return GetSpecialType(SpecialType.System_Void);
             }
 
-            var lastStatement = (GlobalStatementSyntax)tree.GetCompilationUnitRoot().Members.LastOrDefault(decl => decl.Kind() == SyntaxKind.GlobalStatement);
-            if (lastStatement == null || lastStatement.Statement.Kind() != SyntaxKind.ExpressionStatement)
+            // TODO: look for return statements
+            // https://github.com/dotnet/roslyn/issues/5773
+
+            var lastStatement = (GlobalStatementSyntax)tree.GetCompilationUnitRoot().Members.LastOrDefault(decl => decl.IsKind(SyntaxKind.GlobalStatement));
+            if (lastStatement == null || !lastStatement.Statement.IsKind(SyntaxKind.ExpressionStatement))
             {
                 return GetSpecialType(SpecialType.System_Void);
             }

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref DeclarationTable declTable)
         {
             var sourceCodeKind = tree.Options.Kind;
-            if (sourceCodeKind == SourceCodeKind.Interactive || sourceCodeKind == SourceCodeKind.Script)
+            if (sourceCodeKind == SourceCodeKind.Script)
             {
                 AppendAllLoadedSyntaxTrees(treesBuilder, tree, scriptClassName, resolver, messageProvider, isSubmission, ordinalMapBuilder, loadDirectiveMapBuilder, loadedSyntaxTreeMapBuilder, declMapBuilder, ref declTable);
             }
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableDictionary<string, SyntaxTree> loadedSyntaxTreeMap)
         {
             var sourceCodeKind = tree.Options.Kind;
-            if (sourceCodeKind == SourceCodeKind.Interactive || sourceCodeKind == SourceCodeKind.Script)
+            if (sourceCodeKind == SourceCodeKind.Script)
             {
                 ImmutableArray<LoadDirective> loadDirectives;
                 if (loadDirectiveMap.TryGetValue(tree, out loadDirectives))

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             Debug.Assert(this.CurrentToken.Kind == SyntaxKind.NamespaceKeyword);
             var namespaceToken = this.EatToken(SyntaxKind.NamespaceKeyword);
 
-            if (IsScriptOrInteractive)
+            if (IsScript)
             {
                 namespaceToken = this.AddError(namespaceToken, ErrorCode.ERR_NamespaceNotAllowedInScript);
             }
@@ -592,7 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             Debug.Assert(!IsInAsync);
 
             bool isGlobal = openBrace == null;
-            bool isGlobalScript = isGlobal && this.IsScriptOrInteractive;
+            bool isGlobalScript = isGlobal && this.IsScript;
 
             var saveTerm = _termState;
             _termState |= TerminatorState.IsNamespaceMemberStartOrStop;
@@ -629,7 +629,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                                 var token = this.EatToken();
                                 token = this.AddError(token,
-                                    IsScriptOrInteractive ? ErrorCode.ERR_GlobalDefinitionOrStatementExpected : ErrorCode.ERR_EOFExpected);
+                                    IsScript ? ErrorCode.ERR_GlobalDefinitionOrStatementExpected : ErrorCode.ERR_EOFExpected);
 
                                 this.AddSkippedNamespaceText(ref openBrace, ref body, ref initialBadNodes, token);
                                 reportUnexpectedToken = true;
@@ -738,7 +738,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 if (reportUnexpectedToken && !skippedToken.ContainsDiagnostics)
                                 {
                                     skippedToken = this.AddError(skippedToken,
-                                        IsScriptOrInteractive ? ErrorCode.ERR_GlobalDefinitionOrStatementExpected : ErrorCode.ERR_EOFExpected);
+                                        IsScript ? ErrorCode.ERR_GlobalDefinitionOrStatementExpected : ErrorCode.ERR_EOFExpected);
 
                                     // do not report the error multiple times for subsequent tokens:
                                     reportUnexpectedToken = false;
@@ -2230,7 +2230,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            bool isGlobalScript = parentKind == SyntaxKind.CompilationUnit && this.IsScriptOrInteractive;
+            bool isGlobalScript = parentKind == SyntaxKind.CompilationUnit && this.IsScript;
             bool acceptStatement = isGlobalScript;
 
             // don't reuse members if they were previously declared under a different type keyword kind
@@ -2498,7 +2498,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         return incompleteMember;
                     }
                     else if (parentKind == SyntaxKind.NamespaceDeclaration ||
-                             parentKind == SyntaxKind.CompilationUnit && !IsScriptOrInteractive)
+                             parentKind == SyntaxKind.CompilationUnit && !IsScript)
                     {
                         return this.AddErrorToLastToken(incompleteMember, ErrorCode.ERR_NamespaceUnexpected);
                     }
@@ -4520,7 +4520,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             // the reported errors should take into consideration whether or not one expects them in the current context.
             bool variableDeclarationsExpected =
                 parentKind != SyntaxKind.NamespaceDeclaration &&
-                (parentKind != SyntaxKind.CompilationUnit || IsScriptOrInteractive);
+                (parentKind != SyntaxKind.CompilationUnit || IsScript);
 
             ParseVariableDeclarators(type, flags, variables, variableDeclarationsExpected);
         }
@@ -8022,7 +8022,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private ExpressionStatementSyntax ParseExpressionStatement(ExpressionSyntax expression)
         {
             SyntaxToken semicolon;
-            if (IsInteractive && this.CurrentToken.Kind == SyntaxKind.EndOfFileToken)
+            if (IsScript && this.CurrentToken.Kind == SyntaxKind.EndOfFileToken)
             {
                 semicolon = SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken);
             }
@@ -8231,7 +8231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private bool IsPossibleAwaitExpressionStatement()
         {
-            return (this.IsScriptOrInteractive || this.IsInAsync) && this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword;
+            return (this.IsScript || this.IsInAsync) && this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword;
         }
 
         private bool IsAwaitExpression()

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -182,20 +182,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             get { return this.lexer.Options; }
         }
 
-        /// <summary>
-        /// Interactive code - global statements, member declarations and expressions allowed.
-        /// </summary>
-        public bool IsInteractive
+        public bool IsScript
         {
-            get { return Options.Kind == SourceCodeKind.Interactive; }
-        }
-
-        /// <summary>
-        /// Script or interactive - global statements, member declarations, and expressions allowed.
-        /// </summary>
-        public bool IsScriptOrInteractive
-        {
-            get { return (Options.Kind == SourceCodeKind.Script) || (Options.Kind == SourceCodeKind.Interactive); }
+            get { return Options.Kind == SourceCodeKind.Script; }
         }
 
         protected LexerMode Mode

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -103,10 +103,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                Debug.Assert(this.HasCompilationUnitRoot);
+                Debug.Assert(HasCompilationUnitRoot);
 
-                return (Options.Kind == SourceCodeKind.Interactive || Options.Kind == SourceCodeKind.Script) &&
-                        this.GetCompilationUnitRoot().GetReferenceDirectives().Count > 0;
+                return Options.Kind == SourceCodeKind.Script && GetCompilationUnitRoot().GetReferenceDirectives().Count > 0;
             }
         }
 
@@ -114,11 +113,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                Debug.Assert(this.HasCompilationUnitRoot);
+                Debug.Assert(HasCompilationUnitRoot);
 
-                if (Options.Kind == SourceCodeKind.Interactive || Options.Kind == SourceCodeKind.Script)
+                if (Options.Kind == SourceCodeKind.Script)
                 {
-                    var compilationUnitRoot = this.GetCompilationUnitRoot();
+                    var compilationUnitRoot = GetCompilationUnitRoot();
                     return compilationUnitRoot.GetReferenceDirectives().Count > 0 || compilationUnitRoot.GetLoadDirectives().Count > 0;
                 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -1822,15 +1822,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (token.IsMissing)
             {
-                // expression statement terminating semicolon might be missing in interactive code:
-                if (tree.Options.Kind != SourceCodeKind.Interactive ||
-                    globalStatement.Statement.Kind() != SyntaxKind.ExpressionStatement ||
-                    token.Kind() != SyntaxKind.SemicolonToken)
+                // expression statement terminating semicolon might be missing in script code:
+                if (tree.Options.Kind == SourceCodeKind.Regular ||
+                    !globalStatement.Statement.IsKind(SyntaxKind.ExpressionStatement) ||
+                    !token.IsKind(SyntaxKind.SemicolonToken))
                 {
                     return false;
                 }
 
-                token = token.GetPreviousToken(predicate: SyntaxToken.Any, stepInto: Microsoft.CodeAnalysis.SyntaxTrivia.Any);
+                token = token.GetPreviousToken(predicate: SyntaxToken.Any, stepInto: CodeAnalysis.SyntaxTrivia.Any);
                 if (token.IsMissing)
                 {
                     return false;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineScriptTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineScriptTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         {
             // As in VS/ETA, make a new list of references for each submission.
 
-            var options = new CSharpParseOptions(kind: SourceCodeKind.Interactive, documentationMode: DocumentationMode.None);
+            var options = new CSharpParseOptions(kind: SourceCodeKind.Script, documentationMode: DocumentationMode.None);
             var corLib = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.mscorlib);
 
             var s1 = CSharpCompilation.CreateSubmission("s1.dll",
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         {
             // As in VS/ETA, make a new list of references for each submission.
 
-            var options = new CSharpParseOptions(kind: SourceCodeKind.Interactive, documentationMode: DocumentationMode.None);
+            var options = new CSharpParseOptions(kind: SourceCodeKind.Script, documentationMode: DocumentationMode.None);
             var corLib = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.mscorlib);
 
             var s1 = CSharpCompilation.CreateSubmission("s1.dll",

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -844,9 +844,6 @@ class Attr: System.Attribute
 
             // Script
             TestNoCS1980WhenNotInContextWhichNeedsDynamicAttributeHelper(parseOptions: TestOptions.Script);
-
-            // Interactive
-            TestNoCS1980WhenNotInContextWhichNeedsDynamicAttributeHelper(parseOptions: TestOptions.Interactive);
         }
 
         private void TestNoCS1980WhenNotInContextWhichNeedsDynamicAttributeHelper(CSharpParseOptions parseOptions)
@@ -878,9 +875,6 @@ class Attr: System.Attribute
 
             // Script
             TestDynamicAttributeInAliasContextHelper(parseOptions: TestOptions.Script);
-
-            // Interactive
-            TestDynamicAttributeInAliasContextHelper(parseOptions: TestOptions.Interactive);
         }
 
         private void TestDynamicAttributeInAliasContextHelper(CSharpParseOptions parseOptions)
@@ -943,9 +937,6 @@ public class Gen2<T> : X    // CS1980
         {
             // Script
             TestDynamicAttributeForSubmissionFieldHelper(parseOptions: TestOptions.Script);
-
-            // Interactive
-            TestDynamicAttributeForSubmissionFieldHelper(parseOptions: TestOptions.Interactive);
         }
 
         private void TestDynamicAttributeForSubmissionFieldHelper(CSharpParseOptions parseOptions)
@@ -1009,9 +1000,6 @@ X x = null;";
         {
             // Script
             TestDynamicAttributeForSubmissionGlobalStatementHelper(parseOptions: TestOptions.Script);
-
-            // Interactive
-            TestDynamicAttributeForSubmissionGlobalStatementHelper(parseOptions: TestOptions.Interactive);
         }
 
         private void TestDynamicAttributeForSubmissionGlobalStatementHelper(CSharpParseOptions parseOptions)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -3640,8 +3640,8 @@ System.Console.WriteLine(x);";
 }";
             var source1 =
 @"await F()";
-            var s0 = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Interactive), references);
-            var s1 = CSharpCompilation.CreateSubmission("s1.dll", SyntaxFactory.ParseSyntaxTree(source1, options: TestOptions.Interactive), references, previousSubmission: s0);
+            var s0 = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Script), references);
+            var s1 = CSharpCompilation.CreateSubmission("s1.dll", SyntaxFactory.ParseSyntaxTree(source1, options: TestOptions.Script), references, previousSubmission: s0);
             s1.VerifyDiagnostics();
         }
 
@@ -3651,18 +3651,7 @@ System.Console.WriteLine(x);";
             var references = new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef };
             var source0 =
 @"await System.Threading.Tasks.Task.FromResult(5);";
-            var s0 = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Interactive), references);
-            s0.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void AwaitInInteractiveDeclaration()
-        {
-            var references = new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef };
-            var source0 =
-@"int x = await System.Threading.Tasks.Task.Run(() => 4);
-System.Console.WriteLine(x);";
-            var s0 = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Interactive), references);
+            var s0 = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Script), references);
             s0.VerifyDiagnostics();
         }
 
@@ -3685,21 +3674,6 @@ int y = x +
                 // (2,5): error CS8100: The 'await' operator cannot be used in a static script variable initializer.
                 //     await System.Threading.Tasks.Task.FromResult(1);
                 Diagnostic(ErrorCode.ERR_BadAwaitInStaticVariableInitializer, "await System.Threading.Tasks.Task.FromResult(1)").WithLocation(2, 5));
-        }
-
-        [WorkItem(5787)]
-        [Fact]
-        public void AwaitInInteractiveStaticInitializer()
-        {
-            var references = new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef };
-            var source =
-@"static int x = await System.Threading.Tasks.Task.FromResult(1);
-int y = await System.Threading.Tasks.Task.FromResult(2);";
-            var compilation = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Interactive), references);
-            compilation.VerifyDiagnostics(
-                // (1,16): error CS8100: The 'await' operator cannot be used in a static script variable initializer.
-                // static int x = await System.Threading.Tasks.Task.FromResult(1);
-                Diagnostic(ErrorCode.ERR_BadAwaitInStaticVariableInitializer, "await System.Threading.Tasks.Task.FromResult(1)").WithLocation(1, 16));
         }
 
         [Fact, WorkItem(4839, "https://github.com/dotnet/roslyn/issues/4839")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
@@ -539,7 +539,7 @@ public abstract class C
         }
 
         [Fact]
-        public void InteractiveEntryPoint()
+        public void SubmissionEntryPoint()
         {
             var references = new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef };
             var source0 =
@@ -549,7 +549,7 @@ public abstract class C
 }";
             var s0 = CSharpCompilation.CreateSubmission(
                 "s0.dll",
-                SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Interactive),
+                SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Script),
                 references);
             var verifier = CompileAndVerify(s0, verify: false);
             var methodData = verifier.TestData.GetMethodData("<Initialize>");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3138,7 +3138,7 @@ Task.FromResult(2);";
         }
 
         [Fact]
-        public void UnobservedAwaitableExpression_Interactive()
+        public void UnobservedAwaitableExpression_Submission()
         {
             var source0 =
 @"using System.Threading.Tasks;
@@ -3146,7 +3146,7 @@ Task.FromResult(1);
 Task.FromResult(2)";
             var submission = CSharpCompilation.CreateSubmission(
                 "s0.dll",
-                syntaxTree: SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Interactive),
+                syntaxTree: SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Script),
                 references: new[] { MscorlibRef_v4_0_30316_17626 });
             submission.VerifyDiagnostics(
                 // (2,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -1301,7 +1301,7 @@ class Program
 
         [WorkItem(542460, "DevDiv")]
         [Fact]
-        public void QueryWithMultipleParseErrorsAndInteractiveParseOption()
+        public void QueryWithMultipleParseErrorsAndScriptParseOption()
         {
             string sourceCode = @"
 using System;
@@ -1318,7 +1318,7 @@ public class QueryExpressionTest
     }
 }";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode, parseOptions: TestOptions.Script);
             var tree = compilation.SyntaxTrees[0];
             var semanticModel = compilation.GetSemanticModel(tree);
             var queryExpr = tree.GetCompilationUnitRoot().DescendantNodes().OfType<QueryExpressionSyntax>().Where(x => x.ToFullString() == "from i in expr1 let ").Single();
@@ -1329,7 +1329,7 @@ public class QueryExpressionTest
 
         [WorkItem(542496, "DevDiv")]
         [Fact]
-        public void QueryExpressionInFieldInitReferencingAnotherFieldWithInteractiveParseOption()
+        public void QueryExpressionInFieldInitReferencingAnotherFieldWithScriptParseOption()
         {
             string sourceCode = @"
 using System.Linq;
@@ -1344,7 +1344,7 @@ class P
                select x + one;
 }";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode, parseOptions: TestOptions.Script);
             var tree = compilation.SyntaxTrees[0];
             var semanticModel = compilation.GetSemanticModel(tree);
             var queryExpr = tree.GetCompilationUnitRoot().DescendantNodes().OfType<QueryExpressionSyntax>().Single();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string test = @"
 this[1]
 ";
-            var compilation = CreateCompilationWithMscorlib45(test, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlib45(test, parseOptions: TestOptions.Script);
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
 
@@ -86,7 +86,7 @@ this[1]
         [Fact]
         public void NoReferences()
         {
-            var submission = CSharpCompilation.CreateSubmission("test", syntaxTree: SyntaxFactory.ParseSyntaxTree("1", options: TestOptions.Interactive), returnType: typeof(int));
+            var submission = CSharpCompilation.CreateSubmission("test", syntaxTree: SyntaxFactory.ParseSyntaxTree("1", options: TestOptions.Script), returnType: typeof(int));
             submission.VerifyDiagnostics(
                 // (1,1): error CS0518: Predefined type 'System.Object' is not defined or imported
                 // 1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -2115,7 +2115,7 @@ namespace Test
         }
 
         [Fact]
-        public void SwitchFallOut_Script()
+        public void SwitchFallOut_Script1()
         {
             var source =
 @"using System;
@@ -2137,7 +2137,7 @@ switch (1)
         }
 
         [Fact]
-        public void SwitchFallOut_Interactive()
+        public void SwitchFallOut_Script2()
         {
             var source =
 @"using System;
@@ -2150,7 +2150,7 @@ switch (1)
 }";
             var submission = CSharpCompilation.CreateSubmission(
                 "s0.dll",
-                syntaxTree: SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Interactive),
+                syntaxTree: SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Script),
                 references: new[] { MscorlibRef, SystemCoreRef });
             submission.VerifyDiagnostics(
                 // (4,5): error CS0163: Control cannot fall through from one case label ('case 1:') to another

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -1386,7 +1386,7 @@ class A
             var source = @"1 + 1";
             var compilation = CSharpCompilation.CreateSubmission("sub",
                 references: new[] { MscorlibRef },
-                syntaxTree: Parse(source, options: TestOptions.Interactive));
+                syntaxTree: Parse(source, options: TestOptions.Script));
             compilation.VerifyDiagnostics();
 
             var scriptMethod = compilation.GetMember<MethodSymbol>("Script.<Factory>");
@@ -1410,7 +1410,7 @@ class A
 ";
             var compilation = CSharpCompilation.CreateSubmission("sub",
                 references: new[] { MscorlibRef },
-                syntaxTree: Parse(source, options: TestOptions.Interactive));
+                syntaxTree: Parse(source, options: TestOptions.Script));
             compilation.VerifyDiagnostics(
                 // (4,17): warning CS7022: The entry point of the program is global script code; ignoring 'A.Main()' entry point.
                 //     static void Main() { }
@@ -1973,16 +1973,15 @@ public class C { public static FrameworkName Foo() { return null; }}";
             Assert.Equal(SpecialType.System_Void, submission.GetSubmissionResultType(out hasValue).SpecialType);
             Assert.False(hasValue);
 
-            TestSubmissionResult(CreateSubmission("1", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Void, expectedHasValue: false);
-            TestSubmissionResult(CreateSubmission("1", parseOptions: TestOptions.Interactive), expectedType: SpecialType.System_Int32, expectedHasValue: true);
-            TestSubmissionResult(CreateSubmission("1;", parseOptions: TestOptions.Interactive), expectedType: SpecialType.System_Void, expectedHasValue: false);
-            TestSubmissionResult(CreateSubmission("void foo() { }", parseOptions: TestOptions.Interactive), expectedType: SpecialType.System_Void, expectedHasValue: false);
-            TestSubmissionResult(CreateSubmission("using System;", parseOptions: TestOptions.Interactive), expectedType: SpecialType.System_Void, expectedHasValue: false);
-            TestSubmissionResult(CreateSubmission("int i;", parseOptions: TestOptions.Interactive), expectedType: SpecialType.System_Void, expectedHasValue: false);
-            TestSubmissionResult(CreateSubmission("System.Console.WriteLine();", parseOptions: TestOptions.Interactive), expectedType: SpecialType.System_Void, expectedHasValue: false);
-            TestSubmissionResult(CreateSubmission("System.Console.WriteLine()", parseOptions: TestOptions.Interactive), expectedType: SpecialType.System_Void, expectedHasValue: true);
-            TestSubmissionResult(CreateSubmission("null", parseOptions: TestOptions.Interactive), expectedType: null, expectedHasValue: true);
-            TestSubmissionResult(CreateSubmission("System.Console.WriteLine", parseOptions: TestOptions.Interactive), expectedType: null, expectedHasValue: true);
+            TestSubmissionResult(CreateSubmission("1", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Int32, expectedHasValue: true);
+            TestSubmissionResult(CreateSubmission("1;", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Void, expectedHasValue: false);
+            TestSubmissionResult(CreateSubmission("void foo() { }", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Void, expectedHasValue: false);
+            TestSubmissionResult(CreateSubmission("using System;", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Void, expectedHasValue: false);
+            TestSubmissionResult(CreateSubmission("int i;", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Void, expectedHasValue: false);
+            TestSubmissionResult(CreateSubmission("System.Console.WriteLine();", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Void, expectedHasValue: false);
+            TestSubmissionResult(CreateSubmission("System.Console.WriteLine()", parseOptions: TestOptions.Script), expectedType: SpecialType.System_Void, expectedHasValue: true);
+            TestSubmissionResult(CreateSubmission("null", parseOptions: TestOptions.Script), expectedType: null, expectedHasValue: true);
+            TestSubmissionResult(CreateSubmission("System.Console.WriteLine", parseOptions: TestOptions.Script), expectedType: null, expectedHasValue: true);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
@@ -359,7 +359,7 @@ using System;
         [Fact]
         public void UnusedUsingInteractive()
         {
-            var tree = Parse("using System;", options: TestOptions.Interactive);
+            var tree = Parse("using System;", options: TestOptions.Script);
             var comp = CSharpCompilation.CreateSubmission("sub1", tree, new[] { MscorlibRef_v4_0_30316_17626 });
 
             comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var code = "#load \"\"";
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(TestSourceReferenceResolver.Default);
-            var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Script);
 
             Assert.Single(compilation.SyntaxTrees);
             compilation.VerifyDiagnostics(
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var code = "#load \"missing\"";
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(TestSourceReferenceResolver.Default);
-            var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlib45(code, options: options, parseOptions: TestOptions.Script);
 
             Assert.Single(compilation.SyntaxTrees);
             compilation.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -3597,9 +3597,9 @@ class Program
 
         [WorkItem(541800, "DevDiv")]
         [Fact]
-        public void GetDeclaredSymbolOnGlobalStmtParseOptionInteractive()
+        public void GetDeclaredSymbolOnGlobalStmtParseOptionScript()
         {
-            var parseOptions = TestOptions.Interactive;
+            var parseOptions = TestOptions.Script;
             var compilation = CreateCompilationWithMscorlib(@"/", parseOptions: parseOptions);
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);
@@ -3679,7 +3679,7 @@ class Program
 
         [WorkItem(542459, "DevDiv")]
         [Fact]
-        public void StructKeywordInsideSwitchWithInteractiveParseOption()
+        public void StructKeywordInsideSwitchWithScriptParseOption()
         {
             var compilation = CreateCompilationWithMscorlib(@"
 using System;
@@ -3701,7 +3701,7 @@ class Test
         }
     }
 }
-", parseOptions: TestOptions.Interactive
+", parseOptions: TestOptions.Script
  );
 
             var tree = compilation.SyntaxTrees[0];
@@ -3720,7 +3720,7 @@ using System;
 struct break;
 ";
 
-            var compilation = CreateCompilationWithMscorlib(code, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlib(code, parseOptions: TestOptions.Script);
 
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);
@@ -3750,7 +3750,7 @@ namespace N1
 
         [WorkItem(542583, "DevDiv")]
         [Fact]
-        public void LambdaExpressionInFieldInitReferencingAnotherFieldWithInteractiveParseOption()
+        public void LambdaExpressionInFieldInitReferencingAnotherFieldWithScriptParseOption()
         {
             string sourceCode = @"
 using System.Linq;
@@ -3761,7 +3761,7 @@ class P
     double one = 1;
     public Func<int, int> z = (x => x + one);
 }";
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode, parseOptions: TestOptions.Interactive);
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode, parseOptions: TestOptions.Script);
             var tree = compilation.SyntaxTrees[0];
             var semanticModel = compilation.GetSemanticModel(tree);
             var queryExpr = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ParenthesizedExpressionSyntax>().First();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -3689,7 +3689,7 @@ o.F();";
         [Fact]
         public void InteractiveExtensionMethods()
         {
-            var parseOptions = TestOptions.Interactive;
+            var parseOptions = TestOptions.Script;
             var references = new[] { MscorlibRef, SystemCoreRef };
             var source0 =
 @"static object F(this object o) { return 0; }
@@ -3699,11 +3699,13 @@ o.F();";
 @"static object G(this object o) { return 1; }
 var o = new object();
 o.G().F();";
+
             var s0 = CSharpCompilation.CreateSubmission(
                 "s0.dll",
                 syntaxTree: SyntaxFactory.ParseSyntaxTree(source0, options: parseOptions),
                 references: references);
             s0.VerifyDiagnostics();
+
             var s1 = CSharpCompilation.CreateSubmission(
                 "s1.dll",
                 syntaxTree: SyntaxFactory.ParseSyntaxTree(source1, options: parseOptions),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
@@ -101,36 +101,34 @@ private void M6() { }
 extern void M7();
 static void M12() { }
 ";
-            foreach (var options in new[] { TestOptions.Script, TestOptions.Interactive })
-            {
-                var comp = CreateCompilationWithMscorlib45(text, parseOptions: options);
-                var script = comp.ScriptClass;
-                var m1 = script.GetMembers("M1").Single() as MethodSymbol;
-                Assert.Equal(Accessibility.Private, m1.DeclaredAccessibility);
-                var m2 = script.GetMembers("M2").Single() as MethodSymbol;
-                Assert.Equal(Accessibility.Public, m2.DeclaredAccessibility);
-                var m3 = script.GetMembers("M3").Single() as MethodSymbol;
-                Assert.Equal(Accessibility.Protected, m3.DeclaredAccessibility);
-                var m4 = script.GetMembers("M4").Single() as MethodSymbol;
-                Assert.Equal(Accessibility.Internal, m4.DeclaredAccessibility);
-                var m5 = script.GetMembers("M5").Single() as MethodSymbol;
-                Assert.Equal(Accessibility.ProtectedOrInternal, m5.DeclaredAccessibility);
-                var m6 = script.GetMembers("M6").Single() as MethodSymbol;
-                Assert.Equal(Accessibility.Private, m6.DeclaredAccessibility);
-                var m7 = script.GetMembers("M7").Single() as MethodSymbol;
-                Assert.True(m7.IsExtern);
-                var m12 = script.GetMembers("M12").Single() as MethodSymbol;
-                Assert.True(m12.IsStatic);
 
-                comp.VerifyDiagnostics(
-                    // (4,16): warning CS0628: 'M3()': new protected member declared in sealed class
-                    Diagnostic(ErrorCode.WRN_ProtectedInSealed, "M3").WithArguments("M3()"),
-                    // (6,25): warning CS0628: 'M5()': new protected member declared in sealed class
-                    Diagnostic(ErrorCode.WRN_ProtectedInSealed, "M5").WithArguments("M5()"),
-                    // (8,13): warning CS0626: Method, operator, or accessor 'M7()' is marked external and has no attributes on it. Consider adding a DllImport attribute to specify the external implementation.
-                    Diagnostic(ErrorCode.WRN_ExternMethodNoImplementation, "M7").WithArguments("M7()")
-                );
-            }
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Script);
+            var script = comp.ScriptClass;
+            var m1 = script.GetMembers("M1").Single() as MethodSymbol;
+            Assert.Equal(Accessibility.Private, m1.DeclaredAccessibility);
+            var m2 = script.GetMembers("M2").Single() as MethodSymbol;
+            Assert.Equal(Accessibility.Public, m2.DeclaredAccessibility);
+            var m3 = script.GetMembers("M3").Single() as MethodSymbol;
+            Assert.Equal(Accessibility.Protected, m3.DeclaredAccessibility);
+            var m4 = script.GetMembers("M4").Single() as MethodSymbol;
+            Assert.Equal(Accessibility.Internal, m4.DeclaredAccessibility);
+            var m5 = script.GetMembers("M5").Single() as MethodSymbol;
+            Assert.Equal(Accessibility.ProtectedOrInternal, m5.DeclaredAccessibility);
+            var m6 = script.GetMembers("M6").Single() as MethodSymbol;
+            Assert.Equal(Accessibility.Private, m6.DeclaredAccessibility);
+            var m7 = script.GetMembers("M7").Single() as MethodSymbol;
+            Assert.True(m7.IsExtern);
+            var m12 = script.GetMembers("M12").Single() as MethodSymbol;
+            Assert.True(m12.IsStatic);
+
+            comp.VerifyDiagnostics(
+                // (4,16): warning CS0628: 'M3()': new protected member declared in sealed class
+                Diagnostic(ErrorCode.WRN_ProtectedInSealed, "M3").WithArguments("M3()"),
+                // (6,25): warning CS0628: 'M5()': new protected member declared in sealed class
+                Diagnostic(ErrorCode.WRN_ProtectedInSealed, "M5").WithArguments("M5()"),
+                // (8,13): warning CS0626: Method, operator, or accessor 'M7()' is marked external and has no attributes on it. Consider adding a DllImport attribute to specify the external implementation.
+                Diagnostic(ErrorCode.WRN_ExternMethodNoImplementation, "M7").WithArguments("M7()")
+            );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -15628,7 +15628,6 @@ namespace N1
             };
 
             CreateCompilationWithMscorlib45(new[] { Parse(text, options: TestOptions.Script) }).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilationWithMscorlib45(new[] { Parse(text, options: TestOptions.Interactive) }).VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -19171,7 +19170,7 @@ internal abstract event System.EventHandler E;";
 @"internal abstract void M();
 internal abstract object P { get; }
 internal abstract event System.EventHandler E;";
-            var submission = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Interactive), new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef });
+            var submission = CSharpCompilation.CreateSubmission("s0.dll", SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Script), new[] { MscorlibRef_v4_0_30316_17626, SystemCoreRef });
             submission.VerifyDiagnostics(
                 // (1,24): error CS0513: 'M()' is abstract but it is contained in non-abstract class 'Script'
                 // internal abstract void M();

--- a/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
+++ b/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
@@ -105,7 +105,7 @@
     <Compile Include="Parsing\DeclarationParsingTests.cs" />
     <Compile Include="Parsing\ExpressionParsingTests.cs" />
     <Compile Include="Parsing\FuzzTesting.cs" />
-    <Compile Include="Parsing\InteractiveParsingTests.cs" />
+    <Compile Include="Parsing\ScriptParsingTests.cs" />
     <Compile Include="Parsing\LambdaParameterParsingTests.cs" />
     <Compile Include="Parsing\NameAttributeValueParsingTests.cs" />
     <Compile Include="Parsing\NameParsingTests.cs" />

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -3830,7 +3830,7 @@ static void Main() { }
         public void TestLoadWithoutFile()
         {
             var text = "#load";
-            var node = Parse(text, SourceCodeKind.Interactive);
+            var node = Parse(text, SourceCodeKind.Script);
             TestRoundTripping(node, text, disallowErrors: false);
             VerifyErrorCode(node, (int)ErrorCode.ERR_ExpectedPPFile);
             VerifyDirectivesSpecial(node, new DirectiveInfo
@@ -3845,7 +3845,7 @@ static void Main() { }
         public void TestLoadWithSemicolon()
         {
             var text = "#load \"\";";
-            var node = Parse(text, SourceCodeKind.Interactive);
+            var node = Parse(text, SourceCodeKind.Script);
             TestRoundTripping(node, text, disallowErrors: false);
             VerifyErrorCode(node, (int)ErrorCode.ERR_EndOfPPLineExpected);
             VerifyDirectivesSpecial(node, new DirectiveInfo

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public class InteractiveParsingTests : ParsingTests
+    public class ScriptParsingTests : ParsingTests
     {
         #region Helpers
 
@@ -67,10 +67,10 @@ static partial class C { }
 int a  
 Console.Foo
 ";
-            ParseAndValidate(test, TestOptions.Interactive,
+            ParseAndValidate(test, TestOptions.Script,
                 new ErrorDescription[] {
-                    new ErrorDescription { Code = 1002, Line = 2, Column = 6 },
-                    new ErrorDescription { Code = 1002, Line = 3, Column = 12 }});
+                    new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 6 },
+                    new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 3, Column = 12 }});
         }
 
         [Fact]
@@ -239,7 +239,7 @@ bar();
             var test = @"
 Script() { }
 ";
-            ParseAndValidate(test, new ErrorDescription { Code = 1002, Line = 2, Column = 10 });
+            ParseAndValidate(test, new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 10 });
         }
 
         [Fact]
@@ -257,7 +257,7 @@ static Script() { }
             var test = @"
 ~Script() { }
 ";
-            ParseAndValidate(test, new ErrorDescription { Code = 1002, Line = 2, Column = 11 });
+            ParseAndValidate(test, new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 11 });
         }
 
         #endregion
@@ -1667,8 +1667,8 @@ delegate void Foo();
 delegate void MyDel(int i);
 ";
             ParseAndValidate(test,
-                new ErrorDescription { Code = 1002, Line = 2, Column = 13 },
-                new ErrorDescription { Code = 1002, Line = 3, Column = 15 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 13 },
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 3, Column = 15 });
         }
 
         [Fact]
@@ -2425,7 +2425,11 @@ fixed int x[10];
 
             // pointer decl
             test = @"a.b * c";
-            ParseAndValidate(test, TestOptions.Regular, new[] { new ErrorDescription { Code = 1002, Line = 1, Column = 8 } }); // expected ';'
+            ParseAndValidate(test, TestOptions.Regular, new[] { new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 1, Column = 8 } }); // expected ';'
+
+            // multiplication
+            test = @"a.b * c;";
+            ParseAndValidate(test, TestOptions.Script);
 
             // multiplication
             test = @"a.b * c;";
@@ -2433,21 +2437,13 @@ fixed int x[10];
 
             // multiplication
             test = @"a.b * c";
-            ParseAndValidate(test, TestOptions.Script, new[] { new ErrorDescription { Code = 1002, Line = 1, Column = 8 } });   // expected ';'
-
-            // multiplication
-            test = @"a.b * c;";
-            ParseAndValidate(test, TestOptions.Interactive);
-
-            // multiplication
-            test = @"a.b * c";
-            ParseAndValidate(test, TestOptions.Interactive);
+            ParseAndValidate(test, TestOptions.Script);
         }
 
         [Fact]
         public void Multiplication_Interactive_Semicolon()
         {
-            var tree = UsingTree(@"a * b;", TestOptions.Interactive);
+            var tree = UsingTree(@"a * b;", TestOptions.Script);
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2477,7 +2473,7 @@ fixed int x[10];
         [Fact]
         public void Multiplication_Interactive_NoSemicolon()
         {
-            var tree = UsingTree(@"a * b", TestOptions.Interactive);
+            var tree = UsingTree(@"a * b", TestOptions.Script);
 
             Assert.False(tree.GetCompilationUnitRoot().ContainsDiagnostics);
 
@@ -2509,7 +2505,7 @@ fixed int x[10];
         [Fact]
         public void Multiplication_Complex()
         {
-            var tree = UsingTree(@"a<t>.n * f(x)", TestOptions.Interactive);
+            var tree = UsingTree(@"a<t>.n * f(x)", TestOptions.Script);
             Assert.False(tree.GetCompilationUnitRoot().ContainsDiagnostics);
 
             N(SyntaxKind.CompilationUnit);
@@ -2644,7 +2640,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_FieldDecl_Semicolon1()
         {
-            var tree = UsingTree(@"T ? a;", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a;", TestOptions.Script);
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2674,7 +2670,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_FieldDecl_Semicolon2()
         {
-            var tree = UsingTree(@"T ? b, c = 1;", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? b, c = 1;", TestOptions.Script);
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2717,7 +2713,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_FieldDecl_Semicolon3()
         {
-            var tree = UsingTree(@"T ? b = d => { };", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? b = d => { };", TestOptions.Script);
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2764,7 +2760,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_FieldDecl_Semicolon4()
         {
-            var tree = UsingTree(@"T ? b = x ? y : z;", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? b = x ? y : z;", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.FieldDeclaration);
@@ -2814,7 +2810,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_FieldDecl_Comma1()
         {
-            var tree = UsingTree(@"T ? a,", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a,", TestOptions.Script);
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2849,7 +2845,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_FieldDecl_Comma2()
         {
-            var tree = UsingTree(@"T ? a = 1,", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a = 1,", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.FieldDeclaration);
@@ -2893,7 +2889,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_PropertyDecl1()
         {
-            var tree = UsingTree(@"T ? a {", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a {", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.PropertyDeclaration);
@@ -2920,7 +2916,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_PropertyDecl2()
         {
-            var tree = UsingTree(@"T ? a.b {", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a.b {", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.PropertyDeclaration);
@@ -2955,7 +2951,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_PropertyDecl3()
         {
-            var tree = UsingTree(@"T ? a<T>.b {", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<T>.b {", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.PropertyDeclaration);
@@ -2999,7 +2995,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_PropertyDecl4()
         {
-            var tree = UsingTree(@"T ? a<T?>.b<S>.c {", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<T?>.b<S>.c {", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.PropertyDeclaration);
@@ -3066,7 +3062,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl1()
         {
-            var tree = UsingTree(@"T ? a() {", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a() {", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3098,7 +3094,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl1_Where()
         {
-            var tree = UsingTree(@"T ? a() where", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a() where", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3142,7 +3138,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl2()
         {
-            var tree = UsingTree(@"T ? a(T b", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T b", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3178,7 +3174,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl3()
         {
-            var tree = UsingTree(@"T ? a.b(T c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a.b(T c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3222,7 +3218,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl4()
         {
-            var tree = UsingTree(@"T ? a<A>.b<B>(C c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<A>.b<B>(C c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3284,7 +3280,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl5()
         {
-            var tree = UsingTree(@"T ? a([Attr]C c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a([Attr]C c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3332,7 +3328,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl6()
         {
-            var tree = UsingTree(@"T ? a([Attr(a = b)]c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a([Attr(a = b)]c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3400,7 +3396,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl7()
         {
-            var tree = UsingTree(@"T ? a(out C c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(out C c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3437,7 +3433,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl8()
         {
-            var tree = UsingTree(@"T ? a(C[] a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(C[] a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3485,7 +3481,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl9()
         {
-            var tree = UsingTree(@"T ? a(params", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(params", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3522,7 +3518,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl10()
         {
-            var tree = UsingTree(@"T ? a(out T ? b", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(out T ? b", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3563,7 +3559,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl11()
         {
-            var tree = UsingTree(@"T ? a(ref T ? b", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(ref T ? b", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3604,7 +3600,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl12()
         {
-            var tree = UsingTree(@"T ? a(params T ? b", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(params T ? b", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3645,7 +3641,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl13()
         {
-            var tree = UsingTree(@"T ? a([Attr]T ? b", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a([Attr]T ? b", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3697,7 +3693,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl14A()
         {
-            var tree = UsingTree(@"T ? a(T ? b,", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T ? b,", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3746,7 +3742,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl14B()
         {
-            var tree = UsingTree(@"T ? a(T ? b)", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T ? b)", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3786,7 +3782,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl15()
         {
-            var tree = UsingTree(@"T ? a(T c)", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T c)", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3822,7 +3818,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl16()
         {
-            var tree = UsingTree(@"T ? a(this c d", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(this c d", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3859,7 +3855,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl17()
         {
-            var tree = UsingTree(@"T ? a(ref out T a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(ref out T a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3897,7 +3893,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl18()
         {
-            var tree = UsingTree(@"T ? a(int a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(int a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3933,7 +3929,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl19()
         {
-            var tree = UsingTree(@"T ? a(ref int a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(ref int a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -3970,7 +3966,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl20()
         {
-            var tree = UsingTree(@"T ? a(T a =", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T a =", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -4014,7 +4010,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl21()
         {
-            var tree = UsingTree(@"T ? a(T[,] a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T[,] a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -4122,7 +4118,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl_GenericAmbiguity1()
         {
-            var tree = UsingTree(@"T ? m(a < b, c > d)", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(a < b, c > d)", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
@@ -4174,7 +4170,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression1()
         {
-            var tree = UsingTree(@"T ? 1", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? 1", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4208,7 +4204,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression2()
         {
-            var tree = UsingTree(@"T ? a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4242,7 +4238,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression3()
         {
-            var tree = UsingTree(@"T ? a.", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a.", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4284,7 +4280,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression4()
         {
-            var tree = UsingTree(@"T ? a[", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a[", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4326,7 +4322,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression5()
         {
-            var tree = UsingTree(@"T ? a<", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4368,7 +4364,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression6()
         {
-            var tree = UsingTree(@"T ? a<b", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<b", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4410,7 +4406,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression7()
         {
-            var tree = UsingTree(@"T ? a<b>", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<b>", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4453,7 +4449,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression8()
         {
-            var tree = UsingTree(@"T ? a<b,c>", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<b,c>", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4501,7 +4497,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression9()
         {
-            var tree = UsingTree(@"T ? a<b>.", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<b>.", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4552,7 +4548,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression10()
         {
-            var tree = UsingTree(@"T ? a<b>.c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<b>.c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4603,7 +4599,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression11()
         {
-            var tree = UsingTree(@"T ? a<b>.c(", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a<b>.c(", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4662,7 +4658,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression12()
         {
-            var tree = UsingTree(@"T ? a(", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4704,7 +4700,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression13()
         {
-            var tree = UsingTree(@"T ? a.b(", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a.b(", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4754,7 +4750,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression14()
         {
-            var tree = UsingTree(@"T ? m(c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4803,7 +4799,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression15()
         {
-            var tree = UsingTree(@"T ? m(c,", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(c,", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4860,7 +4856,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression16()
         {
-            var tree = UsingTree(@"T ? m(c:", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(c:", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4917,7 +4913,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression17()
         {
-            var tree = UsingTree(@"T ? m(c?", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(c?", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -4979,7 +4975,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression18()
         {
-            var tree = UsingTree(@"T ? m(c? a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(c? a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5041,7 +5037,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression19()
         {
-            var tree = UsingTree(@"T ? m(c? a =", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(c? a =", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5111,7 +5107,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression20()
         {
-            var tree = UsingTree(@"T ? m(c? a = b ?", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(c? a = b ?", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5194,7 +5190,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression21()
         {
-            var tree = UsingTree(@"T ? m()", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m()", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5236,7 +5232,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression22()
         {
-            var tree = UsingTree(@"T ? m(a)", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(a)", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5285,7 +5281,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression23()
         {
-            var tree = UsingTree(@"T ? m();", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m();", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5327,7 +5323,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression24()
         {
-            var tree = UsingTree(@"T ? m(a);", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(a);", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5376,7 +5372,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression25()
         {
-            var tree = UsingTree(@"T ? m(x: 1", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(x: 1", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5433,7 +5429,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression26()
         {
-            var tree = UsingTree(@"T ? m(x: 1, y: a ? b : c)", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(x: 1, y: a ? b : c)", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5519,7 +5515,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression27()
         {
-            var tree = UsingTree(@"T ? u => { } : v => { }", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? u => { } : v => { }", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5571,7 +5567,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression28()
         {
-            var tree = UsingTree(@"T ? u => (d ? e => 1 : f => 2)(3) : c => 2", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? u => (d ? e => 1 : f => 2)(3) : c => 2", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5670,7 +5666,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression30()
         {
-            var tree = UsingTree(@"T ? a ?", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a ?", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5717,7 +5713,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression31()
         {
-            var tree = UsingTree(@"T ? a =", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a =", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5757,7 +5753,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression32()
         {
-            var tree = UsingTree(@"T ? a = b", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a = b", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5799,7 +5795,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression33()
         {
-            var tree = UsingTree(@"T ? a = b : ", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a = b : ", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5841,7 +5837,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression34()
         {
-            var tree = UsingTree(@"T ? m(out c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(out c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5891,7 +5887,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression35()
         {
-            var tree = UsingTree(@"T ? m(ref c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(ref c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -5941,7 +5937,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression36()
         {
-            var tree = UsingTree(@"T ? m(ref out", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(ref out", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6000,7 +5996,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression37()
         {
-            var tree = UsingTree(@"T ? m(ref out c", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(ref out c", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6059,7 +6055,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression38()
         {
-            var tree = UsingTree(@"T ? m(this", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(this", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6108,7 +6104,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression39()
         {
-            var tree = UsingTree(@"T ? m(this.", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(this.", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6163,7 +6159,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression40()
         {
-            var tree = UsingTree(@"T ? m(this<", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(this<", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6220,7 +6216,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression41()
         {
-            var tree = UsingTree(@"T ? m(this[", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(this[", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6277,7 +6273,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression41A()
         {
-            var tree = UsingTree(@"T ? m(this a", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(this a", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6334,7 +6330,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression42()
         {
-            var tree = UsingTree(@"T ? m(this(", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(this(", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6389,7 +6385,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression43()
         {
-            var tree = UsingTree(@"T ? m(T[", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(T[", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6446,7 +6442,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression44()
         {
-            var tree = UsingTree(@"T ? m(T[1", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(T[1", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6510,7 +6506,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression45()
         {
-            var tree = UsingTree(@"T ? m(T[1]", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(T[1]", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6574,7 +6570,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_MethodDecl46()
         {
-            var tree = UsingTree(@"T ? a(T ? a =", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T ? a =", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6644,7 +6640,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression47()
         {
-            var tree = UsingTree(@"T ? a(T)", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T)", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6691,7 +6687,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression48()
         {
-            var tree = UsingTree(@"T ? a(ref int.MaxValue)", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(ref int.MaxValue)", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6749,7 +6745,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression49()
         {
-            var tree = UsingTree(@"T ? a(ref a,", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(ref a,", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6805,7 +6801,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression50()
         {
-            var tree = UsingTree(@"T ? a(,", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(,", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -6862,7 +6858,7 @@ fixed int x[10];
         [Fact]
         public void Ternary_Expression51()
         {
-            var tree = UsingTree(@"T ? a(T ? b[1] : b[2])", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? a(T ? b[1] : b[2])", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -7021,7 +7017,7 @@ T ? f(a ? b : c)
         [Fact]
         public void Ternary_Expression_GenericAmbiguity1()
         {
-            var tree = UsingTree(@"T ? m(a < b, c > d) :", TestOptions.Interactive);
+            var tree = UsingTree(@"T ? m(a < b, c > d) :", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -7352,7 +7348,7 @@ T ? f(from x
         [Fact]
         public void From_Identifier()
         {
-            var tree = UsingTree(@"from", TestOptions.Interactive);
+            var tree = UsingTree(@"from", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -7373,7 +7369,7 @@ T ? f(from x
         [Fact]
         public void From_FieldDecl()
         {
-            var tree = UsingTree(@"from c", TestOptions.Interactive);
+            var tree = UsingTree(@"from c", TestOptions.Script);
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -8012,7 +8008,7 @@ T ? f(from x
         [Fact]
         public void GlobalStatementSeparators_Comma1()
         {
-            var tree = UsingTree("a < b,c.", TestOptions.Interactive);
+            var tree = UsingTree("a < b,c.", TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -8266,8 +8262,7 @@ H �oz
 ";
             ParseAndValidate(test,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 3 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_UnexpectedCharacter, Line = 2, Column = 3 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 6 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_UnexpectedCharacter, Line = 2, Column = 3 });
         }
 
         [Fact]
@@ -8289,8 +8284,7 @@ int a
 Console.Foo()
 ";
             ParseAndValidate(test,
-                new ErrorDescription { Code = 1002, Line = 3, Column = 6 },
-                new ErrorDescription { Code = 1002, Line = 4, Column = 14 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 3, Column = 6 });
         }
 
         #endregion
@@ -8307,7 +8301,7 @@ Console.Foo()
                 new ErrorDescription { Code = 1003, Line = 1, Column = 1 },
                 new ErrorDescription { Code = 1019, Line = 1, Column = 9 },
                 new ErrorDescription { Code = 1026, Line = 1, Column = 9 },
-                new ErrorDescription { Code = 1002, Line = 1, Column = 9 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 1, Column = 9 });
         }
 
         [Fact]
@@ -8320,7 +8314,7 @@ Console.Foo()
                 new ErrorDescription { Code = 1003, Line = 1, Column = 9 },
                 new ErrorDescription { Code = 1019, Line = 1, Column = 9 },
                 new ErrorDescription { Code = 1026, Line = 1, Column = 9 },
-                new ErrorDescription { Code = 1002, Line = 1, Column = 9 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 1, Column = 9 });
         }
 
         [Fact]
@@ -8333,7 +8327,7 @@ Console.Foo()
                 new ErrorDescription { Code = 1003, Line = 1, Column = 9 },
                 new ErrorDescription { Code = 1019, Line = 1, Column = 9 },
                 new ErrorDescription { Code = 1026, Line = 1, Column = 9 },
-                new ErrorDescription { Code = 1002, Line = 1, Column = 9 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 1, Column = 9 });
         }
 
         #endregion
@@ -8380,11 +8374,10 @@ interface IC { }
 ";
             ParseAndValidate(test,
                 new ErrorDescription { Code = 1525, Line = 2, Column = 1 },
-                new ErrorDescription { Code = 1002, Line = 2, Column = 10 },
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 10 },
                 new ErrorDescription { Code = 1525, Line = 2, Column = 25 },
                 new ErrorDescription { Code = 1525, Line = 2, Column = 26 },
-                new ErrorDescription { Code = 1733, Line = 2, Column = 35 },
-                new ErrorDescription { Code = 1002, Line = 2, Column = 35 });
+                new ErrorDescription { Code = 1733, Line = 2, Column = 35 });
         }
 
         [Fact]
@@ -8396,7 +8389,7 @@ parial class Test
 }
 ";
             ParseAndValidate(test,
-                new ErrorDescription { Code = 1002, Line = 2, Column = 8 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 8 });
         }
 
         [Fact]
@@ -8408,7 +8401,7 @@ p class A
  }
 ";
             ParseAndValidate(test,
-                new ErrorDescription { Code = 1002, Line = 2, Column = 3 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 2, Column = 3 });
         }
 
         [WorkItem(528532, "DevDiv")]
@@ -8416,7 +8409,7 @@ p class A
         public void ParseForwardSlash()
         {
             var test = @"/";
-            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Interactive);
+            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Script);
 
             Assert.Equal(1, tree.GetCompilationUnitRoot().ChildNodes().Count());
             Assert.Equal(SyntaxKind.GlobalStatement, tree.GetCompilationUnitRoot().ChildNodes().ToList()[0].Kind());
@@ -8431,8 +8424,7 @@ p class A
             ParseAndValidate(test,
                 new ErrorDescription { Code = 1733, Line = 1, Column = 28 },
                 new ErrorDescription { Code = 1003, Line = 1, Column = 28 },
-                new ErrorDescription { Code = 1733, Line = 1, Column = 28 },
-                new ErrorDescription { Code = 1002, Line = 1, Column = 28 });
+                new ErrorDescription { Code = 1733, Line = 1, Column = 28 });
         }
 
         #region Shebang
@@ -8440,7 +8432,7 @@ p class A
         [Fact]
         public void Shebang()
         {
-            var tree = ParseAndValidate("#!/usr/bin/env scriptcs", TestOptions.Script);
+            var tree = ParseAndValidate("#!/usr/bin/env csi", TestOptions.Script);
             var root = tree.GetCompilationUnitRoot();
 
             Assert.Empty(root.ChildNodes());
@@ -8448,7 +8440,7 @@ p class A
             Assert.Equal(SyntaxKind.EndOfFileToken, eof.Kind());
             Assert.Equal(SyntaxKind.ShebangTrivia, eof.GetLeadingTrivia().Single().Kind());
 
-            tree = ParseAndValidate("#! /usr/bin/env scriptcs\r\n ", TestOptions.Script);
+            tree = ParseAndValidate("#! /usr/bin/env csi\r\n ", TestOptions.Script);
             root = tree.GetCompilationUnitRoot();
 
             Assert.Empty(root.ChildNodes());
@@ -8461,7 +8453,7 @@ p class A
             Assert.Equal(SyntaxKind.WhitespaceTrivia, leading[2].Kind());
 
             tree = ParseAndValidate(
-@"#!/usr/bin/env scriptcs
+@"#!/usr/bin/env csi
 Console.WriteLine(""Hi!"");", TestOptions.Script);
             root = tree.GetCompilationUnitRoot();
 
@@ -8476,30 +8468,30 @@ Console.WriteLine(""Hi!"");", TestOptions.Script);
         [Fact]
         public void ShebangNotFirstCharacter()
         {
-            ParseAndValidate(" #!/usr/bin/env scriptcs", TestOptions.Script,
+            ParseAndValidate(" #!/usr/bin/env csi", TestOptions.Script,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_PPDirectiveExpected, Line = 1, Column = 2 });
 
-            ParseAndValidate("\n#!/usr/bin/env scriptcs", TestOptions.Script,
+            ParseAndValidate("\n#!/usr/bin/env csi", TestOptions.Script,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_PPDirectiveExpected, Line = 2, Column = 1 });
 
-            ParseAndValidate("\r\n#!/usr/bin/env scriptcs", TestOptions.Script,
+            ParseAndValidate("\r\n#!/usr/bin/env csi", TestOptions.Script,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_PPDirectiveExpected, Line = 2, Column = 1 });
 
-            ParseAndValidate("#!/bin/sh\r\n#!/usr/bin/env scriptcs", TestOptions.Script,
+            ParseAndValidate("#!/bin/sh\r\n#!/usr/bin/env csi", TestOptions.Script,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_PPDirectiveExpected, Line = 2, Column = 1 });
         }
 
         [Fact]
         public void ShebangNoBang()
         {
-            ParseAndValidate("#/usr/bin/env scriptcs", TestOptions.Script,
+            ParseAndValidate("#/usr/bin/env csi", TestOptions.Script,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_PPDirectiveExpected, Line = 1, Column = 1 });
         }
 
         [Fact]
         public void ShebangInComment()
         {
-            var tree = ParseAndValidate("//#!/usr/bin/env scriptcs", TestOptions.Script);
+            var tree = ParseAndValidate("//#!/usr/bin/env csi", TestOptions.Script);
             var root = tree.GetCompilationUnitRoot();
 
             Assert.Empty(root.ChildNodes());
@@ -8511,11 +8503,8 @@ Console.WriteLine(""Hi!"");", TestOptions.Script);
         [Fact]
         public void ShebangNotInScript()
         {
-            foreach (var kind in Enum.GetValues(typeof(SourceCodeKind)).Cast<SourceCodeKind>().Where(k => k != SourceCodeKind.Script))
-            {
-                ParseAndValidate("#!/usr/bin/env scriptcs", new CSharpParseOptions(kind: kind),
-                    new ErrorDescription { Code = (int)ErrorCode.ERR_PPDirectiveExpected, Line = 1, Column = 1 });
-            }
+            ParseAndValidate("#!/usr/bin/env csi", TestOptions.Regular,
+                new ErrorDescription { Code = (int)ErrorCode.ERR_PPDirectiveExpected, Line = 1, Column = 1 });
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -15,13 +11,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         private static void AssertIncompleteSubmission(string code)
         {
-            AssertCompleteSubmission(code, script: false, interactive: false);
+            Assert.False(SyntaxFactory.IsCompleteSubmission(SyntaxFactory.ParseSyntaxTree(code, options: TestOptions.Script)));
         }
 
-        private static void AssertCompleteSubmission(string code, bool script = true, bool interactive = true)
+        private static void AssertCompleteSubmission(string code, bool isComplete = true)
         {
-            Assert.Equal(script, SyntaxFactory.IsCompleteSubmission(SyntaxFactory.ParseSyntaxTree(code, options: TestOptions.Script)));
-            Assert.Equal(interactive, SyntaxFactory.IsCompleteSubmission(SyntaxFactory.ParseSyntaxTree(code, options: TestOptions.Interactive)));
+            Assert.True(SyntaxFactory.IsCompleteSubmission(SyntaxFactory.ParseSyntaxTree(code, options: TestOptions.Script)));
         }
 
         [Fact]
@@ -58,7 +53,7 @@ void foo()
 }
 ");
 
-            AssertCompleteSubmission("1", script: false, interactive: true);
+            AssertCompleteSubmission("1");
             AssertCompleteSubmission("1;");
 
             AssertIncompleteSubmission("\"");
@@ -81,7 +76,7 @@ void foo()
             AssertIncompleteSubmission("1 + new T");
 
             // invalid escape sequence in a string
-            AssertCompleteSubmission("\"\\q\"", script: false, interactive: true);
+            AssertCompleteSubmission("\"\\q\"");
 
             AssertIncompleteSubmission("void foo(");
             AssertIncompleteSubmission("void foo()");
@@ -106,7 +101,7 @@ void foo()
             AssertCompleteSubmission("interface foo {}");
             AssertCompleteSubmission("interface foo : {}");
 
-            AssertCompleteSubmission("partial", script: false, interactive: true);
+            AssertCompleteSubmission("partial");
             AssertIncompleteSubmission("partial class");
 
             AssertIncompleteSubmission("int x = 1");
@@ -141,6 +136,8 @@ void foo()
             AssertIncompleteSubmission("try { } catch (Exception e");
             AssertIncompleteSubmission("try { } catch (Exception e)");
             AssertIncompleteSubmission("try { } catch (Exception e) {");
+
+            AssertCompleteSubmission("from x in await GetStuffAsync() where x > 2 select x * x");
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -5,8 +5,8 @@ Microsoft.CodeAnalysis.Compilation.GetSubmissionResultType(out bool hasValue) ->
 Microsoft.CodeAnalysis.Compilation.PreviousSubmission.get -> Microsoft.CodeAnalysis.Compilation
 Microsoft.CodeAnalysis.Compilation.ScriptClass.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.Compilation.WithPreviousSubmission(Microsoft.CodeAnalysis.Compilation newPreviousSubmission) -> Microsoft.CodeAnalysis.Compilation
-Microsoft.CodeAnalysis.CompilationOptions.ReportSuppressedDiagnostics.get -> bool
 Microsoft.CodeAnalysis.CompilationOptions.Deterministic.get -> bool
+Microsoft.CodeAnalysis.CompilationOptions.ReportSuppressedDiagnostics.get -> bool
 Microsoft.CodeAnalysis.CompilationOptions.WithReportSuppressedDiagnostics(bool value) -> Microsoft.CodeAnalysis.CompilationOptions
 Microsoft.CodeAnalysis.Diagnostic.GetSuppressionInfo(Microsoft.CodeAnalysis.Compilation compilation) -> Microsoft.CodeAnalysis.Diagnostics.SuppressionInfo
 Microsoft.CodeAnalysis.DiagnosticDescriptor.GetEffectiveSeverity(Microsoft.CodeAnalysis.CompilationOptions compilationOptions) -> Microsoft.CodeAnalysis.ReportDiagnostic
@@ -50,6 +50,7 @@ Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Embedded = 3 -> Microsoft.Cod
 Microsoft.CodeAnalysis.Emit.DebugInformationFormat.PortablePdb = 2 -> Microsoft.CodeAnalysis.Emit.DebugInformationFormat
 Microsoft.CodeAnalysis.MetadataReference.MetadataReference(Microsoft.CodeAnalysis.MetadataReferenceProperties properties) -> void
 Microsoft.CodeAnalysis.ParseOptions.WithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
+Microsoft.CodeAnalysis.SourceCodeKind.Interactive = 2 -> Microsoft.CodeAnalysis.SourceCodeKind
 Microsoft.CodeAnalysis.StrongNameProvider.StrongNameProvider() -> void
 abstract Microsoft.CodeAnalysis.Diagnostic.IsSuppressed.get -> bool
 abstract Microsoft.CodeAnalysis.ParseOptions.CommonWithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions

--- a/src/Compilers/Core/Portable/SourceCodeKind.cs
+++ b/src/Compilers/Core/Portable/SourceCodeKind.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.ComponentModel;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
@@ -15,13 +17,16 @@ namespace Microsoft.CodeAnalysis
         Regular = 0,
 
         /// <summary>
-        /// Allows top-level statements and declarations. Used for .csx/.vbx file parsing.
+        /// Allows top-level statementsm, declarations, and optional trailing expression. 
+        /// Used for parsing .csx/.vbx and interactive submissions.
         /// </summary>
         Script = 1,
 
         /// <summary>
-        /// Allows top-level expressions and optional semicolon.
+        /// The same as <see cref="Script"/>.
         /// </summary>
+        [Obsolete("Use Script instead", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         Interactive = 2,
     }
 
@@ -29,7 +34,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal static bool IsValid(this SourceCodeKind value)
         {
-            return value >= SourceCodeKind.Regular && value <= SourceCodeKind.Interactive;
+            return value >= SourceCodeKind.Regular && value <= SourceCodeKind.Script;
         }
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 GetUniqueName(),
                 references: (references != null) ? new[] { MscorlibRef_v4_0_30316_17626 }.Concat(references) : new[] { MscorlibRef_v4_0_30316_17626 },
                 options: options,
-                syntaxTree: Parse(code, options: parseOptions ?? TestOptions.Interactive),
+                syntaxTree: Parse(code, options: parseOptions ?? TestOptions.Script),
                 previousSubmission: previous,
                 returnType: returnType,
                 hostObjectType: hostObjectType);

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         // Disable documentation comments by default so that we don't need to
         // document every public member of every test input.
         public static readonly CSharpParseOptions Script = new CSharpParseOptions(kind: SourceCodeKind.Script, documentationMode: DocumentationMode.None);
-        public static readonly CSharpParseOptions Interactive = new CSharpParseOptions(kind: SourceCodeKind.Interactive, documentationMode: DocumentationMode.None);
         public static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None);
         public static readonly CSharpParseOptions RegularWithDocumentationComments = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Diagnose);
 

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -382,7 +382,7 @@ Public MustInherit Class BasicTestBaseBase
                 GetUniqueName(),
                 references:=If(references Is Nothing, {MscorlibRef_v4_0_30316_17626, MsvbRef_v4_0_30319_17929}, {MscorlibRef_v4_0_30316_17626, MsvbRef_v4_0_30319_17929}.Concat(references)),
                 options:=options,
-                syntaxTree:=Parse(code, options:=If(parseOptions, TestOptions.Interactive)),
+                syntaxTree:=Parse(code, options:=If(parseOptions, TestOptions.Script)),
                 previousSubmission:=previous,
                 returnType:=returnType,
                 hostObjectType:=hostObjectType)

--- a/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
@@ -4,7 +4,6 @@ Imports System.Runtime.CompilerServices
 
 Public Class TestOptions
     Public Shared ReadOnly Script As New VisualBasicParseOptions(kind:=SourceCodeKind.Script)
-    Public Shared ReadOnly Interactive As New VisualBasicParseOptions(kind:=SourceCodeKind.Interactive)
     Public Shared ReadOnly Regular As New VisualBasicParseOptions(kind:=SourceCodeKind.Regular)
 
     Public Shared ReadOnly ReleaseDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Release).WithExtendedCustomDebugInformation(True)

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
@@ -31,8 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private ReadOnly Property InScript As Boolean
             Get
-                Dim treeOptionsKind = _tree.Options.Kind
-                Return treeOptionsKind = SourceCodeKind.Interactive OrElse treeOptionsKind = SourceCodeKind.Script
+                Return _tree.Options.Kind = SourceCodeKind.Script
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -733,8 +733,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             hasValue = False
             Dim tree = SyntaxTrees.SingleOrDefault()
 
+            ' TODO: look for return statements
+            ' https://github.com/dotnet/roslyn/issues/5773
+
             ' submission can be empty or comprise of a script file
-            If tree Is Nothing OrElse tree.Options.Kind <> SourceCodeKind.Interactive Then
+            If tree Is Nothing Then
                 Return GetSpecialType(SpecialType.System_Void)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
@@ -1864,7 +1864,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' skip possible statement terminator
             Dim lookahead = PeekToken(1)
 
-            If lookahead.Kind <> SyntaxKind.EndOfFileToken OrElse _scanner.Options.Kind <> SourceCodeKind.Interactive Then
+            If lookahead.Kind <> SyntaxKind.EndOfFileToken OrElse _scanner.Options.Kind = SourceCodeKind.Regular Then
                 result = result.AddError(ERRID.ERR_UnexpectedExpressionStatement)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend ReadOnly Property IsScript As Boolean
             Get
-                Return _scanner.Options.Kind = SourceCodeKind.Interactive Or _scanner.Options.Kind = SourceCodeKind.Script
+                Return _scanner.Options.Kind = SourceCodeKind.Script
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
@@ -82,8 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Get
                 Debug.Assert(Me.HasCompilationUnitRoot)
 
-                Return (Options.Kind = SourceCodeKind.Interactive OrElse Options.Kind = SourceCodeKind.Script) AndAlso
-                        GetCompilationUnitRoot().GetReferenceDirectives().Count > 0
+                Return Options.Kind = SourceCodeKind.Script AndAlso GetCompilationUnitRoot().GetReferenceDirectives().Count > 0
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
@@ -179,27 +179,27 @@ Next
 
             Dim s0 = VisualBasicCompilation.CreateSubmission("s0.dll",
                                                   syntaxTree:=VisualBasicSyntaxTree.ParseText(
-                                                      "Dim x = New With {.a = 1}", options:=TestOptions.Interactive),
+                                                      "Dim x = New With {.a = 1}", options:=TestOptions.Script),
                                                   references:=references,
                                                   returnType:=GetType(Object))
 
             Dim s__ = VisualBasicCompilation.CreateSubmission("s__.dll",
                                                    syntaxTree:=VisualBasicSyntaxTree.ParseText(
-                                                       "Dim y = New With {.b = 1}", options:=TestOptions.Interactive),
+                                                       "Dim y = New With {.b = 1}", options:=TestOptions.Script),
                                                    previousSubmission:=s0,
                                                    references:=references,
                                                    returnType:=GetType(Object))
 
             Dim s1 = VisualBasicCompilation.CreateSubmission("s1.dll",
                                                   syntaxTree:=VisualBasicSyntaxTree.ParseText(
-                                                      "Dim y = New With {.a = New With {.b = 1} }", options:=TestOptions.Interactive),
+                                                      "Dim y = New With {.a = New With {.b = 1} }", options:=TestOptions.Script),
                                                   previousSubmission:=s0,
                                                   references:=references,
                                                   returnType:=GetType(Object))
 
             Dim s2 = VisualBasicCompilation.CreateSubmission("s2.dll",
                                                   syntaxTree:=VisualBasicSyntaxTree.ParseText(
-                                                      "? x.GetType() Is y.GetType()", options:=TestOptions.Interactive),
+                                                      "? x.GetType() Is y.GetType()", options:=TestOptions.Script),
                                                   previousSubmission:=s1,
                                                   references:=references,
                                                   returnType:=GetType(Object))
@@ -345,8 +345,8 @@ System.Console.Write("complete")
         End Sub
 
         <Fact>
-        Public Sub InteractiveEntryPoint()
-            Dim parseOptions = TestOptions.Interactive
+        Public Sub SubmissionEntryPoint()
+            Dim parseOptions = TestOptions.Script
             Dim references = {MscorlibRef_v4_0_30316_17626, SystemCoreRef, MsvbRef}
             Dim source0 = <![CDATA[
 System.Threading.Tasks.Task.Delay(100)

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -1321,11 +1321,11 @@ End Class
 
         <Fact()>
         Public Sub GetEntryPoint_Submission()
-            Dim source = <![CDATA[? 1 + 1]]>
-            Dim compilation = Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.CreateSubmission(
+            Dim source = "? 1 + 1"
+            Dim compilation = VisualBasicCompilation.CreateSubmission(
                 "sub",
                 references:={MscorlibRef},
-                syntaxTree:=Parse(source.Value, options:=TestOptions.Interactive))
+                syntaxTree:=Parse(source, options:=TestOptions.Script))
             compilation.VerifyDiagnostics()
 
             Dim scriptMethod = compilation.GetMember("Script.<Factory>")
@@ -1340,16 +1340,16 @@ End Class
 
         <Fact()>
         Public Sub GetEntryPoint_Submission_MainIgnored()
-            Dim source = <![CDATA[
+            Dim source = "
     Class A
         Shared Sub Main()
         End Sub
     End Class
-    ]]>
-            Dim compilation = Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.CreateSubmission(
-                "sub",
+"
+            Dim compilation = VisualBasicCompilation.CreateSubmission(
+                "Sub",
                 references:={MscorlibRef},
-                syntaxTree:=Parse(source.Value, options:=TestOptions.Interactive))
+                syntaxTree:=Parse(source, options:=TestOptions.Script))
             compilation.VerifyDiagnostics(Diagnostic(ERRID.WRN_MainIgnored, "Main").WithArguments("Public Shared Sub Main()").WithLocation(3, 20))
 
             Dim scriptMethod = compilation.GetMember("Script.<Factory>")
@@ -1753,8 +1753,7 @@ End Namespace
             Assert.Equal(SpecialType.System_Void, submission.GetSubmissionResultType(hasValue).SpecialType)
             Assert.False(hasValue)
 
-            TestSubmissionResult(CreateSubmission("?1", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
-            TestSubmissionResult(CreateSubmission("?1", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_Int32, expectedHasValue:=True)
+            TestSubmissionResult(CreateSubmission("?1", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Int32, expectedHasValue:=True)
 
             TestSubmissionResult(CreateSubmission("1", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
             ' TODO (https://github.com/dotnet/roslyn/issues/4763): '?' should be optional
@@ -1768,15 +1767,15 @@ Sub Foo()
 End Sub
 "), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
 
-            TestSubmissionResult(CreateSubmission("Imports System", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
-            TestSubmissionResult(CreateSubmission("Dim i As Integer", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
-            TestSubmissionResult(CreateSubmission("System.Console.WriteLine()", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
-            TestSubmissionResult(CreateSubmission("?System.Console.WriteLine()", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_Void, expectedHasValue:=True)
-            TestSubmissionResult(CreateSubmission("System.Console.ReadLine()", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_String, expectedHasValue:=True)
-            TestSubmissionResult(CreateSubmission("?System.Console.ReadLine()", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_String, expectedHasValue:=True)
-            TestSubmissionResult(CreateSubmission("?Nothing", parseOptions:=TestOptions.Interactive), expectedType:=SpecialType.System_Object, expectedHasValue:=True)
-            TestSubmissionResult(CreateSubmission("?AddressOf System.Console.WriteLine", parseOptions:=TestOptions.Interactive), expectedType:=DirectCast(Nothing, SpecialType?), expectedHasValue:=True)
-            TestSubmissionResult(CreateSubmission("?Function(x) x", parseOptions:=TestOptions.Interactive), expectedType:=AddressOf IsDelegateType, expectedHasValue:=True)
+            TestSubmissionResult(CreateSubmission("Imports System", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
+            TestSubmissionResult(CreateSubmission("Dim i As Integer", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
+            TestSubmissionResult(CreateSubmission("System.Console.WriteLine()", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Void, expectedHasValue:=False)
+            TestSubmissionResult(CreateSubmission("?System.Console.WriteLine()", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Void, expectedHasValue:=True)
+            TestSubmissionResult(CreateSubmission("System.Console.ReadLine()", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_String, expectedHasValue:=True)
+            TestSubmissionResult(CreateSubmission("?System.Console.ReadLine()", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_String, expectedHasValue:=True)
+            TestSubmissionResult(CreateSubmission("?Nothing", parseOptions:=TestOptions.Script), expectedType:=SpecialType.System_Object, expectedHasValue:=True)
+            TestSubmissionResult(CreateSubmission("?AddressOf System.Console.WriteLine", parseOptions:=TestOptions.Script), expectedType:=DirectCast(Nothing, SpecialType?), expectedHasValue:=True)
+            TestSubmissionResult(CreateSubmission("?Function(x) x", parseOptions:=TestOptions.Script), expectedType:=AddressOf IsDelegateType, expectedHasValue:=True)
         End Sub
 
         Private Shared Sub TestSubmissionResult(s As VisualBasicCompilation, expectedType As SpecialType?, expectedHasValue As Boolean)

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             TestProperty(Function(old, value) old.WithOptionCompareText(value), Function(opt) opt.OptionCompareText, True)
 
             TestProperty(Function(old, value) old.WithParseOptions(value), Function(opt) opt.ParseOptions,
-                         New VisualBasicParseOptions(kind:=SourceCodeKind.Interactive))
+                         New VisualBasicParseOptions(kind:=SourceCodeKind.Script))
 
             TestProperty(Function(old, value) old.WithEmbedVbCoreRuntime(value), Function(opt) opt.EmbedVbCoreRuntime, True)
             TestProperty(Function(old, value) old.WithOptimizationLevel(value), Function(opt) opt.OptimizationLevel, OptimizationLevel.Release)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
@@ -298,7 +298,7 @@ Imports System
 
         <Fact>
         Public Sub UnusedImportInteractive()
-            Dim tree = Parse("Imports System", options:=TestOptions.Interactive)
+            Dim tree = Parse("Imports System", options:=TestOptions.Script)
             Dim compilation = VisualBasicCompilation.CreateSubmission("sub1", tree, {MscorlibRef_v4_0_30316_17626})
             compilation.AssertNoDiagnostics(suppressInfos:=False)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -2449,33 +2449,36 @@ o.F()]]>
 
         <Fact>
         Public Sub InteractiveExtensionMethods()
-            Dim parseOptions = TestOptions.Interactive
             Dim references = {MscorlibRef, SystemCoreRef}
-            Dim source0 = <![CDATA[
+            
+            Dim source0 = "
 Imports System.Runtime.CompilerServices
 <Extension>
 Shared Function F(o As Object) As Object
     Return 0
 End Function
 Dim o As New Object()
-? o.F()]]>
-            Dim source1 = <![CDATA[
+? o.F()"
+
+            Dim source1 = "
 Imports System.Runtime.CompilerServices
 <Extension>
 Shared Function G(o As Object) As Object
     Return 1
 End Function
 Dim o As New Object()
-? o.G().F()]]>
+? o.G().F()"
+
             Dim s0 = VisualBasicCompilation.CreateSubmission(
                 "s0.dll",
-                syntaxTree:=Parse(source0.Value, parseOptions),
+                syntaxTree:=Parse(source0, TestOptions.Script),
                 references:=references)
             s0.VerifyDiagnostics()
             Assert.True(s0.SourceAssembly.MightContainExtensionMethods)
+            
             Dim s1 = VisualBasicCompilation.CreateSubmission(
                 "s1.dll",
-                syntaxTree:=Parse(source1.Value, parseOptions),
+                syntaxTree:=Parse(source1, TestOptions.Script),
                 previousSubmission:=s0,
                 references:=references)
             s1.VerifyDiagnostics()

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -23700,7 +23700,7 @@ Friend MustOverride ReadOnly Property P
 ]]>
             Dim submission = VisualBasicCompilation.CreateSubmission(
                 "s0.dll",
-                syntaxTree:=Parse(source.Value, TestOptions.Interactive),
+                syntaxTree:=Parse(source.Value, TestOptions.Script),
                 references:={MscorlibRef, SystemCoreRef})
             submission.AssertTheseDiagnostics(<expected>
 BC30607: 'NotInheritable' classes cannot have members declared 'MustOverride'.

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAsyncTests.vb
@@ -409,9 +409,7 @@ End Class]]>.Value)
     <Fact>
     Public Sub ParseAwaitInScriptingAndInteractive()
 
-        For Each mode In {SourceCodeKind.Script, SourceCodeKind.Interactive}
-
-            Dim tree = VisualBasicSyntaxTree.ParseText(<![CDATA[
+        Dim source = "
 Dim i = Await T + Await(T)      ' Yes, Yes
 
 Dim l = Sub()
@@ -429,18 +427,16 @@ End Sub
 
 Async Function F()
     Return Await(T)             ' Yes
-End Function]]>.Value,
-                options:=VisualBasicParseOptions.Default.WithKind(mode))
+End Function"
 
-            Dim awaitExpressions = tree.GetRoot().DescendantNodes.OfType(Of AwaitExpressionSyntax).ToArray()
+        Dim tree = VisualBasicSyntaxTree.ParseText(source, options:=TestOptions.Script)
 
-            Assert.Equal(5, awaitExpressions.Count)
+        Dim awaitExpressions = tree.GetRoot().DescendantNodes.OfType(Of AwaitExpressionSyntax).ToArray()
 
-            Dim awaitParsedAsIdentifier = tree.GetRoot().DescendantNodes.OfType(Of IdentifierNameSyntax).Where(Function(id) id.Identifier.ValueText.Equals("Await")).ToArray()
+        Assert.Equal(5, awaitExpressions.Count)
 
-            Assert.Equal(2, awaitParsedAsIdentifier.Count)
-        Next
+        Dim awaitParsedAsIdentifier = tree.GetRoot().DescendantNodes.OfType(Of IdentifierNameSyntax).Where(Function(id) id.Identifier.ValueText.Equals("Await")).ToArray()
 
+        Assert.Equal(2, awaitParsedAsIdentifier.Count)
     End Sub
-
 End Class

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDeclarationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDeclarationTests.vb
@@ -1009,13 +1009,11 @@ Namespace N
 End Namespace
 "
 
-        Dim expectedDiagnostics = <errors><![CDATA[
+        Parse(source, TestOptions.Script).AssertTheseDiagnostics(<errors><![CDATA[
 BC36965: You cannot declare Namespace in script code
 Namespace N
 ~~~~~~~~~
-]]></errors>
-        Parse(source, TestOptions.Script).AssertTheseDiagnostics(expectedDiagnostics)
-        Parse(source, TestOptions.Interactive).AssertTheseDiagnostics(expectedDiagnostics)
+]]></errors>)
     End Sub
 
 #End Region

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseIteratorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseIteratorTests.vb
@@ -369,9 +369,7 @@ End Class]]>.Value)
     <Fact>
     Public Sub ParseYieldInScriptingAndInteractive()
 
-        For Each mode In {SourceCodeKind.Script, SourceCodeKind.Interactive}
-
-            Dim tree = VisualBasicSyntaxTree.ParseText(<![CDATA[
+        Dim source = "
 Yield T                                     ' No
 Yield (T)                                   ' No
 Yield T + Yield (T)                         ' No, No
@@ -402,18 +400,17 @@ Iterator Function F()
     Yield T + Yield (T)                     ' Yes, No
     Dim i = Yield T + Yield (T)             ' No, No
     Return Yield T                          ' No
-End Function]]>.Value,
-                options:=VisualBasicParseOptions.Default.WithKind(mode))
+End Function"
 
-            Dim yieldStatements = tree.GetRoot().DescendantNodes.OfType(Of YieldStatementSyntax).ToArray()
+        Dim tree = VisualBasicSyntaxTree.ParseText(source, options:=TestOptions.Script)
 
-            Assert.Equal(6, yieldStatements.Count)
+        Dim yieldStatements = tree.GetRoot().DescendantNodes.OfType(Of YieldStatementSyntax).ToArray()
 
-            For Each yieldStatement In yieldStatements
-                Assert.True(IsInIteratorMethod(yieldStatement))
-            Next
+        Assert.Equal(6, yieldStatements.Count)
+
+        For Each yieldStatement In yieldStatements
+            Assert.True(IsInIteratorMethod(yieldStatement))
         Next
-
     End Sub
 
     Private Shared Function IsIteratorMethod(methodSyntax As MethodBlockBaseSyntax) As Boolean

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -115,7 +115,7 @@ $$
         {
             var markup = "#r \"$$\"";
 
-            VerifyNoItemsExist(markup, SourceCodeKind.Interactive);
+            VerifyNoItemsExist(markup, SourceCodeKind.Script);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
@@ -135,7 +135,7 @@ $$
         {
             var markup = "#r \"$$\"";
 
-            VerifyNoItemsExist(markup, SourceCodeKind.Interactive);
+            VerifyNoItemsExist(markup, SourceCodeKind.Script);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -272,8 +272,8 @@ class C {
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void OpenStringLiteralInDirective()
         {
-            VerifyItemIsAbsent("#r \"$$", "String", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Interactive);
-            VerifyItemIsAbsent("#r \"$$", "System", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Interactive);
+            VerifyItemIsAbsent("#r \"$$", "String", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
+            VerifyItemIsAbsent("#r \"$$", "System", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -286,8 +286,8 @@ class C {
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void StringLiteralInDirective()
         {
-            VerifyItemIsAbsent("#r \"$$\"", "String", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Interactive);
-            VerifyItemIsAbsent("#r \"$$\"", "System", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Interactive);
+            VerifyItemIsAbsent("#r \"$$\"", "String", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
+            VerifyItemIsAbsent("#r \"$$\"", "System", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -8349,7 +8349,7 @@ class A {
 int aaa = 1;
 int bbb = $$
 ";
-            VerifyItemExists(markup, "aaa", sourceCodeKind: SourceCodeKind.Interactive);
+            VerifyItemExists(markup, "aaa", sourceCodeKind: SourceCodeKind.Script);
         }
 
         [WorkItem(5069, "https://github.com/dotnet/roslyn/issues/5069")]
@@ -8360,7 +8360,7 @@ int bbb = $$
 Action aaa = null;
 event Action bbb = $$
 ";
-            VerifyItemExists(markup, "aaa", sourceCodeKind: SourceCodeKind.Interactive);
+            VerifyItemExists(markup, "aaa", sourceCodeKind: SourceCodeKind.Script);
         }
 
         [WorkItem(33, "https://github.com/dotnet/roslyn/issues/33")]

--- a/src/EditorFeatures/CSharpTest/Completion/LoadDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/LoadDirectiveCompletionProviderTests.cs
@@ -40,20 +40,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
                 glyph);
         }
 
-        private void VerifyItemExistsInInteractive(string markup, string expected)
+        private void VerifyItemExistsInScript(string markup, string expected)
         {
-            VerifyItemExists(markup, expected, expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Interactive, usePreviousCharAsTrigger: false);
+            VerifyItemExists(markup, expected, expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script, usePreviousCharAsTrigger: false);
         }
 
         private void VerifyItemIsAbsentInInteractive(string markup, string expected)
         {
-            VerifyItemIsAbsent(markup, expected, expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Interactive, usePreviousCharAsTrigger: false);
+            VerifyItemIsAbsent(markup, expected, expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script, usePreviousCharAsTrigger: false);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void NetworkPath()
         {
-            VerifyItemExistsInInteractive(
+            VerifyItemExistsInScript(
                 @"#load ""$$",
                 @"\\");
         }
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public void NetworkPathAfterInitialBackslash()
         {
-            VerifyItemExistsInInteractive(
+            VerifyItemExistsInScript(
                 @"#load ""\$$",
                 @"\\");
         }
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
             int depth = Directory.GetCurrentDirectory().Count(c => c == Path.DirectorySeparatorChar);
             var pathToRoot = string.Concat(Enumerable.Repeat(@"..\", depth));
 
-            VerifyItemExistsInInteractive(
+            VerifyItemExistsInScript(
                 @"#load ""$$",
                 "..");
             VerifyItemIsAbsentInInteractive(

--- a/src/EditorFeatures/CSharpTest/Completion/ReferenceDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/ReferenceDirectiveCompletionProviderTests.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntelliSense.Completion
             foreach (var ex in expected)
             {
                 VerifyItemExists(code, ex, expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Script);
-                VerifyItemExists(code, ex, expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.Interactive);
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -1413,11 +1413,11 @@ index: 0);
 
         [WorkItem(541748)]
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
-        public void TestOnErrorInInteractive()
+        public void TestOnErrorInScript()
         {
             TestMissing(
 @"[|Console.WrieLine();|]",
-Options.Interactive);
+Options.Script);
         }
 
         [WpfFact(Skip = "1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -8813,7 +8813,7 @@ int NewMethod()
 }
 
 i = 3;";
-            TestExtractMethod(code, expected, parseOptions: Interactive);
+            TestExtractMethod(code, expected, parseOptions: Options.Script);
         }
 
         [WorkItem(542670)]
@@ -9169,7 +9169,7 @@ class Node<K, T> where T : new()
 
         [WorkItem(542708)]
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
-        public void InteractiveArgumentException()
+        public void Script_ArgumentException()
         {
             var code = @"using System;
 public static void GetNonVirtualMethod<TDelegate>( Type type, string name)
@@ -9189,7 +9189,7 @@ Type GetDelegateType(Type delegateType)
     return delegateType;
 }";
 
-            TestExtractMethod(code, expected, parseOptions: Interactive);
+            TestExtractMethod(code, expected, parseOptions: Options.Script);
         }
 
         [WorkItem(529008)]
@@ -9544,7 +9544,7 @@ void NewMethod()
     }
 }";
 
-            TestExtractMethod(code, expected, parseOptions: new CSharpParseOptions(kind: SourceCodeKind.Interactive));
+            TestExtractMethod(code, expected, parseOptions: new CSharpParseOptions(kind: SourceCodeKind.Script));
         }
 
         [WorkItem(530322)]
@@ -10266,14 +10266,6 @@ namespace ClassLibrary9
                 var state = handler.GetCommandState(new Commands.ExtractMethodCommandArgs(textView, textView.TextBuffer), nextHandler);
                 Assert.True(delegatedToNext);
                 Assert.False(state.IsAvailable);
-            }
-        }
-
-        private CSharpParseOptions Interactive
-        {
-            get
-            {
-                return new CSharpParseOptions(kind: SourceCodeKind.Interactive);
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/Recommendations/AsyncKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/AsyncKeywordRecommenderTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         public void MethodDeclarationInGlobalStatement1()
         {
             const string text = @"$$";
-            VerifyKeyword(SourceCodeKind.Interactive, text);
             VerifyKeyword(SourceCodeKind.Script, text);
         }
 
@@ -46,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         public void MethodDeclarationInGlobalStatement2()
         {
             const string text = @"public $$";
-            VerifyKeyword(SourceCodeKind.Interactive, text);
             VerifyKeyword(SourceCodeKind.Script, text);
         }  
 

--- a/src/EditorFeatures/CSharpTest/Recommendations/AwaitKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/AwaitKeywordRecommenderTests.cs
@@ -142,7 +142,6 @@ class Program
         public void InGlobalStatement()
         {
             const string text = @"$$";
-            VerifyKeyword(SourceCodeKind.Interactive, text);
             VerifyKeyword(SourceCodeKind.Script, text);
         } 
     }

--- a/src/EditorFeatures/CSharpTest/Recommendations/ConstKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/ConstKeywordRecommenderTests.cs
@@ -272,9 +272,9 @@ $$");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public void AfterPrivate_Interactive()
+        public void AfterPrivate_Script()
         {
-            VerifyKeyword(SourceCodeKind.Interactive,
+            VerifyKeyword(SourceCodeKind.Script,
 @"private $$");
         }
 

--- a/src/EditorFeatures/CSharpTest/Recommendations/EventKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/EventKeywordRecommenderTests.cs
@@ -266,9 +266,9 @@ $$");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public void AfterPrivate_Interactive()
+        public void AfterPrivate_Script()
         {
-            VerifyKeyword(SourceCodeKind.Interactive,
+            VerifyKeyword(SourceCodeKind.Script,
 @"private $$");
         }
 

--- a/src/EditorFeatures/CSharpTest/Recommendations/NewKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/NewKeywordRecommenderTests.cs
@@ -806,9 +806,9 @@ $$");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public void AfterPrivate_Interactive()
+        public void AfterPrivate_Script()
         {
-            VerifyKeyword(SourceCodeKind.Interactive,
+            VerifyKeyword(SourceCodeKind.Script,
 @"private $$");
         }
 

--- a/src/EditorFeatures/CSharpTest/Recommendations/ReadOnlyKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/ReadOnlyKeywordRecommenderTests.cs
@@ -272,9 +272,9 @@ $$");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public void AfterPrivate_Interactive()
+        public void AfterPrivate_Script()
         {
-            VerifyKeyword(SourceCodeKind.Interactive,
+            VerifyKeyword(SourceCodeKind.Script,
 @"private $$");
         }
 

--- a/src/EditorFeatures/CSharpTest/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/RecommenderTests.cs
@@ -172,11 +172,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 case SourceCodeKind.Regular:
                     VerifyWorker(text, absent: false);
                     break;
+
                 case SourceCodeKind.Script:
                     VerifyWorker(text, absent: false, options: Options.Script);
-                    break;
-                case SourceCodeKind.Interactive:
-                    VerifyWorker(text, absent: false, options: Options.Interactive);
                     break;
             }
         }
@@ -197,9 +195,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                     break;
                 case SourceCodeKind.Script:
                     VerifyWorker(text, absent: true, options: Options.Script);
-                    break;
-                case SourceCodeKind.Interactive:
-                    VerifyWorker(text, absent: true, options: Options.Interactive);
                     break;
             }
         }

--- a/src/EditorFeatures/CSharpTest/Recommendations/VoidKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/VoidKeywordRecommenderTests.cs
@@ -325,9 +325,9 @@ $$");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public void AfterPrivate_Interactive()
+        public void AfterPrivate_Script()
         {
-            VerifyKeyword(SourceCodeKind.Interactive,
+            VerifyKeyword(SourceCodeKind.Script,
 @"private $$");
         }
 

--- a/src/EditorFeatures/CSharpTest/Recommendations/VolatileKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Recommendations/VolatileKeywordRecommenderTests.cs
@@ -272,9 +272,9 @@ $$");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public void AfterPrivate_Interactive()
+        public void AfterPrivate_Script()
         {
-            VerifyKeyword(SourceCodeKind.Interactive,
+            VerifyKeyword(SourceCodeKind.Script,
 @"private $$");
         }
 

--- a/src/EditorFeatures/CSharpTest/Utilities/Options.cs
+++ b/src/EditorFeatures/CSharpTest/Utilities/Options.cs
@@ -1,17 +1,12 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests
 {
     internal static class Options
     {
         internal static readonly CSharpParseOptions Script = new CSharpParseOptions(kind: SourceCodeKind.Script);
-        internal static readonly CSharpParseOptions Interactive = new CSharpParseOptions(kind: SourceCodeKind.Interactive);
         internal static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular);
     }
 }

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
                 // The project
 
-                var document = new TestHostDocument(exportProvider, languageServices, textBuffer, submissionName, cursorPosition, spans, SourceCodeKind.Interactive);
+                var document = new TestHostDocument(exportProvider, languageServices, textBuffer, submissionName, cursorPosition, spans, SourceCodeKind.Script);
                 var documents = new List<TestHostDocument> { document };
 
                 if (languageName == NoCompilationConstants.LanguageName)
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 var compilationFactory = languageServices.GetService<ICompilationFactoryService>();
                 var compilationOptions = compilationFactory.GetDefaultCompilationOptions().WithOutputKind(OutputKind.DynamicallyLinkedLibrary);
 
-                var parseOptions = syntaxFactory.GetDefaultParseOptions().WithKind(SourceCodeKind.Interactive);
+                var parseOptions = syntaxFactory.GetDefaultParseOptions().WithKind(SourceCodeKind.Script);
 
                 var references = CreateCommonReferences(workspace, submissionElement);
 

--- a/src/Features/CSharp/Portable/CodeRefactorings/GenerateDefaultConstructors/GenerateDefaultConstructorsCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/GenerateDefaultConstructors/GenerateDefaultConstructorsCodeRefactoringProvider.cs
@@ -17,8 +17,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.GenerateDefaultConstruc
             var textSpan = context.Span;
             var cancellationToken = context.CancellationToken;
 
-            // NOTE(DustinCa): Not supported in REPL for now.
-            if (document.SourceCodeKind == SourceCodeKind.Interactive)
+            // TODO: https://github.com/dotnet/roslyn/issues/5778
+            // Not supported in REPL for now.
+            if (document.Project.IsSubmission)
             {
                 return;
             }

--- a/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
@@ -15,8 +15,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes.GenerateMember
     {
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            // NOTE(DustinCa): Not supported in REPL for now.
-            if (context.Document.SourceCodeKind == SourceCodeKind.Interactive)
+            // TODO: https://github.com/dotnet/roslyn/issues/5777
+            // Not supported in REPL for now.
+            if (context.Project.IsSubmission)
             {
                 return;
             }

--- a/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Interactive
     public sealed class CSharpInteractiveEvaluator : InteractiveEvaluator
     {
         private static readonly CSharpParseOptions s_parseOptions =
-            new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Interactive);
+            new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Script);
 
         private const string InteractiveResponseFile = "CSharpInteractive.rsp";
 

--- a/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
+++ b/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Interactive
     Public NotInheritable Class VisualBasicInteractiveEvaluator
         Inherits InteractiveEvaluator
 
-        Private Shared ReadOnly s_parseOptions As ParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Interactive)
+        Private Shared ReadOnly s_parseOptions As ParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Script)
 
         Private Const s_interactiveResponseFile As String = "VisualBasicInteractive.rsp"
 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -750,7 +750,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             {
                 Script script;
 
-                var scriptOptions = options.WithPath(path).WithIsInteractive(path == null);
+                var scriptOptions = options.WithPath(path);
 
                 if (previousScript != null)
                 {

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -351,13 +351,13 @@ while(true) {}
         [Fact]
         public void AsyncExecuteFile_SourceKind()
         {
-            var file = Temp.CreateFile().WriteAllText("1+1").Path;
+            var file = Temp.CreateFile().WriteAllText("1 1").Path;
             var task = Host.ExecuteFileAsync(file);
             task.Wait();
             Assert.False(task.Result.Success);
 
             var errorOut = ReadErrorOutputToEnd().Trim();
-            Assert.True(errorOut.StartsWith(file + "(1,4):", StringComparison.Ordinal), "Error output should start with file name, line and column");
+            Assert.True(errorOut.StartsWith(file + "(1,3):", StringComparison.Ordinal), "Error output should start with file name, line and column");
             Assert.True(errorOut.Contains("CS1002"), "Error output should include error CS1002");
         }
 

--- a/src/Scripting/CSharp/CSharpScriptCompiler.cs
+++ b/src/Scripting/CSharp/CSharpScriptCompiler.cs
@@ -11,8 +11,7 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp
     {
         public static readonly ScriptCompiler Instance = new CSharpScriptCompiler();
 
-        private static readonly CSharpParseOptions s_defaultInteractive = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Interactive);
-        private static readonly CSharpParseOptions s_defaultScript = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Script);
+        private static readonly CSharpParseOptions s_defaultOptions = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Script);
 
         private CSharpScriptCompiler()
         {
@@ -25,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp
         public override bool IsCompleteSubmission(SyntaxTree tree) => SyntaxFactory.IsCompleteSubmission(tree);
 
         public override SyntaxTree ParseSubmission(SourceText text, CancellationToken cancellationToken) =>
-            SyntaxFactory.ParseSyntaxTree(text, s_defaultInteractive, cancellationToken: cancellationToken);
+            SyntaxFactory.ParseSyntaxTree(text, s_defaultOptions, cancellationToken: cancellationToken);
 
         public override Compilation CreateSubmission(Script script)
         {
@@ -41,8 +40,7 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp
             // TODO: report diagnostics
             diagnostics.Free();
 
-            var parseOptions = script.Options.IsInteractive ? s_defaultInteractive : s_defaultScript;
-            var tree = SyntaxFactory.ParseSyntaxTree(script.Code, parseOptions, script.Options.Path);
+            var tree = SyntaxFactory.ParseSyntaxTree(script.Code, s_defaultOptions, script.Options.Path);
 
             string assemblyName, submissionTypeName;
             script.Builder.GenerateSubmissionId(out assemblyName, out submissionTypeName);

--- a/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
@@ -152,9 +152,9 @@ new System.Data.DataSet()
 using System.Linq;
 
 var x = from a in new[] { 1, 2 ,3 } select a + 1;
-", options.WithPath(@"C:\dir\a.csx").WithIsInteractive(false));
+", options.WithPath(@"C:\dir\a.csx"));
 
-            var state = await script.RunAsync().ContinueWith<IEnumerable<int>>("x", options.WithPath(null).WithIsInteractive(true));
+            var state = await script.RunAsync().ContinueWith<IEnumerable<int>>("x", options.WithPath(null));
 
             AssertEx.Equal(new[] { 2, 3, 4 }, state.ReturnValue);
         }

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -44,7 +44,7 @@ select x * x
 ");
             runner.RunInteractive();
 
-            Assert.Equal(
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
 $@"Microsoft (R) Visual C# Interactive Compiler version {CompilerVersion}
 Copyright (C) Microsoft Corporation. All rights reserved.
 

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             var globals = new CommandLineScriptGlobals(_console.Out, _objectFormatter);
             globals.Args.AddRange(_compiler.Arguments.ScriptArguments);
 
-            options = options.WithPath(scriptPath).WithIsInteractive(false);
+            options = options.WithPath(scriptPath);
             var script = Script.CreateInitialScript<object>(_scriptCompiler, code, options, globals.GetType(), assemblyLoaderOpt: null);
             try
             {

--- a/src/Scripting/Core/PublicAPI.Unshipped.txt
+++ b/src/Scripting/Core/PublicAPI.Unshipped.txt
@@ -65,7 +65,6 @@ Microsoft.CodeAnalysis.Scripting.ScriptOptions.AddReferences(System.Collections.
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.AddReferences(params Microsoft.CodeAnalysis.MetadataReference[] references) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.AddReferences(params System.Reflection.Assembly[] references) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.AddReferences(params string[] references) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
-Microsoft.CodeAnalysis.Scripting.ScriptOptions.IsInteractive.get -> bool
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.MetadataReferences.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.MetadataReference>
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.MetadataResolver.get -> Microsoft.CodeAnalysis.MetadataReferenceResolver
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.Namespaces.get -> System.Collections.Immutable.ImmutableArray<string>
@@ -79,7 +78,6 @@ Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithDefaultMetadataResolution(par
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithDefaultSourceResolution(System.Collections.Generic.IEnumerable<string> searchPaths) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithDefaultSourceResolution(System.Collections.Immutable.ImmutableArray<string> searchPaths) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithDefaultSourceResolution(params string[] searchPaths) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
-Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithIsInteractive(bool isInteractive) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithNamespaces(System.Collections.Generic.IEnumerable<string> namespaces) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithNamespaces(System.Collections.Immutable.ImmutableArray<string> namespaces) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
 Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithNamespaces(params string[] namespaces) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -21,8 +21,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             references: ImmutableArray<MetadataReference>.Empty,
             namespaces: ImmutableArray<string>.Empty,
             metadataResolver: RuntimeMetadataReferenceResolver.Default,
-            sourceResolver: SourceFileResolver.Default,
-            isInteractive: true);
+            sourceResolver: SourceFileResolver.Default);
 
         /// <summary>
         /// An array of <see cref="MetadataReference"/>s to be added to the script.
@@ -55,19 +54,12 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// </summary>
         public string Path { get; private set; }
 
-        /// <summary>
-        /// True if the script is interactive. 
-        /// Interactive scripts may contain a final expression whose value is returned when the script is run.
-        /// </summary>
-        public bool IsInteractive { get; private set; }
-
         private ScriptOptions(
             string path,
             ImmutableArray<MetadataReference> references,
             ImmutableArray<string> namespaces,
             MetadataReferenceResolver metadataResolver,
-            SourceReferenceResolver sourceResolver,
-            bool isInteractive)
+            SourceReferenceResolver sourceResolver)
         {
             Debug.Assert(path != null);
             Debug.Assert(!references.IsDefault);
@@ -80,7 +72,6 @@ namespace Microsoft.CodeAnalysis.Scripting
             Namespaces = namespaces;
             MetadataResolver = metadataResolver;
             SourceResolver = sourceResolver;
-            IsInteractive = isInteractive;
         }
 
         private ScriptOptions(ScriptOptions other) 
@@ -88,8 +79,7 @@ namespace Microsoft.CodeAnalysis.Scripting
                    references: other.MetadataReferences,
                    namespaces: other.Namespaces,
                    metadataResolver: other.MetadataResolver,
-                   sourceResolver: other.SourceResolver,
-                   isInteractive: other.IsInteractive)
+                   sourceResolver: other.SourceResolver)
         {
         }
 
@@ -309,13 +299,6 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// <exception cref="ArgumentNullException"><paramref name="namespaces"/> is null or contains a null reference.</exception>
         public ScriptOptions AddNamespaces(params string[] namespaces) => 
             AddNamespaces((IEnumerable<string>)namespaces);
-
-        /// <summary>
-        /// Create a new <see cref="ScriptOptions"/> with the interactive state specified.
-        /// Interactive scripts may contain a final expression whose value is returned when the script is run.
-        /// </summary>
-        public ScriptOptions WithIsInteractive(bool isInteractive) =>
-            IsInteractive == isInteractive ? this : new ScriptOptions(this) { IsInteractive = isInteractive };
 
         #region Parameter Validation
 

--- a/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
+++ b/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
@@ -12,8 +12,7 @@ Namespace Microsoft.CodeAnalysis.Scripting.VisualBasic
 
         Public Shared ReadOnly Instance As ScriptCompiler = New VisualBasicScriptCompiler()
 
-        Private Shared ReadOnly s_defaultInteractive As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Interactive)
-        Private Shared ReadOnly s_defaultScript As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Script)
+        Private Shared ReadOnly s_defaultOptions As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Script)
         Private Shared ReadOnly s_vbRuntimeReference As MetadataReference = MetadataReference.CreateFromAssemblyInternal(GetType(CompilerServices.NewLateBinding).GetTypeInfo().Assembly)
 
         Private Sub New()
@@ -37,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.Scripting.VisualBasic
         End Function
 
         Public Overrides Function ParseSubmission(text As SourceText, cancellationToken As CancellationToken) As SyntaxTree
-            Return SyntaxFactory.ParseSyntaxTree(text, s_defaultInteractive, cancellationToken:=cancellationToken)
+            Return SyntaxFactory.ParseSyntaxTree(text, s_defaultOptions, cancellationToken:=cancellationToken)
         End Function
 
         Private Shared Function GetGlobalImportsForCompilation(script As Script) As IEnumerable(Of GlobalImport)
@@ -59,8 +58,7 @@ Namespace Microsoft.CodeAnalysis.Scripting.VisualBasic
             diagnostics.Free()
 
             ' parse:
-            Dim parseOptions = If(script.Options.IsInteractive, s_defaultInteractive, s_defaultScript)
-            Dim tree = VisualBasicSyntaxTree.ParseText(script.Code, parseOptions, script.Options.Path)
+            Dim tree = VisualBasicSyntaxTree.ParseText(script.Code, s_defaultOptions, script.Options.Path)
 
             ' create compilation:
             Dim assemblyName As String = Nothing

--- a/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
@@ -489,7 +489,7 @@ $$}
 @"
 
 $$System.Console.WriteLine(""Hello"")
-", null, 0, new CSharpParseOptions(kind: SourceCodeKind.Interactive));
+", null, 0, new CSharpParseOptions(kind: SourceCodeKind.Script));
         }
     }
 }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -420,7 +420,7 @@ class C : B, I
             TestAddClass(code, expected, New ClassData With {.Name = "C", .Position = "I", .Bases = "B", .ImplementedInterfaces = "I"})
         End Sub
 
-        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5868"), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddClass10()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
@@ -419,7 +419,7 @@ $$End Function
             Test(<text>
 
 $$System.Console.WriteLine("Hello")
-</text>.NormalizedValue, Nothing, 0, New VisualBasicParseOptions(kind:=SourceCodeKind.Interactive))
+</text>.NormalizedValue, Nothing, 0, New VisualBasicParseOptions(kind:=SourceCodeKind.Script))
         End Sub
 
     End Class


### PR DESCRIPTION
Make SourceCodeKind.Interactive obsolete, use SourceCodeKind.Script instead.

We now allow script files to end with an expression. That means a script file has a value. If a script file is #loaded to another script file the value is ignored. Command line runner should interpret the value as an exit code. We are also allowing return statement in top-level code in https://github.com/dotnet/roslyn/issues/5773 (not included in this change) to return a value from a script explicitly.