### PR TITLE
Back out the configure block change

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -112,22 +112,19 @@ static void addPushTrigger(def myJob) {
 
 static void addPullRequestTrigger(def myJob, String contextName, String opsysName, String triggerKeyword = 'this', Boolean triggerOnly = false) {
   myJob.with {
-    configure { node ->
-      node / 'triggers' << {
-        'org.jenkinsci.plugins.ghprb.GhprbTrigger'('plugin': 'ghprb@1.29') {
-          'adminlist'('Microsoft')
-          'useGitHubHooks'(true)
-          'configVersion'(3)
-          'triggerPhrase'("(?i).*test\\W+(${contextName.replace('_', '/').substring(7)}|${opsysName}|${triggerKeyword}|${opsysName}\\W+${triggerKeyword}|${triggerKeyword}\\W+${opsysName})\\W+please.*")
-          'onlyTriggerPhrase'(triggerOnly)
-          'autoCloseFailedPullRequests'(false)
-          'orgslist'('Microsoft')
-          'allowMembersOfWhitelistedOrgsAsAdmin'(true)
-          'permitAll'(true)
-          'extensions' {
-            'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus' {
-              'commitStatusContext'(contextName.replace('_', '/').substring(7))
-            }
+    triggers {
+      pullRequest {
+        admin('Microsoft')
+        useGitHubHooks(true)
+        triggerPhrase("(?i).*test\\W+(${contextName.replace('_', '/').substring(7)}|${opsysName}|${triggerKeyword}|${opsysName}\\W+${triggerKeyword}|${triggerKeyword}\\W+${opsysName})\\W+please.*")
+        onlyTriggerPhrase(triggerOnly)
+        autoCloseFailedPullRequests(false)
+        orgWhitelist('Microsoft')
+        allowMembersOfWhitelistedOrgsAsAdmin(true)
+        permitAll(true)
+        extensions {
+          commitStatus {
+            context(contextName.replace('_', '/').substring(7))
           }
         }
       }


### PR DESCRIPTION
This change produced XML that was malformed based on what the pull request build plugin was expecting.  This was causing an exception in the pull request builder, cancelling pull request processing.  I modified the plugin to avoid the exception, but it still appears the Roslyn requests are malformed.

I am backing this out for now until we can understand what is really going on.