### PR TITLE
First attempt at a netcore compilers NuGet package

### DIFF
--- a/build/BuildNuGets.csx
+++ b/build/BuildNuGets.csx
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+string usage = @"usage: BuildNuGets.csx <binaries-dir> <build-version>";
+
+if (Args.Length != 2)
+{
+    Console.WriteLine(usage);
+    Environment.Exit(1);
+}
+
+var binDir = Path.GetFullPath(Args[0]);
+var buildVersion = Args[1].Trim();
+var nuspecDirPath = Path.GetFullPath("../../src/NuGet");
+
+var licenseUrl = @"http://go.microsoft.com/fwlink/?LinkId=529443";
+var authors = @"Microsoft";
+var projectURL = @"http://msdn.com/roslyn";
+var tags = @"Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics";
+
+var files = Directory.GetFiles(nuspecDirPath, "*.nuspec");
+var procs = new List<Process>(files.Length);
+
+foreach (var file in files)
+{
+    var nugetArgs = $@"pack {file} " +
+        $@"-BasePath ""{binDir}"" " +
+        "-ExcludeEmptyDirectories " +
+        $@"-prop licenseUrl=""{licenseUrl}"" " +
+        $@"-prop version=""{buildVersion}"" " +
+        $"-prop authors={authors} " +
+        $@"-prop projectURL=""{projectURL}"" " +
+        $@"-prop tags=""{tags}""";
+    Console.WriteLine(nugetArgs);
+    var p = Process.Start(Path.GetFullPath("../../nuget.exe"), nugetArgs);
+}
+
+foreach (var p in procs)
+{
+    p.WaitForExit();
+}

--- a/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
@@ -17,6 +17,7 @@
         <tags>$tags$</tags>
         <dependencies>
             <group>
+                <dependency id="Microsoft.CodeAnalysis.Compilers" version="$version$" />
                 <dependency id="System.AppContext" version="4.0.1-beta-23401" />
                 <dependency id="System.Collections" version="4.0.11-beta-23401" />
                 <dependency id="System.Collections.Immutable" version="1.1.36" />
@@ -54,9 +55,6 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="Microsoft.CodeAnalysis.dll" target="runtimes/any/lib/dotnet" />
-        <file src="Microsoft.CodeAnalysis.CSharp.dll" target="runtimes/any/lib/dotnet" />
-        <file src="Microsoft.CodeAnalysis.VisualBasic.dll" target="runtimes/any/lib/dotnet" />
         <file src="csc.exe" target="runtimes/any/native" />
         <file src="vbc.exe" target="runtimes/any/native" />
     </files>

--- a/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>Microsoft.Net.Compilers.netcore</id>
+        <description>
+            CoreCLR-compatible versions of the C# and VB compilers.
+
+            Supported Platforms:
+            - .NET Core (dnxcore50)
+        </description>
+        <language>en-US</language>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <version>$version$</version>
+        <authors>$authors$</authors>
+        <licenseUrl>$licenseUrl$</licenseUrl>
+        <projectUrl>$projectUrl$</projectUrl>
+        <tags>$tags$</tags>
+        <dependencies>
+            <group>
+                <dependency id="System.AppContext" version="4.0.1-beta-23401" />
+                <dependency id="System.Collections" version="4.0.11-beta-23401" />
+                <dependency id="System.Collections.Immutable" version="1.1.36" />
+                <dependency id="System.Console" version="4.0.0-beta-23401" />
+                <dependency id="System.Diagnostics.Debug" version="4.0.11-beta-23401" />
+                <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0-beta-23401" />
+                <dependency id="System.Diagnostics.Process" version="4.1.0-beta-23401" />
+                <dependency id="System.Diagnostics.Tools" version="4.0.1-beta-23401" />
+                <dependency id="System.Dynamic.Runtime" version="4.0.11-beta-23401" />
+                <dependency id="System.IO.FileSystem" version="4.0.1-beta-23401" />
+                <dependency id="System.IO.Pipes" version="4.0.0-beta-23401" />
+                <dependency id="System.Linq" version="4.0.1-beta-23401" />
+                <dependency id="System.Private.Uri" version="4.0.1-beta-23401" />
+                <dependency id="System.Reflection" version="4.1.0-beta-23401" />
+                <dependency id="System.Reflection.Metadata" version="1.1.0-alpha-00014" />
+                <dependency id="System.Reflection.Primitives" version="4.0.1-beta-23401" />
+                <dependency id="System.Resources.ResourceManager" version="4.0.1-beta-23401" />
+                <dependency id="System.Runtime" version="4.0.21-beta-23401" />
+                <dependency id="System.Runtime.Extensions" version="4.0.11-beta-23401" />
+                <dependency id="System.Runtime.Handles" version="4.0.1-beta-23401" />
+                <dependency id="System.Runtime.InteropServices" version="4.0.21-beta-23401" />
+                <dependency id="System.Runtime.Loader" version="4.0.0-beta-23401" />
+                <dependency id="System.Runtime.Serialization.Json" version="4.0.1-beta-23401" />
+                <dependency id="System.Security.Cryptography.Algorithms" version="4.0.0-beta-23401" />
+                <dependency id="System.Text.Encoding" version="4.0.11-beta-23401" />
+                <dependency id="System.Text.Encoding.CodePages" version="4.0.1-beta-23401" />
+                <dependency id="System.Text.Encoding.Extensions" version="4.0.11-beta-23401" />
+                <dependency id="System.Threading" version="4.0.11-beta-23401" />
+                <dependency id="System.Threading.Tasks" version="4.0.11-beta-23401" />
+                <dependency id="System.Threading.Tasks.Parallel" version="4.0.1-beta-23401" />
+                <dependency id="System.Threading.Thread" version="4.0.0-beta-23401" />
+                <dependency id="System.Xml.XDocument" version="4.0.11-beta-23401" />
+                <dependency id="System.Xml.XmlDocument" version="4.0.1-beta-23401" />
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="Microsoft.CodeAnalysis.dll" target="runtimes/any/lib/dotnet" />
+        <file src="Microsoft.CodeAnalysis.CSharp.dll" target="runtimes/any/lib/dotnet" />
+        <file src="Microsoft.CodeAnalysis.VisualBasic.dll" target="runtimes/any/lib/dotnet" />
+        <file src="csc.exe" target="runtimes/any/native" />
+        <file src="vbc.exe" target="runtimes/any/native" />
+    </files>
+</package>


### PR DESCRIPTION
I'd like to bring in my first hacky attempt at a CoreCLR-compatible compilers NuGet package.

Right now the BuildNuGets script has a lot of limitations (you can only run it from the csi.exe parent directory) but since this isn't part of any regular build infrastructure this shouldn't matter for our actual builds.

It would be nice to be able to point to a file in our repository for soliciting advice on getting this up to snuff.