### PR TITLE
Implements recursive reference aliases

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -357,6 +357,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Dictionary<MetadataReference, int> referencedAssembliesMap, referencedModulesMap;
                     ImmutableArray<ImmutableArray<string>> aliasesOfReferencedAssemblies;
                     BuildReferencedAssembliesAndModulesMaps(
+                        bindingResult,
                         references,
                         referenceMap,
                         modules.Length,

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferencePropertiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferencePropertiesTests.cs
@@ -49,14 +49,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void WithXxx()
         {
-            var p = new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a"), embedInteropTypes: false);
+            var a = new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a"), embedInteropTypes: true);
 
-            Assert.Equal(p.WithAliases(null), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray<string>.Empty, embedInteropTypes: false));
-            Assert.Equal(p.WithAliases(default(ImmutableArray<string>)), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray<string>.Empty, embedInteropTypes: false));
-            Assert.Equal(p.WithAliases(ImmutableArray<string>.Empty), new MetadataReferenceProperties(MetadataImageKind.Assembly, default(ImmutableArray<string>), embedInteropTypes: false));
-            Assert.Equal(p.WithAliases(new string[0]), new MetadataReferenceProperties(MetadataImageKind.Assembly, default(ImmutableArray<string>), embedInteropTypes: false));
-            Assert.Equal(p.WithAliases(new[] { "foo", "aaa" }), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("foo", "aaa"), embedInteropTypes: false));
-            Assert.Equal(p.WithEmbedInteropTypes(true), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a"), embedInteropTypes: true));
+            Assert.Equal(a.WithAliases(null), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray<string>.Empty, embedInteropTypes: true));
+            Assert.Equal(a.WithAliases(default(ImmutableArray<string>)), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray<string>.Empty, embedInteropTypes: true));
+            Assert.Equal(a.WithAliases(ImmutableArray<string>.Empty), new MetadataReferenceProperties(MetadataImageKind.Assembly, default(ImmutableArray<string>), embedInteropTypes: true));
+            Assert.Equal(a.WithAliases(new string[0]), new MetadataReferenceProperties(MetadataImageKind.Assembly, default(ImmutableArray<string>), embedInteropTypes: true));
+            Assert.Equal(a.WithAliases(new[] { "foo", "aaa" }), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("foo", "aaa"), embedInteropTypes: true));
+            Assert.Equal(a.WithEmbedInteropTypes(false), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a"), embedInteropTypes: false));
+            Assert.Equal(a.WithRecursiveAliases(true), new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a"), embedInteropTypes: true, hasRecursiveAliases: true));
 
             var m = new MetadataReferenceProperties(MetadataImageKind.Module);
             Assert.Equal(m.WithAliases(default(ImmutableArray<string>)), new MetadataReferenceProperties(MetadataImageKind.Module, default(ImmutableArray<string>), embedInteropTypes: false));

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void CreateFromFile()
+        public void CreateFromFile_Assembly()
         {
             var file = Temp.CreateFile().WriteAllBytes(TestResources.NetFX.v4_0_30319.mscorlib);
 
@@ -91,10 +91,34 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.False(r.Properties.EmbedInteropTypes);
             Assert.True(r.Properties.Aliases.IsEmpty);
 
+            var props = new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a", "b"), embedInteropTypes: true, hasRecursiveAliases: true);
+            Assert.Equal(props, MetadataReference.CreateFromFile(file.Path, props).Properties);
+
             // check that the metadata is in memory and the file can be deleted:
             File.Delete(file.Path);
             var metadata = (AssemblyMetadata)r.GetMetadata();
             Assert.Equal("CommonLanguageRuntimeLibrary", metadata.GetModules()[0].Name);
+        }
+
+        [Fact]
+        public void CreateFromFile_Module()
+        {
+            var file = Temp.CreateFile().WriteAllBytes(TestResources.MetadataTests.NetModule01.ModuleCS00);
+
+            var r = MetadataReference.CreateFromFile(file.Path, MetadataReferenceProperties.Module);
+            Assert.Equal(file.Path, r.FilePath);
+            Assert.Equal(file.Path, r.Display);
+            Assert.Equal(MetadataImageKind.Module, r.Properties.Kind);
+            Assert.False(r.Properties.EmbedInteropTypes);
+            Assert.True(r.Properties.Aliases.IsEmpty);
+
+            var props = new MetadataReferenceProperties(MetadataImageKind.Module);
+            Assert.Equal(props, MetadataReference.CreateFromFile(file.Path, props).Properties);
+
+            // check that the metadata is in memory and the file can be deleted:
+            File.Delete(file.Path);
+            var metadata = (ModuleMetadata)r.GetMetadata();
+            Assert.Equal("ModuleCS00.netmodule", metadata.Name);
         }
 
         [Fact]
@@ -108,6 +132,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.False(r.Properties.EmbedInteropTypes);
             Assert.True(r.Properties.Aliases.IsEmpty);
             Assert.Same(DocumentationProvider.Default, r.DocumentationProvider);
+
+            var props = new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("a", "b"), embedInteropTypes: true, hasRecursiveAliases: true);
+            Assert.Equal(props, MetadataReference.CreateFromAssemblyInternal(assembly, props).Properties);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -58,6 +58,7 @@
     <Compile Include="InternalUtilities\StackGuard.cs" />
     <Compile Include="InternalUtilities\StreamExtensions.cs" />
     <Compile Include="RealParser.cs" />
+    <Compile Include="ReferenceManager\MergedAliases.cs" />
     <Compile Include="UnicodeCharacterUtilities.cs" />
     <Compile Include="CodeAnalysisResources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Compilers/Core/Portable/MetadataReference/CompilationReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/CompilationReference.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException">Alias is invalid for the metadata kind.</exception> 
         public new CompilationReference WithAliases(ImmutableArray<string> aliases)
         {
-            return WithProperties(new MetadataReferenceProperties(this.Properties.Kind, aliases, this.Properties.EmbedInteropTypes));
+            return WithProperties(Properties.WithAliases(aliases));
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException">Interop types can't be embedded from modules.</exception> 
         public new CompilationReference WithEmbedInteropTypes(bool value)
         {
-            return WithProperties(new MetadataReferenceProperties(this.Properties.Kind, this.Properties.Aliases, value));
+            return WithProperties(Properties.WithEmbedInteropTypes(value));
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException">Interop types can't be embedded from modules.</exception> 
         public MetadataReference WithEmbedInteropTypes(bool value)
         {
-            return WithProperties(new MetadataReferenceProperties(this.Properties.Kind, this.Properties.Aliases, value));
+            return WithProperties(Properties.WithEmbedInteropTypes(value));
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException">Alias is invalid for the metadata kind.</exception> 
         public MetadataReference WithAliases(ImmutableArray<string> aliases)
         {
-            return WithProperties(new MetadataReferenceProperties(this.Properties.Kind, aliases, this.Properties.EmbedInteropTypes));
+            return WithProperties(Properties.WithAliases(aliases));
         }
 
         /// <summary>
@@ -236,13 +236,12 @@ namespace Microsoft.CodeAnalysis
 
             if (properties.Kind == MetadataImageKind.Module)
             {
-                return module.GetReference(documentation, path);
+                return new MetadataImageReference(module, properties, documentation, path, display: null);
             }
 
             // any additional modules constituting the assembly will be read lazily:
             var assemblyMetadata = AssemblyMetadata.CreateFromFile(module, path);
-
-            return assemblyMetadata.GetReference(documentation, properties.Aliases, properties.EmbedInteropTypes, path);
+            return new MetadataImageReference(assemblyMetadata, properties, documentation, path, display: null);
         }
 
         /// <summary>
@@ -326,7 +325,7 @@ namespace Microsoft.CodeAnalysis
             // which might also lock the file until the reference is GC'd.
             var metadata = AssemblyMetadata.CreateFromStream(peStream);
 
-            return metadata.GetReference(documentation, properties.Aliases, properties.EmbedInteropTypes, filePath: location);
+            return new MetadataImageReference(metadata, properties, documentation, location, display: null);
         }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceProperties.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceProperties.cs
@@ -68,7 +68,13 @@ namespace Microsoft.CodeAnalysis
             _kind = kind;
             _aliases = aliases;
             _embedInteropTypes = embedInteropTypes;
-            IsRecursive = false;
+            HasRecursiveAliases = false;
+        }
+
+        internal MetadataReferenceProperties(MetadataImageKind kind, ImmutableArray<string> aliases, bool embedInteropTypes, bool hasRecursiveAliases)
+            : this(kind, aliases, embedInteropTypes)
+        {
+            HasRecursiveAliases = hasRecursiveAliases;
         }
 
         /// <summary>
@@ -90,7 +96,7 @@ namespace Microsoft.CodeAnalysis
         /// </exception>
         public MetadataReferenceProperties WithAliases(ImmutableArray<string> aliases)
         {
-            return new MetadataReferenceProperties(_kind, aliases, this.EmbedInteropTypes);
+            return new MetadataReferenceProperties(_kind, aliases, _embedInteropTypes, HasRecursiveAliases);
         }
 
         /// <summary>
@@ -99,15 +105,15 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException"><see cref="Kind"/> is <see cref="MetadataImageKind.Module"/>, as interop types can't be embedded from modules.</exception>
         public MetadataReferenceProperties WithEmbedInteropTypes(bool embedInteropTypes)
         {
-            return new MetadataReferenceProperties(_kind, _aliases, embedInteropTypes);
+            return new MetadataReferenceProperties(_kind, _aliases, embedInteropTypes, HasRecursiveAliases);
         }
 
         /// <summary>
-        /// Returns <see cref="MetadataReferenceProperties"/> with <see cref="IsRecursive"/> set to specified value.
+        /// Returns <see cref="MetadataReferenceProperties"/> with <see cref="HasRecursiveAliases"/> set to specified value.
         /// </summary>
-        internal MetadataReferenceProperties WithIsRecursive(bool value)
+        internal MetadataReferenceProperties WithRecursiveAliases(bool value)
         {
-            return new MetadataReferenceProperties(_kind, _aliases, _embedInteropTypes) { IsRecursive = value };
+            return new MetadataReferenceProperties(_kind, _aliases, _embedInteropTypes, value);
         }
 
         /// <summary>
@@ -143,7 +149,11 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public bool EmbedInteropTypes => _embedInteropTypes;
 
-        internal bool IsRecursive { get; private set; }
+        /// <summary>
+        /// True to apply <see cref="Aliases"/> recursively on the target assembly and on all its transitive dependencies.
+        /// False to apply <see cref="Aliases"/> only on the target assembly.
+        /// </summary>
+        internal bool HasRecursiveAliases { get; private set; }
 
         public override bool Equals(object obj)
         {
@@ -155,12 +165,12 @@ namespace Microsoft.CodeAnalysis
             return Aliases.SequenceEqual(other.Aliases)
                 && _embedInteropTypes == other._embedInteropTypes
                 && _kind == other._kind
-                && IsRecursive == other.IsRecursive;
+                && HasRecursiveAliases == other.HasRecursiveAliases;
         }
 
         public override int GetHashCode()
         {
-            return Hash.Combine(Hash.CombineValues(Aliases), Hash.Combine(_embedInteropTypes, Hash.Combine(IsRecursive, _kind.GetHashCode())));
+            return Hash.Combine(Hash.CombineValues(Aliases), Hash.Combine(_embedInteropTypes, Hash.Combine(HasRecursiveAliases, _kind.GetHashCode())));
         }
 
         public static bool operator ==(MetadataReferenceProperties left, MetadataReferenceProperties right)

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceProperties.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceProperties.cs
@@ -68,6 +68,7 @@ namespace Microsoft.CodeAnalysis
             _kind = kind;
             _aliases = aliases;
             _embedInteropTypes = embedInteropTypes;
+            IsRecursive = false;
         }
 
         /// <summary>
@@ -99,6 +100,14 @@ namespace Microsoft.CodeAnalysis
         public MetadataReferenceProperties WithEmbedInteropTypes(bool embedInteropTypes)
         {
             return new MetadataReferenceProperties(_kind, _aliases, embedInteropTypes);
+        }
+
+        /// <summary>
+        /// Returns <see cref="MetadataReferenceProperties"/> with <see cref="IsRecursive"/> set to specified value.
+        /// </summary>
+        internal MetadataReferenceProperties WithIsRecursive(bool value)
+        {
+            return new MetadataReferenceProperties(_kind, _aliases, _embedInteropTypes) { IsRecursive = value };
         }
 
         /// <summary>
@@ -134,6 +143,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public bool EmbedInteropTypes => _embedInteropTypes;
 
+        internal bool IsRecursive { get; private set; }
+
         public override bool Equals(object obj)
         {
             return obj is MetadataReferenceProperties && Equals((MetadataReferenceProperties)obj);
@@ -143,12 +154,13 @@ namespace Microsoft.CodeAnalysis
         {
             return Aliases.SequenceEqual(other.Aliases)
                 && _embedInteropTypes == other._embedInteropTypes
-                && _kind == other._kind;
+                && _kind == other._kind
+                && IsRecursive == other.IsRecursive;
         }
 
         public override int GetHashCode()
         {
-            return Hash.Combine(Hash.CombineValues(Aliases), Hash.Combine(_embedInteropTypes, _kind.GetHashCode()));
+            return Hash.Combine(Hash.CombineValues(Aliases), Hash.Combine(_embedInteropTypes, Hash.Combine(IsRecursive, _kind.GetHashCode())));
         }
 
         public static bool operator ==(MetadataReferenceProperties left, MetadataReferenceProperties right)

--- a/src/Compilers/Core/Portable/MetadataReference/PortableExecutableReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/PortableExecutableReference.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException">Alias is invalid for the metadata kind.</exception> 
         public new PortableExecutableReference WithAliases(ImmutableArray<string> aliases)
         {
-            return WithProperties(new MetadataReferenceProperties(this.Properties.Kind, aliases, this.Properties.EmbedInteropTypes));
+            return WithProperties(Properties.WithAliases(aliases));
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentException">Interop types can't be embedded from modules.</exception> 
         public new PortableExecutableReference WithEmbedInteropTypes(bool value)
         {
-            return WithProperties(new MetadataReferenceProperties(this.Properties.Kind, this.Properties.Aliases, value));
+            return WithProperties(Properties.WithEmbedInteropTypes(value));
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis
             var metadataReferencesBuilder = ArrayBuilder<MetadataReference>.GetInstance();
 
             Dictionary<string, List<ReferencedAssemblyIdentity>> lazyResolvedReferencesBySimpleName = null;
-            Dictionary<MetadataReference, ArrayBuilder<string>> lazyAliasMap = null;
+            Dictionary<MetadataReference, MergedAliases> lazyAliasMap = null;
 
             // metadata references and corresponding bindings of their references, used to calculate a fixed point:
             var referenceBindingsToProcess = ArrayBuilder<ValueTuple<MetadataReference, ArraySegment<AssemblyReferenceBinding>>>.GetInstance();
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis
                     var referenceAndBindings = referenceBindingsToProcess.Pop();
                     var requestingReference = referenceAndBindings.Item1;
                     var bindings = referenceAndBindings.Item2;
-
+                    
                     foreach (var binding in bindings)
                     {
                         // only attempt to resolve unbound references (regardless of version difference of the bound ones)
@@ -380,14 +380,14 @@ namespace Microsoft.CodeAnalysis
 
         private static ImmutableArray<ResolvedReference> ToResolvedAssemblyReferences(
             ImmutableArray<MetadataReference> references,           
-            Dictionary<MetadataReference, ArrayBuilder<string>> aliasMapOpt,
+            Dictionary<MetadataReference, MergedAliases> propertyMapOpt,
             int explicitAssemblyCount)
         {
             var result = ArrayBuilder<ResolvedReference>.GetInstance(references.Length);
             for (int i = 0; i < references.Length; i++)
             {
                 // -1 for assembly being built
-                result.Add(new ResolvedReference(explicitAssemblyCount - 1 + i, MetadataImageKind.Assembly, GetAndFreeAliases(references[i], aliasMapOpt)));
+                result.Add(GetResolvedReferenceAndFreePropertyMapEntry(references[i], explicitAssemblyCount - 1 + i, MetadataImageKind.Assembly, propertyMapOpt));
             }
 
             return result.ToImmutableAndFree();

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -52,23 +52,54 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly MetadataImageKind _kind;
             private readonly int _index;
-            private readonly ImmutableArray<string> _aliases;
+            private readonly ImmutableArray<string> _aliasesOpt;
+            private readonly ImmutableArray<string> _recursiveAliasesOpt;
 
-            public ResolvedReference(int index, MetadataImageKind kind, ImmutableArray<string> aliases)
+            // uninitialized aliases
+            public ResolvedReference(int index, MetadataImageKind kind)
+                : this(index, kind, default(ImmutableArray<string>), default(ImmutableArray<string>))
+            {
+            }
+
+            // initialized aliases
+            public ResolvedReference(int index, MetadataImageKind kind, ImmutableArray<string> aliasesOpt, ImmutableArray<string> recursiveAliasesOpt)
             {
                 Debug.Assert(index >= 0);
+                Debug.Assert(_aliasesOpt.IsDefault || _recursiveAliasesOpt.IsDefault);
 
                 _index = index + 1;
                 _kind = kind;
-                _aliases = aliases;
+                _aliasesOpt = aliasesOpt;
+                _recursiveAliasesOpt = recursiveAliasesOpt;
             }
 
-            public ImmutableArray<string> Aliases
+            private bool IsUninitialized => _aliasesOpt.IsDefault && _recursiveAliasesOpt.IsDefault;
+
+            /// <summary>
+            /// Aliases that should be applied to the referenced assembly. 
+            /// Empty array means {global} (all namespaces and global types are accessible without qualification).
+            /// Null if not applicable (the reference only has recursive aliases).
+            /// </summary>
+            public ImmutableArray<string> AliasesOpt
             {
                 get
                 {
-                    Debug.Assert(!_aliases.IsDefault);
-                    return _aliases;
+                    Debug.Assert(!IsUninitialized);
+                    return _aliasesOpt;
+                }
+            }
+
+            /// <summary>
+            /// Aliases that should be applied recursively to all dependent assemblies. 
+            /// Empty array means {global} (all namespaces and global types are accessible without qualification).
+            /// Null if not applicable (the reference only has simple aliases).
+            /// </summary>
+            public ImmutableArray<string> RecursiveAliasesOpt
+            {
+                get
+                {
+                    Debug.Assert(!IsUninitialized);
+                    return _recursiveAliasesOpt;
                 }
             }
 
@@ -106,7 +137,12 @@ namespace Microsoft.CodeAnalysis
 
             private string GetDebuggerDisplay()
             {
-                return IsSkipped ? "<skipped>" : $"{(_kind == MetadataImageKind.Assembly ? "A" : "M")}[{Index}]: aliases='{string.Join("','", _aliases)}'";
+                return IsSkipped ? "<skipped>" : $"{(_kind == MetadataImageKind.Assembly ? "A" : "M")}[{Index}]:{DisplayAliases(_aliasesOpt, "aliases")}{DisplayAliases(_recursiveAliasesOpt, "recursive-aliases")}";
+            }
+
+            private static string DisplayAliases(ImmutableArray<string> aliasesOpt, string name)
+            {
+                return aliasesOpt.IsDefault ? "" : $" {name} = '{string.Join("','", aliasesOpt)}'";
             }
         }
 
@@ -156,7 +192,7 @@ namespace Microsoft.CodeAnalysis
 
             // Maps references that were added to the reference set (i.e. not filtered out as duplicates) to a set of names that 
             // can be used to alias these references. Duplicate assemblies contribute their aliases into this set.
-            Dictionary<MetadataReference, ArrayBuilder<string>> aliasMap = null;
+            Dictionary<MetadataReference, MergedAliases> lazyAliasMap = null;
 
             // Used to filter out duplicate references that reference the same file (resolve to the same full normalized path).
             var boundReferences = new Dictionary<MetadataReference, MetadataReference>(MetadataReferenceEqualityComparer.Instance);
@@ -187,7 +223,7 @@ namespace Microsoft.CodeAnalysis
                     // merge properties of compilation-based references if the underlying compilations are the same
                     if ((object)boundReference != existingReference)
                     {
-                        MergeReferenceProperties(existingReference, boundReference, diagnostics, ref aliasMap);
+                        MergeReferenceProperties(existingReference, boundReference, diagnostics, ref lazyAliasMap);
                     }
 
                     continue;
@@ -223,7 +259,7 @@ namespace Microsoft.CodeAnalysis
 
                             if (existingReference != null)
                             {
-                                MergeReferenceProperties(existingReference, boundReference, diagnostics, ref aliasMap);
+                                MergeReferenceProperties(existingReference, boundReference, diagnostics, ref lazyAliasMap);
                                 continue;
                             }
 
@@ -270,7 +306,7 @@ namespace Microsoft.CodeAnalysis
 
                                 if (existingReference != null)
                                 {
-                                    MergeReferenceProperties(existingReference, boundReference, diagnostics, ref aliasMap);
+                                    MergeReferenceProperties(existingReference, boundReference, diagnostics, ref lazyAliasMap);
                                     continue;
                                 }
 
@@ -344,7 +380,7 @@ namespace Microsoft.CodeAnalysis
                         : ((object)modulesBuilder == null ? 0 : modulesBuilder.Count);
 
                     int reversedIndex = count - 1 - referenceMap[i].Index;
-                    referenceMap[i] = new ResolvedReference(reversedIndex, referenceMap[i].Kind, GetAndFreeAliases(references[i], aliasMap));
+                    referenceMap[i] = GetResolvedReferenceAndFreePropertyMapEntry(references[i], reversedIndex, referenceMap[i].Kind, lazyAliasMap);
                 }
             }
 
@@ -371,15 +407,28 @@ namespace Microsoft.CodeAnalysis
             return ImmutableArray.CreateRange(referenceMap);
         }
 
-        private static ImmutableArray<string> GetAndFreeAliases(MetadataReference reference, Dictionary<MetadataReference, ArrayBuilder<string>> aliasMapOpt)
+        private static ResolvedReference GetResolvedReferenceAndFreePropertyMapEntry(MetadataReference reference, int index, MetadataImageKind kind, Dictionary<MetadataReference, MergedAliases> propertyMapOpt)
         {
-            ArrayBuilder<string> aliases;
-            if (aliasMapOpt != null && aliasMapOpt.TryGetValue(reference, out aliases))
+            ImmutableArray<string> aliasesOpt, recursiveAliasesOpt;
+
+            MergedAliases mergedProperties;
+            if (propertyMapOpt != null && propertyMapOpt.TryGetValue(reference, out mergedProperties))
             {
-                return aliases.ToImmutableAndFree();
+                aliasesOpt = mergedProperties.AliasesOpt?.ToImmutableAndFree() ?? default(ImmutableArray<string>);
+                recursiveAliasesOpt = mergedProperties.RecursiveAliasesOpt?.ToImmutableAndFree() ?? default(ImmutableArray<string>);
+            }
+            else if (reference.Properties.IsRecursive)
+            {
+                aliasesOpt = default(ImmutableArray<string>);
+                recursiveAliasesOpt = reference.Properties.Aliases;
+            }
+            else
+            {
+                aliasesOpt = reference.Properties.Aliases;
+                recursiveAliasesOpt = default(ImmutableArray<string>);
             }
 
-            return reference.Properties.Aliases;
+            return new ResolvedReference(index, kind, aliasesOpt, recursiveAliasesOpt);
         }
 
         /// <summary>
@@ -505,43 +554,27 @@ namespace Microsoft.CodeAnalysis
         /// Merges aliases of the first observed reference (<paramref name="primaryReference"/>) with aliases specified for an equivalent reference (<paramref name="newReference"/>).
         /// Empty alias list is considered to be the same as a list containing "global", since in both cases C# allows unqualified access to the symbols.
         /// </summary>
-        private void MergeReferenceProperties(MetadataReference primaryReference, MetadataReference newReference, DiagnosticBag diagnostics, ref Dictionary<MetadataReference, ArrayBuilder<string>> aliasMap)
+        private void MergeReferenceProperties(MetadataReference primaryReference, MetadataReference newReference, DiagnosticBag diagnostics, ref Dictionary<MetadataReference, MergedAliases> lazyAliasMap)
         {
             if (!CheckPropertiesConsistency(newReference, primaryReference, diagnostics))
             {
                 return;
             }
 
-            if (aliasMap == null)
+            if (lazyAliasMap == null)
             {
-                aliasMap = new Dictionary<MetadataReference, ArrayBuilder<string>>();
+                lazyAliasMap = new Dictionary<MetadataReference, MergedAliases>();
             }
 
-            ArrayBuilder<string> aliases;
-            if (!aliasMap.TryGetValue(primaryReference, out aliases))
+            MergedAliases mergedAliases;
+            if (!lazyAliasMap.TryGetValue(primaryReference, out mergedAliases))
             {
-                aliases = ArrayBuilder<string>.GetInstance();
-                aliasMap.Add(primaryReference, aliases);
-
-                if (primaryReference.Properties.Aliases.IsEmpty)
-                {
-                    aliases.Add(MetadataReferenceProperties.GlobalAlias);
-                }
-                else
-                {
-                    aliases.AddRange(primaryReference.Properties.Aliases);
-                }
+                mergedAliases = new MergedAliases();
+                lazyAliasMap.Add(primaryReference, mergedAliases);
+                mergedAliases.Merge(primaryReference);
             }
 
-            // we could avoid duplicates but there is no need to do so:
-            if (newReference.Properties.Aliases.IsEmpty)
-            {
-                aliases.Add(MetadataReferenceProperties.GlobalAlias);
-            }
-            else
-            {
-                aliases.AddRange(newReference.Properties.Aliases);
-            }
+            mergedAliases.Merge(newReference);
         }
 
         /// <remarks>
@@ -555,7 +588,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // aliases will be filled in later:
-            referenceMap[referenceIndex] = new ResolvedReference(assemblies.Count, MetadataImageKind.Assembly, default(ImmutableArray<string>));
+            referenceMap[referenceIndex] = new ResolvedReference(assemblies.Count, MetadataImageKind.Assembly);
             assemblies.Add(data);
         }
 
@@ -569,7 +602,7 @@ namespace Microsoft.CodeAnalysis
                 modules = ArrayBuilder<PEModule>.GetInstance();
             }
 
-            referenceMap[referenceIndex] = new ResolvedReference(modules.Count, MetadataImageKind.Module, default(ImmutableArray<string>));
+            referenceMap[referenceIndex] = new ResolvedReference(modules.Count, MetadataImageKind.Module);
             modules.Add(module);
         }
 

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -381,6 +381,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         protected static void BuildReferencedAssembliesAndModulesMaps(
+            BoundInputAssembly[] bindingResult,
             ImmutableArray<MetadataReference> references,
             ImmutableArray<ResolvedReference> referenceMap,
             int referencedModuleCount,
@@ -391,6 +392,7 @@ namespace Microsoft.CodeAnalysis
             referencedAssembliesMap = new Dictionary<MetadataReference, int>(referenceMap.Length);
             referencedModulesMap = new Dictionary<MetadataReference, int>(referencedModuleCount);
             var aliasesOfReferencedAssembliesBuilder = ArrayBuilder<ImmutableArray<string>>.GetInstance(referenceMap.Length - referencedModuleCount);
+            bool hasRecursiveAliases = false;
 
             for (int i = 0; i < referenceMap.Length; i++)
             {
@@ -412,11 +414,87 @@ namespace Microsoft.CodeAnalysis
                     Debug.Assert(aliasesOfReferencedAssembliesBuilder.Count == assemblyIndex);
 
                     referencedAssembliesMap.Add(references[i], assemblyIndex);
-                    aliasesOfReferencedAssembliesBuilder.Add(referenceMap[i].Aliases);
+                    aliasesOfReferencedAssembliesBuilder.Add(referenceMap[i].AliasesOpt);
+
+                    hasRecursiveAliases |= !referenceMap[i].RecursiveAliasesOpt.IsDefault;
                 }
             }
 
+            if (hasRecursiveAliases)
+            {
+                PropagateRecursiveAliases(bindingResult, referenceMap, aliasesOfReferencedAssembliesBuilder);
+            }
+
+            Debug.Assert(!aliasesOfReferencedAssembliesBuilder.Any(a => a.IsDefault));
             aliasesOfReferencedAssemblies = aliasesOfReferencedAssembliesBuilder.ToImmutableAndFree();
+        }
+
+        // #r references are recursive, their aliases should be merged into all their dependencies.
+        //
+        // For example, if a compilation has a reference to LibA with alias A and the user #r's LibB with alias B,
+        // which references LibA, LibA should be available under both aliases A and B. B is usually "global",
+        // which means LibA namespaces should become available to the compilation without any qualification when #r LibB 
+        // is encountered.
+        // 
+        // Pairs: (assembly index -- index into bindingResult array; index of the #r reference in referenceMap array).
+        private static void PropagateRecursiveAliases(
+            BoundInputAssembly[] bindingResult,
+            ImmutableArray<ResolvedReference> referenceMap,
+            ArrayBuilder<ImmutableArray<string>> aliasesOfReferencedAssembliesBuilder)
+        {
+            var assemblyIndicesToProcess = ArrayBuilder<int>.GetInstance();
+            var visitedAssemblies = BitVector.Create(bindingResult.Length);
+
+            // +1 for assembly being built
+            Debug.Assert(bindingResult.Length == aliasesOfReferencedAssembliesBuilder.Count + 1);
+
+            foreach (ResolvedReference reference in referenceMap)
+            {
+                if (!reference.IsSkipped && !reference.RecursiveAliasesOpt.IsDefault)
+                {
+                    var recursiveAliases = reference.RecursiveAliasesOpt;
+
+                    Debug.Assert(reference.Kind == MetadataImageKind.Assembly);
+                    visitedAssemblies.Clear();
+                    
+                    Debug.Assert(assemblyIndicesToProcess.Count == 0);
+                    assemblyIndicesToProcess.Add(reference.Index);
+
+                    while (assemblyIndicesToProcess.Count > 0)
+                    {
+                        int assemblyIndex = assemblyIndicesToProcess.Pop();
+                        visitedAssemblies[assemblyIndex] = true;
+
+                        // merge aliases:
+                        aliasesOfReferencedAssembliesBuilder[assemblyIndex] = MergedAliases.Merge(aliasesOfReferencedAssembliesBuilder[assemblyIndex], recursiveAliases);
+
+                        // push dependencies onto the stack:
+                        // +1 for the assembly being built:
+                        foreach (var binding in bindingResult[assemblyIndex + 1].ReferenceBinding)
+                        {
+                            if (binding.IsBound)
+                            {
+                                // -1 for the assembly being built:
+                                int dependentAssemblyIndex = binding.DefinitionIndex - 1;
+                                if (!visitedAssemblies[dependentAssemblyIndex])
+                                {
+                                    assemblyIndicesToProcess.Add(dependentAssemblyIndex);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            for (int i = 0; i < aliasesOfReferencedAssembliesBuilder.Count; i++)
+            {
+                if (aliasesOfReferencedAssembliesBuilder[i].IsDefault)
+                {
+                    aliasesOfReferencedAssembliesBuilder[i] = ImmutableArray<string>.Empty;
+                }
+            }
+
+            assemblyIndicesToProcess.Free();
         }
 
         #region Compilation APIs Implementation

--- a/src/Compilers/Core/Portable/ReferenceManager/MergedAliases.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/MergedAliases.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal void Merge(MetadataReference reference)
         {
-            if (reference.Properties.IsRecursive)
+            if (reference.Properties.HasRecursiveAliases)
             {
                 if (RecursiveAliasesOpt == null)
                 {
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             Merge(
-                aliases: reference.Properties.IsRecursive ? RecursiveAliasesOpt : AliasesOpt, 
+                aliases: reference.Properties.HasRecursiveAliases ? RecursiveAliasesOpt : AliasesOpt, 
                 newAliases: reference.Properties.Aliases);
         }
 

--- a/src/Compilers/Core/Portable/ReferenceManager/MergedAliases.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/MergedAliases.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed class MergedAliases
+    {
+        public ArrayBuilder<string> AliasesOpt;
+        public ArrayBuilder<string> RecursiveAliasesOpt;
+
+        /// <summary>
+        /// Adds aliases of a specified reference to the merged set of aliases.
+        /// Consider the following special cases:
+        /// 
+        /// o {} + {} = {} 
+        ///   If neither reference has any aliases then the result has no aliases.
+        /// 
+        /// o {A} + {} = {A, global}
+        ///   {} + {A} = {A, global}
+        ///   
+        ///   If one and only one of the references has aliases we add the global alias since the 
+        ///   referenced declarations should now be accessible both via existing aliases 
+        ///   as well as unqualified.
+        ///   
+        /// o {A, A} + {A, B, B} = {A, A, B, B}
+        ///   We preserve dups in each alias array, but avoid making more dups when merging.
+        /// </summary>
+        internal void Merge(MetadataReference reference)
+        {
+            if (reference.Properties.IsRecursive)
+            {
+                if (RecursiveAliasesOpt == null)
+                {
+                    RecursiveAliasesOpt = ArrayBuilder<string>.GetInstance();
+                    RecursiveAliasesOpt.AddRange(reference.Properties.Aliases);
+                    return;
+                }
+            }
+            else
+            {
+                if (AliasesOpt == null)
+                {
+                    AliasesOpt = ArrayBuilder<string>.GetInstance();
+                    AliasesOpt.AddRange(reference.Properties.Aliases);
+                    return;
+                }
+            }
+
+            Merge(
+                aliases: reference.Properties.IsRecursive ? RecursiveAliasesOpt : AliasesOpt, 
+                newAliases: reference.Properties.Aliases);
+        }
+
+        internal static void Merge(ArrayBuilder<string> aliases, ImmutableArray<string> newAliases)
+        {
+            if (aliases.Count == 0 ^ newAliases.IsEmpty)
+            {
+                AddNonIncluded(aliases, MetadataReferenceProperties.GlobalAlias);
+            }
+
+            AddNonIncluded(aliases, newAliases);
+        }
+
+        internal static ImmutableArray<string> Merge(ImmutableArray<string> aliasesOpt, ImmutableArray<string> newAliases)
+        {
+            if (aliasesOpt.IsDefault)
+            {
+                return newAliases;
+            }
+
+            var result = ArrayBuilder<string>.GetInstance(aliasesOpt.Length);
+            result.AddRange(aliasesOpt);
+            Merge(result, newAliases);
+            return result.ToImmutableAndFree();
+        }
+
+        private static void AddNonIncluded(ArrayBuilder<string> builder, string item)
+        {
+            if (!builder.Contains(item))
+            {
+                builder.Add(item);
+            }
+        }
+
+        private static void AddNonIncluded(ArrayBuilder<string> builder, ImmutableArray<string> items)
+        {
+            int originalCount = builder.Count;
+
+            foreach (var item in items)
+            {
+                if (builder.IndexOf(item, 0, originalCount) < 0)
+                {
+                    builder.Add(item);
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
+++ b/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
@@ -123,6 +123,11 @@ namespace Microsoft.CodeAnalysis
             return _builder.IndexOf(item);
         }
 
+        public int IndexOf(T item, int startIndex, int count)
+        {
+            return _builder.IndexOf(item, startIndex, count);
+        }
+
         public void RemoveAt(int index)
         {
             _builder.RemoveAt(index);

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -307,6 +307,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim aliasesOfReferencedAssemblies As ImmutableArray(Of ImmutableArray(Of String)) = Nothing
 
                     BuildReferencedAssembliesAndModulesMaps(
+                        bindingResult,
                         references,
                         referenceMap,
                         modules.Length,

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 var path = GacFileResolver.Resolve(referenceIdentity.GetDisplayName());
                 if (path != null)
                 {
-                    return _fileReferenceProvider(path, MetadataReferenceProperties.Assembly);
+                    return CreateReference(path);
                 }
             }
 
@@ -70,12 +70,17 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                     var fullPath = pathWithoutExtension + extension;
                     if (File.Exists(fullPath))
                     {
-                        return _fileReferenceProvider(fullPath, MetadataReferenceProperties.Assembly);
+                        return CreateReference(fullPath);
                     }
                 }
             }
 
             return null;
+        }
+
+        private PortableExecutableReference CreateReference(string fullPath)
+        {
+            return _fileReferenceProvider(fullPath, MetadataReferenceProperties.Assembly.WithIsRecursive(true));
         }
 
         public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)

--- a/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/RuntimeMetadataReferenceResolver.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
 
         private PortableExecutableReference CreateReference(string fullPath)
         {
-            return _fileReferenceProvider(fullPath, MetadataReferenceProperties.Assembly.WithIsRecursive(true));
+            return _fileReferenceProvider(fullPath, MetadataReferenceProperties.Assembly.WithRecursiveAliases(true));
         }
 
         public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)


### PR DESCRIPTION
#r reference directive is designed to add metadata references to the target assembly and all its dependencies. This is mostly achieved via missing assembly resolution implemented earlier. However, the desired experience is currently broken in presence of aliases.

For example, consider a compilation with explicit dependency B imported under alias X, and a library A with dependency B.

```#r "A"``` in this compilation should make all global types and namespaces of A and B accessible to the script. However, since B is already imported to the compilation under alias X its members won't be accessible to the script. 

This change implements logic in ReferenceManager that propagates aliases of metadata references marked as "recursive" to all their transitive dependencies (including the "global" alias). Recursivity is a new property of MetadataReferenceProperties. Since this is a new unproven concept this change doesn't expose it thru public API yet, so that we can adjust the behavior based on feedback if needed. If it works well we can make it public in a later release.

This change will also allow us to hide the content of the host application assemblies from the script. The script compilation needs to have a reference to the assembly containing the globals object type, so that it's able to access the host object members. Adding this reference however includes all global types and namespaces of the host assembly and its dependencies (since we auto-resolve missing assemblies). Once recursive aliases feature is available we could hide them under a recursive alias ```<hidden>```. Doing so will also enable scenario described in issue https://github.com/dotnet/roslyn/issues/6037, where we import a version of Roslyn binaries into a script that is different from the Roslyn version running the script.

