### PR TITLE
Porting fix for #4524 to stabilization branch

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
@@ -142,7 +142,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function VisitAssignmentOperator(node As BoundAssignmentOperator) As BoundNode
-            If Me.IsInExpressionLambda Then
+            'COMPAT: old compiler used to allow assignments to properties
+            '        we will continue allowing that too
+            'NOTE:   native vbc also allows compound assignments like += but generates incorrect code.
+            '        we are not going to support += assuming that it is not likely to be used in real scenarios.
+            If Me.IsInExpressionLambda AndAlso
+                    Not (node.Left.Kind = BoundKind.PropertyAccess AndAlso node.LeftOnTheRightOpt Is Nothing) Then
+
                 ' Do not support explicit assignments
                 GenerateExpressionTreeNotSupportedDiagnostic(node)
             End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
@@ -666,7 +666,7 @@ lSelect:
             ' All other cases are not supported, note that some cases of invalid
             ' sequences are handled in DiagnosticsPass, but we still want to catch
             ' here those sequences created in lowering
-            Return GenerateDiagnosticAndReturnDummyExpression(ERRID.ERR_ExpressionTreeNotSupported, value)
+            Return GenerateDiagnosticAndReturnDummyExpression(ERRID.ERR_ExpressionTreeNotSupported, node)
         End Function
 
         Private Function VisitArrayLength(node As BoundArrayLength) As BoundExpression

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -8014,6 +8014,7 @@ Module Module1
         Public Field As String
 
         Public Sub Verify(expression As Expression(Of Action(Of Address)))
+            Console.WriteLine(expression.ToString())
             expression.Compile()(Me)
         End Sub
 
@@ -8048,7 +8049,11 @@ End Module
             CompileAndVerify(source,
                  additionalRefs:={SystemCoreRef},
                  options:=TestOptions.ReleaseExe,
-                 expectedOutput:=<![CDATA[aa]]>).VerifyDiagnostics()
+                 expectedOutput:=<![CDATA[
+x => x.set_City(ItIs(s => IsNullOrEmpty(s)))
+x => x.set_City("aa")
+aa
+]]>).VerifyDiagnostics()
 
 
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -8059,6 +8059,82 @@ aa
         End Sub
 
         <Fact, WorkItem(4524, "https://github.com/dotnet/roslyn/issues/4524")>
+        Public Sub PropertyAssignmentParameterized()
+
+            Dim source = <compilation>
+                             <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Linq.Expressions
+
+Module Module1
+
+    Public Interface IAddress
+        Property City(i As Integer) As String
+    End Interface
+
+    Public Class Address
+        Implements IAddress
+
+        Private c As String
+
+        Public Property City(i As Integer) As String Implements IAddress.City
+            Get
+                Return c & i
+            End Get
+            Set(value As String)
+                c = value & i
+            End Set
+        End Property
+
+        Public Field As String
+
+        Public Sub Verify(expression As Expression(Of Action(Of Address)))
+            Console.WriteLine(expression.ToString())
+            expression.Compile()(Me)
+        End Sub
+
+    End Class
+
+    Public Class Customer
+        Public Property Address As IAddress
+
+        Public Sub DoWork(newValue As String)
+            Address.City(0) = newValue
+        End Sub
+    End Class
+
+    Public Function ItIs(Of TValue)(match As Expression(Of Func(Of TValue, Boolean))) As TValue
+    End Function
+
+    Sub Main()
+        Dim a As New Address
+
+        a.Verify(Sub(x) x.City(1) = ItIs(Of String)(Function(s) String.IsNullOrEmpty(s)))
+
+        Dim i As Integer = 2
+        a.Verify(Sub(x) x.City(i) = "aa")
+
+        System.Console.WriteLine(a.City(3))
+    End Sub
+
+End Module
+
+                            ]]></file>
+                         </compilation>
+
+            CompileAndVerify(source,
+                 additionalRefs:={SystemCoreRef},
+                 options:=TestOptions.ReleaseExe,
+                 expectedOutput:=<![CDATA[
+x => x.set_City(1, ItIs(s => IsNullOrEmpty(s)))
+x => x.set_City(value(Module1+_Closure$__4-0).$VB$Local_i, "aa")
+aa23
+]]>).VerifyDiagnostics()
+
+
+        End Sub
+
+        <Fact, WorkItem(4524, "https://github.com/dotnet/roslyn/issues/4524")>
         Public Sub PropertyAssignmentCompound()
 
             Dim source = <compilation>


### PR DESCRIPTION
Old vbc compiler used to allow property assignments (even though technically no assignments should be allowed)
This fixes #4524

Caveat: old compiler also allowed compound property assignments like += and generated bad code for them

We are not going to allow that unless some major use patterns are discovered.
It is generally not possible to implement that correctly using Expression Trees v1.0 node set.