### PR TITLE
Re-unskip code model tests

### DIFF
--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
@@ -618,7 +618,7 @@ class C { }
 
         End Sub
 
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttributeArgument3()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
@@ -639,6 +639,26 @@ class CAttribute : Attribute { }
             TestAddAttributeArgument(code, expectedCode, New AttributeArgumentData With {.Name = "AllowMultiple", .Value = "false", .Position = 1})
 
         End Sub
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub AddAttributeArgumentStress()
+            Dim code =
+<Code>
+[$$A]
+class C
+{
+}
+</Code>
+
+            TestElement(code,
+                Sub(codeAttribute)
+                    For i = 1 To 100
+                        Dim value = i.ToString()
+                        Dim codeAttributeArgument = codeAttribute.AddArgument(value, Position:=1)
+                    Next
+                End Sub)
+        End Sub
+
 #End Region
 
 #Region "Delete tests"

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
@@ -798,7 +798,7 @@ End Class
 
         End Sub
 
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttributeArgument2()
             Dim code =
 <Code>
@@ -822,7 +822,7 @@ End Class
 
         End Sub
 
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub TestAddArgument3()
             Dim code =
 <Code>


### PR DESCRIPTION
It appears that a handful of code model tests that were previously skipped and then unskipped, were inadvertently re-skipped by commit: https://github.com/dotnet/roslyn/commit/978df2e2d505d6326017ae79307ff9ac7283d5ff.

This change puts things back the way they were before.

Tagging @dotnet/roslyn-ide, @jaredpar 