### PR TITLE
Remove Microsoft.CodeAnalysis.Test.Resources.Proprietary reference to fix #6199

### DIFF
--- a/src/EditorFeatures/CSharpTest2/project.json
+++ b/src/EditorFeatures/CSharpTest2/project.json
@@ -1,6 +1,5 @@
 ﻿{
   "dependencies": {
-    "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.1.0-beta1-20150824-02",
     "Moq": "4.2.1402.2112",
     "System.Diagnostics.Process": "4.0.0-beta-23123",
     "xunit": "2.1.0",


### PR DESCRIPTION
This package is now transitivity referenced at root.