### PR TITLE
Don't add accessors for a property with an arrow-body

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
         {
             Test(
 @"class C { int [||]GetFoo() => 0; }",
-@"class C { int Foo { get; } => 0; }");
+@"class C { int Foo => 0; }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        [WorkItem(6034, "https://github.com/dotnet/roslyn/issues/6034")]
         public void TestMethodWithArrowBody()
         {
             Test(

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -74,16 +74,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             var getAccessor = CreateGetAccessor(getAndSetMethods);
             var setAccessor = CreateSetAccessor(semanticModel, generator, getAndSetMethods);
 
-            var accessorList = SyntaxFactory.AccessorList(SyntaxFactory.SingletonList(getAccessor));
-            if (setAccessor != null)
-            {
-                accessorList = accessorList.AddAccessors(new[] { setAccessor });
-            }
-
             var property = SyntaxFactory.PropertyDeclaration(
                 getMethodDeclaration.AttributeLists, getMethodDeclaration.Modifiers, 
                 getMethodDeclaration.ReturnType, getMethodDeclaration.ExplicitInterfaceSpecifier, 
-                GetPropertyName(getMethodDeclaration.Identifier, propertyName, nameChanged), accessorList);
+                GetPropertyName(getMethodDeclaration.Identifier, propertyName, nameChanged), accessorList: null);
 
             IEnumerable<SyntaxTrivia> trivia = getMethodDeclaration.GetLeadingTrivia();
             var setMethodDeclaration = getAndSetMethods.SetMethodDeclaration;
@@ -97,6 +91,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             {
                 property = property.WithExpressionBody(getMethodDeclaration.ExpressionBody);
                 property = property.WithSemicolonToken(getMethodDeclaration.SemicolonToken);
+            }
+            else
+            {
+                var accessorList = SyntaxFactory.AccessorList(SyntaxFactory.SingletonList(getAccessor));
+                if (setAccessor != null)
+                {
+                    accessorList = accessorList.AddAccessors(new[] { setAccessor });
+                }
+
+                property = property.WithAccessorList(accessorList);
             }
 
             return property.WithAdditionalAnnotations(Formatter.Annotation);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/6034