### PR TITLE
Add missing /deterministic command line switch

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CommandLineParser.cs
@@ -572,6 +572,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             optimize = false;
                             continue;
 
+                        case "deterministic":
                         case "deterministic+":
                             if (value != null)
                                 break;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1442,6 +1442,10 @@ d.cs
             parsedArgs.Errors.Verify();
             Assert.Equal(true, parsedArgs.CompilationOptions.Deterministic);
 
+            parsedArgs = DefaultParse(new[] { "/deterministic", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(true, parsedArgs.CompilationOptions.Deterministic);
+
             parsedArgs = DefaultParse(new[] { "/deterministic-", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
             Assert.Equal(false, parsedArgs.CompilationOptions.Deterministic);

--- a/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/CommandLineParser.vb
@@ -643,7 +643,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             concurrentBuild = True
                             Continue For
 
-                        Case "deterministic+"
+                        Case "deterministic", "deterministic+"
                             If value IsNot Nothing Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_SwitchNeedsBool, name)
                                 Continue For

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1122,6 +1122,10 @@ a.vb
             ParsedArgs.Errors.Verify()
             Assert.Equal(True, ParsedArgs.CompilationOptions.Deterministic)
 
+            ParsedArgs = DefaultParse({"/deterministic", "a.vb"}, _baseDirectory)
+            ParsedArgs.Errors.Verify()
+            Assert.Equal(True, ParsedArgs.CompilationOptions.Deterministic)
+
             ParsedArgs = DefaultParse({"/DETERMINISTIC+", "a.vb"}, _baseDirectory)
             ParsedArgs.Errors.Verify()
             Assert.Equal(True, ParsedArgs.CompilationOptions.Deterministic)


### PR DESCRIPTION
We had /deterministic+ and /deterministic- but forgot /deterministic.