### PR TITLE
Don't call PumpingWaitResult for the result of GetSyntaxTreeAsync

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             {
                 var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
 
-                var syntaxTree = document.GetSyntaxTreeAsync().PumpingWaitResult();
+                var syntaxTree = document.GetSyntaxTreeAsync().Result;
 
                 var service = document.GetLanguageService<IClassificationService>();
                 var classifiers = service.GetDefaultSyntaxClassifiers();

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             {
                 var snapshot = workspace.Documents.First().TextBuffer.CurrentSnapshot;
                 var document = workspace.CurrentSolution.Projects.First().Documents.First();
-                var tree = document.GetSyntaxTreeAsync().PumpingWaitResult();
+                var tree = document.GetSyntaxTreeAsync().Result;
 
                 var service = document.GetLanguageService<IClassificationService>();
                 var result = new List<ClassifiedSpan>();

--- a/src/EditorFeatures/TestUtilities/Async/WaitHelper.cs
+++ b/src/EditorFeatures/TestUtilities/Async/WaitHelper.cs
@@ -35,28 +35,6 @@ namespace Roslyn.Test.Utilities
             }
         }
 
-        public static async Task<bool> WhenAll(this IEnumerable<Task> tasks, TimeSpan timeout)
-        {
-            var delay = Task.Delay(timeout);
-            var list = tasks.Where(x => !x.IsCompleted).ToList();
-
-            list.Add(delay);
-            do
-            {
-                await Task.WhenAny(list).ConfigureAwait(true);
-                list.RemoveAll(x => x.IsCompleted);
-                if (list.Count == 0)
-                {
-                    return true;
-                }
-
-                if (delay.IsCompleted)
-                {
-                    return false;
-                }
-            } while (true);
-        }
-
         public static void WaitForDispatchedOperationsToComplete(DispatcherPriority priority)
         {
             Action action = delegate { };


### PR DESCRIPTION
We guarantee the tasks returned from GetSyntaxTreeAsync() are always
safe to wait for on any thread directly, so this was never necessary.

Reviewers: @dotnet/roslyn-ide, @davkean, @jaredpar