### PR TITLE
Fix checks in the ForegroundNotificationServiceTests

### DIFF
--- a/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
+++ b/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
         public ForegroundNotificationServiceTests()
         {
             TestWorkspace.ResetThreadAffinity();
-            _service = TestExportProvider.ExportProviderWithCSharpAndVisualBasic.GetExportedValue<IForegroundNotificationService>();
+            _service = new ForegroundNotificationService();
         }
 
         [ConditionalWpfFact(typeof(x86))]


### PR DESCRIPTION
The ForegroundNotificationService is a shared resource when it is
accessed as an exported MEF component.  This means it's possible for
other components to still be posting messages to the work queue from
background threads.  This is exactly how some of the asynchronous
taggers behave.

As it is a shared resource tests which look to see if the work queue is
empty are inherently flaky.  There is no reasonable way to control it.
The fix is to create a non-shared service for this particular set of
checks.  This makes it possible to check definitively if the work queue
is empty.