### PR TITLE
TryReduce should return TypeArgumentList span for GenericNameSyntax node

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
@@ -1182,7 +1182,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Dim genericName = DirectCast(name, GenericNameSyntax)
                     replacementNode = SyntaxFactory.IdentifierName(genericName.Identifier).WithLeadingTrivia(genericName.GetLeadingTrivia()).WithTrailingTrivia(genericName.GetTrailingTrivia())
 
-                    issueSpan = name.Span
+                    issueSpan = genericName.TypeArgumentList.Span
                     Return name.CanReplaceWithReducedName(replacementNode, semanticModel, cancellationToken)
                 End If
 


### PR DESCRIPTION
This change resolves the issue reported in #3300 