### PR TITLE
Break dependency on prerelease metadata feature

### DIFF
--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Microsoft.DiaSymReader.PortablePdb.csproj
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Microsoft.DiaSymReader.PortablePdb.csproj
@@ -31,6 +31,27 @@
     <Compile Include="..\..\Compilers\Core\Portable\PortableShim.cs">
       <Link>Utilities\PortableShim.cs</Link>
     </Compile>
+    <Compile Include="..\Roslyn.Reflection.Metadata.Decoding\ArrayShape.cs">
+      <Link>System.Reflection.Metadata.Decoding\ArrayShape.cs</Link>
+    </Compile>
+    <Compile Include="..\Roslyn.Reflection.Metadata.Decoding\CustomModifier.cs">
+      <Link>System.Reflection.Metadata.Decoding\CustomModifier.cs</Link>
+    </Compile>
+    <Compile Include="..\Roslyn.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs">
+      <Link>System.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\Roslyn.Reflection.Metadata.Decoding\ITypeProvider.cs">
+      <Link>System.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\Roslyn.Reflection.Metadata.Decoding\MethodSignature.cs">
+      <Link>System.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\Roslyn.Reflection.Metadata.Decoding\PrimitiveTypeCode.cs">
+      <Link>System.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\Roslyn.Reflection.Metadata.Decoding\SignatureDecoder.cs">
+      <Link>System.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
     <Compile Include="AsyncMethodData.cs" />
     <Compile Include="MethodMap.cs" />
     <Compile Include="Utilities\BlobWriter.cs" />

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/SymVariable.cs
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/SymVariable.cs
@@ -3,9 +3,18 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Decoding;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
+
+// Point-in-time conflict between System.Reflection.Metadata and temporary internal Roslyn.Reflection.Metadata
+// Replace this with using System.Reflection.Metadata.Decoding and uncomment type parameters when switching
+// back to public System.Reflection.Metadata API. 
+using ArrayShape = Roslyn.Reflection.Metadata.Decoding.ArrayShape;
+using CustomModifier = Roslyn.Reflection.Metadata.Decoding.CustomModifier<object>;
+using MethodSignature = Roslyn.Reflection.Metadata.Decoding.MethodSignature<object>;
+using ISignatureTypeProvider = Roslyn.Reflection.Metadata.Decoding.ISignatureTypeProvider<object>;
+using PrimitiveTypeCode = Roslyn.Reflection.Metadata.Decoding.PrimitiveTypeCode;
+using SignatureDecoder = Roslyn.Reflection.Metadata.Decoding.SignatureDecoder;
 
 namespace Microsoft.DiaSymReader.PortablePdb
 {
@@ -139,7 +148,7 @@ namespace Microsoft.DiaSymReader.PortablePdb
             return HResult.S_OK;
         }
 
-        private sealed class DummyTypeProvider : ISignatureTypeProvider<object>
+        private sealed class DummyTypeProvider : ISignatureTypeProvider/*<object>*/
         {
             public DummyTypeProvider(MetadataReader reader)
             {
@@ -151,11 +160,11 @@ namespace Microsoft.DiaSymReader.PortablePdb
 
             public object GetArrayType(object elementType, ArrayShape shape) => null;
             public object GetByReferenceType(object elementType) => null;
-            public object GetFunctionPointerType(MethodSignature<object> signature) => null;
+            public object GetFunctionPointerType(MethodSignature/*<object>*/ signature) => null;
             public object GetGenericInstance(object genericType, ImmutableArray<object> typeArguments) => null;
             public object GetGenericMethodParameter(int index) => null;
             public object GetGenericTypeParameter(int index) => null;
-            public object GetModifiedType(object unmodifiedType, ImmutableArray<CustomModifier<object>> customModifiers) => null;
+            public object GetModifiedType(object unmodifiedType, ImmutableArray<CustomModifier/*<object>*/> customModifiers) => null;
             public object GetPinnedType(object elementType) => null;
             public object GetPointerType(object elementType) => null;
             public object GetPrimitiveType(PrimitiveTypeCode typeCode) => null;

--- a/src/Debugging/Roslyn.Reflection.Metadata.Decoding/ArrayShape.cs
+++ b/src/Debugging/Roslyn.Reflection.Metadata.Decoding/ArrayShape.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// NOTE: This is a temporary internal copy of code that will be cut from System.Reflection.Metadata v1.1 and
+//       ship in System.Reflection.Metadata v1.2 (with breaking changes). Remove and use the public API when
+//       a v1.2 prerelease is available and code flow is such that we can start to depend on it.
+
+using System.Collections.Immutable;
+
+namespace Roslyn.Reflection.Metadata.Decoding
+{
+    internal struct ArrayShape
+    {
+        private readonly int _rank;
+        private readonly ImmutableArray<int> _sizes;
+        private readonly ImmutableArray<int> _lowerBounds;
+
+        public ArrayShape(int rank, ImmutableArray<int> sizes, ImmutableArray<int> lowerBounds)
+        {
+            _rank = rank;
+            _sizes = sizes;
+            _lowerBounds = lowerBounds;
+        }
+
+        public int Rank
+        {
+            get { return _rank; }
+        }
+
+        public ImmutableArray<int> Sizes
+        {
+            get { return _sizes; }
+        }
+
+        public ImmutableArray<int> LowerBounds
+        {
+            get { return _lowerBounds; }
+        }
+    }
+}

--- a/src/Debugging/Roslyn.Reflection.Metadata.Decoding/CustomModifier.cs
+++ b/src/Debugging/Roslyn.Reflection.Metadata.Decoding/CustomModifier.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// NOTE: This is a temporary internal copy of code that will be cut from System.Reflection.Metadata v1.1 and
+//       ship in System.Reflection.Metadata v1.2 (with breaking changes). Remove and use the public API when
+//       a v1.2 prerelease is available and code flow is such that we can start to depend on it.
+
+namespace Roslyn.Reflection.Metadata.Decoding
+{
+    internal struct CustomModifier<TType>
+    {
+        private readonly TType _type;
+        private readonly bool _isRequired;
+
+        public CustomModifier(TType type, bool isRequired)
+        {
+            _type = type;
+            _isRequired = isRequired;
+        }
+
+        public TType Type
+        {
+            get { return _type; }
+        }
+
+        public bool IsRequired
+        {
+            get { return _isRequired; }
+        }
+    }
+}

--- a/src/Debugging/Roslyn.Reflection.Metadata.Decoding/ISignatureTypeProvider.cs
+++ b/src/Debugging/Roslyn.Reflection.Metadata.Decoding/ISignatureTypeProvider.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// NOTE: This is a temporary internal copy of code that will be cut from System.Reflection.Metadata v1.1 and
+//       ship in System.Reflection.Metadata v1.2 (with breaking changes). Remove and use the public API when
+//       a v1.2 prerelease is available and code flow is such that we can start to depend on it.
+
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace Roslyn.Reflection.Metadata.Decoding
+{
+    internal interface ISignatureTypeProvider<TType> : ITypeProvider<TType>
+    {
+        MetadataReader Reader { get; }
+        TType GetFunctionPointerType(MethodSignature<TType> signature);
+        TType GetGenericMethodParameter(int index);
+        TType GetGenericTypeParameter(int index);
+        TType GetModifiedType(TType unmodifiedType, ImmutableArray<CustomModifier<TType>> customModifiers);
+        TType GetPinnedType(TType elementType);
+        TType GetPrimitiveType(PrimitiveTypeCode typeCode);
+        TType GetTypeFromDefinition(TypeDefinitionHandle handle, bool? isValueType);
+        TType GetTypeFromReference(TypeReferenceHandle handle, bool? isValueType);
+    }
+}

--- a/src/Debugging/Roslyn.Reflection.Metadata.Decoding/ITypeProvider.cs
+++ b/src/Debugging/Roslyn.Reflection.Metadata.Decoding/ITypeProvider.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// NOTE: This is a temporary internal copy of code that will be cut from System.Reflection.Metadata v1.1 and
+//       ship in System.Reflection.Metadata v1.2 (with breaking changes). Remove and use the public API when
+//       a v1.2 prerelease is available and code flow is such that we can start to depend on it.
+
+using System.Collections.Immutable;
+
+namespace Roslyn.Reflection.Metadata.Decoding
+{
+    internal interface ITypeProvider<TType>
+    {
+        TType GetGenericInstance(TType genericType, ImmutableArray<TType> typeArguments);
+        TType GetArrayType(TType elementType, ArrayShape shape);
+        TType GetByReferenceType(TType elementType);
+        TType GetSZArrayType(TType elementType);
+        TType GetPointerType(TType elementType);
+    }
+}

--- a/src/Debugging/Roslyn.Reflection.Metadata.Decoding/MethodSignature.cs
+++ b/src/Debugging/Roslyn.Reflection.Metadata.Decoding/MethodSignature.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace Roslyn.Reflection.Metadata.Decoding
+{
+    internal struct MethodSignature<TType>
+    {
+        private readonly SignatureHeader _header;
+        private readonly TType _returnType;
+        private readonly int _requiredParameterCount;
+        private readonly int _genericParameterCount;
+        private readonly ImmutableArray<TType> _parameterTypes;
+
+        public MethodSignature(SignatureHeader header, TType returnType, int requiredParameterCount, int genericParameterCount, ImmutableArray<TType> parameterTypes)
+        {
+            _header = header;
+            _returnType = returnType;
+            _genericParameterCount = genericParameterCount;
+            _requiredParameterCount = requiredParameterCount;
+            _parameterTypes = parameterTypes;
+        }
+
+        public SignatureHeader Header
+        {
+            get { return _header; }
+        }
+
+        public TType ReturnType
+        {
+            get { return _returnType; }
+        }
+
+        public int RequiredParameterCount
+        {
+            get { return _requiredParameterCount; }
+        }
+
+        public int GenericParameterCount
+        {
+            get { return _genericParameterCount; }
+        }
+
+        public ImmutableArray<TType> ParameterTypes
+        {
+            get { return _parameterTypes; }
+        }
+    }
+}

--- a/src/Debugging/Roslyn.Reflection.Metadata.Decoding/PrimitiveTypeCode.cs
+++ b/src/Debugging/Roslyn.Reflection.Metadata.Decoding/PrimitiveTypeCode.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// NOTE: This is a temporary internal copy of code that will be cut from System.Reflection.Metadata v1.1 and
+//       ship in System.Reflection.Metadata v1.2 (with breaking changes). Remove and use the public API when
+//       a v1.2 prerelease is available and code flow is such that we can start to depend on it.
+
+using System.Reflection.Metadata;
+
+namespace Roslyn.Reflection.Metadata.Decoding
+{
+    /// <summary>
+    /// Represents a primitive type found in metadata signatures.
+    /// </summary>
+    internal enum PrimitiveTypeCode : byte
+    {
+        Boolean = SignatureTypeCode.Boolean,
+        Byte = SignatureTypeCode.Byte,
+        SByte = SignatureTypeCode.SByte,
+        Char = SignatureTypeCode.Char,
+        Single = SignatureTypeCode.Single,
+        Double = SignatureTypeCode.Double,
+        Int16 = SignatureTypeCode.Int16,
+        Int32 = SignatureTypeCode.Int32,
+        Int64 = SignatureTypeCode.Int64,
+        UInt16 = SignatureTypeCode.UInt16,
+        UInt32 = SignatureTypeCode.UInt32,
+        UInt64 = SignatureTypeCode.UInt64,
+        IntPtr = SignatureTypeCode.IntPtr,
+        UIntPtr = SignatureTypeCode.UIntPtr,
+        Object = SignatureTypeCode.Object,
+        String = SignatureTypeCode.String,
+        TypedReference = SignatureTypeCode.TypedReference,
+        Void = SignatureTypeCode.Void,
+    }
+}

--- a/src/Debugging/Roslyn.Reflection.Metadata.Decoding/SignatureDecoder.cs
+++ b/src/Debugging/Roslyn.Reflection.Metadata.Decoding/SignatureDecoder.cs
@@ -1,0 +1,425 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// NOTE: This is a temporary internal copy of code that will be cut from System.Reflection.Metadata v1.1 and
+//       ship in System.Reflection.Metadata v1.2 (with breaking changes). Remove and use the public API when
+//       a v1.2 prerelease is available and code flow is such that we can start to depend on it.
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace Roslyn.Reflection.Metadata.Decoding
+{
+    /// <summary>
+    /// Decodes signature blobs.
+    /// </summary>
+    internal static class SignatureDecoder
+    {
+        /// <summary>
+        /// Decodes a type definition, reference or specification to its representation as TType.
+        /// </summary>
+        /// <param name="handle">A type definition, reference, or specification handle.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <param name="isValueType">Is the type a class or a value type. Null signifies that the current type signature does not have the prefix</param>
+        /// <exception cref="System.BadImageFormatException">The handle does not represent a valid type reference, definition, or specification.</exception>
+        public static TType DecodeType<TType>(Handle handle, ISignatureTypeProvider<TType> provider, bool? isValueType)
+        {
+            switch (handle.Kind)
+            {
+                case HandleKind.TypeReference:
+                    return provider.GetTypeFromReference((TypeReferenceHandle)handle, isValueType);
+
+                case HandleKind.TypeDefinition:
+                    return provider.GetTypeFromDefinition((TypeDefinitionHandle)handle, isValueType);
+
+                case HandleKind.TypeSpecification:
+                    return DecodeTypeSpecification((TypeSpecificationHandle)handle, provider);
+
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
+        /// <summary>
+        /// Decodes a type specification.
+        /// </summary>
+        /// <param name="handle">The type specification handle.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The decoded type.</returns>
+        /// <exception cref="System.BadImageFormatException">The type specification has an invalid signature.</exception>
+        private static TType DecodeTypeSpecification<TType>(TypeSpecificationHandle handle, ISignatureTypeProvider<TType> provider)
+        {
+            BlobHandle blobHandle = provider.Reader.GetTypeSpecification(handle).Signature;
+            BlobReader blobReader = provider.Reader.GetBlobReader(blobHandle);
+            return DecodeType(ref blobReader, provider);
+        }
+
+        /// <summary>
+        /// Decodes a type from within a signature from a BlobReader positioned at its leading SignatureTypeCode.
+        /// </summary>
+        /// <param name="blobReader">The blob reader.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The decoded type.</returns>
+        /// <exception cref="System.BadImageFormatException">The reader was not positioned at a valid signature type.</exception>
+        public static TType DecodeType<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            return DecodeType(ref blobReader, blobReader.ReadCompressedInteger(), provider);
+        }
+
+        /// <summary>
+        /// Decodes a type from within a signature from a BlobReader positioned immediately past the given SignatureTypeCode.
+        /// </summary>
+        /// <param name="blobReader">The blob reader.</param>
+        /// <param name="typeCode">The SignatureTypeCode that immediately preceded the reader's current position.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The decoded type.</returns>
+        /// <exception cref="System.BadImageFormatException">The reader was not positioned at a valud signature type.</exception>
+        private static TType DecodeType<TType>(ref BlobReader blobReader, int typeCode, ISignatureTypeProvider<TType> provider)
+        {
+            TType elementType;
+            int index;
+            if(typeCode > byte.MaxValue)
+            {
+                typeCode = (int)SignatureTypeCode.Invalid;
+            }
+            switch (typeCode)
+            {
+                case (int)SignatureTypeCode.Boolean:
+                case (int)SignatureTypeCode.Char:
+                case (int)SignatureTypeCode.SByte:
+                case (int)SignatureTypeCode.Byte:
+                case (int)SignatureTypeCode.Int16:
+                case (int)SignatureTypeCode.UInt16:
+                case (int)SignatureTypeCode.Int32:
+                case (int)SignatureTypeCode.UInt32:
+                case (int)SignatureTypeCode.Int64:
+                case (int)SignatureTypeCode.UInt64:
+                case (int)SignatureTypeCode.Single:
+                case (int)SignatureTypeCode.Double:
+                case (int)SignatureTypeCode.IntPtr:
+                case (int)SignatureTypeCode.UIntPtr:
+                case (int)SignatureTypeCode.Object:
+                case (int)SignatureTypeCode.String:
+                case (int)SignatureTypeCode.Void:
+                case (int)SignatureTypeCode.TypedReference:
+                    return provider.GetPrimitiveType((PrimitiveTypeCode)typeCode);
+
+                case (int)SignatureTypeCode.Pointer:
+                    elementType = DecodeType(ref blobReader, provider);
+                    return provider.GetPointerType(elementType);
+
+                case (int)SignatureTypeCode.ByReference:
+                    elementType = DecodeType(ref blobReader, provider);
+                    return provider.GetByReferenceType(elementType);
+
+                case (int)SignatureTypeCode.Pinned:
+                    elementType = DecodeType(ref blobReader, provider);
+                    return provider.GetPinnedType(elementType);
+
+                case (int)SignatureTypeCode.SZArray:
+                    elementType = DecodeType(ref blobReader, provider);
+                    return provider.GetSZArrayType(elementType);
+
+                case (int)SignatureTypeCode.FunctionPointer:
+                    MethodSignature<TType> methodSignature = DecodeMethodSignature(ref blobReader, provider);
+                    return provider.GetFunctionPointerType(methodSignature);
+
+                case (int)SignatureTypeCode.Array:
+                    return DecodeArrayType(ref blobReader, provider);
+
+                case (int)SignatureTypeCode.RequiredModifier:
+                    return DecodeModifiedType(ref blobReader, provider, isRequired: true);
+
+                case (int)SignatureTypeCode.OptionalModifier:
+                    return DecodeModifiedType(ref blobReader, provider, isRequired: false);
+
+                case (int)SignatureTypeCode.GenericTypeInstance:
+                    return DecodeGenericTypeInstance(ref blobReader, provider);
+
+                case (int)SignatureTypeCode.GenericTypeParameter:
+                    index = blobReader.ReadCompressedInteger();
+                    return provider.GetGenericTypeParameter(index);
+
+                case (int)SignatureTypeCode.GenericMethodParameter:
+                    index = blobReader.ReadCompressedInteger();
+                    return provider.GetGenericMethodParameter(index);
+
+                case 0x11://(int)CorElementType.ELEMENT_TYPE_CLASS
+                    return DecodeTypeHandle(ref blobReader, provider, false);
+
+                case 0x12: //(int)CorElementType.ELEMENT_TYPE_VALUETYPE:
+                    return DecodeTypeHandle(ref blobReader, provider, true);
+
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
+        // Decodes a list of types preceded by their count as a compressed integer.
+        private static ImmutableArray<TType> DecodeTypes<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            int count = blobReader.ReadCompressedInteger();
+            if (count == 0)
+            {
+                return ImmutableArray<TType>.Empty;
+            }
+
+            var types = new TType[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                types[i] = DecodeType(ref blobReader, provider);
+            }
+
+            return ImmutableArray.Create(types);
+        }
+
+        /// <summary>
+        /// Decodes a method signature blob.
+        /// </summary>
+        /// <param name="handle">Handle to the method signature.</param>
+        /// <returns>The decoded method signature.</returns>
+        /// <param name="provider">The type provider.</param>
+        /// <exception cref="System.BadImageFormatException">The method signature is invalid.</exception>
+        public static MethodSignature<TType> DecodeMethodSignature<TType>(BlobHandle handle, ISignatureTypeProvider<TType> provider)
+        {
+            BlobReader blobReader = provider.Reader.GetBlobReader(handle);
+            return DecodeMethodSignature(ref blobReader, provider);
+        }
+
+        /// <summary>
+        /// Decodes a method signature blob.
+        /// </summary>
+        /// <param name="blobReader">BlobReader positioned at a method signature.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The decoded method signature.</returns>
+        /// <exception cref="System.BadImageFormatException">The method signature is invalid.</exception>
+        private static MethodSignature<TType> DecodeMethodSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            SignatureHeader header = blobReader.ReadSignatureHeader();
+
+            if (header.Kind != SignatureKind.Method && header.Kind != SignatureKind.Property)
+            {
+                throw new BadImageFormatException();
+            }
+
+            int genericParameterCount = 0;
+            if (header.IsGeneric)
+            {
+                genericParameterCount = blobReader.ReadCompressedInteger();
+            }
+
+            int parameterCount = blobReader.ReadCompressedInteger();
+            TType returnType = DecodeType(ref blobReader, provider);
+
+            if (parameterCount == 0)
+            {
+                return new MethodSignature<TType>(header, returnType, 0, genericParameterCount, ImmutableArray<TType>.Empty);
+            }
+
+            var parameterTypes = new TType[parameterCount];
+            SignatureTypeCode typeCode;
+            int parameterIndex;
+
+            for (parameterIndex = 0; parameterIndex < parameterCount; parameterIndex++)
+            {
+                var reader = blobReader;
+                typeCode = reader.ReadSignatureTypeCode();
+
+                if (typeCode == SignatureTypeCode.Sentinel)
+                {
+                    break;
+                }
+                parameterTypes[parameterIndex] = DecodeType(ref blobReader, provider);
+            }
+
+            int requiredParameterCount = parameterIndex;
+
+            for (; parameterIndex < parameterCount; parameterIndex++)
+            {
+                parameterTypes[parameterIndex] = DecodeType(ref blobReader, provider);
+            }
+
+            return new MethodSignature<TType>(header, returnType, requiredParameterCount, genericParameterCount, ImmutableArray.Create(parameterTypes));
+        }
+
+        /// <summary>
+        /// Decodes a method specification signature blob.
+        /// </summary>
+        /// <param name="handle">The handle to the method specification signature blob. See <see cref="MethodSpecification.Signature"/>.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The types used to instantiate a generic method via a method specification.</returns>
+        /// <exception cref="System.BadImageFormatException">The method specification signature is invalid.</exception>
+        public static ImmutableArray<TType> DecodeMethodSpecificationSignature<TType>(BlobHandle handle, ISignatureTypeProvider<TType> provider)
+        {
+            BlobReader blobReader = provider.Reader.GetBlobReader(handle);
+            return DecodeMethodSpecificationSignature(ref blobReader, provider);
+        }
+
+        /// <summary>
+        /// Decodes a method specification signature blob.
+        /// </summary>
+        /// <param name="blobReader">A BlobReader positioned at a valid method specification signature.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The types used to instantiate a generic method via the method specification.</returns>
+        public static ImmutableArray<TType> DecodeMethodSpecificationSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            SignatureHeader header = blobReader.ReadSignatureHeader();
+            if (header.Kind != SignatureKind.MethodSpecification)
+            {
+                throw new BadImageFormatException();
+            }
+
+            return DecodeTypes(ref blobReader, provider);
+        }
+
+        /// <summary>
+        /// Decodes a local variable signature blob.
+        /// </summary>
+        /// <param name="handle">The local variable signature handle.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The local variable types.</returns>
+        /// <exception cref="System.BadImageFormatException">The local variable signature is invalid.</exception>
+        public static ImmutableArray<TType> DecodeLocalSignature<TType>(StandaloneSignatureHandle handle, ISignatureTypeProvider<TType> provider)
+        {
+            BlobHandle blobHandle = provider.Reader.GetStandaloneSignature(handle).Signature;
+            BlobReader blobReader = provider.Reader.GetBlobReader(blobHandle);
+            return DecodeLocalSignature(ref blobReader, provider);
+        }
+
+        /// <summary>
+        /// Decodes a local variable signature blob and advances the reader past the signature.
+        /// </summary>
+        /// <param name="blobReader">The blob reader.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The local variable types.</returns>
+        /// <exception cref="System.BadImageFormatException">The local variable signature is invalid.</exception>
+        public static ImmutableArray<TType> DecodeLocalSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            SignatureHeader header = blobReader.ReadSignatureHeader();
+            if (header.Kind != SignatureKind.LocalVariables)
+            {
+                throw new BadImageFormatException();
+            }
+
+            return DecodeTypes(ref blobReader, provider);
+        }
+
+        /// <summary>
+        /// Decodes a field signature.
+        /// </summary>
+        /// <param name="handle">The field signature handle.</param>
+        /// <param name="provider">The type provider.</param>
+        /// <returns>The decoded field type.</returns>
+        /// <exception cref="System.BadImageFormatException">The field signature is invalid.</exception>
+        public static TType DecodeFieldSignature<TType>(BlobHandle handle, ISignatureTypeProvider<TType> provider)
+        {
+            BlobReader blobReader = provider.Reader.GetBlobReader(handle);
+            return DecodeFieldSignature(ref blobReader, provider);
+        }
+
+        /// <summary>
+        /// Decodes a field signature.
+        /// </summary>
+        /// <returns>The decoded field type.</returns>
+        public static TType DecodeFieldSignature<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            SignatureHeader header = blobReader.ReadSignatureHeader();
+
+            if (header.Kind != SignatureKind.Field)
+            {
+                throw new BadImageFormatException();
+            }
+
+            return DecodeType(ref blobReader, provider);
+        }
+
+        // Decodes a generalized (non-SZ/vector) array type represented by the element type followed by
+        // its rank and optional sizes and lower bounds.
+        private static TType DecodeArrayType<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            TType elementType = DecodeType(ref blobReader, provider);
+            int rank = blobReader.ReadCompressedInteger();
+            var sizes = ImmutableArray<int>.Empty;
+            var lowerBounds = ImmutableArray<int>.Empty;
+
+            int sizesCount = blobReader.ReadCompressedInteger();
+            if (sizesCount > 0)
+            {
+                var array = new int[sizesCount];
+                for (int i = 0; i < sizesCount; i++)
+                {
+                    array[i] = blobReader.ReadCompressedInteger();
+                }
+                sizes = ImmutableArray.Create(array);
+            }
+
+            int lowerBoundsCount = blobReader.ReadCompressedInteger();
+            if (lowerBoundsCount > 0)
+            {
+                var array = new int[lowerBoundsCount];
+                for (int i = 0; i < lowerBoundsCount; i++)
+                {
+                    array[i] = blobReader.ReadCompressedSignedInteger();
+                }
+                lowerBounds = ImmutableArray.Create(array);
+            }
+
+            var arrayShape = new ArrayShape(rank, sizes, lowerBounds);
+            return provider.GetArrayType(elementType, arrayShape);
+        }
+
+        // Decodes a generic type instantiation encoded as the generic type followed by the types used to instantiate it.
+        private static TType DecodeGenericTypeInstance<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider)
+        {
+            TType genericType = DecodeType(ref blobReader, provider);
+            ImmutableArray<TType> types = DecodeTypes(ref blobReader, provider);
+            return provider.GetGenericInstance(genericType, types);
+        }
+
+        // Decodes a type with custom modifiers starting with the first modifier type that is required iff isRequired is passed,\
+        // followed by an optional sequence of additional modifiers (<SignaureTypeCode.Required|OptionalModifier> <type>) and 
+        // terminated by the unmodified type.
+        private static TType DecodeModifiedType<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider, bool isRequired)
+        {
+            TType type = DecodeTypeHandle(ref blobReader, provider, null);
+            var modifier = new CustomModifier<TType>(type, isRequired);
+
+            ImmutableArray<CustomModifier<TType>> modifiers;
+            int typeCode = blobReader.ReadCompressedInteger();
+
+            isRequired = typeCode == (int)SignatureTypeCode.RequiredModifier;
+            if (!isRequired && typeCode != (int)SignatureTypeCode.OptionalModifier)
+            {
+                // common case: 1 modifier.
+                modifiers = ImmutableArray.Create(modifier);
+            }
+            else
+            {
+                // uncommon case: multiple modifiers.
+                var builder = ImmutableArray.CreateBuilder<CustomModifier<TType>>();
+                builder.Add(modifier);
+
+                do
+                {
+                    type = DecodeTypeHandle(ref blobReader, provider, null);
+                    modifier = new CustomModifier<TType>(type, isRequired);
+                    builder.Add(modifier);
+                    typeCode = blobReader.ReadCompressedInteger();
+                    isRequired = typeCode == (int)SignatureTypeCode.RequiredModifier;
+                } while (isRequired || typeCode == (int)SignatureTypeCode.OptionalModifier);
+
+                modifiers = builder.ToImmutable();
+            }
+            TType unmodifiedType = DecodeType(ref blobReader, typeCode, provider);
+            return provider.GetModifiedType(unmodifiedType, modifiers);
+        }
+
+        // Decodes a type definition, reference, or specification from the type handle at the given blob reader's current position.
+        private static TType DecodeTypeHandle<TType>(ref BlobReader blobReader, ISignatureTypeProvider<TType> provider, bool? isValueType)
+        {
+            Handle handle = blobReader.ReadTypeHandle();
+            return DecodeType(handle, provider, isValueType);
+        }
+    }
+}

--- a/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
+++ b/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Decoding;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
 

--- a/src/Test/PdbUtilities/Pdb/PdbToXml.cs
+++ b/src/Test/PdbUtilities/Pdb/PdbToXml.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Decoding;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
@@ -21,6 +20,16 @@ using CDI = Microsoft.CodeAnalysis.CustomDebugInfoReader;
 using CDIC = Microsoft.Cci.CustomDebugInfoConstants;
 using ImportScope = Microsoft.CodeAnalysis.ImportScope;
 using PooledStringBuilder = Microsoft.CodeAnalysis.Collections.PooledStringBuilder;
+
+// Point-in-time conflict between System.Reflection.Metadata and temporary internal Roslyn.Reflection.Metadata
+// Replace this with using System.Reflection.Metadata.Decoding and uncomment type parameters when switching
+// back to public System.Reflection.Metadata API. 
+using ArrayShape = Roslyn.Reflection.Metadata.Decoding.ArrayShape;
+using CustomModifier = Roslyn.Reflection.Metadata.Decoding.CustomModifier<string>;
+using MethodSignature = Roslyn.Reflection.Metadata.Decoding.MethodSignature<string>;
+using ISignatureTypeProvider = Roslyn.Reflection.Metadata.Decoding.ISignatureTypeProvider<string>;
+using PrimitiveTypeCode = Roslyn.Reflection.Metadata.Decoding.PrimitiveTypeCode;
+using SignatureDecoder = Roslyn.Reflection.Metadata.Decoding.SignatureDecoder;
 
 namespace Roslyn.Test.PdbUtilities
 {
@@ -1053,7 +1062,7 @@ namespace Roslyn.Test.PdbUtilities
             }
         }
 
-        private sealed class SignatureVisualizer : ISignatureTypeProvider<string>
+        private sealed class SignatureVisualizer : ISignatureTypeProvider/*<string>*/
         {
             private readonly MetadataReader _reader;
 
@@ -1074,7 +1083,7 @@ namespace Roslyn.Test.PdbUtilities
                 return elementType + "&";  
             }
 
-            public string GetFunctionPointerType(MethodSignature<string> signature)
+            public string GetFunctionPointerType(MethodSignature/*<string>*/ signature)
             {
                 // TODO:
                 return "method-ptr"; 
@@ -1096,7 +1105,7 @@ namespace Roslyn.Test.PdbUtilities
                 return "!" + index;
             }
 
-            public string GetModifiedType(string unmodifiedType, ImmutableArray<CustomModifier<string>> customModifiers)
+            public string GetModifiedType(string unmodifiedType, ImmutableArray<CustomModifier/*<string>*/> customModifiers)
             {
                 return string.Join(" ", customModifiers.Select(mod => (mod.IsRequired ? "modreq(" : "modopt(") + mod.Type + ")")) + 
                     unmodifiedType;

--- a/src/Test/PdbUtilities/PdbUtilities.csproj
+++ b/src/Test/PdbUtilities/PdbUtilities.csproj
@@ -76,6 +76,27 @@
     <Compile Include="..\..\Compilers\Core\Portable\PEWriter\CustomDebugInfoConstants.cs">
       <Link>Shared\CustomDebugInfoConstants.cs</Link>
     </Compile>
+    <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\ArrayShape.cs">
+      <Link>Roslyn.Reflection.Metadata.Decoding\ArrayShape.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\CustomModifier.cs">
+      <Link>Roslyn.Reflection.Metadata.Decoding\CustomModifier.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs">
+      <Link>Roslyn.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\ITypeProvider.cs">
+      <Link>Roslyn.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\MethodSignature.cs">
+      <Link>Roslyn.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\PrimitiveTypeCode.cs">
+      <Link>Roslyn.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\SignatureDecoder.cs">
+      <Link>Roslyn.Reflection.Metadata.Decoding\ISignatureTypeProvider.cs</Link>
+    </Compile>
     <Compile Include="Metadata\ILVisualizer.cs" />
     <Compile Include="Metadata\ILVisualizerAsTokens.cs" />
     <Compile Include="Metadata\MetadataVisualizer.cs" />


### PR DESCRIPTION
The signature decoder out of the dev/metadata branch will not ship in v1.1
RTM of System.Reflection.Metadata. Breaking changes to the API are coming
and the API will be officially reviewed and only checked in to corefx master
after v1.1 has snapped.

This temporarily forks the relevant code from corefx dev/metadata in to the
Roslyn tree as internal types. It sets things up so that dotnet/corefx#3560
being merged to master will be enough to get Roslyn using -rc builds out of
corefx master instead of -alpha builds out of corefx dev/metadata.

cc @tmat