### PR TITLE
Change several tests to WpfFact

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -3570,7 +3570,7 @@ catch (System.Exception) when (true)
                 Punctuation.CloseCurly);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
         public void OutVar()
         {
             var code = @"
@@ -3584,7 +3584,7 @@ F(out var);";
                 Punctuation.Semicolon);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
         public void ReferenceDirective()
         {
             var code = @"
@@ -3595,7 +3595,7 @@ F(out var);";
                 String("\"file.dll\""));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
         public void LoadDirective()
         {
             var code = @"
@@ -3606,7 +3606,7 @@ F(out var);";
                 String("\"file.csx\""));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
         public void IncompleteAwaitInNonAsyncContext()
         {
             var code = @"
@@ -3627,7 +3627,7 @@ void M()
                 Punctuation.CloseCurly);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
         public void CompleteAwaitInNonAsyncContext()
         {
             var code = @"


### PR DESCRIPTION
The SyntacticClassifierTests all need to be WpfFact due to their dependency on STA threads.  This was causing sporadic test failures in Jenkins.