### PR TITLE
Adjust XmlDocumentationCommentTextReader.Reader to be finite.

### DIFF
--- a/src/Compilers/Core/Portable/DocumentationComments/XmlDocumentationCommentTextReader.cs
+++ b/src/Compilers/Core/Portable/DocumentationComments/XmlDocumentationCommentTextReader.cs
@@ -52,6 +52,13 @@ So we suppress this error until the reporting for CA3053 has been updated to acc
                 }
                 while (!Reader.ReachedEnd(_reader));
 
+                if (_textReader.Eof)
+                {
+                    _reader.Dispose();
+                    _reader = null;
+                    _textReader.Reset();
+                }
+
                 return null;
             }
             catch (XmlException ex)


### PR DESCRIPTION
Fixes #4699.

@gafter, @VSadov, @jaredpar, @agocke, @TyOverby Please review.
CC @amcasey, @tmat  