### PR TITLE
Updating TestRunner to sort unit test assemblies by size.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -71,7 +71,7 @@ static void addUnitPublisher(def myJob) {
       'xunit'('plugin': 'xunit@1.97') {
       'types' {
         'XUnitDotNetTestType' {
-          'pattern'('**/*TestResults.xml')
+          'pattern'('**/xUnitResults/*.xml')
             'skipNoTestFiles'(false)
             'failIfNotNew'(true)
             'deleteOutputFiles'(true)

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -48,8 +48,8 @@ namespace RunTests
             var testRunner = new TestRunner(xunit, useHtml);
             var start = DateTime.Now;
             Console.WriteLine("Running {0} tests", list.Count);
-            OrderAssemblyList(list);
-            var result = testRunner.RunAllAsync(list, cts.Token).Result;
+            var orderedList = OrderAssemblyList(list);
+            var result = testRunner.RunAllAsync(orderedList, cts.Token).Result;
             var span = DateTime.Now - start;
             if (!result)
             {
@@ -90,25 +90,11 @@ namespace RunTests
         }
 
         /// <summary>
-        /// Order the assembly list so the known slower test begin running earlier.  This
-        /// should really be dynamically calculated and not hard coded like this.
+        /// Order the assembly list so that the largest assemblies come first.  This
+        /// is not ideal as the largest assembly does not necessarily take the most time.
         /// </summary>
         /// <param name="list"></param>
-        private static void OrderAssemblyList(List<string> list)
-        {
-            var regex = new Regex(@"Roslyn.Services.Editor.(\w+).UnitTests", RegexOptions.IgnoreCase);
-            var i = 1;
-            while (i < list.Count)
-            {
-                var cur = list[i];
-                if (regex.IsMatch(cur))
-                {
-                    list.RemoveAt(i);
-                    list.Insert(0, cur);
-                }
-
-                i++;
-            }
-        }
+        private static IOrderedEnumerable<string> OrderAssemblyList(List<string> list) =>
+            list.OrderByDescending((assemblyName) => new FileInfo(assemblyName).Length);
     }
 }

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -115,19 +115,13 @@ namespace RunTests
             Console.WriteLine("================");
         }
 
-        private static readonly string[] UpgradedTests = new string[] {
-            "Microsoft.DiaSymReader.PortablePdb.UnitTests.dll",
-            "Microsoft.CodeAnalysis.Scripting.VisualBasic.UnitTests.dll",
-            "Microsoft.CodeAnalysis.Scripting.CSharp.UnitTests.dll"
-        };
-
         private async Task<TestResult> RunTest(string assemblyPath, CancellationToken cancellationToken)
         {
             try
             { 
                 var assemblyName = Path.GetFileName(assemblyPath);
-                var extension = _useHtml ? ".TestResults.html" : ".TestResults.xml";
-                var resultsPath = Path.Combine(Path.GetDirectoryName(assemblyPath), Path.ChangeExtension(assemblyName, extension));
+                var extension = _useHtml ? "html" : "xml";
+                var resultsPath = Path.Combine(Path.GetDirectoryName(assemblyPath), "xUnitResults", $"{assemblyName}.{extension}");
                 DeleteFile(resultsPath);
 
                 var builder = new StringBuilder();
@@ -138,7 +132,7 @@ namespace RunTests
                 var errorOutput = new StringBuilder();
                 var start = DateTime.UtcNow;
 
-                var xunitPath = UpgradedTests.Contains(assemblyName) ? Path.Combine($"{Path.GetDirectoryName(_xunitConsolePath)}", @"..\..\..\xunit.runner.console\2.1.0\tools", $"{Path.GetFileName(_xunitConsolePath)}") : _xunitConsolePath;
+                var xunitPath = _xunitConsolePath;
                 var processOutput = await ProcessRunner.RunProcessAsync(
                     xunitPath,
                     builder.ToString(),


### PR DESCRIPTION
FYI. @jaredpar, @ManishJayaswal, @jmarolf, @heejaechang 

This is a partial fix. I will be merging the internal and external test runners (where appropriate) and getting these sorted based off time (hopefully later today).