### PR TITLE
Use ISymUnmanagedWriter100 to set deterministic PDB ID, timestamp

### DIFF
--- a/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
@@ -152,6 +152,14 @@ namespace Microsoft.Cci
 
         // ISymUnmanagedWriter6
         void InitializeDeterministic([MarshalAs(UnmanagedType.IUnknown)] object emitter, [MarshalAs(UnmanagedType.IUnknown)] object stream);
+    }
+
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("B473C610-C958-4C3D-99A0-F2BA0A38807C"), SuppressUnmanagedCodeSecurity]
+    interface ISymUnmanagedWriter100 : ISymUnmanagedWriter6
+    {
+        //  ISymUnmanagedWriter, ISymUnmanagedWriter2, ISymUnmanagedWriter3, ISymUnmanagedWriter4, ISymUnmanagedWriter5, ISymUnmanagedWriter6
+        void _VtblGap1_34();
+
         void SetSignature(uint sig, Guid sig70);
     }
 

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -845,7 +845,7 @@ namespace Microsoft.Cci
                 try
                 {
                     Debug.Assert(BitConverter.IsLittleEndian);
-                    ((ISymUnmanagedWriter6)_symWriter).SetSignature(BitConverter.ToUInt32(id.Stamp, 0), new Guid(id.Guid));
+                    ((ISymUnmanagedWriter100)_symWriter).SetSignature(BitConverter.ToUInt32(id.Stamp, 0), new Guid(id.Guid));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Note: this doesn't fix the issue with DiaSymReader 1.0.6 package, which is missing ISymUnmanagedWriter100 interface. This just prepares our code to consume the interface once it's back.