### PR TITLE
Log low VM telemetry at most once per session

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices
     internal sealed class VirtualMemoryNotificationListener : ForegroundThreadAffinitizedObject, IVsBroadcastMessageEvents
     {
         private WorkspaceCacheService _workspaceCacheService;
+        private bool _alreadyLogged;
 
         [ImportingConstructor]
         private VirtualMemoryNotificationListener(
@@ -52,8 +53,12 @@ namespace Microsoft.VisualStudio.LanguageServices
                 case VSConstants.VSM_VIRTUALMEMORYLOW:
                 case VSConstants.VSM_VIRTUALMEMORYCRITICAL:
                     {
-                        // record that we had hit critical memory barrier
-                        Logger.Log(FunctionId.VirtualMemory_MemoryLow, KeyValueLogMessage.Create(m => m["Memory"] = msg));
+                        if (!_alreadyLogged)
+                        {
+                            // record that we had hit critical memory barrier
+                            Logger.Log(FunctionId.VirtualMemory_MemoryLow, KeyValueLogMessage.Create(m => m["Memory"] = msg));
+                            _alreadyLogged = true;
+                        }
 
                         _workspaceCacheService.FlushCaches();
                         break;


### PR DESCRIPTION
Fixes #6279 

@heejaechang @Pilchie 

This is the simplest fix for Update 1.

Note: The shell will keep broadcasting VSM_VIRTUALMEMORYLOW/CRITICAL once a minute while the low VM situation persists. There is no corresponding message indicating "VM is back to normal".

Another approach might be to do some rate limiting on the telemetry. i.e. note the time of the last notification and log telemetry only if it's been more than some interval (say 30 minutes or an hour). Thoughts?