### PR TITLE
Fix issue with code model eventing and VB type characters on parameter names

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -816,7 +816,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                     return ((EventDeclarationSyntax)node).ExplicitInterfaceSpecifier?.ToString() +
                         ((EventDeclarationSyntax)node).Identifier.ToString();
                 case SyntaxKind.Parameter:
-                    return ((ParameterSyntax)node).Identifier.ToString();
+                    return GetParameterName(node);
                 case SyntaxKind.NamespaceDeclaration:
                     return ((NamespaceDeclarationSyntax)node).Name.ToString();
                 case SyntaxKind.OperatorDeclaration:

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/EventCollectorTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/EventCollectorTests.vb
@@ -1817,6 +1817,50 @@ End Class
                  Unknown("i"))
         End Sub
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
+        Public Sub TestParameter_ChangeTypeToTypeCharacter()
+            Dim code =
+<Code>
+Class C
+    Sub M(b As Boolean)
+    End Sub
+End Class
+</Code>
+
+            Dim changedCode =
+<Code>
+Class C
+    Sub M(b%)
+    End Sub
+End Class
+</Code>
+
+            Test(code, changedCode,
+                 TypeRefChange("b"))
+        End Sub
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
+        Public Sub TestParameter_ChangeTypeFromTypeCharacter()
+            Dim code =
+<Code>
+Class C
+    Sub M(b%)
+    End Sub
+End Class
+</Code>
+
+            Dim changedCode =
+<Code>
+Class C
+    Sub M(b As Boolean)
+    End Sub
+End Class
+</Code>
+
+            Test(code, changedCode,
+                 TypeRefChange("b"))
+        End Sub
+
 #End Region
 
 #Region "Attribute Arguments"

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.CodeModelEventCollector.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.CodeModelEventCollector.vb
@@ -894,7 +894,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Dim typesChange As CodeModelEventType = 0
                 Dim valuesChange As CodeModelEventType = 0
 
-                If Not StringComparer.OrdinalIgnoreCase.Equals(oldParameter.Identifier.ToString(), newParameter.Identifier.ToString()) Then
+                If Not StringComparer.OrdinalIgnoreCase.Equals(Me.CodeModelService.GetParameterName(oldParameter), Me.CodeModelService.GetParameterName(newParameter)) Then
                     namesChange = CodeModelEventType.Rename
                     hasChanges = True
                 End If

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -899,7 +899,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Case SyntaxKind.OmittedArgument
                     Return String.Empty
                 Case SyntaxKind.Parameter
-                    Return DirectCast(node, ParameterSyntax).Identifier.Identifier.ToString()
+                    Return GetParameterName(node)
                 Case SyntaxKind.OptionStatement
                     Return GetNormalizedName(node)
                 Case SyntaxKind.SimpleImportsClause


### PR DESCRIPTION
Fixes #6002

**Customer scenario**:

1. VB project
2. Have class designer open.
3. Change an existing parameter to use a type character. For example, ```i As Integer``` -> ```i%```

VS crashes!

**Description of fix**:

Essentially, the problem is that the type character should never be considered as part of the parameter name. This was happening in two places:

1. Comparison of parameter names in code model events. Because the type character was being included, a Rename event would be incorrectly triggered.
2. ```ICodeModelService.GetName(...)``` incorrectly returned the type character for parameters. This resulted in downstream effects of not being able to look up the ```CodeElement``` for a node by name.

**Testing done**:

1. Added failing unit tests, fixed bug and watched unit tests pass.
2. Verified customer scenario.

Tagging @dotnet/roslyn-ide 