### PR TITLE
Fix further issues with Code Model lifetime management

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
             if (_table.TryGetValue(key, out handle))
             {
                 value = handle.ComAggregateObject;
-                return true;
+                return value != null;
             }
 
             value = null;

--- a/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
@@ -169,6 +169,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
         {
             this.AssertIsForeground();
 
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             if (_table.ContainsKey(key))
             {
                 throw new InvalidOperationException("Key already exists in table.");

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -177,7 +177,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         internal void UpdateCodeElementNodeKey(AbstractKeyedCodeElement keyedElement, SyntaxNodeKey oldNodeKey, SyntaxNodeKey newNodeKey)
         {
-            var codeElement = _codeElementTable.Remove(oldNodeKey);
+            EnvDTE.CodeElement codeElement;
+            if (!_codeElementTable.TryGetValue(oldNodeKey, out codeElement))
+            {
+                throw new InvalidOperationException($"Could not find {oldNodeKey} in Code Model element table.");
+            }
+
+            _codeElementTable.Remove(oldNodeKey);
 
             var managedElement = ComAggregate.GetManagedObject<AbstractKeyedCodeElement>(codeElement);
             if (!object.Equals(managedElement, keyedElement))
@@ -219,9 +225,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                             throw new InvalidOperationException($"Found a valid code element for {nodeKey}, but it is not of type, {typeof(T).ToString()}");
                         }
                     }
-
-                    _codeElementTable.Remove(nodeKey);
                 }
+
+                // Go ahead and remove the nodeKey from the table. At this point, we'll be creating a new one.
+                _codeElementTable.Remove(nodeKey);
             }
 
             return (T)CodeModelService.CreateInternalCodeElement(this.State, this, node);

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -420,7 +420,7 @@ class C : B, I
             TestAddClass(code, expected, New ClassData With {.Name = "C", .Position = "I", .Bases = "B", .ImplementedInterfaces = "I"})
         End Sub
 
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5868"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddClass10()
             Dim code =
 <Code>
@@ -441,6 +441,26 @@ class C : B, IFoo, IBar
 </Code>
 
             TestAddClass(code, expected, New ClassData With {.Name = "C", .Position = "IBar", .Bases = "B", .ImplementedInterfaces = {"IFoo", "IBar"}})
+        End Sub
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddClass_Stress()
+            Dim code =
+<Code>
+class B { }
+interface $$IFoo { }
+interface IBar { }
+</Code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    For i = 1 To 100
+                        Dim name = $"C{i}"
+                        Dim newClass = fileCodeModel.AddClass(name, Position:=-1, Bases:="B", ImplementedInterfaces:={"IFoo", "IBar"})
+                        Assert.NotNull(newClass)
+                        Assert.Equal(name, newClass.Name)
+                    Next
+                End Sub)
         End Sub
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
@@ -774,7 +774,7 @@ End Class
 #End Region
 
 #Region "AddAttributeArgument tests"
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5841"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttributeArgument1()
             Dim code =
 <Code>


### PR DESCRIPTION
Fixes #5868
Fixes #5837
Fixes #5841

* Added another "stress" test that performs 100 operations to catch failures in the element table.
* Addressed problem where CleanableWeakComHandleTable.TryGetValue() might incorrectly return true.
* Fixed issue in FileCodeModel.GetOrCreateCodeElement() where a node key might not be removed from the element table.
* Unskip tests

tagging @dotnet/roslyn-ide, @jaredpar 