### PR TITLE
Inline Rename Dashboard: Less aggressive identifier truncation

### DIFF
--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -1205,15 +1205,6 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid identifier.
-        /// </summary>
-        internal static string IsNotAValidIdentifier {
-            get {
-                return ResourceManager.GetString("IsNotAValidIdentifier", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Light bulb session is already dismissed..
         /// </summary>
         internal static string LightBulbSessionIsAlreadyDismissed {
@@ -1520,7 +1511,7 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename: &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Rename: {0}.
         /// </summary>
         internal static string Rename1 {
             get {
@@ -1759,6 +1750,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string TheDefinitionOfTheObjectIsHidden {
             get {
                 return ResourceManager.GetString("TheDefinitionOfTheObjectIsHidden", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The new name is not a valid identifier..
+        /// </summary>
+        internal static string TheNewNameIsNotAValidIdentifier {
+            get {
+                return ResourceManager.GetString("TheNewNameIsNotAValidIdentifier", resourceCulture);
             }
         }
         

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -492,8 +492,8 @@
   <data name="HighlightedDefinition" xml:space="preserve">
     <value>Highlighted Definition</value>
   </data>
-  <data name="IsNotAValidIdentifier" xml:space="preserve">
-    <value>'{0}' is not a valid identifier</value>
+  <data name="TheNewNameIsNotAValidIdentifier" xml:space="preserve">
+    <value>The new name is not a valid identifier.</value>
   </data>
   <data name="InlineRenameFixup" xml:space="preserve">
     <value>Inline Rename Fixup</value>
@@ -538,7 +538,7 @@
     <value>Variadic SignatureHelpItem must have at least one parameter.</value>
   </data>
   <data name="Rename1" xml:space="preserve">
-    <value>Rename: '{0}'</value>
+    <value>Rename: {0}</value>
   </data>
   <data name="LightBulbSessionIsAlreadyDismissed" xml:space="preserve">
     <value>Light bulb session is already dismissed.</value>

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
@@ -89,7 +89,15 @@
                         </imaging:CrispImage>
                     </Grid>
 
-                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding HeaderText}" FontWeight="Bold" TextWrapping="Wrap" FontSize="14" MaxWidth="400" VerticalAlignment="Center" HorizontalAlignment="Stretch">
+                    <TextBlock Grid.Row="0"
+                               Grid.Column="1"
+                               Text="{Binding HeaderText}"
+                               FontWeight="Bold"
+                               TextTrimming="CharacterEllipsis"
+                               FontSize="14"
+                               MaxWidth="260"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Left">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Foreground" Value="{StaticResource ForegroundText}"/>
@@ -120,12 +128,12 @@
 
                 <!-- Display the new name if it has been adjusted, or instructional text if it has not. -->
                 
-                <TextBlock Text="{Binding NewNameDescription}" 
-                           TextWrapping="Wrap" 
-                           MaxWidth="400" 
-                           Padding="0,3,0,12" 
-                           VerticalAlignment="Center" 
-                           HorizontalAlignment="Stretch"
+                <TextBlock Text="{Binding NewNameDescription}"
+                           MaxWidth="280"
+                           TextTrimming="CharacterEllipsis"
+                           Padding="0,3,0,12"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Left"
                            Visibility="{Binding ShouldShowNewName, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                 <TextBlock Name="Instructions" 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
@@ -15,7 +15,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal class DashboardViewModel : INotifyPropertyChanged, IDisposable
     {
-        private const int SymbolDescriptionTextLength = 15;
         private readonly Visibility _renameOverloadsVisibility;
 
         private DashboardSeverity _severity = DashboardSeverity.None;
@@ -87,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 _errorText = string.IsNullOrEmpty(session.ReplacementText)
                     ? null
-                    : string.Format(EditorFeaturesResources.IsNotAValidIdentifier, GetTruncatedName(session.ReplacementText));
+                    : EditorFeaturesResources.TheNewNameIsNotAValidIdentifier;
             }
 
             UpdateSeverity();
@@ -167,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             get
             {
-                return string.Format(EditorFeaturesResources.Rename1, GetTruncatedName(Session.OriginalSymbolName));
+                return string.Format(EditorFeaturesResources.Rename1, Session.OriginalSymbolName);
             }
         }
 
@@ -175,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             get
             {
-                return string.Format(EditorFeaturesResources.NewName1, GetTruncatedName(Session.ReplacementText));
+                return string.Format(EditorFeaturesResources.NewName1, Session.ReplacementText);
             }
         }
 
@@ -193,14 +192,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 return !ShouldShowInstructions;
             }
-        }
-
-
-        private static string GetTruncatedName(string fullName)
-        {
-            return fullName.Length < SymbolDescriptionTextLength
-                ? fullName
-                : fullName.Substring(0, SymbolDescriptionTextLength) + "...";
         }
 
         public string SearchText


### PR DESCRIPTION
Fixes #5730

Instead of truncating at 15 characters, we limit the (pixel) width of
the names, allowing WPF to truncate with "..." appropriately.