### PR TITLE
Added quotes to filepath variables in GenerateCompilerInternals.targets

### DIFF
--- a/build/Targets/GenerateCompilerInternals.targets
+++ b/build/Targets/GenerateCompilerInternals.targets
@@ -51,7 +51,7 @@
     </PropertyGroup>
 
     <Exec
-      Command='$(SyntaxGenerator) @(SyntaxDefinition) $(GeneratedSyntaxModel)'
+      Command='$(SyntaxGenerator) "@(SyntaxDefinition)" "$(GeneratedSyntaxModel)"'
       Outputs="$(GeneratedSyntaxModel)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
@@ -144,7 +144,7 @@
     </PropertyGroup>
 
     <Exec
-      Command='$(BoundTreeGenerator) $(Language) @(BoundTreeDefinition) $(GeneratedBoundTree)'
+      Command='$(BoundTreeGenerator) $(Language) "@(BoundTreeDefinition)" "$(GeneratedBoundTree)"'
       Outputs="$(GeneratedBoundTree)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
@@ -181,7 +181,7 @@
     </PropertyGroup>
 
     <Exec
-      Command='$(ErrorFactsGenerator) @(ErrorCode) $(GeneratedErrorFacts)'
+      Command='$(ErrorFactsGenerator) "@(ErrorCode)" "$(GeneratedErrorFacts)"'
       Outputs="$(GeneratedErrorFacts)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />


### PR DESCRIPTION
While building CSharpCodeAnalysis.csproj, calls to SyntaxGenerator, BoundTreeGenerator and ErrorFactsGenerator fails when input or output filepaths have spaces in file or folder names.

This fix adds quotes around the filename variables in the Exec elements so that those generators can find source files in paths that have spaces.

Examples of build errors encountered are:

5>------ Rebuild All started: Project: CSharpCodeAnalysis, Configuration: Release Any CPU ------
5>  Invalid usage
5>  CSharpSyntaxGenerator.exe input-file output-file [/write-test]
5>CSC : error CS2001: Source file 'C:\Users\code\src\Roslyn Two\Roslyn\roslyn\Binaries\Obj\CSharpCodeAnalysis\Release\Syntax.xml.Generated.cs' could not be found.


5>------ Rebuild All started: Project: CSharpCodeAnalysis, Configuration: Release Any CPU ------
5>  Wrote C:\Users\code\src\Roslyn Two\Roslyn\roslyn\Binaries\Obj\CSharpCodeAnalysis\Release\Syntax.xml.Generated.cs
5>  Usage: "BoundTreeGenerator <language> <input> <output>", where <language> is "VB" or "CSharp"
5>C:\Users\code\src\Roslyn Two\Roslyn\roslyn\build\Targets\GenerateCompilerInternals.targets(146,5): error MSB3073: The command " "..\..\..\..\Binaries\Release\BoundTreeGenerator.exe" C# BoundTree\BoundNodes.xml C:\Users\code\src\Roslyn Two\Roslyn\roslyn\Binaries\Obj\CSharpCodeAnalysis\Release\BoundNodes.xml.Generated.cs" exited with code 1.


5>------ Rebuild All started: Project: CSharpCodeAnalysis, Configuration: Release Any CPU ------
5>  Wrote C:\Users\code\src\Roslyn Two\Roslyn\roslyn\Binaries\Obj\CSharpCodeAnalysis\Release\Syntax.xml.Generated.cs
5>  Usage: CSharpErrorFactsGenerator input output
5>    input     The path to ErrorCode.cs
5>    output    The path to GeneratedErrorFacts.cs
5>C:\Users\code\src\Roslyn Two\Roslyn\roslyn\build\Targets\GenerateCompilerInternals.targets(183,5): error MSB3073: The command " "..\..\..\..\Binaries\Release\CSharpErrorFactsGenerator.exe" Errors\ErrorCode.cs C:\Users\code\src\Roslyn Two\Roslyn\roslyn\Binaries\Obj\CSharpCodeAnalysis\Release\ErrorFacts.Generated.cs" exited with code -1.