### PR TITLE
Support for ISymUnmanagedWriter7 deterministic PDB ID setting

### DIFF
--- a/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
@@ -154,12 +154,23 @@ namespace Microsoft.Cci
         void InitializeDeterministic([MarshalAs(UnmanagedType.IUnknown)] object emitter, [MarshalAs(UnmanagedType.IUnknown)] object stream);
     }
 
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("22DAEAF2-70F6-4EF1-B0C3-984F0BF27BFD"), SuppressUnmanagedCodeSecurity]
+    interface ISymUnmanagedWriter7 : ISymUnmanagedWriter6
+    {
+        //  ISymUnmanagedWriter, ISymUnmanagedWriter2, ISymUnmanagedWriter3, ISymUnmanagedWriter4, ISymUnmanagedWriter5, ISymUnmanagedWriter6
+        void _VtblGap1_34();
+
+        // ISymUnmanagedWriter7
+        unsafe void UpdateSignatureByHashingContent([In]byte* buffer, int size);
+    }
+
     [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("B473C610-C958-4C3D-99A0-F2BA0A38807C"), SuppressUnmanagedCodeSecurity]
     interface ISymUnmanagedWriter100 : ISymUnmanagedWriter6
     {
         //  ISymUnmanagedWriter, ISymUnmanagedWriter2, ISymUnmanagedWriter3, ISymUnmanagedWriter4, ISymUnmanagedWriter5, ISymUnmanagedWriter6
         void _VtblGap1_34();
 
+        // ISymUnmanagedWriter100
         void SetSignature(uint sig, Guid sig70);
     }
 

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Cci
             }
         }
 
-        internal ContentId ContentIdFromLog()
+        internal byte[] GetLogHash()
         {
             Debug.Assert(_logData != null);
 
@@ -104,7 +104,7 @@ namespace Microsoft.Cci
             Debug.Assert(remaining == 0);
 
             _logData.Clear();
-            return ContentId.FromHash(_hashAlgorithm.Hash.ToImmutableArray());
+            return _hashAlgorithm.Hash;
         }
 
         internal void Close()
@@ -813,13 +813,12 @@ namespace Microsoft.Cci
 
                 if (_deterministic)
                 {
-                    var deterministicSymWriter = symWriter as ISymUnmanagedWriter6;
-                    if (deterministicSymWriter == null)
+                    if (!(symWriter is ISymUnmanagedWriter7 || symWriter is ISymUnmanagedWriter100))
                     {
                         throw new NotSupportedException(CodeAnalysisResources.SymWriterNotDeterministic);
                     }
 
-                    deterministicSymWriter.InitializeDeterministic(new PdbMetadataWrapper(metadataWriter), _pdbStream);
+                    ((ISymUnmanagedWriter6)symWriter).InitializeDeterministic(new PdbMetadataWrapper(metadataWriter), _pdbStream);
                 }
                 else
                 {
@@ -839,20 +838,32 @@ namespace Microsoft.Cci
         {
             if (_deterministic)
             {
-                // Call to GetDebugInfo fails for SymWriter initialized using InitializeDeterministic.
-                // We already have all the info we need though.
-                var id = _callLogger.ContentIdFromLog();
+                // rewrite GUID and timestamp in the PDB with hash of a has of the log content:
+                byte[] hash = _callLogger.GetLogHash();
+
                 try
                 {
-                    Debug.Assert(BitConverter.IsLittleEndian);
-                    ((ISymUnmanagedWriter100)_symWriter).SetSignature(BitConverter.ToUInt32(id.Stamp, 0), new Guid(id.Guid));
+                    // TODO: remove once we can rely on the presence of ISymUnmanagedWriter7
+                    var writer100 = _symWriter as ISymUnmanagedWriter100;
+                    if (writer100 != null)
+                    {
+                        var id = ContentId.FromHash(ImmutableArray.CreateRange(hash));
+
+                        Debug.Assert(BitConverter.IsLittleEndian);
+                        writer100.SetSignature(BitConverter.ToUInt32(id.Stamp, 0), new Guid(id.Guid));
+
+                        return id;
+                    }
+                    
+                    fixed (byte* hashPtr = &hash[0])
+                    {
+                        ((ISymUnmanagedWriter7)_symWriter).UpdateSignatureByHashingContent(hashPtr, hash.Length);
+                    }
                 }
                 catch (Exception ex)
                 {
                     throw new PdbWritingException(ex);
                 }
-
-                return id;
             }
 
             // See symwrite.cpp - the data byte[] doesn't depend on the content of metadata tables or IL.


### PR DESCRIPTION
Set deterministic PDB ID via new symreader API -- ISymUnmanagedWriter7 if available.
