### PR TITLE
Fixes a crash when analysing "omitted ref on COM" errors

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -212,7 +212,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool IsComCallWithRefOmitted(MethodSymbol method, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKindsOpt)
         {
-            if ((object)method.ContainingType == null || !method.ContainingType.IsComImport) return false;
+            if (method.ParameterCount != arguments.Length ||
+                (object)method.ContainingType == null || 
+                !method.ContainingType.IsComImport) return false;
+
             for (int i = 0; i < arguments.Length; i++)
             {
                 if (method.Parameters[i].RefKind != RefKind.None && (argumentRefKindsOpt.IsDefault || argumentRefKindsOpt[i] == RefKind.None)) return true;


### PR DESCRIPTION
In error conditions (common while typing), there is a possibility that are dealing with a broken case and method parameter count does not match argument length and result  in IndexOutOfRange exception.
We should not check for "omitted ref on COM" in such cases.

Fixes #5728