### PR TITLE
Loosen VSIX dependencies

### DIFF
--- a/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
+++ b/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
   <Dependencies>
-    <Dependency Version="|VisualStudioSetup;GetBuildVersion|" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
+    <Dependency Version="[|VisualStudioSetup;GetBuildVersion|,]" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
   </Dependencies>
   <Assets>
     <Asset Type="DebuggerEngineExtension" d:Source="Project" d:ProjectName="BasicExpressionCompiler" Path="|BasicExpressionCompiler;VsdConfigOutputGroup|" />

--- a/src/VisualStudio/SetupInteractive/source.extension.vsixmanifest
+++ b/src/VisualStudio/SetupInteractive/source.extension.vsixmanifest
@@ -13,9 +13,9 @@
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Version="|VisualStudioSetup;GetBuildVersion|" DisplayName="Roslyn Components" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
-    <Dependency Version="|VisualStudioInteractiveComponents;GetBuildVersion|" DisplayName="Roslyn Interactive Components" Id="500fff63-afcf-4195-8db4-3fa8a5180e79" />
-    <Dependency Version="|VisualStudioInteractiveWindow;GetBuildVersion|" DisplayName="VisualStudio Interactive Components" Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" />
+    <Dependency Version="[|VisualStudioSetup;GetBuildVersion|,]" DisplayName="Roslyn Components" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
+    <Dependency Version="[|VisualStudioInteractiveComponents;GetBuildVersion|,]" DisplayName="Roslyn Interactive Components" Id="500fff63-afcf-4195-8db4-3fa8a5180e79" />
+    <Dependency Version="[|VisualStudioInteractiveWindow;GetBuildVersion|,]" DisplayName="VisualStudio Interactive Components" Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="BasicVisualStudioRepl" Path="|BasicVisualStudioRepl|" />

--- a/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
@@ -13,8 +13,8 @@
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Version="|VisualStudioSetup;GetBuildVersion|" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
-    <Dependency Version="|VisualStudioInteractiveWindow;GetBuildVersion|" DisplayName="VisualStudio Interactive Components" Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" />
+    <Dependency Version="[|VisualStudioSetup;GetBuildVersion|,]" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />
+    <Dependency Version="[|VisualStudioInteractiveWindow;GetBuildVersion|,]" DisplayName="VisualStudio Interactive Components" Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures.dll" />


### PR DESCRIPTION
Previously our VSIX dependencies demanded that an exactly-numbered
version was installed. This meant that everything was versioned in
lockstep, but prevents the ability to install a single VSIX that
you built locally atop the base product. For now, let's just allow
any higher version.

Reviewers: @dotnet/roslyn-ide, @KevinH-MS, @amcasey, @jmarolf, @tannergooding, @jaredpar