### PR TITLE
Couple of fixes for bulk suppression

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
         public async override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var diagnostics = await (new IDELatestDiagnosticGetter(this).GetDiagnosticsAsync(solution, projectId, documentId, cancellationToken)).ConfigureAwait(false);
+            var diagnostics = await (new IDELatestDiagnosticGetter(this, concurrent: documentId == null).GetDiagnosticsAsync(solution, projectId, documentId, cancellationToken)).ConfigureAwait(false);
             return FilterSuppressedDiagnostics(diagnostics, includeSuppressedDiagnostics);
         }
 
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     for (int i = 0; i < documents.Length; i++)
                     {
                         var document = documents[i];
-                        tasks[i] = Task.Run(async () => await AppendDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false), cancellationToken);
+                        tasks[i] = AppendDiagnosticsAsync(document, cancellationToken);
                     };
 
                     await Task.WhenAll(tasks).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -128,6 +128,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
             var solution = _workspace.CurrentSolution;
             foreach (var project in solution.Projects)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (shouldFixInProject(project))
                 {
                     var diagnostics = await _diagnosticService.GetDiagnosticsAsync(solution, project.Id, includeSuppressedDiagnostics: true, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -226,6 +228,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                     return;
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
+                
                 // Equivalence key determines what fix will be applied.
                 // Make sure we don't include any specific diagnostic ID, as we want all of the given diagnostics (which can have varied ID) to be fixed.
                 var equivalenceKey = isAddSuppression ?
@@ -240,6 +244,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                 {
                     // Use the Fix multiple occurrences service to compute a bulk suppression fix for the specified document and project diagnostics,
                     // show a preview changes dialog and then apply the fix to the workspace.
+
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     var documentDiagnosticsPerLanguage = GetDocumentDiagnosticsMappedToNewSolution(documentDiagnosticsToFixMap, newSolution, language);
                     if (!documentDiagnosticsPerLanguage.IsEmpty)
@@ -256,7 +262,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                                 equivalenceKey,
                                 title,
                                 waitDialogMessage,
-                                cancellationToken: CancellationToken.None);
+                                cancellationToken);
                             if (newSolution == null)
                             {
                                 // User cancelled or fixer threw an exception, so we just bail out.
@@ -281,7 +287,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                                  equivalenceKey,
                                  title,
                                  waitDialogMessage,
-                                 CancellationToken.None);
+                                 cancellationToken);
                             if (newSolution == null)
                             {
                                 // User cancelled or fixer threw an exception, so we just bail out.


### PR DESCRIPTION
1. Fix a race condition in `IDELatestDiagnosticGetter`, when used is concurrent mode it might return incomplete set of diagnostics. This affects both FixAll behavior as well as bulk suppression from error list - we might drop diagnostics from the batch fix.

2. Thread in the cancellation token into bulk suppression batch fix computation - otherwise IDE becomes unresponsive on cancelling computation of suppressions fix.