### PR TITLE
Hide namespaces and types of the host assembly

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -729,7 +729,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 "Never include references for a non-source assembly, because they don't know about aliases.");
 
             var assemblies = ArrayBuilder<AssemblySymbol>.GetInstance();
-            DeclaringCompilation.GetUnaliasedReferencedAssemblies(assemblies);
+
+            // ignore reference aliases if searching for a type from a specific assembly:
+            if (assemblyOpt != null)
+            {
+                assemblies.AddRange(DeclaringCompilation.GetBoundReferenceManager().ReferencedAssemblies);
+            }
+            else
+            {
+                DeclaringCompilation.GetUnaliasedReferencedAssemblies(assemblies);
+            }
 
             // Lookup in references
             foreach (var assembly in assemblies)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -19,13 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         private static readonly CSharpCompilationOptions s_signedDll = 
             TestOptions.ReleaseDll.WithCryptoPublicKey(TestResources.TestKeys.PublicKey_ce65828c82a341f2);
-
-        private static IEnumerable<string> GetAssemblyAliases(Compilation compilation)
-        {
-            return compilation.GetBoundReferenceManager().GetReferencedAssemblyAliases().
-               Select(t => $"{t.Item1.Identity.Name}{(t.Item2.IsEmpty ? "" : ": " + string.Join(",", t.Item2))}");
-        }
-
+        
         [Fact]
         public void WinRtCompilationReferences()
         {
@@ -2202,12 +2196,11 @@ new B()
 
             c.VerifyDiagnostics();
 
-            AssertEx.Equal(new[] 
-            {
+            c.VerifyAssemblyAliases(
                 "mscorlib",
                 "B: X,global",
                 "A"
-            }, GetAssemblyAliases(c));
+            );
         }
 
         [Fact]
@@ -2234,12 +2227,10 @@ new B()
                 // new B()
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "B").WithArguments("B"));
 
-            AssertEx.Equal(new[]
-            {
+            c.VerifyAssemblyAliases(
                 "mscorlib",
                 "B: X",
-                "A"
-            }, GetAssemblyAliases(c));
+                "A");
         }
 
         [Fact]
@@ -2272,12 +2263,10 @@ public class P
 
             c.VerifyDiagnostics();
 
-            AssertEx.Equal(new[]
-            {
+            c.VerifyAssemblyAliases(
                 "B: X,Y",
                 "A: global,Y",
-                "mscorlib: global,Y"
-            }, GetAssemblyAliases(c));
+                "mscorlib: global,Y");
         }
 
         [Fact]
@@ -2310,12 +2299,10 @@ public class P
 
             c.VerifyDiagnostics();
 
-            AssertEx.Equal(new[]
-            {
+            c.VerifyAssemblyAliases(
                 "B: X,Y",
                 "A: global,Y",
-                "mscorlib: global,Y"
-            }, GetAssemblyAliases(c));
+                "mscorlib: global,Y");
         }
 
         [Fact]
@@ -2350,12 +2337,10 @@ public class P
 
             c.VerifyDiagnostics();
 
-            AssertEx.Equal(new[]
-            {
+            c.VerifyAssemblyAliases(
                 "B: X,Y",
                 "A: global,Y",
-                "mscorlib: global,Y"
-            }, GetAssemblyAliases(c));
+                "mscorlib: global,Y");
         }
 
         [Fact]
@@ -2391,13 +2376,11 @@ public class P
 
             c.VerifyDiagnostics();
 
-            AssertEx.Equal(new[]
-            {
+            c.VerifyAssemblyAliases(
                 "B: X,Y,Y,Z",
                 "A: Y,Y,Z",
                 "D: Z",
-                "mscorlib: global,Y,Y,Z"
-            }, GetAssemblyAliases(c));
+                "mscorlib: global,Y,Y,Z");
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -790,7 +790,7 @@ namespace Microsoft.CodeAnalysis
             // checked earlier:
             Debug.Assert(compilation.Options.MetadataReferenceResolver != null);
 
-            var references = compilation.Options.MetadataReferenceResolver.ResolveReference(reference, basePath, MetadataReferenceProperties.Assembly);
+            var references = compilation.Options.MetadataReferenceResolver.ResolveReference(reference, basePath, MetadataReferenceProperties.Assembly.WithRecursiveAliases(true));
             if (references.IsDefaultOrEmpty)
             {
                 return null;

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
 
             var metadataService = _workspace.CurrentSolution.Services.MetadataService;
             var mscorlibRef = metadataService.GetReference(typeof(object).Assembly.Location, MetadataReferenceProperties.Assembly);
-            var interactiveHostObjectRef = metadataService.GetReference(typeof(InteractiveScriptGlobals).Assembly.Location, MetadataReferenceProperties.Assembly);
+            var interactiveHostObjectRef = metadataService.GetReference(typeof(InteractiveScriptGlobals).Assembly.Location, Script.HostAssemblyReferenceProperties);
 
             _references = ImmutableHashSet.Create<MetadataReference>(mscorlibRef, interactiveHostObjectRef);
             _rspImports = ImmutableArray<string>.Empty;

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -939,6 +939,18 @@ WriteLine(new Complex(2, 6).Real);
         }
 
         [Fact]
+        public void Script_NoHostNamespaces()
+        {
+            Execute("nameof(Microsoft.CodeAnalysis)");
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(@"
+(1,8): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)",
+                ReadErrorOutputToEnd());
+
+            Assert.Equal("", ReadOutputToEnd());
+        }
+
+        [Fact]
         public void ExecutesOnStaThread()
         {
             Execute(@"

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -358,6 +358,25 @@ error CS0246: The type or namespace name 'Foo' could not be found (are you missi
         }
 
         [Fact]
+        public void Script_NoHostNamespaces()
+        {
+            var runner = CreateRunner(input: "nameof(Microsoft.CodeAnalysis)");
+
+            runner.RunInteractive();
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+$@"Microsoft (R) Visual C# Interactive Compiler version {CompilerVersion}
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Type ""#help"" for more information.
+> nameof(Microsoft.CodeAnalysis)
+«Red»
+(1,8): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
+«Gray»
+> ", runner.Console.Out.ToString());
+        }
+
+        [Fact]
         public void SourceSearchPaths1()
         {
             var main = Temp.CreateFile(extension: ".csx").WriteAllText(@"

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -10,7 +10,9 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting.Test;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1440,6 +1442,189 @@ new List<ArgumentException>()
             obj = new InteractiveFixtures_TopLevelHostObject { X = 1, Y = 2, Z = 3 };
             var r1 = CSharpScript.EvaluateAsync<int>("X", globals: obj);
             Assert.Equal(1, r1.Result);
+        }
+
+        [Fact]
+        public void HostObjectAssemblyReference1()
+        {
+            var scriptCompilation = CSharpScript.Create(
+                "nameof(Microsoft.CodeAnalysis.Scripting)",
+                globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
+
+            scriptCompilation.VerifyDiagnostics(
+                    // (1,8): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
+                    Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "Microsoft.CodeAnalysis").WithArguments("CodeAnalysis", "Microsoft"));
+
+            scriptCompilation.VerifyAssemblyAliases(
+                "mscorlib: global,<host>",
+                "Microsoft.CodeAnalysis.Scripting: <host>",
+                "System.Collections.Immutable: <implicit>,<host>",
+                "Microsoft.CodeAnalysis: <implicit>,<host>",
+                "System.Diagnostics.Tools: <implicit>,<host>",
+                "System.Resources.ResourceManager: <implicit>,<host>",
+                "System.Console: <implicit>,<host>",
+                "System.Diagnostics.StackTrace: <implicit>,<host>",
+                "System.IO.FileSystem: <implicit>,<host>",
+                "System.Linq: <implicit>,<host>",
+                "System.Text.Encoding: <implicit>,<host>",
+                "System.IO.FileSystem.Primitives: <implicit>,<host>",
+                "System.Reflection.Extensions: <implicit>,<host>",
+                "System.Core: <implicit>,<host>",
+                "System: <implicit>,<host>",
+                "System.Xml: <implicit>,<host>",
+                "System.Numerics: <implicit>,<host>",
+                "System.Security: <implicit>,<host>",
+                "System.Data.SqlXml: <implicit>,<host>",
+                "System.Configuration: <implicit>,<host>",
+                "System.Runtime: <implicit>,<host>",
+                "System.Diagnostics.Debug: <implicit>,<host>",
+                "System.Runtime.InteropServices: <implicit>,<host>",
+                "System.Reflection.Metadata: <implicit>,<host>",
+                "System.IO: <implicit>,<host>",
+                "System.Collections: <implicit>,<host>",
+                "System.Threading.Tasks: <implicit>,<host>",
+                "System.Reflection.Primitives: <implicit>,<host>",
+                "System.Reflection: <implicit>,<host>",
+                "System.Globalization: <implicit>,<host>",
+                "System.Runtime.Extensions: <implicit>,<host>",
+                "System.Runtime.Numerics: <implicit>,<host>",
+                "System.Runtime.Serialization.Json: <implicit>,<host>",
+                "System.Collections.Concurrent: <implicit>,<host>",
+                "System.Xml.ReaderWriter: <implicit>,<host>",
+                "System.Xml.XDocument: <implicit>,<host>",
+                "System.Dynamic.Runtime: <implicit>,<host>",
+                "System.Threading: <implicit>,<host>",
+                "System.Text.Encoding.Extensions: <implicit>,<host>",
+                "System.Xml.Linq: <implicit>,<host>",
+                "System.Runtime.Serialization: <implicit>,<host>",
+                "System.ServiceModel.Internals: <implicit>,<host>",
+                "SMDiagnostics: <implicit>,<host>",
+                "System.ComponentModel.Composition: <implicit>,<host>");
+        }
+
+        [Fact]
+        public void HostObjectAssemblyReference2()
+        {
+            var scriptCompilation = CSharpScript.Create(
+                "typeof(Microsoft.CodeAnalysis.Scripting.Script)",
+                options: ScriptOptions.Default.WithReferences(typeof(CSharpScript).GetTypeInfo().Assembly),
+                globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
+
+            scriptCompilation.VerifyDiagnostics();
+
+            scriptCompilation.VerifyAssemblyAliases(
+                "mscorlib: global,<host>",
+                "Microsoft.CodeAnalysis.Scripting: <host>,global",
+                "Microsoft.CodeAnalysis.Scripting.CSharp",
+                "Microsoft.CodeAnalysis.CSharp: <implicit>,global",
+                "Microsoft.CodeAnalysis: <implicit>,<host>,global",
+                "System.Collections.Immutable: <implicit>,<host>,global",
+                "System.Diagnostics.Tools: <implicit>,<host>,global",
+                "System.Resources.ResourceManager: <implicit>,<host>,global",
+                "System.Text.Encoding: <implicit>,<host>,global",
+                "System.AppContext: <implicit>,global",
+                "System.Reflection.Extensions: <implicit>,<host>,global",
+                "System: <implicit>,<host>,global",
+                "System.Configuration: <implicit>,<host>,global",
+                "System.Xml: <implicit>,<host>,global",
+                "System.Data.SqlXml: <implicit>,<host>,global",
+                "System.Security: <implicit>,<host>,global",
+                "System.Core: <implicit>,<host>,global",
+                "System.Numerics: <implicit>,<host>,global",
+                "System.Runtime: <implicit>,<host>,global",
+                "System.Diagnostics.Debug: <implicit>,<host>,global",
+                "System.Collections: <implicit>,<host>,global",
+                "System.Linq: <implicit>,<host>,global",
+                "System.Runtime.Extensions: <implicit>,<host>,global",
+                "System.Globalization: <implicit>,<host>,global",
+                "System.Threading: <implicit>,<host>,global",
+                "System.ComponentModel.Composition: <implicit>,<host>,global",
+                "System.Runtime.InteropServices: <implicit>,<host>,global",
+                "System.Reflection.Metadata: <implicit>,<host>,global",
+                "System.IO: <implicit>,<host>,global",
+                "System.Threading.Tasks: <implicit>,<host>,global",
+                "System.Reflection.Primitives: <implicit>,<host>,global",
+                "System.Reflection: <implicit>,<host>,global",
+                "System.Runtime.Numerics: <implicit>,<host>,global",
+                "System.Runtime.Serialization.Json: <implicit>,<host>,global",
+                "System.Collections.Concurrent: <implicit>,<host>,global",
+                "System.Xml.ReaderWriter: <implicit>,<host>,global",
+                "System.Xml.XDocument: <implicit>,<host>,global",
+                "System.Dynamic.Runtime: <implicit>,<host>,global",
+                "System.Text.Encoding.Extensions: <implicit>,<host>,global",
+                "System.Xml.Linq: <implicit>,<host>,global",
+                "System.Runtime.Serialization: <implicit>,<host>,global",
+                "System.ServiceModel.Internals: <implicit>,<host>,global",
+                "SMDiagnostics: <implicit>,<host>,global",
+                "System.Linq.Expressions: <implicit>,global",
+                "System.Threading.Tasks.Parallel: <implicit>,global",
+                "System.Console: <implicit>,<host>,global",
+                "System.Diagnostics.StackTrace: <implicit>,<host>,global",
+                "System.IO.FileSystem: <implicit>,<host>,global",
+                "System.IO.FileSystem.Primitives: <implicit>,<host>,global");
+        }
+
+        [Fact]
+        public void HostObjectAssemblyReference3()
+        {
+            string source = $@"
+#r ""{typeof(CSharpScript).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName}""
+typeof(Microsoft.CodeAnalysis.Scripting.Script)
+";
+            var scriptCompilation = CSharpScript.Create(source, globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
+
+            scriptCompilation.VerifyDiagnostics();
+
+            scriptCompilation.VerifyAssemblyAliases(
+                "Microsoft.CodeAnalysis.Scripting.CSharp",
+                "mscorlib: global,<host>",
+                "Microsoft.CodeAnalysis.Scripting: global,<host>",
+                "System.Collections.Immutable: <implicit>,global,<host>",
+                "Microsoft.CodeAnalysis: <implicit>,global,<host>",
+                "System.Diagnostics.Tools: <implicit>,global,<host>",
+                "System.Resources.ResourceManager: <implicit>,global,<host>",
+                "System.Console: <implicit>,global,<host>",
+                "System.Diagnostics.StackTrace: <implicit>,global,<host>",
+                "System.IO.FileSystem: <implicit>,global,<host>",
+                "System.Linq: <implicit>,global,<host>",
+                "System.Text.Encoding: <implicit>,global,<host>",
+                "System.IO.FileSystem.Primitives: <implicit>,global,<host>",
+                "System.Reflection.Extensions: <implicit>,global,<host>",
+                "System.Core: <implicit>,global,<host>",
+                "System: <implicit>,global,<host>",
+                "System.Xml: <implicit>,global,<host>",
+                "System.Numerics: <implicit>,global,<host>",
+                "System.Security: <implicit>,global,<host>",
+                "System.Data.SqlXml: <implicit>,global,<host>",
+                "System.Configuration: <implicit>,global,<host>",
+                "System.Runtime: <implicit>,global,<host>",
+                "System.Diagnostics.Debug: <implicit>,global,<host>",
+                "System.Runtime.InteropServices: <implicit>,global,<host>",
+                "System.Reflection.Metadata: <implicit>,global,<host>",
+                "System.IO: <implicit>,global,<host>",
+                "System.Collections: <implicit>,global,<host>",
+                "System.Threading.Tasks: <implicit>,global,<host>",
+                "System.Reflection.Primitives: <implicit>,global,<host>",
+                "System.Reflection: <implicit>,global,<host>",
+                "System.Globalization: <implicit>,global,<host>",
+                "System.Runtime.Extensions: <implicit>,global,<host>",
+                "System.Runtime.Numerics: <implicit>,global,<host>",
+                "System.Runtime.Serialization.Json: <implicit>,global,<host>",
+                "System.Collections.Concurrent: <implicit>,global,<host>",
+                "System.Xml.ReaderWriter: <implicit>,global,<host>",
+                "System.Xml.XDocument: <implicit>,global,<host>",
+                "System.Dynamic.Runtime: <implicit>,global,<host>",
+                "System.Threading: <implicit>,global,<host>",
+                "System.Text.Encoding.Extensions: <implicit>,global,<host>",
+                "System.Xml.Linq: <implicit>,global,<host>",
+                "System.Runtime.Serialization: <implicit>,global,<host>",
+                "System.ServiceModel.Internals: <implicit>,global,<host>",
+                "SMDiagnostics: <implicit>,global,<host>",
+                "System.ComponentModel.Composition: <implicit>,global,<host>",
+                "Microsoft.CodeAnalysis.CSharp: <implicit>,global",
+                "System.AppContext: <implicit>,global",
+                "System.Linq.Expressions: <implicit>,global",
+                "System.Threading.Tasks.Parallel: <implicit>,global");
         }
 
         #endregion

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 (path, properties) =>
                 {
                     loggerOpt?.AddRead(path);
-                    return MetadataReference.CreateFromFile(path);
+                    return MetadataReference.CreateFromFile(path, properties);
                 });
         }
 

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -171,6 +171,10 @@ namespace Microsoft.CodeAnalysis.Scripting
         internal abstract ImmutableArray<Diagnostic> CommonBuild(CancellationToken cancellationToken);
         internal abstract Func<object[], Task> CommonGetExecutor(CancellationToken cancellationToken);
 
+        // Apply recursive alias <host> to the host assembly reference, so that we hide its namespaces and global types behind it.
+        internal static readonly MetadataReferenceProperties HostAssemblyReferenceProperties = 
+            MetadataReferenceProperties.Assembly.WithAliases(ImmutableArray.Create("<host>")).WithRecursiveAliases(true);
+
         /// <summary>
         /// Gets the references that need to be assigned to the compilation.
         /// This can be different than the list of references defined by the <see cref="ScriptOptions"/> instance.
@@ -197,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
                     if (GlobalsType != null)
                     {
-                        var globalsTypeAssembly = MetadataReference.CreateFromAssemblyInternal(GlobalsType.GetTypeInfo().Assembly);
+                        var globalsTypeAssembly = MetadataReference.CreateFromAssemblyInternal(GlobalsType.GetTypeInfo().Assembly, HostAssemblyReferenceProperties);
                         references.Add(globalsTypeAssembly);
                     }
 

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -84,6 +84,10 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
         }
 
+        // a reference to an assembly should by default be equivalent to #r, which applies recursive global alias:
+        private static readonly MetadataReferenceProperties AssemblyReferenceProperties = 
+            MetadataReferenceProperties.Assembly.WithRecursiveAliases(true);
+
         /// <summary>
         /// Creates a new <see cref="ScriptOptions"/> with the <see cref="FilePath"/> changed.
         /// </summary>
@@ -91,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Scripting
             (FilePath == filePath) ? this : new ScriptOptions(this) { FilePath = filePath ?? "" };
 
         private static MetadataReference CreateUnresolvedReference(string reference) =>
-            new UnresolvedMetadataReference(reference, MetadataReferenceProperties.Assembly);
+            new UnresolvedMetadataReference(reference, AssemblyReferenceProperties);
 
         /// <summary>
         /// Creates a new <see cref="ScriptOptions"/> with the references changed.
@@ -132,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="references"/> is null or contains a null reference.</exception>
         public ScriptOptions WithReferences(IEnumerable<Assembly> references) => 
-            WithReferences(SelectChecked(references, nameof(references), MetadataReference.CreateFromAssemblyInternal));
+            WithReferences(SelectChecked(references, nameof(references), CreateReferenceFromAssembly));
 
         /// <summary>
         /// Creates a new <see cref="ScriptOptions"/> with the references changed.
@@ -146,7 +150,12 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="references"/> is null or contains a null reference.</exception>
         public ScriptOptions AddReferences(IEnumerable<Assembly> references) =>
-            AddReferences(SelectChecked(references, nameof(references), MetadataReference.CreateFromAssemblyInternal));
+            AddReferences(SelectChecked(references, nameof(references), CreateReferenceFromAssembly));
+
+        private static MetadataReference CreateReferenceFromAssembly(Assembly assembly)
+        {
+            return MetadataReference.CreateFromAssemblyInternal(assembly, AssemblyReferenceProperties);
+        }
 
         /// <summary>
         /// Creates a new <see cref="ScriptOptions"/> with references added.

--- a/src/Test/Utilities/Shared/Compilation/CompilationExtensions.cs
+++ b/src/Test/Utilities/Shared/Compilation/CompilationExtensions.cs
@@ -133,5 +133,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     updatedMethods.ToImmutableArray());
             }
         }
+
+        internal static void VerifyAssemblyAliases(this Compilation compilation, params string[] expectedAssembliesAndAliases)
+        {
+            var actual = compilation.GetBoundReferenceManager().GetReferencedAssemblyAliases().
+               Select(t => $"{t.Item1.Identity.Name}{(t.Item2.IsEmpty ? "" : ": " + string.Join(",", t.Item2))}");
+
+            AssertEx.Equal(expectedAssembliesAndAliases, actual, itemInspector: s => '"' + s + '"');
+        }
     }
 }


### PR DESCRIPTION
Use the following combination of aliases to hide host assembly namespaces and types (other than the globals type) from the script:

- #r references apply "global" alias recursively
- references added to script by the host via ScriptOptions.AddRefererence apply "global" alias recursively
- implicitly added globals object assembly uses ```<host>``` recursive alias  
- resolved missing references use simple alias ```<implicit>```

Fixes https://github.com/dotnet/roslyn/issues/6037