### PR TITLE
Documentation file lookup in ms build workspace

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/Host/Documentation/DocumentationProviderServiceFactory.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Documentation/DocumentationProviderServiceFactory.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Composition;
+using System.Globalization;
 using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -29,15 +30,46 @@ namespace Microsoft.CodeAnalysis.Host
                     throw new ArgumentNullException(nameof(assemblyPath));
                 }
 
-                assemblyPath = Path.ChangeExtension(assemblyPath, "xml");
-
-                DocumentationProvider provider;
-                if (!_assemblyPathToDocumentationProviderMap.TryGetValue(assemblyPath, out provider))
+                string xmlDocumentationFilePath;
+                if (!TryFindDocumentationFile(assemblyPath, out xmlDocumentationFilePath))
                 {
-                    provider = _assemblyPathToDocumentationProviderMap.GetOrAdd(assemblyPath, _path => new FileBasedXmlDocumentationProvider(_path));
+                    return _assemblyPathToDocumentationProviderMap.GetOrAdd(nameof(DocumentationProvider.Default), DocumentationProvider.Default);
                 }
 
-                return provider;
+                return _assemblyPathToDocumentationProviderMap.GetOrAdd(xmlDocumentationFilePath, _path => new FileBasedXmlDocumentationProvider(_path));
+            }
+
+            private bool TryFindDocumentationFile(string assemblyPath, out string xmlDocumentationFilePath)
+            {
+                var xmlFileName = Path.ChangeExtension(Path.GetFileName(assemblyPath), "xml");
+                var originalDirectory = Path.GetDirectoryName(assemblyPath);
+
+                // 1. Look in subdirectories based on current culture
+                var culture = CultureInfo.CurrentUICulture;
+                var xmlFilePath = string.Empty;
+
+                while (culture != CultureInfo.InvariantCulture)
+                {
+                    xmlFilePath = Path.Combine(originalDirectory, culture.Name, xmlFileName);
+                    if (File.Exists(xmlFilePath))
+                    {
+                        xmlDocumentationFilePath = xmlFilePath;
+                        return true;
+                    }
+
+                    culture = culture.Parent;
+                }
+
+                // 2. Look in the same directory as the assembly itself
+                xmlFilePath = Path.Combine(originalDirectory, xmlFileName);
+                if (File.Exists(xmlFilePath))
+                {
+                    xmlDocumentationFilePath = xmlFilePath;
+                    return true;
+                }
+
+                xmlDocumentationFilePath = null;
+                return false;
             }
         }
     }

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -2372,6 +2372,7 @@ class C1
             }
         }
 
+        [WorkItem(5668, "https://github.com/dotnet/roslyn/issues/5668")]
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestOpenProject_MetadataReferenceHasDocComments()
         {


### PR DESCRIPTION
Fixes one failure of many at #5668 

MsbuildWorkspace did not have any logic to resolve documentation help files in localized builds. We were only looking beside the assembly and in loc builds this path didnt exist. The compiler's symbol.GetDocumentationCommentXml() would throw and catch an exception and silently fail. We now look for xml help files in subdirectories based on current culture.