### PR TITLE
Fix generate end construct when invoked on an accessor

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
@@ -269,7 +269,7 @@ End Class</File>
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
-        Public Sub TestWriteonlyProperty()
+        Public Sub TestWriteOnlyProperty()
             Dim text = <File>
 Class C
     WriteOnly Property P As Integer[||]

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
@@ -288,6 +288,25 @@ End Class</File>
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        Public Sub TestWriteOnlyPropertyFromSet()
+            Dim text = <File>
+Class C
+    WriteOnly Property P As Integer
+        Set[||]
+End Class</File>
+
+            Dim expected = <File>
+Class C
+    WriteOnly Property P As Integer
+        Set
+        End Set
+    End Property
+End Class</File>
+
+            Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub InvInsideEndsEnum()
             Dim text = <File>
 Public Enum e[||]

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEndConstruct/GenerateEndConstructCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEndConstruct/GenerateEndConstructCodeFixProvider.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEndConstruct
                     context.RegisterCodeFix(
                         New MyCodeAction(
                             VBFeaturesResources.InsertTheMissingEndProper,
-                            Function(c) GeneratePropertyEndConstructAsync(context.Document, DirectCast(endStatement.Parent, PropertyBlockSyntax), c)),
+                            Function(c) GeneratePropertyEndConstructAsync(context.Document, DirectCast(endStatement.Parent.Parent, PropertyBlockSyntax), c)),
                         context.Diagnostics)
                     Return
                 End If

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEndConstruct/GenerateEndConstructCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEndConstruct/GenerateEndConstructCodeFixProvider.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEndConstruct
             End If
 
             If endStatement.Kind = SyntaxKind.EndGetStatement OrElse endStatement.Kind = SyntaxKind.EndSetStatement Then
-                If endStatement.Parent IsNot Nothing AndAlso endStatement.Parent.Parent IsNot Nothing AndAlso endStatement.Parent.Parent.Kind = SyntaxKind.PropertyBlock Then
+                If endStatement?.Parent?.Parent.Kind = SyntaxKind.PropertyBlock Then
                     context.RegisterCodeFix(
                         New MyCodeAction(
                             VBFeaturesResources.InsertTheMissingEndProper,


### PR DESCRIPTION
Fixes internal bug 125463.

This bug is in our code fix that adds "End" constructs when you don't have them. If you have code like:

```
Public Property Foo As String
    Get
```

Without the End Get or the End Property, and you try invoking on the Get, the code fix throws an exception.