### PR TITLE
Transitive #r

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -337,6 +337,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     BoundInputAssembly[] bindingResult = Bind(
                         explicitAssemblyData,
+                        modules,
+                        references,
+                        referenceMap,
                         compilation.Options.MetadataReferenceResolver,
                         compilation.Options.MetadataImportOptions,
                         out allAssemblyData,

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceResolver.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceResolver.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis
         public abstract ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties);
 
         /// <summary>
-        /// True to instruct the compiler to invoke <see cref="ResolveMissingAssembly(AssemblyIdentity)"/> for each assembly reference that
+        /// True to instruct the compiler to invoke <see cref="ResolveMissingAssembly(MetadataReference, AssemblyIdentity)"/> for each assembly reference that
         /// doesn't match any of the assemblies explicitly referenced by the <see cref="Compilation"/> (via <see cref="Compilation.ExternalReferences"/>, or #r directives.
         /// </summary>
         public virtual bool ResolveMissingAssemblies => false;
@@ -23,8 +23,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Resolves a missing assembly reference.
         /// </summary>
-        /// <param name="identity">Identity of the assembly reference.</param>
+        /// <param name="definition">The metadata definition (assembly or module) that declares assembly reference <paramref name="referenceIdentity"/> in its list of dependencies.</param>
+        /// <param name="referenceIdentity">Identity of the assembly reference that couldn't be resolved against metadata references explicitly specified to in the compilation.</param>
         /// <returns>Resolved reference or null if the identity can't be resolved.</returns>
-        public virtual PortableExecutableReference ResolveMissingAssembly(AssemblyIdentity identity) => null;
+        public virtual PortableExecutableReference ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity) => null;
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -63,5 +63,5 @@ static Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetry.GetAnalyze
 static Microsoft.CodeAnalysis.SyntaxNodeExtensions.NormalizeWhitespace<TNode>(this TNode node, string indentation = "    ", string eol = "\r\n", bool elasticTrivia = false) -> TNode
 static Microsoft.CodeAnalysis.SyntaxNodeExtensions.NormalizeWhitespace<TNode>(this TNode node, string indentation, bool elasticTrivia) -> TNode
 virtual Microsoft.CodeAnalysis.MetadataReferenceResolver.ResolveMissingAssemblies.get -> bool
-virtual Microsoft.CodeAnalysis.MetadataReferenceResolver.ResolveMissingAssembly(Microsoft.CodeAnalysis.AssemblyIdentity identity) -> Microsoft.CodeAnalysis.PortableExecutableReference
+virtual Microsoft.CodeAnalysis.MetadataReferenceResolver.ResolveMissingAssembly(Microsoft.CodeAnalysis.MetadataReference definition, Microsoft.CodeAnalysis.AssemblyIdentity referenceIdentity) -> Microsoft.CodeAnalysis.PortableExecutableReference
 virtual Microsoft.CodeAnalysis.SourceReferenceResolver.ReadText(string resolvedPath) -> Microsoft.CodeAnalysis.Text.SourceText

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             /// <summary>
-            /// Index into an array of assemblies or an array of modules, depending on <see cref="Kind"/>.
+            /// Index into an array of assemblies (not including the assembly being built) or an array of modules, depending on <see cref="Kind"/>.
             /// </summary>
             public int Index
             {

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -285,6 +285,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim allAssemblyData As ImmutableArray(Of AssemblyData) = Nothing
 
                     Dim bindingResult() As BoundInputAssembly = Bind(explicitAssemblyData,
+                                                                     modules,
+                                                                     references,
+                                                                     referenceMap,
                                                                      compilation.Options.MetadataReferenceResolver,
                                                                      compilation.Options.MetadataImportOptions,
                                                                      allAssemblyData,

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -71,6 +71,7 @@
     <ProjectReference Include="..\..\Workspaces\Core\Desktop\Workspaces.Desktop.csproj">
       <Project>{2e87fa96-50bb-4607-8676-46521599f998}</Project>
       <Name>Workspaces.Desktop</Name>
+      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\Features\VisualBasic\Portable\BasicFeatures.vbproj">
       <Project>{A1BCD0CE-6C2F-4F8C-9A48-D9D93928E26D}</Project>
@@ -83,6 +84,7 @@
     <ProjectReference Include="..\..\Workspaces\Core\Portable\Workspaces.csproj">
       <Project>{5F8D2414-064A-4B3A-9B42-8E2A04246BE5}</Project>
       <Name>Workspaces</Name>
+      <Aliases>global,WORKSPACES</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\..\Features\CSharp\Portable\CSharpFeatures.csproj">
       <Project>{3973B09A-4FBF-44A5-8359-3D22CEB71F71}</Project>

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory_XmlConsumption.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+extern alias WORKSPACES;
 
 using System;
 using System.Collections.Generic;
@@ -29,6 +30,8 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
+    using RelativePathResolver = WORKSPACES::Microsoft.CodeAnalysis.RelativePathResolver;
+
     public partial class TestWorkspaceFactory
     {
         /// <summary>
@@ -470,12 +473,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             // TODO: Allow these to be specified.
             var languageServices = workspace.Services.GetLanguageServices(language);
+            var metadataService = workspace.Services.GetService<IMetadataService>();
             var compilationOptions = languageServices.GetService<ICompilationFactoryService>().GetDefaultCompilationOptions();
             compilationOptions = compilationOptions.WithOutputKind(OutputKind.DynamicallyLinkedLibrary)
                                                    .WithGeneralDiagnosticOption(reportDiagnostic)
                                                    .WithSourceReferenceResolver(SourceFileResolver.Default)
                                                    .WithXmlReferenceResolver(XmlFileResolver.Default)
-                                                   .WithMetadataReferenceResolver(RuntimeMetadataReferenceResolver.Default)
+                                                   .WithMetadataReferenceResolver(new WorkspaceMetadataFileReferenceResolver(metadataService, new RelativePathResolver(ImmutableArray<string>.Empty, null)))
                                                    .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default);
 
             if (language == LanguageNames.VisualBasic)

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -453,12 +454,19 @@ WriteLine(5);
         }
 
         [Fact]
+        public void AddReference_Path()
+        {
+            Assert.False(Execute("new System.Data.DataSet()"));
+            Assert.True(LoadReference(Assembly.Load(new AssemblyName("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")).Location));
+            Assert.True(Execute("new System.Data.DataSet()"));
+        }
+
+        [Fact]
         public void AddReference_PartialName()
         {
-            Assert.False(Execute("System.Diagnostics.Process.GetCurrentProcess().HasExited"));
-
-            Assert.True(LoadReference("System"));
-            Assert.True(Execute("System.Diagnostics.Process.GetCurrentProcess().HasExited"));
+            Assert.False(Execute("new System.Data.DataSet()"));
+            Assert.True(LoadReference("System.Data"));
+            Assert.True(Execute("new System.Data.DataSet()"));
         }
 
         [Fact]
@@ -476,10 +484,9 @@ WriteLine(5);
         [Fact]
         public void AddReference_FullName()
         {
-            Assert.False(Execute("System.Diagnostics.Process.GetCurrentProcess().HasExited"));
-
-            Assert.True(LoadReference(typeof(Process).Assembly.FullName));
-            Assert.True(Execute("System.Diagnostics.Process.GetCurrentProcess().HasExited"));
+            Assert.False(Execute("new System.Data.DataSet()"));
+            Assert.True(LoadReference("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"));
+            Assert.True(Execute("new System.Data.DataSet()"));
         }
                 
         [ConditionalFact(typeof(Framework35Installed), Skip="https://github.com/dotnet/roslyn/issues/5167")]
@@ -514,15 +521,6 @@ WriteLine(5);
             Assert.Equal("", ReadErrorOutputToEnd().Trim());
             Assert.Equal("", ReadOutputToEnd().Trim());
             Assert.True(result);
-        }
-
-        [Fact]
-        public void AddReference_Path()
-        {
-            Assert.False(Execute("System.Diagnostics.Process.GetCurrentProcess().HasExited"));
-
-            Assert.True(LoadReference(typeof(Process).Assembly.Location));
-            Assert.True(Execute("System.Diagnostics.Process.GetCurrentProcess().HasExited"));
         }
 
         // Caused by submission not inheriting references.

--- a/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
@@ -227,30 +227,6 @@ System.Diagnostics.Process.GetCurrentProcess()
         }
 
         [Fact]
-        public void MissingDependency()
-        {
-            var source = @"
-#r ""WindowsBase""
-#r ""PresentationCore""
-#r ""PresentationFramework""
-
-using System.Windows;
-System.Collections.IEnumerable w = new Window();
-";
-
-            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync(source),
-                // (7,36): error CS0012: The type 'System.ComponentModel.ISupportInitialize' is defined in an assembly that is not referenced. You must add a reference to assembly 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.
-                // System.Collections.IEnumerable w = new Window();
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "new Window()").WithArguments("System.ComponentModel.ISupportInitialize", "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"),
-                // (7,36): error CS0012: The type 'System.Windows.Markup.IQueryAmbient' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Xaml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.
-                // System.Collections.IEnumerable w = new Window();
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "new Window()").WithArguments("System.Windows.Markup.IQueryAmbient", "System.Xaml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"),
-                // (7,36): error CS0266: Cannot implicitly convert type 'System.Windows.Window' to 'System.Collections.IEnumerable'. An explicit conversion exists (are you missing a cast?)
-                // System.Collections.IEnumerable w = new Window();
-                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "new Window()").WithArguments("System.Windows.Window", "System.Collections.IEnumerable"));
-        }
-
-        [Fact]
         public void AssemblyResolution()
         {
             var s0 = CSharpScript.RunAsync("var x = new { a = 3 }; x");

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -528,7 +528,7 @@ Environment.ProcessorCount
         public void CompilationChain_UsingNotHidingHostObjectMembers()
         {
             var result =
-                CSharpScript.RunAsync("using System;", OptionsWithFacades, globals: new C1()).
+                CSharpScript.RunAsync("using System;", globals: new C1()).
                 ContinueWith("Environment").
                 Result.ReturnValue;
 

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -25,13 +25,8 @@ namespace Microsoft.CodeAnalysis.Scripting.CSharp.UnitTests
 
     public class InteractiveSessionTests : TestBase
     {
-        private static readonly Assembly s_lazySystemRuntimeAssembly;
-        internal static readonly Assembly SystemRuntimeAssembly = s_lazySystemRuntimeAssembly ?? (s_lazySystemRuntimeAssembly = Assembly.Load(new AssemblyName("System.Runtime, Version=4.0.20.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")));
         internal static readonly Assembly HostAssembly = typeof(InteractiveSessionTests).GetTypeInfo().Assembly;
-
-        // TODO: shouldn't be needed
-        private static readonly ScriptOptions OptionsWithFacades = ScriptOptions.Default.AddReferences(SystemRuntimeAssembly);
-
+        
         #region Namespaces, Types
 
         [Fact]
@@ -212,7 +207,7 @@ new object[] { new[] { a, c }, new[] { b, d } }
         [Fact]
         public void Dynamic_Expando()
         {
-            var options = OptionsWithFacades.
+            var options = ScriptOptions.Default.
                 AddReferences(
                     typeof(Microsoft.CSharp.RuntimeBinder.RuntimeBinderException).GetTypeInfo().Assembly,
                     typeof(System.Dynamic.ExpandoObject).GetTypeInfo().Assembly).
@@ -220,7 +215,7 @@ new object[] { new[] { a, c }, new[] { b, d } }
                     "System.Dynamic");
 
             var script = CSharpScript.Create(@"
-dynamic expando = new ExpandoObject();
+dynamic expando = new ExpandoObject();  
 ", options).ContinueWith(@"
 expando.foo = 1;
 ").ContinueWith(@"
@@ -402,7 +397,7 @@ pi = i + j + k + l;
         public void CompilationChain_GlobalNamespaceAndUsings()
         {
             var result = 
-                CSharpScript.Create("using InteractiveFixtures.C;", OptionsWithFacades.AddReferences(HostAssembly)).
+                CSharpScript.Create("using InteractiveFixtures.C;", ScriptOptions.Default.AddReferences(HostAssembly)).
                 ContinueWith("using InteractiveFixtures.C;").
                 ContinueWith("System.Environment.ProcessorCount").
                 EvaluateAsync().Result;
@@ -413,7 +408,7 @@ pi = i + j + k + l;
         [Fact]
         public void CompilationChain_CurrentSubmissionUsings()
         {
-            var s0 = CSharpScript.RunAsync("", OptionsWithFacades.AddReferences(HostAssembly));
+            var s0 = CSharpScript.RunAsync("", ScriptOptions.Default.AddReferences(HostAssembly));
 
             var state = s0.
                 ContinueWith("class X { public int foo() { return 1; } }").
@@ -600,7 +595,7 @@ Environment.ProcessorCount
         [Fact]
         public async Task ObjectOverrides1()
         {
-            var state0 = await CSharpScript.RunAsync("", OptionsWithFacades, new HostObjectWithOverrides());
+            var state0 = await CSharpScript.RunAsync("", globals: new HostObjectWithOverrides());
 
             var state1 = await state0.ContinueWithAsync<bool>("Equals(null)");
             Assert.True(state1.ReturnValue);
@@ -615,7 +610,7 @@ Environment.ProcessorCount
         [Fact]
         public async Task ObjectOverrides2()
         {
-            var state0 = await CSharpScript.RunAsync("", OptionsWithFacades, new object());
+            var state0 = await CSharpScript.RunAsync("", globals: new object());
             var state1 = await state0.ContinueWithAsync<bool>(@"
 object x = 1;
 object y = x;
@@ -633,7 +628,7 @@ ReferenceEquals(x, y)");
         [Fact]
         public void ObjectOverrides3()
         {
-            var state0 = CSharpScript.RunAsync("", OptionsWithFacades);
+            var state0 = CSharpScript.RunAsync("");
 
             var src1 = @"
 Equals(null);
@@ -1257,7 +1252,7 @@ d
                 // Can't use Verify() because the version number of the test dll is different in the build lab.
             }
 
-            var options = OptionsWithFacades.AddReferences(HostAssembly);
+            var options = ScriptOptions.Default.AddReferences(HostAssembly);
 
             var cint = CSharpScript.EvaluateAsync<C<int>>("null", options).Result;
             Assert.Equal(null, cint);
@@ -1340,7 +1335,7 @@ new List<ArgumentException>()
         {
             var c = new C();
             
-            var s0 = CSharpScript.RunAsync<int>("x + Y + Z()", OptionsWithFacades, globals: c);
+            var s0 = CSharpScript.RunAsync<int>("x + Y + Z()", globals: c);
             Assert.Equal(6, s0.Result.ReturnValue);
 
             var s1 = s0.ContinueWith<int>("x");
@@ -1356,7 +1351,7 @@ new List<ArgumentException>()
         public void HostObjectBinding_PublicGenericClassMembers()
         {
             var m = new M<string>();
-            var result = CSharpScript.EvaluateAsync<string>("G()", OptionsWithFacades, globals: m);
+            var result = CSharpScript.EvaluateAsync<string>("G()", globals: m);
             Assert.Equal(null, result.Result);
         }
 
@@ -1365,7 +1360,7 @@ new List<ArgumentException>()
         {
             var c = new C();
             
-            var s0 = await CSharpScript.RunAsync<int>("Z()", OptionsWithFacades, c, typeof(I));
+            var s0 = await CSharpScript.RunAsync<int>("Z()", globals: c, globalsType: typeof(I));
             Assert.Equal(3, s0.ReturnValue);
 
             ScriptingTestHelpers.AssertCompilationError(s0, @"x + Y",
@@ -1382,7 +1377,7 @@ new List<ArgumentException>()
         {
             var c = new PrivateClass();
             
-            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", OptionsWithFacades, c),
+            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", globals: c),
                 // (1,1): error CS0122: '<Fully Qualified Name of PrivateClass>.Z()' is inaccessible due to its protection level
                 Diagnostic(ErrorCode.ERR_BadAccess, "Z").WithArguments(typeof(PrivateClass).FullName.Replace("+", ".") + ".Z()"));
         }
@@ -1392,7 +1387,7 @@ new List<ArgumentException>()
         {
             object c = new M<int>();
 
-            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", OptionsWithFacades, c),
+            ScriptingTestHelpers.AssertCompilationError(() => CSharpScript.EvaluateAsync("Z()", globals: c),
                 // (1,1): error CS0103: The name 'z' does not exist in the current context
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "Z").WithArguments("Z"));
         }

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -241,7 +241,6 @@ d.Do()"
             var script = 
                 CSharpScript.Create(
                     "var a = '1';",
-                    options: ScriptOptions.Default.WithReferences(InteractiveSessionTests.SystemRuntimeAssembly),
                     globalsType: globals.GetType()).
                 ContinueWith("var b = 2u;").
                 ContinueWith("var a = 3m;").

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -199,12 +199,6 @@ namespace Microsoft.CodeAnalysis.Scripting
                     {
                         var globalsTypeAssembly = MetadataReference.CreateFromAssemblyInternal(GlobalsType.GetTypeInfo().Assembly);
                         references.Add(globalsTypeAssembly);
-
-                        // TODO: remove
-                        var systemRuntimeFacade = MetadataReference.CreateFromAssemblyInternal(
-                            Assembly.Load(new AssemblyName("System.Runtime, Version=4.0.20.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")));
-
-                        references.Add(systemRuntimeFacade);
                     }
 
                     if (languageRuntimeReferenceOpt != null)

--- a/src/Test/Utilities/Shared/Mocks/TestMissingMetadataReferenceResolver.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestMissingMetadataReferenceResolver.cs
@@ -2,26 +2,45 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Roslyn.Test.Utilities
 {
     internal class TestMissingMetadataReferenceResolver : MetadataReferenceResolver
     {
+        internal struct ReferenceAndIdentity
+        {
+            public readonly MetadataReference Reference;
+            public readonly AssemblyIdentity Identity;
+
+            public ReferenceAndIdentity(MetadataReference reference, AssemblyIdentity identity)
+            {
+                Reference = reference;
+                Identity = identity;
+            }
+
+            public override string ToString()
+            {
+                return $"{Reference.Display} -> {Identity.GetDisplayName()}";
+            }
+        }
+
         private readonly Dictionary<string, MetadataReference> _map;
-        public readonly List<AssemblyIdentity> ResolutionAttempts = new List<AssemblyIdentity>();
+        public readonly List<ReferenceAndIdentity> ResolutionAttempts = new List<ReferenceAndIdentity>();
 
         public TestMissingMetadataReferenceResolver(Dictionary<string, MetadataReference> map)
         {
             _map = map;
         }
 
-        public override PortableExecutableReference ResolveMissingAssembly(AssemblyIdentity identity)
+        public override PortableExecutableReference ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity)
         {
-            ResolutionAttempts.Add(identity);
+            ResolutionAttempts.Add(new ReferenceAndIdentity(definition, referenceIdentity));
 
             MetadataReference reference;
-            string nameAndVersion = identity.Name + (identity.Version != AssemblyIdentity.NullVersion ? $", {identity.Version}" : "");
+            string nameAndVersion = referenceIdentity.Name + (referenceIdentity.Version != AssemblyIdentity.NullVersion ? $", {referenceIdentity.Version}" : "");
             return _map.TryGetValue(nameAndVersion, out reference) ? (PortableExecutableReference)reference : null;
         }
 
@@ -29,5 +48,10 @@ namespace Roslyn.Test.Utilities
         public override bool Equals(object other) => true;
         public override int GetHashCode() => 1;
         public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties) => default(ImmutableArray<PortableExecutableReference>);
+
+        public void VerifyResolutionAttempts(params string[] expected)
+        {
+            AssertEx.Equal(expected, ResolutionAttempts.Select(a => a.ToString()));
+        }
     }
 }


### PR DESCRIPTION
Builds on top of the previously implemented missing assembly resolution feature to automatically add references to transitive closure of metadata starting from the assembly resolved for each #r.

To implement the semantics we want for scripting (i.e. semantics that mimics the runtime assembly resolution of the interactive assembly loader) we need to pass the "requesting reference" to ResolveMissingAssembly. This change modifies the ReferenceManager to do that.

Fixes https://github.com/dotnet/roslyn/issues/4482