### PR TITLE
Disable #r and #load completion outside the REPL...

### DIFF
--- a/src/Interactive/EditorFeatures/CSharp/Completion/FileSystem/LoadDirectiveCompletionProvider.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Completion/FileSystem/LoadDirectiveCompletionProvider.cs
@@ -8,10 +8,16 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.FileSystem;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.FileSystem
 {
     [ExportCompletionProvider("LoadDirectiveCompletionProvider", LanguageNames.CSharp)]
+    // Using TextViewRole here is a temporary work-around to prevent this component from being loaded in
+    // regular C# contexts.  We will need to remove this and implement a new "CSharp Script" Content type
+    // in order to fix #load completion in .csx files (https://github.com/dotnet/roslyn/issues/5325).
+    [TextViewRole(PredefinedInteractiveTextViewRoles.InteractiveTextViewRole)]
     internal partial class LoadDirectiveCompletionProvider : CompletionListProvider
     {
         private const string NetworkPath = "\\\\";

--- a/src/Interactive/EditorFeatures/CSharp/Completion/FileSystem/ReferenceDirectiveCompletionProvider.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Completion/FileSystem/ReferenceDirectiveCompletionProvider.cs
@@ -4,17 +4,19 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.Editor.Completion.FileSystem;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Completion.FileSystem
 {
     // TODO(cyrusn): Use a predefined name here.
     [ExportCompletionProvider("ReferenceDirectiveCompletionProvider", LanguageNames.CSharp)]
+    // Using TextViewRole here is a temporary work-around to prevent this component from being loaded in
+    // regular C# contexts.  We will need to remove this and implement a new "CSharp Script" Content type
+    // in order to fix #r completion in .csx files (https://github.com/dotnet/roslyn/issues/5325).
+    [TextViewRole(PredefinedInteractiveTextViewRoles.InteractiveTextViewRole)]
     internal partial class ReferenceDirectiveCompletionProvider : AbstractReferenceDirectiveCompletionProvider
     {
-        public ReferenceDirectiveCompletionProvider()
-        {
-        }
-
         protected override bool TryGetStringLiteralToken(SyntaxTree tree, int position, out SyntaxToken stringLiteral, CancellationToken cancellationToken)
         {
             if (tree.IsEntirelyWithinStringLiteral(position, cancellationToken))


### PR DESCRIPTION
This is a temporary work-around to prevent Interactive dlls from getting loaded when typing regular C# files (so we can unblock our RI to lab/vsumain).  I'm currently working on a better fix that uses a new ```[ContentType("CSharp Script")]``` for .csx and REPL.