### PR TITLE
Do async locking correctly

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/RecoverableTextAndVersion.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/RecoverableTextAndVersion.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (_text == null)
             {
-                using (Gate.DisposableWait(cancellationToken))
+                using (await Gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                 {
                     if (_text == null)
                     {


### PR DESCRIPTION
Fixes #6012 

Same as #6019 in master

This change fixes incorrect usage of a lock in async method used in most common path in loading text from disk.

This potentially fixes problem reported in devdiv work item 132147.

@Pilchie @mattgertz 