### PR TITLE
Implement MakeDeclaredBase/ MakeDeclaredInterfaces for ImplicitNamedTypeSymbol

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -32,6 +32,14 @@ namespace N
             Assert.Equal(SyntaxKind.NamespaceDeclaration, implicitClass.DeclaringSyntaxReferences.Single().GetSyntax().Kind());
             Assert.False(implicitClass.IsSubmissionClass);
             Assert.False(implicitClass.IsScriptClass);
+
+            var c2 = CreateCompilationWithMscorlib45("", new[] { c.ToMetadataReference() });
+
+            n = ((NamespaceSymbol)c2.GlobalNamespace.GetMembers("N").Single());
+            implicitClass = ((NamedTypeSymbol)n.GetMembers().Single());
+            Assert.IsType<CSharp.Symbols.Retargeting.RetargetingNamedTypeSymbol>(implicitClass);
+            Assert.Equal(0, implicitClass.Interfaces.Length);
+            Assert.Equal(c2.ObjectType, implicitClass.BaseType);
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
@@ -37,6 +37,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+            Return Me.GetDeclaredBase(Nothing)
+        End Function
+
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+            Return ImmutableArray(Of NamedTypeSymbol).Empty
+        End Function
+
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As ConsList(Of Symbol), diagnostics As DiagnosticBag) As NamedTypeSymbol
             Dim baseType = DeclaringCompilation.GetSpecialType(SpecialType.System_Object)
 
             ' check that System.Object is available. 
@@ -49,16 +57,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return If(Me.TypeKind = TypeKind.Submission, Nothing, baseType)
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
-            Return ImmutableArray(Of NamedTypeSymbol).Empty
-        End Function
-
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As ConsList(Of Symbol), diagnostics As DiagnosticBag) As NamedTypeSymbol
-            Throw ExceptionUtilities.Unreachable
-        End Function
-
         Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As ConsList(Of Symbol), diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
-            Throw ExceptionUtilities.Unreachable
+            Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
         Public Overrides ReadOnly Property TypeParameters As ImmutableArray(Of TypeParameterSymbol)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ImplicitClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ImplicitClassTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class ImplicitClassTests
         Inherits BasicTestBase
 
-        <Fact>
+        <Fact, WorkItem(6040, "https://github.com/dotnet/roslyn/issues/6040")>
         Public Sub ImplicitClassSymbol()
             Dim c = CompilationUtils.CreateCompilationWithMscorlib(
 <compilation name="C">
@@ -39,6 +39,14 @@ End Namespace
             Assert.Equal(SyntaxKind.NamespaceStatement, implicitClass.DeclaringSyntaxReferences.Single().GetSyntax().Kind)
             Assert.False(implicitClass.IsSubmissionClass)
             Assert.False(implicitClass.IsScriptClass)
+
+            Dim c2 = CreateCompilationWithMscorlib45({}, {c.ToMetadataReference()})
+
+            n = DirectCast(c2.GlobalNamespace.GetMembers("N").Single(), NamespaceSymbol)
+            implicitClass = DirectCast(n.GetMembers().Single(), NamedTypeSymbol)
+            Assert.IsType(Of Retargeting.RetargetingNamedTypeSymbol)(implicitClass)
+            Assert.Equal(0, implicitClass.Interfaces.Length)
+            Assert.Equal(c2.ObjectType, implicitClass.BaseType)
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes #6040.

@dotnet/roslyn-compiler Please review.