### PR TITLE
Use the same .rsp file for VS REPL as we use for csi.exe

### DIFF
--- a/src/VisualStudio/CSharp/Repl/CSharpInteractive.rsp
+++ b/src/VisualStudio/CSharp/Repl/CSharpInteractive.rsp
@@ -1,11 +1,12 @@
-﻿# This file contains command-line options that the C# REPL
-# will process as part of every compilation, unless 
-# "/noconfig" option is specified in the reset command.
-/r:System
+﻿/r:System
 /r:System.Core
 /r:Microsoft.CSharp
-/r:System.Data
-/r:System.Data.DataSetExtensions
-/r:System.Xml
-/r:System.Xml.Linq
-SeedUsings.csx
+/u:System
+/u:System.IO
+/u:System.Collections.Generic
+/u:System.Diagnostics
+/u:System.Dynamic
+/u:System.Linq
+/u:System.Linq.Expressions
+/u:System.Text
+/u:System.Threading.Tasks

--- a/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
+++ b/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
@@ -149,9 +149,7 @@
     <Compile Include="CSharpVsInteractiveWindowPackage.cs" />
     <Compile Include="CSharpVsInteractiveWindowCommandProvider.cs" />
     <Content Include="CSharpInteractive.rsp" />
-    <Content Include="Resources\CSharpInteractive.png" />
     <Content Include="Resources\ScriptFile.ico" />
-    <Content Include="SeedUsings.csx" />
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="Commands.vsct">

--- a/src/VisualStudio/CSharp/Repl/SeedUsings.csx
+++ b/src/VisualStudio/CSharp/Repl/SeedUsings.csx
@@ -1,4 +1,0 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;


### PR DESCRIPTION
The goal is to provide consistent experience between csi and VS REPL.