### PR TITLE
Change error CS1994 message

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -899,7 +899,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;async&apos; modifier can only be used in methods that have a statement body..
+        ///   Looks up a localized string similar to The &apos;async&apos; modifier can only be used in methods that have a body..
         /// </summary>
         internal static string ERR_BadAsyncLacksBody {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3537,7 +3537,7 @@ Give the compiler some way to differentiate the methods. For example, you can gi
     <value>Cannot await in an unsafe context</value>
   </data>
   <data name="ERR_BadAsyncLacksBody" xml:space="preserve">
-    <value>The 'async' modifier can only be used in methods that have a statement body.</value>
+    <value>The 'async' modifier can only be used in methods that have a body.</value>
   </data>
   <data name="ERR_BadSpecialByRefLocal" xml:space="preserve">
     <value>Parameters or locals of type '{0}' cannot be declared in async methods or lambda expressions.</value>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3168,7 +3168,7 @@ static class Test
     static async Task M1();
 }";
             CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (6,23): error CS1994: The 'async' modifier can only be used in methods that have a statement body
+                // (6,23): error CS1994: The 'async' modifier can only be used in methods that have a body
                 //     static async Task M1();
                 Diagnostic(ErrorCode.ERR_BadAsyncLacksBody, "M1"));
         }
@@ -3184,7 +3184,7 @@ static class Test
     static async Task M1(__arglist);
 }";
             CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (6,23): error CS1994: The 'async' modifier can only be used in methods that have a statement body
+                // (6,23): error CS1994: The 'async' modifier can only be used in methods that have a body
                 //     static async Task M1(__arglist);
                 Diagnostic(ErrorCode.ERR_BadAsyncLacksBody, "M1"));
         }
@@ -3476,7 +3476,7 @@ class Test
     }
 }";
             CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (4,32): error CS1994: The 'async' modifier can only be used in methods that have a statement body.
+                // (4,32): error CS1994: The 'async' modifier can only be used in methods that have a body.
                 //     public async abstract void M1();
                 Diagnostic(ErrorCode.ERR_BadAsyncLacksBody, "M1"));
         }


### PR DESCRIPTION
Closes #91 

Based on @controlflow's suggestion in issue #91, the wording of error CS1994 is changed to reflect the current state of the language.