### PR TITLE
Give non-empty names to copy parameters of anonymous methods.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 parameter.Type,
                 parameter.Ordinal,
                 parameter.RefKind,
-                    string.Empty); // Make sure nothing binds to this.
+                GeneratedNames.LambdaCopyParameterName(parameter)); // Make sure nothing binds to this.
         }
 
         public sealed override bool Equals(object symbol)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -460,5 +460,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert((char)GeneratedNameKind.ReusableHoistedLocalField == '7');
             return "<>7__wrap" + StringExtensions.GetNumeral(number);
         }
+
+        internal static string LambdaCopyParameterName(ParameterSymbol sourceParameter)
+        {
+            return "<" + sourceParameter.Name + ">";
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -1593,7 +1593,7 @@ unsafe public class Test
             Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("p", GetSymbolNamesJoined(analysis.Captured));
             Assert.Equal("i", GetSymbolNamesJoined(analysis.UnsafeAddressTaken));
-            Assert.Equal("", GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Equal("<p>", GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("p", GetSymbolNamesJoined(analysis.DataFlowsIn));
             Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
@@ -1601,7 +1601,7 @@ unsafe public class Test
             Assert.Equal("p", GetSymbolNamesJoined(analysis.ReadInside));
             Assert.Equal("i", GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal("", GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Equal("<p>", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("i, p, d", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 


### PR DESCRIPTION
It is unexpected to have parameters originated from source having empty names in correct programs.
Fixes #4527.

@gafter, @VSadov, @jaredpar, @agocke, @TyOverby Please review.