### PR TITLE
SynthesizedParameterSymbol.DeriveParameters should preserve order between custom modifiers and ByRef modifier.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly int _ordinal;
         private readonly string _name;
         private readonly ImmutableArray<CustomModifier> _customModifiers;
+        private readonly ushort _countOfCustomModifiersPrecedingByRef;
         private readonly RefKind _refKind;
 
         public SynthesizedParameterSymbol(
@@ -27,7 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int ordinal,
             RefKind refKind,
             string name = "",
-            ImmutableArray<CustomModifier> customModifiers = default(ImmutableArray<CustomModifier>))
+            ImmutableArray<CustomModifier> customModifiers = default(ImmutableArray<CustomModifier>),
+            ushort countOfCustomModifiersPrecedingByRef = 0)
         {
             Debug.Assert((object)type != null);
             Debug.Assert(name != null);
@@ -39,6 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _refKind = refKind;
             _name = name;
             _customModifiers = customModifiers.NullToEmpty();
+            _countOfCustomModifiersPrecedingByRef = countOfCustomModifiersPrecedingByRef;
         }
 
         public override TypeSymbol Type
@@ -128,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override ushort CountOfCustomModifiersPrecedingByRef
         {
-            get { return 0; }
+            get { return _countOfCustomModifiersPrecedingByRef; }
         }
 
         public override Symbol ContainingSymbol
@@ -179,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 //same properties as the old one, just change the owner
                 builder.Add(new SynthesizedParameterSymbol(destinationMethod, oldParam.Type, oldParam.Ordinal,
-                    oldParam.RefKind, oldParam.Name, oldParam.CustomModifiers));
+                    oldParam.RefKind, oldParam.Name, oldParam.CustomModifiers, oldParam.CountOfCustomModifiersPrecedingByRef));
             }
 
             return builder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -1579,5 +1579,59 @@ class CL3 : CL2
             CompileAndVerify(compilation, expectedOutput: @"Test
 Overriden");
         }
+
+        [ClrOnlyFact(ClrOnlyReason.Ilasm), WorkItem(5993, "https://github.com/dotnet/roslyn/issues/5993")]
+        public void ConcatModifiersAndByRef_05()
+        {
+            var ilSource = @"
+.class interface public abstract auto ansi beforefieldinit X.I
+{
+  .method public newslot abstract virtual 
+          instance void  A(uint32& modopt([mscorlib]System.Runtime.CompilerServices.IsImplicitlyDereferenced) x) cil managed
+  {
+  } // end of method I::A
+
+  .method public newslot abstract virtual 
+          instance void  B(uint32& x) cil managed
+  {
+  } // end of method I::B
+
+} // end of class X.I
+";
+
+            var source = @"
+using X;
+
+namespace ConsoleApplication21
+{
+    class CI : I 
+    {
+        public void A(ref uint x)
+        {
+            System.Console.WriteLine(""Implemented A"");
+        }
+
+        public void B(ref uint x)
+        {
+            System.Console.WriteLine(""Implemented B"");
+        }
+    }
+
+    internal class Program
+    {
+        private static void Main()
+        {
+            I x = new CI();
+            uint y = 0;
+            x.A(ref y);
+            x.B(ref y);
+        }
+    }
+}";
+            var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseExe);
+
+            CompileAndVerify(compilation, expectedOutput: @"Implemented A
+Implemented B");
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CustomModifiersTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CustomModifiersTests.vb
@@ -1533,5 +1533,57 @@ End Class
 Overriden")
         End Sub
 
+        <Fact, WorkItem(5993, "https://github.com/dotnet/roslyn/issues/5993")>
+        Public Sub ConcatModifiersAndByRef_05()
+            Dim ilSource = <![CDATA[
+.class interface public abstract auto ansi beforefieldinit X.I
+{
+  .method public newslot abstract virtual 
+          instance void  A(uint32& modopt([mscorlib]System.Runtime.CompilerServices.IsImplicitlyDereferenced) x) cil managed
+  {
+  } // end of method I::A
+
+  .method public newslot abstract virtual 
+          instance void  B(uint32& x) cil managed
+  {
+  } // end of method I::B
+
+} // end of class X.I
+]]>.Value
+            Dim vbSource =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+Imports X
+
+Class Module1
+    Shared Sub Main()
+        Dim x As I = new CI()
+        Dim y As UInteger = 0
+        x.A(y)
+        x.B(y)
+    End Sub
+End Class
+
+class CI 
+    Implements I 
+
+    public Sub A(Byref x As UInteger) Implements I.A
+        System.Console.WriteLine("Implemented A")
+    End Sub
+
+    public Sub B(Byref x As UInteger) Implements I.B
+        System.Console.WriteLine("Implemented B")
+    End Sub
+End Class
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithCustomILSource(vbSource, ilSource, options:=TestOptions.ReleaseExe)
+
+            CompileAndVerify(compilation, expectedOutput:="Implemented A
+Implemented B")
+        End Sub
+
     End Class
 End Namespace

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         private ParameterSymbol MakeParameterSymbol(int ordinal, string name, ParameterSymbol sourceParameter)
         {
-            return new SynthesizedParameterSymbol(this, sourceParameter.Type, ordinal, sourceParameter.RefKind, name, sourceParameter.CustomModifiers);
+            return new SynthesizedParameterSymbol(this, sourceParameter.Type, ordinal, sourceParameter.RefKind, name, sourceParameter.CustomModifiers, sourceParameter.CountOfCustomModifiersPrecedingByRef);
         }
 
         internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     method.Name,
                     m => method.TypeParameters.SelectAsArray(t => (TypeParameterSymbol)new SimpleTypeParameterSymbol(m, t.Ordinal, t.Name)),
                     m => m.TypeParameters[0], // return type is <>T&
-                    m => method.Parameters.SelectAsArray(p => (ParameterSymbol)new SynthesizedParameterSymbol(m, p.Type, p.Ordinal, p.RefKind, p.Name, p.CustomModifiers)));
+                    m => method.Parameters.SelectAsArray(p => (ParameterSymbol)new SynthesizedParameterSymbol(m, p.Type, p.Ordinal, p.RefKind, p.Name, p.CustomModifiers, p.CountOfCustomModifiersPrecedingByRef)));
                 var local = variable.LocalSymbol;
                 return InvokeGetMethod(method.Construct(local.Type), variable.Syntax, local.Name);
             }


### PR DESCRIPTION
Fixes #5993.

@dotnet/roslyn-compiler Please review.