### PR TITLE
Fix crash with `yield return` as top level statement in script

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -166,11 +166,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (IsScriptClass)
             {
+                // This is the scenario where a `yield return` exists in the script file as a global statement.
+                // This method is to guard against hitting `BuckStopsHereBinder` and crash. 
                 return this.Compilation.GetSpecialType(SpecialType.System_Object);
             }
             else
             {
-                // this path will eventually throw InvalidOperationException
+                // This path would eventually throw, if we didn't have the case above.
                 return Next.GetIteratorElementType(node, diagnostics);
             }
         }


### PR DESCRIPTION
The crash can be reproduced by typing `yield return int.` and try auto-completion (CTRL + space) in a .csx file in VS. This fixes one of the crashes reported in https://github.com/dotnet/roslyn/issues/5390.

@dotnet/interactive 