### PR TITLE
Address the performance issues for bulk suppression in IDE.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixAllTests.cs
@@ -378,9 +378,8 @@ class Class2
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~M:Class1.Method~System.Int32"")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class1"")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class2"")]
-
-".Replace("<", "&lt;").Replace(">", "&gt;");
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class2"")]"
+    .Replace("<", "&lt;").Replace(">", "&gt;");
 
                     var expected = @"
 <Workspace>
@@ -483,9 +482,8 @@ class Class2
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""member"", Target = ""~M:Class1.Method~System.Int32"")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class1"")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class2"")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class3"")]
-
-".Replace("<", "&lt;").Replace(">", "&gt;");
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"", Scope = ""type"", Target = ""~T:Class3"")]"
+    .Replace("<", "&lt;").Replace(">", "&gt;");
 
                     var expected = @"
 <Workspace>
@@ -710,9 +708,8 @@ class Class2
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""NoLocationDiagnostic"", ""NoLocationDiagnostic:NoLocationDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]
-
-".Replace("<", "&lt;").Replace(">", "&gt;");
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""NoLocationDiagnostic"", ""NoLocationDiagnostic:NoLocationDiagnostic"", Justification = ""{FeaturesResources.SuppressionPendingJustification}"")]"
+    .Replace("<", "&lt;").Replace(">", "&gt;");
 
                 var expected = @"
 <Workspace>

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixAllGetFixesService.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixAllGetFixesService.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             }
 
             fixAllContext.CancellationToken.ThrowIfCancellationRequested();
-            return await codeAction.GetChangedSolutionInternalAsync(fixAllContext.CancellationToken).ConfigureAwait(false);
+            return await codeAction.GetChangedSolutionInternalAsync(cancellationToken: fixAllContext.CancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<CodeActionOperation>> GetFixAllOperationsAsync(FixAllProvider fixAllProvider, FixAllContext fixAllContext, string fixAllTitle, string waitDialogMessage, bool showPreviewChangesDialog)
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            var newSolution = await codeAction.GetChangedSolutionInternalAsync(cancellationToken).ConfigureAwait(false);
+            var newSolution = await codeAction.GetChangedSolutionInternalAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (showPreviewChangesDialog)
             {

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixMultipleSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixMultipleSuggestedAction.cs
@@ -70,7 +70,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             var extensionManager = this.Workspace.Services.GetService<IExtensionManager>();
             extensionManager.PerformAction(Provider, () =>
             {
-                newSolution = CodeAction.GetChangedSolutionInternalAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+                // We don't need to post process changes here as the inner code action created for Fix multiple code fix already executes.
+                newSolution = CodeAction.GetChangedSolutionInternalAsync(postProcessChanges: false, cancellationToken: cancellationToken).WaitAndGetResult(cancellationToken);
             });
 
             return newSolution;

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -1482,7 +1482,7 @@ End Class]]>
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""<Pending>"", Scope:=""type"", Target:=""Class1"")>
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
 "
 
                     Test(source.ToString(), expected)
@@ -1518,7 +1518,7 @@ End Class
 ' Project-level suppressions either have no target or are given 
 ' a specific target and scoped to a namespace, type, member, etc.
 
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
 "
 
                     Test(source.ToString(), expected)
@@ -1564,7 +1564,7 @@ End Class
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""<Pending>"", Scope:=""type"", Target:=""Class1"")>
-<Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
+<Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.SuppressionPendingJustification}"", Scope:=""type"", Target:=""~T:Class2"")>
 "
 
                     Test(source.ToString(), expected)

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.FixAllProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.FixAllProvider.cs
@@ -1,16 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
@@ -50,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 
                     return !isGlobalSuppression ?
                         await batchFixer.GetFixAsync(documentsAndDiagnosticsToFixMap, fixAllContext).ConfigureAwait(false) :
-                        CreateGlobalSuppressionFixAllAction(title, suppressionFixer, fixAllContext.Document, documentsAndDiagnosticsToFixMap);
+                        GlobalSuppressMessageFixAllCodeAction.Create(title, suppressionFixer, fixAllContext.Document, documentsAndDiagnosticsToFixMap);
                 }
                 else
                 {
@@ -60,22 +54,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 
                     return !isGlobalSuppression ?
                         await batchFixer.GetFixAsync(projectsAndDiagnosticsToFixMap, fixAllContext).ConfigureAwait(false) :
-                        CreateGlobalSuppressionFixAllAction(title, suppressionFixer, fixAllContext.Project, projectsAndDiagnosticsToFixMap);
+                        GlobalSuppressMessageFixAllCodeAction.Create(title, suppressionFixer, fixAllContext.Project, projectsAndDiagnosticsToFixMap);
                 }
-            }
-
-            private static CodeAction CreateGlobalSuppressionFixAllAction(string title, AbstractSuppressionCodeFixProvider fixer, Document triggerDocument, ImmutableDictionary<Document, ImmutableArray<Diagnostic>> diagnosticsByDocument)
-            {
-                return new CodeAction.SolutionChangeAction(title,
-                    ct => GlobalSuppressMessageFixAllCodeAction.CreateChangedSolutionAsync(fixer, triggerDocument, diagnosticsByDocument, ct),
-                    equivalenceKey: title);
-            }
-
-            private static CodeAction CreateGlobalSuppressionFixAllAction(string title, AbstractSuppressionCodeFixProvider fixer, Project triggerProject, ImmutableDictionary<Project, ImmutableArray<Diagnostic>> diagnosticsByProject)
-            {
-                return new CodeAction.SolutionChangeAction(title,
-                    ct => GlobalSuppressMessageFixAllCodeAction.CreateChangedSolutionAsync(fixer, triggerProject, diagnosticsByProject, ct),
-                    equivalenceKey: title);
             }
         }
     }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
@@ -23,9 +23,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             protected override async Task<Document> GetChangedSuppressionDocumentAsync(CancellationToken cancellationToken)
             {
                 var suppressionsDoc = await GetOrCreateSuppressionsDocumentAsync(cancellationToken).ConfigureAwait(false);
+                var workspace = suppressionsDoc.Project.Solution.Workspace;
                 var suppressionsRoot = await suppressionsDoc.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var semanticModel = await suppressionsDoc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                suppressionsRoot = Fixer.AddGlobalSuppressMessageAttribute(suppressionsRoot, _targetSymbol, _diagnostic);
+                suppressionsRoot = Fixer.AddGlobalSuppressMessageAttribute(suppressionsRoot, _targetSymbol, _diagnostic, workspace, cancellationToken);
                 return suppressionsDoc.WithSyntaxRoot(suppressionsRoot);
             }
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 {
     internal abstract partial class AbstractSuppressionCodeFixProvider : ISuppressionFixProvider
     {
-        public const string SuppressMessageAttributeName = "System.Diagnostics.CodeAnalysis.SuppressMessageAttribute";
+        public const string SuppressMessageAttributeName = "System.Diagnostics.CodeAnalysis.SuppressMessage";
         private static readonly string s_globalSuppressionsFileName = "GlobalSuppressions";
         private static readonly string s_suppressionsFileCommentTemplate =
 @"
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         protected abstract SyntaxTriviaList CreatePragmaDisableDirectiveTrivia(Diagnostic diagnostic, Func<SyntaxNode, SyntaxNode> formatNode, bool needsLeadingEndOfLine, bool needsTrailingEndOfLine);
         protected abstract SyntaxTriviaList CreatePragmaRestoreDirectiveTrivia(Diagnostic diagnostic, Func<SyntaxNode, SyntaxNode> formatNode, bool needsLeadingEndOfLine, bool needsTrailingEndOfLine);
 
-        protected abstract SyntaxNode AddGlobalSuppressMessageAttribute(SyntaxNode newRoot, ISymbol targetSymbol, Diagnostic diagnostic);
+        protected abstract SyntaxNode AddGlobalSuppressMessageAttribute(SyntaxNode newRoot, ISymbol targetSymbol, Diagnostic diagnostic, Workspace workspace, CancellationToken cancellationToken);
 
         protected abstract string DefaultFileExtension { get; }
         protected abstract string SingleLineCommentStart { get; }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
@@ -28,14 +28,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             var documentDiagnostics = diagnostics.Where(d => d.Location.IsInSource).ToImmutableArray();
             if (!documentDiagnostics.IsEmpty)
             {
-                var suppressionFixes = await _suppressionFixProvider.GetSuppressionsAsync(context.Document, context.Span, diagnostics, context.CancellationToken).ConfigureAwait(false);
+                var suppressionFixes = await _suppressionFixProvider.GetSuppressionsAsync(context.Document, context.Span, documentDiagnostics, context.CancellationToken).ConfigureAwait(false);
                 RegisterSuppressionFixes(context, suppressionFixes);
             }
 
             var projectDiagnostics = diagnostics.Where(d => !d.Location.IsInSource).ToImmutableArray();
             if (!projectDiagnostics.IsEmpty)
             {
-                var suppressionFixes = await _suppressionFixProvider.GetSuppressionsAsync(context.Project, diagnostics, context.CancellationToken).ConfigureAwait(false);
+                var suppressionFixes = await _suppressionFixProvider.GetSuppressionsAsync(context.Project, projectDiagnostics, context.CancellationToken).ConfigureAwait(false);
                 RegisterSuppressionFixes(context, suppressionFixes);
             }
         }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -414,8 +414,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 if (document != null)
                 {
                     Contract.Requires(stateType != StateType.Project);
-                    var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                    return new DiagnosticAnalyzerDriver(document, root.FullSpan, root, this.Owner, cancellationToken);
+                    var root = document.SupportsSyntaxTree ? await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) : null;
+                    return new DiagnosticAnalyzerDriver(document, root?.FullSpan, root, this.Owner, cancellationToken);
                 }
 
                 var project = documentOrProject as Project;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -17,13 +17,11 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
+using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Roslyn.Utilities;
-
-using Task = System.Threading.Tasks.Task;
-
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
 {
     /// <summary>
@@ -35,6 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly IWpfTableControl _tableControl;
         private readonly IDiagnosticAnalyzerService _diagnosticService;
+        private readonly ExternalErrorDiagnosticUpdateSource _buildErrorDiagnosticService;
         private readonly ICodeFixService _codeFixService;
         private readonly IFixMultipleOccurrencesService _fixMultipleOccurencesService;
         private readonly ICodeActionEditHandlerService _editHandlerService;
@@ -46,6 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
             SVsServiceProvider serviceProvider,
             VisualStudioWorkspaceImpl workspace,
             IDiagnosticAnalyzerService diagnosticService,
+            ExternalErrorDiagnosticUpdateSource buildErrorDiagnosticService,
             ICodeFixService codeFixService,
             ICodeActionEditHandlerService editHandlerService,
             IVisualStudioDiagnosticListSuppressionStateService suppressionStateService,
@@ -53,6 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
         {
             _workspace = workspace;
             _diagnosticService = diagnosticService;
+            _buildErrorDiagnosticService = buildErrorDiagnosticService;
             _codeFixService = codeFixService;
             _suppressionStateService = (VisualStudioDiagnosticListSuppressionStateService)suppressionStateService;
             _editHandlerService = editHandlerService;
@@ -122,16 +123,48 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
             }
         }
 
-        private async Task<ImmutableArray<DiagnosticData>> GetAllDiagnosticsAsync(Func<Project, bool> shouldFixInProject, CancellationToken cancellationToken)
+        private async Task<ImmutableArray<DiagnosticData>> GetAllBuildDiagnosticsAsync(Func<Project, bool> shouldFixInProject, CancellationToken cancellationToken)
         {
             var builder = ImmutableArray.CreateBuilder<DiagnosticData>();
+            var buildDiagnostics = _buildErrorDiagnosticService.GetBuildErrors().Where(d => d.ProjectId != null && d.Severity != DiagnosticSeverity.Hidden);
             var solution = _workspace.CurrentSolution;
-            foreach (var project in solution.Projects)
+            foreach (var diagnosticsByProject in buildDiagnostics.GroupBy(d => d.ProjectId))
             {
-                if (shouldFixInProject(project))
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (diagnosticsByProject.Key == null)
                 {
-                    var diagnostics = await _diagnosticService.GetDiagnosticsAsync(solution, project.Id, includeSuppressedDiagnostics: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-                    builder.AddRange(diagnostics.Where(d => d.Severity != DiagnosticSeverity.Hidden));
+                    // Diagnostics with no projectId cannot be suppressed.
+                    continue;
+                }
+
+                var project = solution.GetProject(diagnosticsByProject.Key);
+                if (project != null && shouldFixInProject(project))
+                {
+                    var diagnosticsByDocument = diagnosticsByProject.GroupBy(d => d.DocumentId);
+                    foreach (var group in diagnosticsByDocument)
+                    {
+                        var documentId = group.Key;
+                        if (documentId == null)
+                        {
+                            // Project diagnostics, just add all of them.
+                            builder.AddRange(group);
+                            continue;
+                        }
+
+                        // For document diagnostics, build does not have the computed text span info.
+                        // So we explicitly calculate the text span from the source text for the diagnostics.
+                        var document = project.GetDocument(documentId);
+                        if (document != null)
+                        {
+                            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                            var text = await tree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                            foreach (var diagnostic in group)
+                            {
+                                builder.Add(diagnostic.WithCalculatedSpan(text));
+                            }
+                        }
+                    }
                 }
             }
 
@@ -150,16 +183,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
 
         private IEnumerable<DiagnosticData> GetDiagnosticsToFix(Func<Project, bool> shouldFixInProject, bool selectedEntriesOnly, bool isAddSuppression)
         {
-            var diagnosticsToFix = SpecializedCollections.EmptyEnumerable<DiagnosticData>();
+            var diagnosticsToFix = ImmutableHashSet<DiagnosticData>.Empty;
             Action<CancellationToken> computeDiagnosticsToFix = cancellationToken =>
             {
                 // If we are fixing selected diagnostics in error list, then get the diagnostics from error list entry snapshots.
                 // Otherwise, get all diagnostics from the diagnostic service.
                 var diagnosticsToFixTask = selectedEntriesOnly ?
-                    _suppressionStateService.GetSelectedItemsAsync(isAddSuppression, cancellationToken) :
-                    GetAllDiagnosticsAsync(shouldFixInProject, cancellationToken);
+                    _suppressionStateService.GetSelectedItemsAsync(isAddSuppression, cancellationToken):
+                    GetAllBuildDiagnosticsAsync(shouldFixInProject, cancellationToken);
 
-                diagnosticsToFix = diagnosticsToFixTask.WaitAndGetResult(cancellationToken);
+                diagnosticsToFix = diagnosticsToFixTask.WaitAndGetResult(cancellationToken).ToImmutableHashSet();
             };
 
             var title = GetFixTitle(isAddSuppression);
@@ -226,6 +259,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                     return;
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // Equivalence key determines what fix will be applied.
                 // Make sure we don't include any specific diagnostic ID, as we want all of the given diagnostics (which can have varied ID) to be fixed.
                 var equivalenceKey = isAddSuppression ?
@@ -240,6 +275,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                 {
                     // Use the Fix multiple occurrences service to compute a bulk suppression fix for the specified document and project diagnostics,
                     // show a preview changes dialog and then apply the fix to the workspace.
+
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     var documentDiagnosticsPerLanguage = GetDocumentDiagnosticsMappedToNewSolution(documentDiagnosticsToFixMap, newSolution, language);
                     if (!documentDiagnosticsPerLanguage.IsEmpty)
@@ -256,7 +293,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                                 equivalenceKey,
                                 title,
                                 waitDialogMessage,
-                                cancellationToken: CancellationToken.None);
+                                cancellationToken);
                             if (newSolution == null)
                             {
                                 // User cancelled or fixer threw an exception, so we just bail out.
@@ -281,7 +318,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                                  equivalenceKey,
                                  title,
                                  waitDialogMessage,
-                                 CancellationToken.None);
+                                 cancellationToken);
                             if (newSolution == null)
                             {
                                 // User cancelled or fixer threw an exception, so we just bail out.

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
     {
         internal static readonly ImmutableDictionary<string, string> Properties = ImmutableDictionary<string, string>.Empty.Add(WellKnownDiagnosticPropertyNames.Origin, WellKnownDiagnosticTags.Build);
         internal static readonly IReadOnlyList<string> CustomTags = ImmutableArray.Create(WellKnownDiagnosticTags.Telemetry);
+        internal static readonly IReadOnlyList<string> CompilerDiagnosticCustomTags = ImmutableArray.Create(WellKnownDiagnosticTags.Compiler, WellKnownDiagnosticTags.Telemetry);
 
         private readonly ProjectId _projectId;
         private readonly string _errorCodePrefix;
@@ -219,6 +220,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 id, GetErrorId(error), error.bstrText, GetDiagnosticSeverity(error), null, 0, 0, 0, 0, null, 0, 0, 0, 0);
         }
 
+        private static bool IsCompilerDiagnostic(string errorId)
+        {
+            if (!string.IsNullOrEmpty(errorId) && errorId.Length > 2)
+            {
+                var prefix = errorId.Substring(0, 2);
+                if (prefix.Equals("CS", StringComparison.OrdinalIgnoreCase) || prefix.Equals("BC", StringComparison.OrdinalIgnoreCase))
+                {
+                    var suffix = errorId.Substring(2);
+                    int id;
+                    return int.TryParse(suffix, out id);
+                }
+            }
+
+            return false;
+        }
+
+        private static IReadOnlyList<string> GetCustomTags(string errorId)
+        {
+            return IsCompilerDiagnostic(errorId) ? CompilerDiagnosticCustomTags : CustomTags;
+        }
+
         private DiagnosticData GetDiagnosticData(
             DocumentId id, string errorId, string message, DiagnosticSeverity severity,
             string mappedFilePath, int mappedStartLine, int mappedStartColumn, int mappedEndLine, int mappedEndColumn,
@@ -228,12 +250,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 id: errorId,
                 category: WellKnownDiagnosticTags.Build,
                 message: message,
+                title: message,
                 enuMessageForBingSearch: message, // Unfortunately, there is no way to get ENU text for this since this is an external error.
                 severity: severity,
                 defaultSeverity: severity,
                 isEnabledByDefault: true,
                 warningLevel: GetWarningLevel(severity),
-                customTags: CustomTags,
+                customTags: GetCustomTags(errorId),
                 properties: Properties,
                 workspace: _workspace,
                 projectId: _projectId,

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -138,12 +138,12 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <summary>
         /// used by batch fixer engine to get new solution
         /// </summary>
-        internal async Task<Solution> GetChangedSolutionInternalAsync(CancellationToken cancellationToken)
+        internal async Task<Solution> GetChangedSolutionInternalAsync(bool postProcessChanges = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             var solution = await GetChangedSolutionAsync(cancellationToken).ConfigureAwait(false);
-            if (solution == null)
+            if (solution == null || !postProcessChanges)
             {
-                return null;
+                return solution;
             }
 
             return await this.PostProcessChangesAsync(solution, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 // TODO: Parallelize GetChangedSolutionInternalAsync for codeActions
-                var changedSolution = await codeAction.GetChangedSolutionInternalAsync(cancellationToken).ConfigureAwait(false);
+                var changedSolution = await codeAction.GetChangedSolutionInternalAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 var solutionChanges = new SolutionChanges(changedSolution, oldSolution);
 

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -63,6 +63,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             OriginalEndLine = originalEndLine;
             OriginalEndColumn = originalEndColumn;
         }
+
+        internal DiagnosticDataLocation WithCalculatedSpan(TextSpan newSourceSpan)
+        {
+            Contract.ThrowIfTrue(this.SourceSpan.HasValue);
+
+            return new DiagnosticDataLocation(this.DocumentId,
+                newSourceSpan, this.OriginalFilePath,
+                this.OriginalStartLine, this.OriginalStartColumn,
+                this.OriginalEndLine, this.OriginalEndColumn,
+                this.MappedFilePath, this.MappedStartLine, this.MappedStartColumn,
+                this.MappedEndLine, this.MappedEndColumn);
+        }
     }
 
     internal sealed class DiagnosticData
@@ -219,6 +231,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public TextSpan GetExistingOrCalculatedTextSpan(SourceText text)
         {
             return HasTextSpan ? TextSpan : GetTextSpan(this.DataLocation, text);
+        }
+
+        public DiagnosticData WithCalculatedSpan(SourceText text)
+        {
+            Contract.ThrowIfNull(this.DocumentId);
+            Contract.ThrowIfNull(this.DataLocation);
+            Contract.ThrowIfTrue(HasTextSpan);
+
+            var span = GetTextSpan(this.DataLocation, text);
+            var newLocation = this.DataLocation.WithCalculatedSpan(span);
+            return new DiagnosticData(this.Id, this.Category, this.Message, this.ENUMessageForBingSearch,
+                this.Severity, this.DefaultSeverity, this.IsEnabledByDefault, this.WarningLevel, 
+                this.CustomTags, this.Properties, this.Workspace, this.ProjectId,
+                newLocation, this.AdditionalLocations, this.Title, this.Description, this.HelpLink, this.IsSuppressed);
         }
 
         public async Task<Diagnostic> ToDiagnosticAsync(Project project, CancellationToken cancellationToken)


### PR DESCRIPTION
1. "Suppress active issues" command from solution explorer was doing couple of builds - one command line build to compute the FxCop diagnostics and another intellisense build to fetch Roslyn diagnostics. This change removes the second build and instead uses the diagnostics emitted from the build for suppression.

2. Bulk suppressing multiple diagnostics from error list/suppress active issues command was spending more than 50% of time in formatting the generated global suppressions file. This delay grows significantly larger with 1000+ issues being suppressed. This fix changes us to not format the entire suppressions file at once, but instead format each attribute separately and avoid formatting the batched file. This significantly brings down the formatting time.

3. Thread in the cancellation token during batch fix computation - otherwise cancelling the wait dialog while computing suppressions fix will make VS unresponsive.

Fixes #6066