### PR TITLE
Supply CodeBases for binding redirects

### DIFF
--- a/src/ExpressionEvaluator/Package/AssemblyRedirects.cs
+++ b/src/ExpressionEvaluator/Package/AssemblyRedirects.cs
@@ -1,69 +1,10 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Shell;
+using Roslyn.VisualStudio.Setup;
 
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ExpressionCompiler",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ResultProvider",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.ExpressionEvaluator.ExpressionCompiler",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.ExpressionEvaluator.ResultProvider",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ExpressionCompiler",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-internal class Constants
-{
-#if OFFICIAL_BUILD
-    // If this is an official build we want to generate binding
-    // redirects from our old versions to the release version 
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "0.7.0.0";
-    public const string NewVersion = "1.0.0.0";
-#else
-    // Non-official builds get redirects to local 42.42.42.42,
-    // which will only be built locally
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "1.0.0.0";
-    public const string NewVersion = "42.42.42.42";
-#endif
-    public const string PublicKeyToken = "31BF3856AD364E35";
-}
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ExpressionCompiler")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ResultProvider")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.ExpressionEvaluator.ExpressionCompiler")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.ExpressionEvaluator.ResultProvider")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ExpressionCompiler")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider")]

--- a/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
+++ b/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
@@ -103,6 +103,9 @@
     <DefineConstants>$(DefineConstants);OFFICIAL_BUILD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\VisualStudio\Setup\ProvideRoslynBindingRedirection.cs">
+      <Link>ProvideRoslynBindingRedirection.cs</Link>
+    </Compile>
     <Compile Include="AssemblyRedirects.cs" Condition="('$(AssemblyVersion)' == '42.42.42.42') or ('$(OfficialBuild)' == 'true')" />
   </ItemGroup>
   <ImportGroup Label="Targets">

--- a/src/InteractiveWindow/VisualStudio/AssemblyRedirects.cs
+++ b/src/InteractiveWindow/VisualStudio/AssemblyRedirects.cs
@@ -1,37 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Shell;
+using Roslyn.VisualStudio.Setup;
 
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.InteractiveWindow",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.VsInteractiveWindow",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-internal class Constants
-{
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "1.1.0.0";
-
-#if OFFICIAL_BUILD
-    // If this is an official build we want to generate binding
-    // redirects from our old versions to the release version 
-    public const string NewVersion = "1.1.0.0";
-#else
-    // Non-official builds get redirects to local 42.42.42.42,
-    // which will only be built locally
-    public const string NewVersion = "42.42.42.42";
-#endif
-
-    public const string PublicKeyToken = "31BF3856AD364E35";
-}
+[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.InteractiveWindow")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.VsInteractiveWindow")]

--- a/src/InteractiveWindow/VisualStudio/VisualStudioInteractiveWindow.csproj
+++ b/src/InteractiveWindow/VisualStudio/VisualStudioInteractiveWindow.csproj
@@ -124,6 +124,9 @@
     <DefineConstants>$(DefineConstants);OFFICIAL_BUILD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\VisualStudio\Setup\ProvideRoslynBindingRedirection.cs">
+      <Link>ProvideRoslynBindingRedirection.cs</Link>
+    </Compile>
     <Compile Include="AssemblyRedirects.cs" Condition="('$(AssemblyVersion)' == '42.42.42.42') or ('$(OfficialBuild)' == 'true')" />
     <Compile Include="CommandIds.cs" />
     <Compile Include="Guids.cs" />

--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -1,166 +1,29 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Shell;
+using Roslyn.VisualStudio.Setup;
 
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.Build.Tasks.CodeAnalysis",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.Build.Tasks.CodeAnalysis")]
 
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp.EditorFeatures",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp.Features",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp.Workspaces",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Text",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.Features",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.EditorFeatures",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Features",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.Workspaces.Desktop",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.Workspaces",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices.Implementation",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices.VisualBasic",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices.CSharp",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
-
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices.SolutionExplorer",
-    OldVersionLowerBound = Constants.OldVersionLowerBound,
-    OldVersionUpperBound = Constants.OldVersionUpperBound,
-    NewVersion = Constants.NewVersion,
-    PublicKeyToken = Constants.PublicKeyToken,
-    GenerateCodeBase = false)]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp.EditorFeatures")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp.Features")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp.Workspaces")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.EditorFeatures")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.EditorFeatures.Text")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.Features")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.VisualBasic")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.VisualBasic.EditorFeatures")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.VisualBasic.Features")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.VisualBasic.Workspaces")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.Workspaces.Desktop")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.Workspaces")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServices")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServices.Implementation")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServices.VisualBasic")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServices.CSharp")]
+[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServices.SolutionExplorer")]
 
 [assembly: ProvideBindingRedirection(
     AssemblyName = "System.Reflection.Metadata",
@@ -168,22 +31,4 @@ using Microsoft.VisualStudio.Shell;
     OldVersionUpperBound = "1.0.99.0",
     NewVersion = "1.1.0.0",
     PublicKeyToken = "b03f5f7f11d50a3a",
-    GenerateCodeBase = false)]
-
-internal class Constants
-{
-    public const string OldVersionLowerBound = "0.7.0.0";
-    public const string OldVersionUpperBound = "1.1.0.0";
-
-#if OFFICIAL_BUILD
-    // If this is an official build we want to generate binding
-    // redirects from our old versions to the release version 
-    public const string NewVersion = "1.1.0.0";
-#else
-    // Non-official builds get redirects to local 42.42.42.42,
-    // which will only be built locally
-    public const string NewVersion = "42.42.42.42";
-#endif
-
-    public const string PublicKeyToken = "31BF3856AD364E35";
-}
+    GenerateCodeBase = ProvideRoslynBindingRedirectionAttribute.GenerateCodeBase)]

--- a/src/VisualStudio/Setup/BindingPath.pkgdef
+++ b/src/VisualStudio/Setup/BindingPath.pkgdef
@@ -1,2 +1,0 @@
-[$RootKey$\BindingPaths\{5EABCC64-FDFC-478D-9123-DAE27341DE85}]
-"$PackageFolder$"=""

--- a/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
+++ b/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Roslyn.VisualStudio.Setup
+{
+    /// <summary>
+    /// A <see cref="RegistrationAttribute"/> that provides binding redirects with all of the Roslyn settings we need.
+    /// It's just a wrapper for <see cref="ProvideBindingRedirectionAttribute"/> that sets all the defaults rather than duplicating them.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    internal sealed class ProvideRoslynBindingRedirectionAttribute : RegistrationAttribute
+    {
+        private readonly ProvideBindingRedirectionAttribute _redirectionAttribute;
+
+#if OFFICIAL_BUILD
+
+        // We should not include CodeBase attributes because we want them to get loaded from PrivateAssemblies
+        public const bool GenerateCodeBase = false;
+
+#else
+        // We should include CodeBase attributes so they always are loaded from this extension
+        public const bool GenerateCodeBase = true;
+
+#endif
+
+        public ProvideRoslynBindingRedirectionAttribute(string assemblyName)
+        {
+            // ProvideBindingRedirectionAttribute is sealed, so we can't inherit from it to provide defaults.
+            // Instead, we'll do more of an aggregation pattern here.
+            _redirectionAttribute = new ProvideBindingRedirectionAttribute
+            {
+                AssemblyName = assemblyName,
+                PublicKeyToken = "31BF3856AD364E35",
+                OldVersionLowerBound = "0.7.0.0",
+                OldVersionUpperBound = "1.1.0.0",
+
+#if OFFICIAL_BUILD
+                // If this is an official build we want to generate binding
+                // redirects from our old versions to the release version 
+                NewVersion = "1.1.0.0",
+#else
+                // Non-official builds get redirects to local 42.42.42.42,
+                // which will only be built locally
+                NewVersion = "42.42.42.42",
+#endif
+
+                GenerateCodeBase = GenerateCodeBase,
+            };
+        }
+
+        public override void Register(RegistrationContext context)
+        {
+            _redirectionAttribute.Register(context);
+        }
+
+        public override void Unregister(RegistrationContext context)
+        {
+            _redirectionAttribute.Unregister(context);
+        }
+    }
+}

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -202,9 +202,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyRedirects.cs" Condition="('$(AssemblyVersion)' == '42.42.42.42') or ('$(OfficialBuild)' == 'true')" />
-    <Content Include="BindingPath.pkgdef">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Compile Include="ProvideRoslynBindingRedirection.cs" />
   </ItemGroup>
   <ImportGroup Label="Targets">

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -189,6 +189,7 @@
     <Content Include="BindingPath.pkgdef">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Compile Include="ProvideRoslynBindingRedirection.cs" />
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\VSL.Imports.targets" />

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -171,17 +171,33 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -15,7 +15,6 @@
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" Path="BindingPath.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.Workspaces.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.Workspaces.Desktop.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.EditorFeatures.dll" />


### PR DESCRIPTION
A change to how we produce binding redirects to help unblock the ability to install our VSIXes atop a clean Visual Studio 2015 install, once we have the full support for that in place. I recommend you read the full comments in the underlying commits to understand the change better.

This is a duplicate of pull request #5745 but targeting the stabilization branch.