### PR TITLE
Temporarily disable linux vbc CoreCLR bootstrap

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -154,8 +154,7 @@ build_roslyn()
     local bootstrapArg=""
 
     if [ "$OS_NAME" == "Linux" ]; then
-        bootstrapArg="/p:CscToolPath=$(pwd)/Binaries/Bootstrap /p:CscToolExe=csc \
-/p:VbcToolPath=$(pwd)/Binaries/Bootstrap /p:VbcToolExe=vbc"
+        bootstrapArg="/p:CscToolPath=$(pwd)/Binaries/Bootstrap /p:CscToolExe=csc"
     fi
 
     echo Building CrossPlatform.sln


### PR DESCRIPTION
It looks like CoreRun is hanging on the build machines and preventing
runs from starting. This only seems to be happening with vbc, so
disabling should get us back and running while I investigate.