### PR TITLE
Add outdir parameter to BuildNuGets.csx

### DIFF
--- a/build/BuildNuGets.csx
+++ b/build/BuildNuGets.csx
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 
 string usage = @"usage: BuildNuGets.csx <binaries-dir> <build-version> <output-directory>";
 
@@ -11,9 +12,16 @@ if (Args.Count() != 3)
     Environment.Exit(1);
 }
 
+var csiRoot = AppDomain.CurrentDomain.BaseDirectory;
+var slnRoot = Path.GetFullPath(Path.Combine(csiRoot, "../../"));
+
+// Strip trailing '\' characters because if the path is later passed on the
+// command line when surrounded by quotes (in case the path has spaces) some
+// utilities will consider the '\"' as an escape sequence for the end quote
+
 var binDir = Path.GetFullPath(Args[0]).TrimEnd('\\');
 var buildVersion = Args[1].Trim();
-var nuspecDirPath = Path.GetFullPath("../../src/NuGet");
+var nuspecDirPath = Path.GetFullPath(Path.Combine(slnRoot, "src/NuGet"));
 var outDir = Path.GetFullPath(Args[2]).TrimEnd('\\');
 
 var licenseUrl = @"http://go.microsoft.com/fwlink/?LinkId=529443";
@@ -22,7 +30,8 @@ var projectURL = @"http://msdn.com/roslyn";
 var tags = @"Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics";
 
 var files = Directory.GetFiles(nuspecDirPath, "*.nuspec");
-var procs = new List<Process>(files.Length);
+
+int exit = 0;
 
 foreach (var file in files)
 {
@@ -35,7 +44,7 @@ foreach (var file in files)
         $"-prop authors={authors} " +
         $@"-prop projectURL=""{projectURL}"" " +
         $@"-prop tags=""{tags}""";
-    var nugetExePath = Path.GetFullPath("../../nuget.exe");
+    var nugetExePath = Path.GetFullPath(Path.Combine(slnRoot, "nuget.exe"));
     var p = new Process();
     p.StartInfo.FileName = nugetExePath;
     p.StartInfo.Arguments = nugetArgs;
@@ -43,15 +52,13 @@ foreach (var file in files)
 
     Console.WriteLine($"Running: nuget.exe {nugetArgs}");
     p.Start();
-    procs.Add(p);
-}
-
-int exit = 0;
-
-foreach (var p in procs)
-{
     p.WaitForExit();
-    exit += p.ExitCode;
+    exit = p.ExitCode;
+
+    if (exit != 0)
+    {
+        break;
+    }
 }
 
 Environment.Exit(exit);

--- a/build/BuildNuGets.csx
+++ b/build/BuildNuGets.csx
@@ -3,17 +3,18 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
-string usage = @"usage: BuildNuGets.csx <binaries-dir> <build-version>";
+string usage = @"usage: BuildNuGets.csx <binaries-dir> <build-version> <output-directory>";
 
-if (Args.Length != 2)
+if (Args.Count() != 3)
 {
     Console.WriteLine(usage);
     Environment.Exit(1);
 }
 
-var binDir = Path.GetFullPath(Args[0]);
+var binDir = Path.GetFullPath(Args[0]).TrimEnd('\\');
 var buildVersion = Args[1].Trim();
 var nuspecDirPath = Path.GetFullPath("../../src/NuGet");
+var outDir = Path.GetFullPath(Args[2]).TrimEnd('\\');
 
 var licenseUrl = @"http://go.microsoft.com/fwlink/?LinkId=529443";
 var authors = @"Microsoft";
@@ -27,17 +28,30 @@ foreach (var file in files)
 {
     var nugetArgs = $@"pack {file} " +
         $@"-BasePath ""{binDir}"" " +
+        $@"-OutputDirectory ""{outDir}"" " +
         "-ExcludeEmptyDirectories " +
         $@"-prop licenseUrl=""{licenseUrl}"" " +
         $@"-prop version=""{buildVersion}"" " +
         $"-prop authors={authors} " +
         $@"-prop projectURL=""{projectURL}"" " +
         $@"-prop tags=""{tags}""";
-    Console.WriteLine(nugetArgs);
-    var p = Process.Start(Path.GetFullPath("../../nuget.exe"), nugetArgs);
+    var nugetExePath = Path.GetFullPath("../../nuget.exe");
+    var p = new Process();
+    p.StartInfo.FileName = nugetExePath;
+    p.StartInfo.Arguments = nugetArgs;
+    p.StartInfo.UseShellExecute = false;
+
+    Console.WriteLine($"Running: nuget.exe {nugetArgs}");
+    p.Start();
+    procs.Add(p);
 }
+
+int exit = 0;
 
 foreach (var p in procs)
 {
     p.WaitForExit();
+    exit += p.ExitCode;
 }
+
+Environment.Exit(exit);


### PR DESCRIPTION
The NuGet build script should explicitly take a directory to which we
write the built package.

@dotnet/roslyn-compiler Please review