### PR TITLE
Test `EmitSequenceOfBinaryExpressions_03` in VB is failing in signed builds.

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -13247,7 +13247,9 @@ End Class
             CompileAndVerify(compilation, expectedOutput:="11461640193")
         End Sub
 
-        <Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/6077")>
+        <WorkItem(6077, "https://github.com/dotnet/roslyn/issues/6077")>
+        <WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")>
         Public Sub EmitSequenceOfBinaryExpressions_03()
             Dim source =
 $"


### PR DESCRIPTION
This is the VB portion of commit 2877a0b0a647201b00212ffcec3b9557e72fd385.  Part of #6077.

FYI: @agocke @amcasey @jaredpar @tannergooding