### PR TITLE
When filtering completion in the Turkish locale, attempt matches in t…

### DIFF
--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -169,6 +169,7 @@
     <Compile Include="Diagnostics\InMemoryAssemblyLoader.vb" />
     <Compile Include="Diagnostics\UseAutoProperty\UseAutoPropertyTests.vb" />
     <Compile Include="GoToImplementation\GoToImplementationTests.vb" />
+    <Compile Include="IntelliSense\CompletionRulesTests.vb" />
     <Compile Include="LanguageServices\SyntaxFactsServiceTests.vb" />
     <Compile Include="Simplification\SimplifierAPITests.vb" />
     <Compile Include="Utilities\GoToHelpers\GoToTestHelpers.vb" />

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1,5 +1,6 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Globalization
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
@@ -1620,6 +1621,56 @@ class C
                     view.Close()
                 End Try
             End Using
+        End Function
+
+        <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround1() As Task
+            Dim originalCulture = CultureInfo.CurrentCulture
+            Dim trCulture = New CultureInfo("tr-TR")
+            System.Threading.Thread.CurrentThread.CurrentCulture = trCulture
+
+            Try
+                Using state = TestState.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class C
+        {
+            void foo(int x)
+            {
+                string.$$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("is")
+                    Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                    state.AssertSelectedCompletionItem("IsNullOrEmpty")
+                End Using
+            Finally
+                System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture
+            End Try
+
+        End Function
+
+        <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround2() As Task
+            Dim originalCulture = CultureInfo.CurrentCulture
+            Dim trCulture = New CultureInfo("tr-TR")
+            System.Threading.Thread.CurrentThread.CurrentCulture = trCulture
+
+            Try
+                Using state = TestState.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class C
+        {
+            void foo(int x)
+            {
+                string.$$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("ı")
+                    Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                    state.AssertSelectedCompletionItem()
+                End Using
+            Finally
+                System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture
+            End Try
+
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionRulesTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionRulesTests.vb
@@ -1,0 +1,77 @@
+﻿Imports System.Globalization
+Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.CSharp.Completion
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+    Public Class CompletionRulesTests
+        <Fact>
+        Public Sub TestMatchLowerCaseEnglishI()
+            Dim wordsToMatch = {"index", "Index", "işte", "İşte"}
+            Dim wordsToNotMatch = {"ırak"}
+
+            TestMatches("i", wordsToMatch)
+            TestNotMatches("i", wordsToNotMatch)
+        End Sub
+
+        <Fact>
+        Public Sub TestMatchDottedUpperTurkishI()
+            Dim wordsToMatch = {"index", "işte", "İşte"}
+            Dim wordsToNotMatch = {"ırak", "Irak", "Index"}
+
+            TestMatches("İ", wordsToMatch)
+            TestNotMatches("İ", wordsToNotMatch)
+        End Sub
+
+        <Fact>
+        Public Sub TestMatchNonDottedLowerTurkishI()
+            Dim wordsToMatch = {"ırak", "Irak"}
+            Dim wordsToNotMatch = {"Index", "index", "işte", "İşte"}
+
+            TestMatches("ı", wordsToMatch)
+            TestNotMatches("ı", wordsToNotMatch)
+        End Sub
+
+        <Fact>
+        Public Sub TestMatchEnglishUpperI()
+            Dim wordsToMatch = {"Index", "index", "ırak", "Irak"}
+            Dim wordsToNotMatch = {"İşte"}
+
+            TestMatches("I", wordsToMatch)
+            TestNotMatches("I", wordsToNotMatch)
+        End Sub
+
+        Private Sub TestMatches(v As String, wordsToMatch() As String)
+            Dim rules = New CompletionRules(New CSharpCompletionService())
+            Dim currentCulture = CultureInfo.CurrentCulture
+            Dim trCulture = New CultureInfo("tr-TR")
+            System.Threading.Thread.CurrentThread.CurrentCulture = trCulture
+
+            Try
+                For Each word In wordsToMatch
+                    Dim item = New CompletionItem(Nothing, word, Nothing)
+                    Assert.True(rules.MatchesFilterText(item, v, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo(), CompletionFilterReason.TypeChar))
+                Next
+            Finally
+                System.Threading.Thread.CurrentThread.CurrentCulture = currentCulture
+            End Try
+
+        End Sub
+
+        Private Sub TestNotMatches(v As String, wordsToNotMatch() As String)
+            Dim rules = New CompletionRules(New CSharpCompletionService())
+            Dim currentCulture = CultureInfo.CurrentCulture
+            Dim trCulture = New CultureInfo("tr-TR")
+            System.Threading.Thread.CurrentThread.CurrentCulture = trCulture
+
+            Try
+                For Each word In wordsToNotMatch
+                    Dim item = New CompletionItem(Nothing, word, Nothing)
+                    Assert.False(rules.MatchesFilterText(item, v, CompletionTriggerInfo.CreateInvokeCompletionTriggerInfo(), CompletionFilterReason.TypeChar))
+                Next
+            Finally
+                System.Threading.Thread.CurrentThread.CurrentCulture = currentCulture
+            End Try
+
+        End Sub
+    End Class
+End Namespace

--- a/src/Features/Core/Portable/Completion/CompletionRules.cs
+++ b/src/Features/Core/Portable/Completion/CompletionRules.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -20,21 +21,37 @@ namespace Microsoft.CodeAnalysis.Completion
         private readonly object _gate = new object();
         private readonly AbstractCompletionService _completionService;
         private readonly Dictionary<string, PatternMatcher> _patternMatcherMap = new Dictionary<string, PatternMatcher>();
+        private readonly Dictionary<string, PatternMatcher> _invariantCulturePatternMatcherMap = new Dictionary<string, PatternMatcher>();
 
         public CompletionRules(AbstractCompletionService completionService)
         {
             _completionService = completionService;
         }
 
-        protected PatternMatcher GetPatternMatcher(string value)
+        protected PatternMatcher GetPatternMatcher(string value, CultureInfo culture)
         {
             lock (_gate)
             {
                 PatternMatcher patternMatcher;
                 if (!_patternMatcherMap.TryGetValue(value, out patternMatcher))
                 {
-                    patternMatcher = new PatternMatcher(value, verbatimIdentifierPrefixIsWordCharacter: true);
+                    patternMatcher = new PatternMatcher(value, culture, verbatimIdentifierPrefixIsWordCharacter: true);
                     _patternMatcherMap.Add(value, patternMatcher);
+                }
+
+                return patternMatcher;
+            }
+        }
+
+        protected PatternMatcher GetInvariantCulturePatternMatcher(string value)
+        {
+            lock (_gate)
+            {
+                PatternMatcher patternMatcher;
+                if (!_invariantCulturePatternMatcherMap.TryGetValue(value, out patternMatcher))
+                {
+                    patternMatcher = new PatternMatcher(value, CultureInfo.InvariantCulture, verbatimIdentifierPrefixIsWordCharacter: true);
+                    _invariantCulturePatternMatcherMap.Add(value, patternMatcher);
                 }
 
                 return patternMatcher;
@@ -65,9 +82,32 @@ namespace Microsoft.CodeAnalysis.Completion
                 return false;
             }
 
-            var patternMatcher = this.GetPatternMatcher(_completionService.GetCultureSpecificQuirks(filterText));
+            return GetMatchWithWorkaround(item, filterText) != null;
+        }
+
+        // Hack for Turkish:
+        // start with the culture-specific comparison, and fallback to the invariant one if that fails
+        protected PatternMatch? GetMatchWithWorkaround(CompletionItem item, string filterText)
+        {
+            var patternMatcher = this.GetPatternMatcher(_completionService.GetCultureSpecificQuirks(filterText), CultureInfo.CurrentCulture);
             var match = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item.FilterText));
-            return match != null;
+
+            if (match != null)
+            {
+                return match;
+            }
+
+            if (CultureInfo.CurrentCulture.Name == "tr-TR")
+            {
+                patternMatcher = this.GetInvariantCulturePatternMatcher(_completionService.GetCultureSpecificQuirks(filterText));
+                match = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item.FilterText));
+                if (match != null)
+                {
+                    return match;
+                }
+            }
+
+            return null;
         }
 
         private static bool IsAllDigits(string filterText)
@@ -89,9 +129,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         public virtual bool IsBetterFilterMatch(CompletionItem item1, CompletionItem item2, string filterText, CompletionTriggerInfo triggerInfo, CompletionFilterReason filterReason)
         {
-            var patternMatcher = GetPatternMatcher(_completionService.GetCultureSpecificQuirks(filterText));
-            var match1 = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item1.FilterText));
-            var match2 = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item2.FilterText));
+            var patternMatcher = GetPatternMatcher(_completionService.GetCultureSpecificQuirks(filterText), CultureInfo.CurrentCulture);
+            var match1_z = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item1.FilterText));
+            var match2_z = patternMatcher.GetFirstMatch(_completionService.GetCultureSpecificQuirks(item2.FilterText));
+
+            var match1 = GetMatchWithWorkaround(item1, _completionService.GetCultureSpecificQuirks(filterText));
+            var match2 = GetMatchWithWorkaround(item2, _completionService.GetCultureSpecificQuirks(filterText));
 
             if (match1 != null && match2 != null)
             {

--- a/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionRules.vb
+++ b/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionRules.vb
@@ -58,9 +58,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
                 End If
 
                 If TypeOf item2.CompletionProvider Is EnumCompletionProvider Then
-                    Dim patternMatcher = GetPatternMatcher(filterText)
-                    Dim match1 = patternMatcher.GetFirstMatch(item1.FilterText)
-                    Dim match2 = patternMatcher.GetFirstMatch(item2.FilterText)
+                    Dim match1 = GetMatchWithWorkaround(item1, filterText)
+                    Dim match2 = GetMatchWithWorkaround(item2, filterText)
 
                     If match1.HasValue AndAlso match2.HasValue Then
                         If match1.Value.Kind = PatternMatchKind.Prefix AndAlso match2.Value.Kind = PatternMatchKind.Substring Then


### PR DESCRIPTION
…he current culture as well as the invariant culture.

This workaround should help with matching against Turkish "I".