### PR TITLE
Fix Code Model tests

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
@@ -197,11 +197,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
                 _deadKeySet.Remove(key);
             }
 
-            TValue value;
-            if (TryGetValue(key, out value))
+            WeakComHandle<TValue, TValue> handle;
+            if (_table.TryGetValue(key, out handle))
             {
                 _table.Remove(key);
-                return value;
+                return handle.ComAggregateObject;
             }
 
             return null;
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
             if (_table.TryGetValue(key, out handle))
             {
                 value = handle.ComAggregateObject;
-                return value != null;
+                return true;
             }
 
             value = null;

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -206,20 +206,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 EnvDTE.CodeElement codeElement;
                 if (_codeElementTable.TryGetValue(nodeKey, out codeElement))
                 {
-                    var element = ComAggregate.TryGetManagedObject<AbstractCodeElement>(codeElement);
-                    if (element.IsValidNode())
+                    if (codeElement != null)
                     {
-                        if (codeElement is T)
+                        var element = ComAggregate.TryGetManagedObject<AbstractCodeElement>(codeElement);
+                        if (element.IsValidNode())
                         {
-                            return (T)codeElement;
-                        }
+                            if (codeElement is T)
+                            {
+                                return (T)codeElement;
+                            }
 
-                        throw new InvalidOperationException($"Found a valid code element for {nodeKey}, but it is not of type, {typeof(T).ToString()}");
+                            throw new InvalidOperationException($"Found a valid code element for {nodeKey}, but it is not of type, {typeof(T).ToString()}");
+                        }
                     }
-                    else
-                    {
-                        _codeElementTable.Remove(nodeKey);
-                    }
+
+                    _codeElementTable.Remove(nodeKey);
                 }
             }
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
@@ -639,6 +639,28 @@ class CAttribute : Attribute { }
             TestAddAttributeArgument(code, expectedCode, New AttributeArgumentData With {.Name = "AllowMultiple", .Value = "false", .Position = 1})
 
         End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttributeArgumentStress()
+            Dim code =
+<Code>
+[$$A]
+class C
+{
+}
+</Code>
+
+            TestElement(code,
+                Sub(codeAttribute)
+                    For i = 1 To 100
+                        Dim value = i.ToString()
+                        Assert.DoesNotThrow(
+                            Sub()
+                                Dim codeAttributeArgument = codeAttribute.AddArgument(value, Position:=1)
+                            End Sub)
+                    Next
+                End Sub)
+        End Sub
 #End Region
 
 #Region "Delete tests"

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
@@ -798,7 +798,7 @@ End Class
 
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttributeArgument2()
             Dim code =
 <Code>
@@ -822,7 +822,7 @@ End Class
 
         End Sub
 
-        <ConditionalFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub TestAddArgument3()
             Dim code =
 <Code>
@@ -835,7 +835,7 @@ End Class
 </Code>
 
             Dim expectedCode =
-<Code>
+    <Code>
 Imports System
 
 &lt;AttributeUsage(AttributeTargets.All, AllowMultiple:=False)&gt;

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
@@ -847,6 +847,27 @@ End Class
             TestAddAttributeArgument(code, expectedCode, New AttributeArgumentData With {.Name = "AllowMultiple", .Value = "False", .Position = 1})
 
         End Sub
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttributeArgumentStress()
+            Dim code =
+<Code>
+&lt;$$A&gt;
+Class C
+End Class
+</Code>
+
+            TestElement(code,
+                Sub(codeAttribute)
+                    For i = 1 To 100
+                        Dim value = i.ToString()
+                        Assert.DoesNotThrow(
+                            Sub()
+                                Dim codeAttributeArgument = codeAttribute.AddArgument(value, Position:=1)
+                            End Sub)
+                    Next
+                End Sub)
+        End Sub
 #End Region
 
 #Region "Delete tests"


### PR DESCRIPTION
Fixes #5800 

There were cases where the CleanableWeakComHandleTable could become inconsistent and the FileCodeModel could inadvertantly miss the need to remove a key from the table.

Sorry about the project.lock.json file changes. These were on my machine after a NuGet restore and getting rid of them meant that I couldn't build. I guess they're necessary?

Tagging @dotnet/roslyn-ide, @jaredpar, @tannergooding, @jmarolf 