### PR TITLE
Fix x64 Jobs

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -65,7 +65,12 @@
           UseHardlinksIfPossible="true" />
 
     <ItemGroup>
-      <TestAssemblies Include="$(OutputDirectory)\**\$(IncludePattern)" />
+      <TestAssemblies Condition="'$(Test64)' != 'true'" 
+                      Include="$(OutputDirectory)\**\$(IncludePattern)" />
+
+      <TestAssemblies Condition="'$(Test64)' == 'true'" 
+                      Include="$(OutputDirectory)\**\$(IncludePattern)" 
+                      Exclude="$(OutputDirectory)\**\Roslyn.Interactive*" />
     </ItemGroup>
 
     <Exec Command="Binaries\$(Configuration)\RunTests.exe $(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')" />

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -351,7 +351,7 @@ BC36977: Executables cannot be satellite assemblies; culture should always be em
 
     End Sub
 
-    <Fact>
+    <ConditionalFact(GetType(x86))>
     Public Sub CultureAttributeMismatch()
         Dim neutral As VisualBasicCompilation = CreateCompilationWithMscorlib(
 <compilation name="neutral">

--- a/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
+++ b/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
             _service = TestExportProvider.ExportProviderWithCSharpAndVisualBasic.GetExportedValue<IForegroundNotificationService>();
         }
 
-        [WpfFact]
+        [ConditionalWpfFact(typeof(x86))]
         public async Task Test_Enqueue()
         {
             var asyncToken = EmptyAsyncToken.Instance;


### PR DESCRIPTION
Fix a couple of issues in the 64 bit queues

- Conditionally disable tests that have flaky behavior on 64 bit
- Disable interactive tests on 64 bit.  They are x86 only assemblies.
Will follow up later to see why they were ever passing in 64 bit mode.