### PR TITLE
No longer call SetSynchronizationContext just to get Dispatcher-based TaskScheduler

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -652,6 +652,7 @@
     <Compile Include="Implementation\Workspaces\TextUndoHistoryWorkspaceServiceFactoryService.cs" />
     <Compile Include="Implementation\Workspaces\WorkspaceTaskSchedulerFactoryFactory.cs" />
     <Compile Include="IRefactorNotifyService.cs" />
+    <Compile Include="Shared\Utilities\SynchronizationContextTaskScheduler.cs" />
     <Compile Include="Tagging\AbstractAsynchronousTaggerProvider.Tagger.cs" />
     <Compile Include="Tagging\AbstractAsynchronousTaggerProvider.TagSource.cs" />
     <Compile Include="Tagging\AbstractAsynchronousTaggerProvider.TagSource_ReferenceCounting.cs" />

--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -32,25 +32,14 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 
         internal static ForegroundThreadData CreateDefault()
         {
-            TaskScheduler taskScheduler;
-            ForegroundThreadDataKind kind;
-
-            var previousContext = SynchronizationContext.Current;
-            try
-            {
-                // None of the work posted to the foregroundTaskScheduler should block pending keyboard/mouse input from the user.
-                // So instead of using the default priority which is above user input, we use Background priority which is 1 level
-                // below user input.
-                SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher, DispatcherPriority.Background));
-                taskScheduler = TaskScheduler.FromCurrentSynchronizationContext();
-                kind = previousContext?.GetType().FullName == "System.Windows.Threading.DispatcherSynchronizationContext"
+            ForegroundThreadDataKind kind = SynchronizationContext.Current?.GetType().FullName == "System.Windows.Threading.DispatcherSynchronizationContext"
                     ? ForegroundThreadDataKind.Wpf
                     : ForegroundThreadDataKind.Unknown;
-            }
-            finally
-            {
-                SynchronizationContext.SetSynchronizationContext(previousContext);
-            }
+
+            // None of the work posted to the foregroundTaskScheduler should block pending keyboard/mouse input from the user.
+            // So instead of using the default priority which is above user input, we use Background priority which is 1 level
+            // below user input.
+            var taskScheduler = new SynchronizationContextTaskScheduler(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher, DispatcherPriority.Background));
 
             return new ForegroundThreadData(Thread.CurrentThread, taskScheduler, kind);
         }

--- a/src/EditorFeatures/Core/Shared/Utilities/SynchronizationContextTaskScheduler.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/SynchronizationContextTaskScheduler.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
+{
+    // Based on CoreCLR's implementation of the TaskScheduler they return from TaskScheduler.FromCurrentSynchronizationContext
+    internal class SynchronizationContextTaskScheduler : TaskScheduler
+    {
+        private readonly SendOrPostCallback _postCallback;
+        private readonly SynchronizationContext _synchronizationContext;
+
+        internal SynchronizationContextTaskScheduler(SynchronizationContext synchronizationContext)
+        {
+            if (synchronizationContext == null)
+                throw new ArgumentNullException(nameof(synchronizationContext));
+
+            _postCallback = new SendOrPostCallback(PostCallback);
+            _synchronizationContext = synchronizationContext;
+        }
+
+        public override Int32 MaximumConcurrencyLevel
+        {
+            get { return 1; }
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            _synchronizationContext.Post(_postCallback, task);
+
+        }
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            if (SynchronizationContext.Current == _synchronizationContext)
+            {
+                return TryExecuteTask(task);
+            }
+
+            return false;
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            return null;
+        }
+
+        private void PostCallback(object obj)
+        {
+            TryExecuteTask((Task)obj);
+        }
+    }
+}


### PR DESCRIPTION
__Note:__ I left and didn't change the bad WPF Sync Context check which breaks when opening Shared Projects. This should be tackled by a different check-in.

tag @Pilchie @dotnet/roslyn-ide 