### PR TITLE
Ensure that a binder used to bind constraints uses correct containing symbol.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // Wrap binder from factory in a generic constraints specific binder 
                     // to avoid checking constraints when binding type names.
                     Debug.Assert(!binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
-                    binder = binder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks);
+                    binder = binder.WithContainingMemberOrLambda(this).WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks);
 
                     var constraints = binder.BindTypeParameterConstraintClauses(this, typeParameters, constraintClauses, diagnostics);
                     Debug.Assert(constraints.Length == arity);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -6628,5 +6628,55 @@ class B : A<ValueType>, I<ValueType>
 }";
             CompileAndVerify(source);
         }
+
+        [WorkItem(4097, "https://github.com/dotnet/roslyn/issues/4097")]
+        [Fact]
+        public void ObsoleteTypeInConstraints()
+        {
+            var source =
+@"
+[System.Obsolete]
+class Class1<T> where T : Class2
+{
+}
+
+[System.Obsolete]
+class Class2
+{
+}
+
+class Class3<T> where T : Class2
+{
+    [System.Obsolete]
+    void M1<S>() where S : Class2
+    {}   
+
+    void M2<S>() where S : Class2
+    {}   
+}
+
+partial class Class4
+{
+    [System.Obsolete]
+    partial void M3<S>() where S : Class2;
+}
+
+partial class Class4
+{
+    partial void M4<S>() where S : Class2;
+}
+";
+            CompileAndVerify(source, options: TestOptions.DebugDll).VerifyDiagnostics(
+    // (12,27): warning CS0612: 'Class2' is obsolete
+    // class Class3<T> where T : Class2
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "Class2").WithArguments("Class2").WithLocation(12, 27),
+    // (18,28): warning CS0612: 'Class2' is obsolete
+    //     void M2<S>() where S : Class2
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "Class2").WithArguments("Class2").WithLocation(18, 28),
+    // (30,36): warning CS0612: 'Class2' is obsolete
+    //     partial void M4<S>() where S : Class2;
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "Class2").WithArguments("Class2").WithLocation(30, 36)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -1998,10 +1998,7 @@ namespace CrashTest
             comp.VerifyDiagnostics(
     // (2,30): warning CS0612: 'Class2' is obsolete
     // using static CrashTest.Crash<CrashTest.Class2>; 
-    Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "CrashTest.Class2").WithArguments("CrashTest.Class2").WithLocation(2, 30),
-    // (13,18): warning CS0612: 'Crash<T>' is obsolete
-    //         where T: Crash<T>.AbstractClass 
-    Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "Crash<T>").WithArguments("CrashTest.Crash<T>").WithLocation(13, 18)
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "CrashTest.Class2").WithArguments("CrashTest.Class2").WithLocation(2, 30)
                 );
         }
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -902,7 +902,7 @@ lReportErrorOnTwoTokens:
 
             ' Wrap constraints binder in a location-specific binder to
             ' avoid checking constraints when binding type names.
-            binder = New LocationSpecificBinder(BindingLocation.GenericConstraintsClause, binder)
+            binder = New LocationSpecificBinder(BindingLocation.GenericConstraintsClause, Me, binder)
             Return binder.BindTypeParameterConstraintClause(Me, syntax.TypeParameterConstraintClause, diagnostics)
         End Function
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/GenericConstraintTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/GenericConstraintTests.vb
@@ -5607,6 +5607,54 @@ End Class
 </compilation>)
         End Sub
 
+        <WorkItem(4097, "https://github.com/dotnet/roslyn/issues/4097")>
+        <Fact>
+        Public Sub ObsoleteTypeInConstraints()
+            CompileAndVerify(
+<compilation>
+    <file name="a.vb"><![CDATA[
+<System.Obsolete>
+class Class1(Of T As Class2)
+End Class
+
+<System.Obsolete>
+class Class2
+End Class
+
+class Class3(Of T As Class2)
+    <System.Obsolete>
+    Sub M1(Of S As Class2)
+    End Sub
+
+    Sub M2(Of S As Class2)
+    End Sub
+End Class
+
+class Class4
+    <System.Obsolete>
+    Private Partial Sub M3(Of S As Class2)
+    End Sub
+End Class
+
+Partial class Class4
+    Private Partial Sub M4(Of S As Class2)
+    End Sub
+End Class
+   ]]></file>
+</compilation>, options:=TestOptions.DebugDll).Diagnostics.AssertTheseDiagnostics(
+<expected>
+BC40008: 'Class2' is obsolete.
+class Class3(Of T As Class2)
+                     ~~~~~~
+BC40008: 'Class2' is obsolete.
+    Sub M2(Of S As Class2)
+                   ~~~~~~
+BC40008: 'Class2' is obsolete.
+    Private Partial Sub M4(Of S As Class2)
+                                   ~~~~~~
+</expected>)
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #4097.

@gafter, @VSadov, @jaredpar, @agocke, @TyOverby Please review.