### PR TITLE
Disable MakeConst assemblies

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -65,12 +65,15 @@
           UseHardlinksIfPossible="true" />
 
     <ItemGroup>
+
+      <!-- MakeConst unit tests tracked by https://github.com/dotnet/roslyn/issues/5918 -->
       <TestAssemblies Condition="'$(Test64)' != 'true'" 
-                      Include="$(OutputDirectory)\**\$(IncludePattern)" />
+                      Include="$(OutputDirectory)\**\$(IncludePattern)"
+                      Exclude="$(OutputDirectory)\**\MakeConst*" />
 
       <TestAssemblies Condition="'$(Test64)' == 'true'" 
                       Include="$(OutputDirectory)\**\$(IncludePattern)" 
-                      Exclude="$(OutputDirectory)\**\Roslyn.Interactive*" />
+                      Exclude="$(OutputDirectory)\**\Roslyn.Interactive*;$(OutputDirectory)\**\MakeConst*" />
     </ItemGroup>
 
     <Exec Command="Binaries\$(Configuration)\RunTests.exe $(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')" />


### PR DESCRIPTION
These unit test assemblies don't actually have any tests in them.  Running a DLL with no tests is exposing a bug in CoreFX and causing our Jenkins runs to fail.  Disabling them for now.

Issue #5918 is tracking this.