### PR TITLE
Disable BackgroundCompiler on low VM

### DIFF
--- a/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
@@ -34,13 +34,8 @@ namespace Microsoft.CodeAnalysis.Host
             _notificationQueue = taskSchedulerFactory.CreateTaskQueue();
             _cancellationSource = new CancellationTokenSource();
             _workspace.WorkspaceChanged += this.OnWorkspaceChanged;
-
-            var editorWorkspace = workspace as Workspace;
-            if (editorWorkspace != null)
-            {
-                editorWorkspace.DocumentOpened += OnDocumentOpened;
-                editorWorkspace.DocumentClosed += OnDocumentClosed;
-            }
+            _workspace.DocumentOpened += OnDocumentOpened;
+            _workspace.DocumentClosed += OnDocumentClosed;
         }
 
         public void Dispose()
@@ -49,13 +44,8 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 this.CancelBuild(releasePreviousCompilations: true);
 
-                var editorWorkspace = _workspace as Workspace;
-                if (editorWorkspace != null)
-                {
-                    editorWorkspace.DocumentClosed -= OnDocumentClosed;
-                    editorWorkspace.DocumentOpened -= OnDocumentOpened;
-                }
-
+                _workspace.DocumentClosed -= OnDocumentClosed;
+                _workspace.DocumentOpened -= OnDocumentOpened;
                 _workspace.WorkspaceChanged -= this.OnWorkspaceChanged;
 
                 _workspace = null;


### PR DESCRIPTION
Fixes #6253 

@jasonmalinowski @heejaechang @KevinH-MS @Pilchie 

This looks fairly straightforward, but can you check the uses of ```PartialSemanticsEnabled``` to determine that, when we've disabled the BackgroundCompiler, we at least make forward progress elsewhere?