### PR TITLE
Remove restore from targets file

### DIFF
--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -1,4 +1,4 @@
-<Project DefaultTargets="Build" InitialTargets="RestoreToolsetPackagesWrapper" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir;Configuration">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir;Configuration">
 
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)..\..\</ProjectDir>
@@ -21,37 +21,6 @@
     <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>
   </PropertyGroup>
 
-  <!-- Wrap the RestoreToolsetPackages target to prevent the output from being
-      referenced by other targets -->
-  <Target Name="RestoreToolsetPackagesWrapper" DependsOnTargets="RestoreToolsetPackages" />
-
-  <Target Name="RestoreToolsetPackages"
-          Inputs="$(ProjectDir)build\ToolsetPackages\project.json"
-          Outputs="$(ToolsetPackagesSemaphore);
-                   $(ToolsetCompilerPropsFilePath);
-                   $(RoslynDiagnosticsPropsFilePath)"
-          Condition="'$(OS)' == 'Windows_NT' AND '$(NuGetRestorePackages)' != 'false'">
-    <Message Importance="High" Text="Restoring toolset packages..." />
-
-    <!-- Run restore -->
-    <Exec Command="$(NuGetToolPath) restore $(ToolsetPackagesDir)project.json" />
-
-    <Error Text="Toolset compilers were not restored correctly. Could not find: $(ToolsetCompilerPropsFilePath)"
-           Condition="!Exists('$(ToolsetCompilerPropsFilePath)')" />
-    <Error Text="RoslynDiagnostics package was not restored correctly. Could not find: $(RoslynDiagnosticsPropsFilePath)"
-           Condition="!Exists('$(RoslynDiagnosticsPropsFilePath)')" />
-
-    <Touch Files="$(ToolsetCompilerPropsFilePath);$(RoslynDiagnosticsPropsFilePath)"
-           ContinueOnError="WarnAndContinue"
-           ForceTouch="true" />
-
-    <!-- Touch semaphore to indicate we're up to date -->
-    <Touch Files="$(ToolsetPackagesSemaphore)"
-           ContinueOnError="WarnAndContinue"
-           AlwaysCreate="true"
-           ForceTouch="true" />
-
-  </Target>
   <!-- This file is imported by all projects at the beginning of the project files -->
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
           Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') AND '$(MSBuildProjectExtension)' != '.vcxproj'" />


### PR DESCRIPTION
Our current setup has restore as a distinct step from build (done before).  Removing this code which used to attempt to restore in the middle of build.  At this point it's just chewing up build cycles.