### PR TITLE
Include the actual underlying exception in "failed to run".

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -200,7 +200,7 @@ namespace RunTests
             }
             catch (Exception ex)
             {
-                throw new Exception($"Unable to run {assemblyPath} with {_xunitConsolePath}", ex);
+                throw new Exception($"Unable to run {assemblyPath} with {_xunitConsolePath}. {ex}");
             }
         }
 


### PR DESCRIPTION
This enables to actually diagnose TestRunner issues if an exception
occurs during execution.