### PR TITLE
build: Fixes unzip option

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -73,7 +73,7 @@ restore_nuget()
 
     rm $package_name 2>/dev/null
     curl -O https://dotnetci.blob.core.windows.net/roslyn/$package_name
-    unzip -uoq $package_name -d ~/
+    unzip -oq $package_name -d ~/
     if [ $? -ne 0 ]; then
         echo "Unable to download NuGet packages"
         exit 1


### PR DESCRIPTION
`u` and `o` are contradictory options. `unzip` utility on FreeBSD considers this mistake as an error:

> unzip: -n, -o and -u are contradictory

##### Rationale:

>
-n means "never overwrite"
-o means "always overwrite"
-u means "sometimes overwrite"

from: http://svn-src-head.freebsd.narkive.com/TzP7fphF/svn-commit-r200068-head-usr-bin.

/cc: @jaredpar, @agocke