### PR TITLE
Added supports clauses to project.json to fix #6073

### DIFF
--- a/src/Compilers/CSharp/CscCore/project.json
+++ b/src/Compilers/CSharp/CscCore/project.json
@@ -1,4 +1,8 @@
 ﻿{
+  "supports": {
+    "net46.app": { },
+    "dnxcore50.app": { }
+  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23401",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23401",
@@ -43,7 +47,7 @@
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "ubuntu.14.04-x64": {}
+    "win7-x64": { },
+    "ubuntu.14.04-x64": { }
   }
 }

--- a/src/Compilers/VisualBasic/VbcCore/project.json
+++ b/src/Compilers/VisualBasic/VbcCore/project.json
@@ -1,4 +1,8 @@
 ﻿{
+  "supports": {
+    "net46.app": { },
+    "dnxcore50.app": { }
+  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23401",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23401",
@@ -43,7 +47,7 @@
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "ubuntu.14.04-x64": {}
+    "win7-x64": { },
+    "ubuntu.14.04-x64": { }
   }
 }

--- a/src/Interactive/CsiCore/project.json
+++ b/src/Interactive/CsiCore/project.json
@@ -1,4 +1,8 @@
 ﻿{
+  "supports": {
+    "net46.app": { },
+    "dnxcore50.app": { }
+  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23401",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23401",
@@ -42,7 +46,7 @@
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "ubuntu.14.04-x64": {}
+    "win7-x64": { },
+    "ubuntu.14.04-x64": { }
   }
 }

--- a/src/Interactive/VbiCore/project.json
+++ b/src/Interactive/VbiCore/project.json
@@ -1,4 +1,8 @@
 ﻿{
+  "supports": {
+    "net46.app": {},
+    "dnxcore50.app": {}
+  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23401",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23401",
@@ -42,7 +46,7 @@
     }
   },
   "runtimes": {
-    "win7-x64": {},
-    "ubuntu.14.04-x64": {}
+    "win7-x64": { },
+    "ubuntu.14.04-x64": { }
   }
 }


### PR DESCRIPTION
Fixes  #6073.

Csc and Csi are portable projects targeting 5.0 portable
without support clauses, this confuses portable as it
doesn't know the projects target and warns when they
reference other portable projects.

This also enables package validation to ensure that these
projects will never reference a package that doesn't work
on its given targets.