### PR TITLE
Keep accessor  with attributes on a single line.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
@@ -363,5 +363,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return (token.IsKind(SyntaxKind.OpenBraceToken) || token.IsKind(SyntaxKind.CommaToken)) &&
                 token.Parent.IsKind(SyntaxKind.ObjectInitializerExpression);
         }
+
+        public static bool IsOpenBraceOfAccessorList(this SyntaxToken token)
+        {
+            return token.IsKind(SyntaxKind.OpenBraceToken) && token.Parent.IsKind(SyntaxKind.AccessorList);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var accessorDeclNode = node as AccessorDeclarationSyntax;
             if (accessorDeclNode != null)
             {
-                AddSuppressWrappingIfOnSingleLineOperation(list, accessorDeclNode.GetFirstToken(includeZeroWidth: true), accessorDeclNode.GetLastToken(includeZeroWidth: true));
+                AddSuppressWrappingIfOnSingleLineOperation(list, accessorDeclNode.Keyword, accessorDeclNode.GetLastToken(includeZeroWidth: true));
                 return;
             }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -2,6 +2,7 @@
 
 using System.Composition;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
@@ -243,9 +244,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // * [
-            if (currentToken.IsKind(SyntaxKind.OpenBracketToken) && !previousToken.IsOpenBraceOrCommaOfObjectInitializer())
+            if (currentToken.IsKind(SyntaxKind.OpenBracketToken) && 
+                !previousToken.IsOpenBraceOrCommaOfObjectInitializer())
             {
-                return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+                if (previousToken.IsOpenBraceOfAccessorList() ||
+                    previousToken.IsLastTokenOfNode<AccessorDeclarationSyntax>())
+                {
+                    return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+                }
+                else
+                {
+                    return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+                }
             }
 
             // case * :

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7081,5 +7081,20 @@ class Program
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(4720, "https://github.com/dotnet/roslyn/issues/4720")]
+        public void OneSpaceBetweenAccessorsAndAttributes()
+        {
+            AssertFormat(@"
+class Program
+{
+    public int SomeProperty { [SomeAttribute] get; [SomeAttribute] private set; }
+}", @"
+class Program
+{
+    public int SomeProperty {    [SomeAttribute] get;    [SomeAttribute] private set; }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7058,5 +7058,28 @@ class C
     string  Name    {    get    ;   set     ;    }
 }", changedOptionSet: changedOptionSet);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(4720, "https://github.com/dotnet/roslyn/issues/4720")]
+        public void KeepAccessorWithAttributeOnSingleLine()
+        {
+            AssertFormat(@"
+class Program
+{
+    public Int32 PaymentMethodID
+    {
+        [System.Diagnostics.DebuggerStepThrough]
+        get { return 10; }
+    }
+}", @"
+class Program
+{
+    public Int32 PaymentMethodID
+    {
+        [System.Diagnostics.DebuggerStepThrough]
+        get { return 10; }
+    }
+}");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/4720
