### PR TITLE
Fix a race condition in AsyncQueue.EnqueueCore

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
@@ -88,7 +88,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 waiter = _waiters.Dequeue();
             }
 
-            waiter.SetResult(value);
+            // Invoke SetResult on a separate task, as this invocation could cause the underlying task to executing,
+            // which could be a long running operation that can potentially cause a deadlock if executed on the current thread.
+            Task.Run(() => waiter.SetResult(value));
+
             return true;
         }
 


### PR DESCRIPTION
**Cause:** We are seeing intermittent deadlocks during build on linux machines running our test suites. The deadlock happens when one thread invokes AtomicSetFlagAndRaiseSymbolDeclaredEvent, and succeeds in setting the flag and invokes SymbolDeclaredEvent while holding onto the lock. The task scheduler decides to inline the event processing, which attempts to execute analyzers while holding onto the _diagnosticLock. Another thread meanwhile is already executing analyzers and calls back into the compiler and is waiting on _diagnosticLock.

**Fix:** Fix the AsyncQueue.EnqueueCore method to invoke `TaskCompletionSource.SetResult` on a separate task. This ensures that no external code executes while attempting to Enqueue a compilation event, and hence cannot deadlock.

**Testing:** All tests pass locally.

**Fixes #https://github.com/dotnet/roslyn/issues/6098**