### PR TITLE
Ensure that flow analysis calls VisitRvalue instead of Visit for expressions in order to enforce proper state transition.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -822,7 +822,7 @@ lUnsplitAndFinish:
             Dim sideEffects = node.SideEffects
             If Not sideEffects.IsEmpty Then
                 For Each sideEffect In node.SideEffects
-                    Visit(sideEffect)
+                    VisitExpressionAsStatement(sideEffect)
                 Next
             End If
             Debug.Assert(node.ValueOpt IsNot Nothing OrElse node.HasErrors OrElse node.Type.SpecialType = SpecialType.System_Void)
@@ -844,7 +844,7 @@ lUnsplitAndFinish:
 
         Public Overrides Function VisitByRefArgumentWithCopyBack(node As BoundByRefArgumentWithCopyBack) As BoundNode
             Me.SetPlaceholderSubstitute(node.InPlaceholder, node.OriginalArgument)
-            Visit(node.InConversion)
+            VisitRvalue(node.InConversion)
             Me.RemovePlaceholderSubstitute(node.InPlaceholder)
             Return Nothing
         End Function
@@ -1009,7 +1009,7 @@ lUnsplitAndFinish:
         End Function
 
         Public Overrides Function VisitAnonymousTypeFieldInitializer(node As BoundAnonymousTypeFieldInitializer) As BoundNode
-            Visit(node.Value)
+            VisitRvalue(node.Value)
             Return Nothing
         End Function
 
@@ -1089,9 +1089,13 @@ lUnsplitAndFinish:
         End Function
 
         Public Overrides Function VisitExpressionStatement(node As BoundExpressionStatement) As BoundNode
-            VisitRvalue(node.Expression)
+            VisitExpressionAsStatement(node.Expression)
             Return Nothing
         End Function
+
+        Private Sub VisitExpressionAsStatement(node As BoundExpression)
+            VisitRvalue(node)
+        End Sub
 
         Public Overrides Function VisitLateMemberAccess(node As BoundLateMemberAccess) As BoundNode
             ' receiver of a latebound access is never modified
@@ -1334,7 +1338,13 @@ lUnsplitAndFinish:
                 If statement IsNot Nothing Then
                     VisitStatement(TryCast(child, BoundStatement))
                 Else
-                    Visit(child)
+                    Dim expression = TryCast(child, BoundExpression)
+
+                    If expression IsNot Nothing Then
+                        VisitExpressionAsStatement(expression)
+                    Else
+                        Visit(child)
+                    End If
                 End If
             Next
             Return Nothing
@@ -1361,7 +1371,7 @@ lUnsplitAndFinish:
         End Function
 
         Public Overrides Function VisitConversion(node As BoundConversion) As BoundNode
-            Visit(node.Operand)
+            VisitRvalue(node.Operand)
             Return Nothing
         End Function
 
@@ -1542,7 +1552,7 @@ lUnsplitAndFinish:
 
         Private Function VisitObjectInitializerExpressionBase(node As BoundObjectInitializerExpressionBase) As BoundNode
             For Each initializer In node.Initializers
-                Visit(initializer)
+                VisitExpressionAsStatement(initializer)
             Next
 
             Return Nothing
@@ -1736,7 +1746,7 @@ lUnsplitAndFinish:
         End Sub
 
         Public Overrides Function VisitAsNewLocalDeclarations(node As BoundAsNewLocalDeclarations) As BoundNode
-            Visit(node.Initializer)
+            VisitRvalue(node.Initializer)
             For Each v In node.LocalDeclarations
                 Visit(v)
             Next
@@ -2247,7 +2257,7 @@ EnteredRegion:
         End Function
 
         Public Overrides Function VisitRaiseEventStatement(node As BoundRaiseEventStatement) As BoundNode
-            Me.Visit(node.EventInvocation)
+            Me.VisitExpressionAsStatement(node.EventInvocation)
             Return Nothing
         End Function
 
@@ -2550,7 +2560,7 @@ EnteredRegion:
         End Function
 
         Public Overrides Function VisitXmlMemberAccess(node As BoundXmlMemberAccess) As BoundNode
-            Visit(node.MemberAccess)
+            VisitRvalue(node.MemberAccess)
             Return Nothing
         End Function
 
@@ -2560,14 +2570,14 @@ EnteredRegion:
         End Function
 
         Public Overrides Function VisitAwaitOperator(node As BoundAwaitOperator) As BoundNode
-            Visit(node.Operand)
+            VisitRvalue(node.Operand)
             Return Nothing
         End Function
 
         Public Overrides Function VisitNameOfOperator(node As BoundNameOfOperator) As BoundNode
             Dim savedState As LocalState = Me.State.Clone()
             SetUnreachable()
-            Visit(node.Argument)
+            VisitRvalue(node.Argument)
             Me.SetState(savedState)
             Return Nothing
         End Function
@@ -2579,6 +2589,7 @@ EnteredRegion:
 
         Public Overrides Function VisitInterpolatedStringExpression(node As BoundInterpolatedStringExpression) As BoundNode
             For Each item In node.Contents
+                Debug.Assert(item.Kind = BoundKind.Literal OrElse item.Kind = BoundKind.Interpolation)
                 Visit(item)
             Next
 
@@ -2586,9 +2597,9 @@ EnteredRegion:
         End Function
 
         Public Overrides Function VisitInterpolation(node As BoundInterpolation) As BoundNode
-            Visit(node.Expression)
-            Visit(node.AlignmentOpt)
-            Visit(node.FormatStringOpt)
+            VisitRvalue(node.Expression)
+            VisitRvalue(node.AlignmentOpt)
+            VisitRvalue(node.FormatStringOpt)
             Return Nothing
         End Function
 #End Region

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractRegionControlFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractRegionControlFlowPass.vb
@@ -41,51 +41,51 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function VisitQueryLambda(node As BoundQueryLambda) As BoundNode
-            Visit(node.Expression)
+            VisitRvalue(node.Expression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitQueryExpression(node As BoundQueryExpression) As BoundNode
-            Visit(node.LastOperator)
+            VisitRvalue(node.LastOperator)
             Return Nothing
         End Function
 
         Public Overrides Function VisitQuerySource(node As BoundQuerySource) As BoundNode
-            Visit(node.Expression)
+            VisitRvalue(node.Expression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitQueryableSource(node As BoundQueryableSource) As BoundNode
-            Visit(node.Source)
+            VisitRvalue(node.Source)
             Return Nothing
         End Function
 
         Public Overrides Function VisitToQueryableCollectionConversion(node As BoundToQueryableCollectionConversion) As BoundNode
-            Visit(node.ConversionCall)
+            VisitRvalue(node.ConversionCall)
             Return Nothing
         End Function
 
         Public Overrides Function VisitQueryClause(node As BoundQueryClause) As BoundNode
-            Visit(node.UnderlyingExpression)
+            VisitRvalue(node.UnderlyingExpression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitAggregateClause(node As BoundAggregateClause) As BoundNode
             If node.CapturedGroupOpt IsNot Nothing Then
-                Visit(node.CapturedGroupOpt)
+                VisitRvalue(node.CapturedGroupOpt)
             End If
 
-            Visit(node.UnderlyingExpression)
+            VisitRvalue(node.UnderlyingExpression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitOrdering(node As BoundOrdering) As BoundNode
-            Visit(node.UnderlyingExpression)
+            VisitRvalue(node.UnderlyingExpression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitRangeVariableAssignment(node As BoundRangeVariableAssignment) As BoundNode
-            Visit(node.Value)
+            VisitRvalue(node.Value)
             Return Nothing
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
@@ -1657,46 +1657,46 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function VisitQueryExpression(node As BoundQueryExpression) As BoundNode
-            Visit(node.LastOperator)
+            VisitRvalue(node.LastOperator)
             Return Nothing
         End Function
 
         Public Overrides Function VisitQuerySource(node As BoundQuerySource) As BoundNode
-            Visit(node.Expression)
+            VisitRvalue(node.Expression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitQueryableSource(node As BoundQueryableSource) As BoundNode
-            Visit(node.Source)
+            VisitRvalue(node.Source)
             Return Nothing
         End Function
 
         Public Overrides Function VisitToQueryableCollectionConversion(node As BoundToQueryableCollectionConversion) As BoundNode
-            Visit(node.ConversionCall)
+            VisitRvalue(node.ConversionCall)
             Return Nothing
         End Function
 
         Public Overrides Function VisitQueryClause(node As BoundQueryClause) As BoundNode
-            Visit(node.UnderlyingExpression)
+            VisitRvalue(node.UnderlyingExpression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitAggregateClause(node As BoundAggregateClause) As BoundNode
             If node.CapturedGroupOpt IsNot Nothing Then
-                Visit(node.CapturedGroupOpt)
+                VisitRvalue(node.CapturedGroupOpt)
             End If
 
-            Visit(node.UnderlyingExpression)
+            VisitRvalue(node.UnderlyingExpression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitOrdering(node As BoundOrdering) As BoundNode
-            Visit(node.UnderlyingExpression)
+            VisitRvalue(node.UnderlyingExpression)
             Return Nothing
         End Function
 
         Public Overrides Function VisitRangeVariableAssignment(node As BoundRangeVariableAssignment) As BoundNode
-            Visit(node.Value)
+            VisitRvalue(node.Value)
             Return Nothing
         End Function
 
@@ -2015,7 +2015,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Me.SetPlaceholderSubstitute(placeholder, New BoundLocal(localDecl.Syntax, localToUseAsSubstitute, localToUseAsSubstitute.Type))
             End If
 
-            Visit(node.Initializer)
+            VisitRvalue(node.Initializer)
             Visit(localDecl)  ' TODO: do we really need that?
 
             ' Visit all other declarations

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/ReadWriteWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/ReadWriteWalker.vb
@@ -196,7 +196,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 NoteWrite(node.RangeVariableOpt, Nothing)
             End If
 
-            Visit(node.Source)
+            VisitRvalue(node.Source)
             Return Nothing
         End Function
 
@@ -205,7 +205,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 NoteWrite(node.RangeVariable, Nothing)
             End If
 
-            Visit(node.Value)
+            VisitRvalue(node.Value)
             Return Nothing
         End Function
 

--- a/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.vb
@@ -1533,6 +1533,40 @@ End Class
             CompilationUtils.AssertTheseDiagnostics(comp)
         End Sub
 
+        <Fact>
+        Public Sub LogicalExpressionInErroneousObjectInitializer()
+            Dim program = <compilation>
+                              <file name="a.b">
+Public Class Class1
+
+    Sub Test()
+        Dim x As S1
+        Dim y As New C1() With {.F1 = x.F1 AndAlso x.F2, .F3 = x.F3}
+    End Sub
+
+End Class
+
+Public Structure S1
+    Public F1 As Boolean
+    Public F2 As Boolean
+    Public F3 As Object
+End Structure
+                            </file>
+                          </compilation>
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlib(program, options:=TestOptions.DebugDll)
+
+            comp.AssertTheseDiagnostics(
+<expected>
+BC30002: Type 'C1' is not defined.
+        Dim y As New C1() With {.F1 = x.F1 AndAlso x.F2, .F3 = x.F3}
+                     ~~
+BC42104: Variable 'F3' is used before it has been assigned a value. A null reference exception could result at runtime.
+        Dim y As New C1() With {.F1 = x.F1 AndAlso x.F2, .F3 = x.F3}
+                                                               ~~~~
+</expected>
+            )
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #5992.

If logical expression is not visited with VisitRvalue method, current state remains splitted, which causes a NullReferenceException when the next expression is visited.

@gafter, @VSadov, @jaredpar, @agocke, @TyOverby Please review.   