### PR TITLE
Fixes REPL initialization and SourcePaths handling

### DIFF
--- a/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
@@ -50,13 +50,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Interactive
             get { return s_parseOptions; }
         }
 
-        protected override CompilationOptions GetSubmissionCompilationOptions(string name, MetadataReferenceResolver metadataReferenceResolver, SourceReferenceResolver sourceReferenceResolver)
+        protected override CompilationOptions GetSubmissionCompilationOptions(string name, MetadataReferenceResolver metadataReferenceResolver, SourceReferenceResolver sourceReferenceResolver, ImmutableArray<string> imports)
         {
             return new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 scriptClassName: name,
                 allowUnsafe: true,
                 xmlReferenceResolver: null, // no support for permission set and doc includes in interactive
+                usings: imports,
                 sourceReferenceResolver: sourceReferenceResolver,
                 metadataReferenceResolver: metadataReferenceResolver,
                 assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -40,12 +40,13 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         private readonly InteractiveHost _interactiveHost;
 
         private string _initialWorkingDirectory;
-        private ImmutableArray<CommandLineSourceFile> _rspSourceFiles;
+        private string _initialScriptFileOpt;
 
         private readonly IContentType _contentType;
         private readonly InteractiveWorkspace _workspace;
         private IInteractiveWindow _currentWindow;
         private ImmutableHashSet<MetadataReference> _references;
+        private ImmutableArray<string> _rspImports;
         private MetadataReferenceResolver _metadataReferenceResolver;
         private SourceReferenceResolver _sourceReferenceResolver;
 
@@ -90,11 +91,17 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             _commandsFactory = commandsFactory;
             _commands = commands;
 
-            var hostPath = interactiveHostPath;
-            _interactiveHost = new InteractiveHost(replType, hostPath, initialWorkingDirectory);
-            _interactiveHost.ProcessStarting += ProcessStarting;
-
+            // The following settings will apply when the REPL starts without .rsp file.
+            // They are discarded once the REPL is reset.
+            ReferenceSearchPaths = ImmutableArray<string>.Empty;
+            SourceSearchPaths = ImmutableArray<string>.Empty;
             WorkingDirectory = initialWorkingDirectory;
+            var metadataService = _workspace.CurrentSolution.Services.MetadataService;
+            _metadataReferenceResolver = CreateMetadataReferenceResolver(metadataService, ReferenceSearchPaths, _initialWorkingDirectory);
+            _sourceReferenceResolver = CreateSourceReferenceResolver(SourceSearchPaths, _initialWorkingDirectory);
+
+            _interactiveHost = new InteractiveHost(replType, interactiveHostPath, initialWorkingDirectory);
+            _interactiveHost.ProcessStarting += ProcessStarting;
         }
 
         public IContentType ContentType
@@ -139,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         }
 
         protected abstract string LanguageName { get; }
-        protected abstract CompilationOptions GetSubmissionCompilationOptions(string name, MetadataReferenceResolver metadataReferenceResolver, SourceReferenceResolver sourceReferenceResolver);
+        protected abstract CompilationOptions GetSubmissionCompilationOptions(string name, MetadataReferenceResolver metadataReferenceResolver, SourceReferenceResolver sourceReferenceResolver, ImmutableArray<string> imports);
         protected abstract ParseOptions ParseOptions { get; }
         protected abstract CommandLineParser CommandLineParser { get; }
 
@@ -197,40 +204,38 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             _previousSubmissionProjectId = null;
 
             var metadataService = _workspace.CurrentSolution.Services.MetadataService;
+            var mscorlibRef = metadataService.GetReference(typeof(object).Assembly.Location, MetadataReferenceProperties.Assembly);
+            var interactiveHostObjectRef = metadataService.GetReference(typeof(InteractiveScriptGlobals).Assembly.Location, MetadataReferenceProperties.Assembly);
 
-            ReferenceSearchPaths = ImmutableArray.Create(FileUtilities.NormalizeDirectoryPath(RuntimeEnvironment.GetRuntimeDirectory()));
-            SourceSearchPaths = ImmutableArray.Create(FileUtilities.NormalizeDirectoryPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+            _references = ImmutableHashSet.Create<MetadataReference>(mscorlibRef, interactiveHostObjectRef);
+            _rspImports = ImmutableArray<string>.Empty;
+            _initialScriptFileOpt = null;
+            ReferenceSearchPaths = ImmutableArray<string>.Empty;
+            SourceSearchPaths = ImmutableArray<string>.Empty;
 
             if (initialize && File.Exists(_responseFilePath))
             {
                 // The base directory for relative paths is the directory that contains the .rsp file.
                 // Note that .rsp files included by this .rsp file will share the base directory (Dev10 behavior of csc/vbc).
-                var rspArguments = this.CommandLineParser.Parse(new[] { "@" + _responseFilePath }, Path.GetDirectoryName(_responseFilePath), RuntimeEnvironment.GetRuntimeDirectory(), null /* TODO: pass a valid value*/);
-                ReferenceSearchPaths = ReferenceSearchPaths.AddRange(rspArguments.ReferencePaths);
+                var rspDirectory = Path.GetDirectoryName(_responseFilePath);
+                var args = this.CommandLineParser.Parse(new[] { "@" + _responseFilePath }, rspDirectory, RuntimeEnvironment.GetRuntimeDirectory(), null);
 
-                // the base directory for references specified in the .rsp file is the .rsp file directory:
-                var rspMetadataReferenceResolver = CreateMetadataReferenceResolver(metadataService, ReferenceSearchPaths, rspArguments.BaseDirectory);
+                if (args.Errors.Length == 0)
+                {
+                    var metadataResolver = CreateMetadataReferenceResolver(metadataService, args.ReferencePaths, rspDirectory);
+                    var sourceResolver = CreateSourceReferenceResolver(args.SourcePaths, rspDirectory);
 
-                // ignore unresolved references, they will be reported in the interactive window:
-                var rspReferences = rspArguments.ResolveMetadataReferences(rspMetadataReferenceResolver)
-                    .Where(r => !(r is UnresolvedMetadataReference));
+                    // ignore unresolved references, they will be reported in the interactive window:
+                    var rspReferences = args.ResolveMetadataReferences(metadataResolver).Where(r => !(r is UnresolvedMetadataReference));
 
-                var interactiveHelpersRef = metadataService.GetReference(typeof(Script).Assembly.Location, MetadataReferenceProperties.Assembly);
-                var interactiveHostObjectRef = metadataService.GetReference(typeof(InteractiveScriptGlobals).Assembly.Location, MetadataReferenceProperties.Assembly);
+                    _initialScriptFileOpt = args.SourceFiles.IsEmpty ? null : args.SourceFiles[0].Path;
 
-                _references = ImmutableHashSet.Create<MetadataReference>(
-                    interactiveHelpersRef,
-                    interactiveHostObjectRef)
-                    .Union(rspReferences);
+                    ReferenceSearchPaths = args.ReferencePaths;
+                    SourceSearchPaths = args.SourcePaths;
 
-                // we need to create projects for these:
-                _rspSourceFiles = rspArguments.SourceFiles;
-            }
-            else
-            {
-                var mscorlibRef = metadataService.GetReference(typeof(object).Assembly.Location, MetadataReferenceProperties.Assembly);
-                _references = ImmutableHashSet.Create<MetadataReference>(mscorlibRef);
-                _rspSourceFiles = ImmutableArray.Create<CommandLineSourceFile>();
+                    _references = _references.Union(rspReferences);
+                    _rspImports = CommandLineHelpers.GetImports(args);
+                }
             }
 
             _metadataReferenceResolver = CreateMetadataReferenceResolver(metadataService, ReferenceSearchPaths, _initialWorkingDirectory);
@@ -324,23 +329,30 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         {
             var solution = _workspace.CurrentSolution;
             Project project;
+            ImmutableArray<string> imports;
 
-            if (_previousSubmissionProjectId == null)
+            if (_previousSubmissionProjectId != null)
             {
-                // insert projects for initialization files listed in .rsp:
-                // If we have separate files, then those are implicitly #loaded. For this, we'll
-                // create a submission chain
-                foreach (var file in _rspSourceFiles)
-                {
-                    project = CreateSubmissionProject(solution, languageName);
-                    var documentId = DocumentId.CreateNewId(project.Id, debugName: file.Path);
-                    solution = project.Solution.AddDocument(documentId, Path.GetFileName(file.Path), new FileTextLoader(file.Path, defaultEncoding: null));
-                    _previousSubmissionProjectId = project.Id;
-                }
+                // only the first project needs imports
+                imports = ImmutableArray<string>.Empty;
+            }
+            else if (_initialScriptFileOpt != null)
+            {
+                // insert a project for initialization script listed in .rsp:
+                project = CreateSubmissionProject(solution, languageName, _rspImports);
+                var documentId = DocumentId.CreateNewId(project.Id, debugName: _initialScriptFileOpt);
+                solution = project.Solution.AddDocument(documentId, Path.GetFileName(_initialScriptFileOpt), new FileTextLoader(_initialScriptFileOpt, defaultEncoding: null));
+                _previousSubmissionProjectId = project.Id;
+
+                imports = ImmutableArray<string>.Empty;
+            }
+            else
+            {
+                imports = _rspImports;
             }
 
             // project for the new submission:
-            project = CreateSubmissionProject(solution, languageName);
+            project = CreateSubmissionProject(solution, languageName, imports);
 
             // Keep track of this buffer so we can freeze the classifications for it in the future.
             var viewAndBuffer = ValueTuple.Create(textView, subjectBuffer);
@@ -365,17 +377,14 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             _currentTextView = textView;
         }
 
-        private Project CreateSubmissionProject(Solution solution, string languageName)
+        private Project CreateSubmissionProject(Solution solution, string languageName, ImmutableArray<string> imports)
         {
             var name = "Submission#" + (_submissionCount++);
 
             // Grab a local copy so we aren't closing over the field that might change. The
             // collection itself is an immutable collection.
             var localReferences = _references;
-
-            // TODO (tomat): needs implementation in InteractiveHostService as well
-            // var localCompilationOptions = (rspArguments != null) ? rspArguments.CompilationOptions : CompilationOptions.Default;
-            var localCompilationOptions = GetSubmissionCompilationOptions(name, _metadataReferenceResolver, _sourceReferenceResolver);
+            var localCompilationOptions = GetSubmissionCompilationOptions(name, _metadataReferenceResolver, _sourceReferenceResolver, imports);
 
             var localParseOptions = ParseOptions;
 
@@ -446,7 +455,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         public Task<ExecutionResult> ResetAsync(bool initialize = true)
         {
             GetInteractiveWindow().AddInput(_interactiveCommands.CommandPrefix + "reset");
-            GetInteractiveWindow().WriteLine("Resetting execution engine.");
+            GetInteractiveWindow().WriteLine(InteractiveEditorFeaturesResources.ResettingExecutionEngine);
             GetInteractiveWindow().FlushOutput();
 
             return ResetAsyncWorker(initialize);

--- a/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.Designer.cs
+++ b/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.Designer.cs
@@ -77,5 +77,14 @@ namespace Microsoft.CodeAnalysis.Editor {
                 return ResourceManager.GetString("ResetCommandParametersDescription", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resetting execution engine..
+        /// </summary>
+        internal static string ResettingExecutionEngine {
+            get {
+                return ResourceManager.GetString("ResettingExecutionEngine", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.resx
+++ b/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.resx
@@ -123,4 +123,7 @@
   <data name="ResetCommandParametersDescription" xml:space="preserve">
     <value>Reset to a clean environment (only mscorlib referenced), do not run initialization script.</value>
   </data>
+  <data name="ResettingExecutionEngine" xml:space="preserve">
+    <value>Resetting execution engine.</value>
+  </data>
 </root>

--- a/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
+++ b/src/Interactive/EditorFeatures/VisualBasic/Interactive/VisualBasicInteractiveEvaluator.vb
@@ -55,7 +55,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Interactive
             End Get
         End Property
 
-        Protected Overrides Function GetSubmissionCompilationOptions(name As String, metadataReferenceResolver As MetadataReferenceResolver, sourceReferenceResolver As SourceReferenceResolver) As CompilationOptions
+        Protected Overrides Function GetSubmissionCompilationOptions(name As String, metadataReferenceResolver As MetadataReferenceResolver, sourceReferenceResolver As SourceReferenceResolver, [imports] As ImmutableArray(Of String)) As CompilationOptions
+            ' TODO: imports
             Return New VisualBasicCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 scriptClassName:=name,

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineHelpers.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineHelpers.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Scripting.Hosting
+{
+    internal static class CommandLineHelpers
+    {
+        // TODO (https://github.com/dotnet/roslyn/issues/5854): remove 
+        public static ImmutableArray<string> GetImports(CommandLineArguments args)
+        {
+            return args.CompilationOptions.GetImports();
+        }
+    }
+}

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -140,13 +140,10 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 return null;
             }
 
-            // TODO: https://github.com/dotnet/roslyn/issues/5854
-            var importedNamespaces = arguments.CompilationOptions.GetImports();
-
             return new ScriptOptions(
                 filePath: scriptPathOpt ?? "", 
                 references: ImmutableArray.CreateRange(resolvedReferences),
-                namespaces: importedNamespaces,
+                namespaces: CommandLineHelpers.GetImports(arguments),
                 metadataResolver: metadataResolver,
                 sourceResolver: sourceResolver);
         }

--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Hosting\AssemblyLoader\CoreAssemblyLoaderImpl.cs" />
     <Compile Include="Hosting\AssemblyLoader\DesktopAssemblyLoaderImpl.cs" />
     <Compile Include="Hosting\AssemblyLoader\AssemblyLoaderImpl.cs" />
+    <Compile Include="Hosting\CommandLine\CommandLineHelpers.cs" />
     <Compile Include="Hosting\CommandLine\CommandLineScriptGlobals.cs" />
     <Compile Include="Hosting\CommandLine\CommandLineRunner.cs" />
     <Compile Include="Hosting\CommandLine\ConsoleIO.cs" />
@@ -111,7 +112,7 @@
     <InternalsVisibleTo Include="csi" />
     <InternalsVisibleTo Include="vbi" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.InteractiveFeatures" />
-     <!-- TODO: remove, see https://github.com/dotnet/roslyn/issues/5661 -->
+    <!-- TODO: remove, see https://github.com/dotnet/roslyn/issues/5661 -->
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures" />


### PR DESCRIPTION
Fixes bug https://github.com/dotnet/roslyn/issues/5438.
Fixes #load completion to consider source search paths.
Fixes .rsp file processing to initialize search paths and imports correctly.