### PR TITLE
This change increases the severity of analyzer exception diagnostic

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -777,7 +777,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var messageFormat = CodeAnalysisResources.CompilerAnalyzerThrows;
             var messageArguments = new[] { analyzerName, e.GetType().ToString(), e.Message };
             var description = string.Format(CodeAnalysisResources.CompilerAnalyzerThrowsDescription, analyzerName, e.ToString());
-            return CreateExceptionDiagnostic(AnalyzerExceptionDiagnosticId, title, description, messageFormat, messageArguments);
+            var descriptor = GetAnalyzerExceptionDiagnosticDescriptor(AnalyzerExceptionDiagnosticId, title, description, messageFormat);
+            return Diagnostic.Create(descriptor, Location.None, messageArguments);
         }
 
         internal static Diagnostic CreateDriverExceptionDiagnostic(Exception e)
@@ -786,25 +787,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var messageFormat = CodeAnalysisResources.AnalyzerDriverThrows;
             var messageArguments = new[] { e.GetType().ToString(), e.Message };
             var description = string.Format(CodeAnalysisResources.AnalyzerDriverThrowsDescription, e.ToString());
-            return CreateExceptionDiagnostic(AnalyzerDriverExceptionDiagnosticId, title, description, messageFormat, messageArguments);
+            var descriptor = GetAnalyzerExceptionDiagnosticDescriptor(AnalyzerDriverExceptionDiagnosticId, title, description, messageFormat);
+            return Diagnostic.Create(descriptor, Location.None, messageArguments);
         }
 
-        private static Diagnostic CreateExceptionDiagnostic(string id, string title, string description, string messageFormat, string[] messageArguments)
+        internal static DiagnosticDescriptor GetAnalyzerExceptionDiagnosticDescriptor(string id = null, string title = null, string description = null, string messageFormat = null)
         {
             // TODO: It is not ideal to create a new descriptor per analyzer exception diagnostic instance.
             // However, until we add a LongMessage field to the Diagnostic, we are forced to park the instance specific description onto the Descriptor's Description field.
             // This requires us to create a new DiagnosticDescriptor instance per diagnostic instance.
-            var descriptor = new DiagnosticDescriptor(
+
+            id = id ?? AnalyzerExceptionDiagnosticId;
+            title = title ?? CodeAnalysisResources.CompilerAnalyzerFailure;
+            messageFormat = messageFormat ?? CodeAnalysisResources.CompilerAnalyzerThrows;
+            description = description ?? CodeAnalysisResources.CompilerAnalyzerFailure;
+
+            return new DiagnosticDescriptor(
                 id,
                 title,
                 messageFormat,
                 description: description,
                 category: DiagnosticCategory,
-                defaultSeverity: DiagnosticSeverity.Info,
+                defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true,
                 customTags: WellKnownDiagnosticTags.AnalyzerException);
-
-            return Diagnostic.Create(descriptor, Location.None, messageArguments);
         }
 
         internal static bool IsAnalyzerExceptionDiagnostic(Diagnostic diagnostic)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     builder.Add(descriptor);
                 }
 
+                builder.Add(AnalyzerExecutor.GetAnalyzerExceptionDiagnosticDescriptor());
                 return builder.ToImmutable();
             }
         }

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7207,6 +7207,27 @@ End Class
         End Sub
 
         <Fact>
+        <WorkItem(3707, "https://github.com/dotnet/roslyn/issues/3707")>
+        Public Sub AnalyzerExceptionDiagnosticCanBeConfigured()
+            Dim source As String = Temp.CreateFile().WriteAllText(<text>
+Class C
+End Class
+</text>.Value).Path
+
+            Dim vbc = New MockVisualBasicCompiler(Nothing, _baseDirectory, {"/t:library", $"/warnaserror:{AnalyzerExecutor.AnalyzerExceptionDiagnosticId}", source},
+                                                  analyzer:=New AnalyzerThatThrowsInGetMessage)
+            Dim outWriter = New StringWriter()
+            Dim exitCode = vbc.Run(outWriter, Nothing)
+            Assert.NotEqual(0, exitCode)
+            Dim output = outWriter.ToString()
+
+            ' Verify that the analyzer exception diagnostic for the exception throw in AnalyzerThatThrowsInGetMessage is also reported.
+            Assert.Contains(AnalyzerExecutor.AnalyzerExceptionDiagnosticId, output, StringComparison.Ordinal)
+            Assert.Contains(NameOf(NotImplementedException), output, StringComparison.Ordinal)
+            CleanupAllGeneratedFiles(source)
+        End Sub
+
+        <Fact>
         <WorkItem(4589, "https://github.com/dotnet/roslyn/issues/4589")>
         Public Sub AnalyzerReportsMisformattedDiagnostic()
             Dim source As String = Temp.CreateFile().WriteAllText(<text>

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 messageFormat: FeaturesResources.UserDiagnosticAnalyzerThrows,
                 description: string.Format(FeaturesResources.UserDiagnosticAnalyzerThrowsDescription, analyzerName, e.ToString()),
                 category: AnalyzerExceptionDiagnosticCategory,
-                defaultSeverity: DiagnosticSeverity.Info,
+                defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true,
                 customTags: WellKnownDiagnosticTags.AnalyzerException);
 


### PR DESCRIPTION
…(AD0001), generated when an analyzer throws an exception, from info to a warning. Additionally, its descriptor is now reported as a supported diagnostic descriptor of the compiler analyzer, which ensures that it shows up in the ruleset editor.

**Customer scenario:** If an analyzer throws an exception, and the user hasn't increased the msbuild output verbosity to normal or higher, msbuild output will not output the diagnostics generated for analyzer exceptions, and the failure will be silently ignored. @jaredpar faced this issue recently while diagnosing another failure.

**Risk:** This is a somewhat breaking change as any project that currently builds fine with faulty analyzers will now fail (if warnaserror is enabled). However, this seems like a good break and the change has been approved by the Roslyn compat council.

**Fixes #3707**