### PR TITLE
[AskMode] VisualBasicUnboundIdentifierDiagnosticAnalyzer fix

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -491,6 +491,14 @@ NewLines("Class Foo \n Private Class Bar \n Private v As Integer \n Public Sub N
 NewLines("Imports System.Linq \n Class C \n Sub New() \n Dim s As Action = Sub() \n Dim a = New [|C|](0)"),
 NewLines("Imports System.Linq \n Class C \n Private v As Integer \n Sub New() \n Dim s As Action = Sub() \n Dim a = New C(0)Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
             End Sub
+
+            <WorkItem(5920, "https://github.com/dotnet/roslyn/issues/5920")>
+            <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+            Public Sub TestGenerateConstructorInIncompleteLambda2()
+                Test(
+    NewLines("Imports System.Linq \n Class C \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n Sub New() \n Dim s As Action = Sub() \n Dim a = New [|C|](0, 0)"),
+    NewLines("Imports System.Linq \n Class C \n Private v As Integer \n Private v1 As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n Sub New() \n Dim s As Action = Sub() \n Dim a = New C(0, 0) \n Public Sub New(v As Integer, v1 As Integer) \n Me.New(v) \n Me.v1 = v1 \n End Sub \n End Class"))
+            End Sub
         End Class
 
     End Class

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics
             Dim count = constructors.Value _
                 .WhereAsArray(Function(constructor) constructor.Parameters.Length = args.Count) _
                 .WhereAsArray(Function(constructor)
-                                  For index = 0 To constructor.Parameters.Length
+                                  For index = 0 To constructor.Parameters.Length - 1
                                       Dim typeInfo = semanticModel.GetTypeInfo(args(index).GetExpression)
                                       If Not constructor.Parameters(index).Type.Equals(typeInfo.ConvertedType) Then
                                           Return False


### PR DESCRIPTION
Fixes an off by one error in
VisualBasicUnboundIdentifierDiagnosticAnalyzer
Fixes #5920

Without the fix, If the user has a lambda that they have not completed typing like so:
```VB
Imports System.Linq 
    Class C 
        Private v As Integer
        Public Sub New(v As Integer) 
            Me.v = v 
        End Sub 
        Sub New() 
            Dim s As Action = Sub() \n Dim a = New C(0, 0)
```
The analyzer will crash.