### PR TITLE
Fix VSIX based analyzers installed in the extensions hive

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         internal TestDiagnosticAnalyzerService(AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null, Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
-           : base(SpecializedCollections.EmptyEnumerable<HostDiagnosticAnalyzerPackage>(), hostDiagnosticUpdateSource, new MockDiagnosticUpdateSourceRegistrationService())
+           : base(SpecializedCollections.EmptyEnumerable<HostDiagnosticAnalyzerPackage>(), null, hostDiagnosticUpdateSource, new MockDiagnosticUpdateSourceRegistrationService())
         {
             _onAnalyzerException = onAnalyzerException;
         }

--- a/src/EditorFeatures/Test/Preview/TestOnly_CompilerDiagnosticAnalyzerProviderService.cs
+++ b/src/EditorFeatures/Test/Preview/TestOnly_CompilerDiagnosticAnalyzerProviderService.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.UnitTests;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
 {
@@ -30,6 +31,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
                     yield return analyzer.GetType().Assembly.Location;
                 }
             }
+        }
+
+        public IAnalyzerAssemblyLoader GetAnalyzerAssemblyLoader()
+        {
+            return FromFileLoader.Instance;
         }
 
         public IEnumerable<HostDiagnosticAnalyzerPackage> GetHostDiagnosticAnalyzerPackages()

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -1,13 +1,11 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
-Imports System.IO
 Imports System.Reflection
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers
 Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.CodeAnalysis.Diagnostics.EngineV1
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
@@ -15,7 +13,6 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.UnitTests.Diagnostics
 Imports Roslyn.Utilities
-Imports Xunit.Sdk
 
 Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
 
@@ -351,7 +348,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim analyzerReference2 = CreateAnalyzerFileReference("x:\temp.dll")
                 project = project.AddAnalyzerReference(analyzerReference1)
 #If DEBUG Then
-                Debug.Assert(project.AnalyzerReferences.Contains(analyzerReference2)) 
+                Debug.Assert(project.AnalyzerReferences.Contains(analyzerReference2))
 #End If
             End Using
         End Sub
@@ -408,7 +405,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 project = project.AddAnalyzerReference(analyzerReference1)
                 project = project.AddAnalyzerReference(analyzerReference2)
 #If DEBUG Then
-                Debug.Assert(project.AnalyzerReferences.Contains(analyzerReference1)) 
+                Debug.Assert(project.AnalyzerReferences.Contains(analyzerReference1))
 #End If
             End Using
         End Sub

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             [Import(AllowDefault = true)]IWorkspaceDiagnosticAnalyzerProviderService diagnosticAnalyzerProviderService = null,
             [Import(AllowDefault = true)]AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null)
             : this(diagnosticAnalyzerProviderService != null ? diagnosticAnalyzerProviderService.GetHostDiagnosticAnalyzerPackages() : SpecializedCollections.EmptyEnumerable<HostDiagnosticAnalyzerPackage>(),
+                diagnosticAnalyzerProviderService?.GetAnalyzerAssemblyLoader(),
                 hostDiagnosticUpdateSource,
                 registrationService, new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.DiagnosticService))
         {
@@ -39,10 +40,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         // protected for testing purposes.
         protected DiagnosticAnalyzerService(
             IEnumerable<HostDiagnosticAnalyzerPackage> workspaceAnalyzerPackages,
+            IAnalyzerAssemblyLoader hostAnalyzerAssemblyLoader,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource,
             IDiagnosticUpdateSourceRegistrationService registrationService,
             IAsynchronousOperationListener listener = null)
-            : this(new HostAnalyzerManager(workspaceAnalyzerPackages, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, registrationService, listener)
+            : this(new HostAnalyzerManager(workspaceAnalyzerPackages, hostAnalyzerAssemblyLoader, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, registrationService, listener)
         {
         }
 

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -79,13 +79,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         private readonly ConditionalWeakTable<DiagnosticAnalyzer, IReadOnlyCollection<DiagnosticDescriptor>> _descriptorCache;
 
-        /// <summary>
-        /// Loader for VSIX-based analyzers.
-        /// </summary>
-        private static readonly IAnalyzerAssemblyLoader s_assemblyLoader = new LoadContextAssemblyLoader();
-
-        public HostAnalyzerManager(IEnumerable<HostDiagnosticAnalyzerPackage> hostAnalyzerPackages, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource) :
-            this(CreateAnalyzerReferencesFromPackages(hostAnalyzerPackages, new HostAnalyzerReferenceDiagnosticReporter(hostDiagnosticUpdateSource)),
+        public HostAnalyzerManager(IEnumerable<HostDiagnosticAnalyzerPackage> hostAnalyzerPackages, IAnalyzerAssemblyLoader hostAnalyzerAssemblyLoader, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource) :
+            this(CreateAnalyzerReferencesFromPackages(hostAnalyzerPackages, new HostAnalyzerReferenceDiagnosticReporter(hostDiagnosticUpdateSource), hostAnalyzerAssemblyLoader),
                  hostAnalyzerPackages.ToImmutableArrayOrEmpty(), hostDiagnosticUpdateSource)
         {
         }
@@ -469,19 +464,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static ImmutableArray<AnalyzerReference> CreateAnalyzerReferencesFromPackages(
             IEnumerable<HostDiagnosticAnalyzerPackage> analyzerPackages,
-            HostAnalyzerReferenceDiagnosticReporter reporter)
+            HostAnalyzerReferenceDiagnosticReporter reporter,
+            IAnalyzerAssemblyLoader hostAnalyzerAssemblyLoader)
         {
             if (analyzerPackages == null || analyzerPackages.IsEmpty())
             {
                 return ImmutableArray<AnalyzerReference>.Empty;
             }
 
+            Contract.ThrowIfNull(hostAnalyzerAssemblyLoader);
+
             var analyzerAssemblies = analyzerPackages.SelectMany(p => p.Assemblies);
 
             var builder = ImmutableArray.CreateBuilder<AnalyzerReference>();
             foreach (var analyzerAssembly in analyzerAssemblies.Distinct(StringComparer.OrdinalIgnoreCase))
             {
-                var reference = new AnalyzerFileReference(analyzerAssembly, s_assemblyLoader);
+                var reference = new AnalyzerFileReference(analyzerAssembly, hostAnalyzerAssemblyLoader);
                 reference.AnalyzerLoadFailed += reporter.OnAnalyzerLoadFailed;
 
                 builder.Add(reference);
@@ -541,57 +539,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     diagnostics: ImmutableArray.Create<DiagnosticData>(diagnostic));
 
                 _hostUpdateSource.RaiseDiagnosticsUpdated(args);
-            }
-        }
-
-        private class LoadContextAssemblyLoader : IAnalyzerAssemblyLoader
-        {
-            public void AddDependencyLocation(string fullPath)
-            {
-            }
-
-            public Assembly LoadFromPath(string fullPath)
-            {
-                // We want to load the analyzer assembly assets in default context.
-                // Use Assembly.Load instead of Assembly.LoadFrom to ensure that if the assembly is ngen'ed, then the native image gets loaded.
-                return Assembly.Load(GetAssemblyName(fullPath));
-            }
-
-            private AssemblyName GetAssemblyName(string fullPath)
-            {
-                using (var stream = PortableShim.File.OpenRead(fullPath))
-                {
-                    using (var peReader = new PEReader(stream))
-                    {
-                        var reader = peReader.GetMetadataReader();
-                        var assemblyDef = reader.GetAssemblyDefinition();
-
-                        var name = reader.GetString(assemblyDef.Name);
-
-                        var cultureName = assemblyDef.Culture.IsNil
-                            ? null
-                            : reader.GetString(assemblyDef.Culture);
-
-                        var publicKeyOrToken = reader.GetBlobContent(assemblyDef.PublicKey);
-                        var hasPublicKey = !publicKeyOrToken.IsEmpty;
-
-                        if (publicKeyOrToken.IsEmpty)
-                        {
-                            publicKeyOrToken = default(ImmutableArray<byte>);
-                        }
-
-                        var identity = new AssemblyIdentity(
-                            name: name,
-                            version: assemblyDef.Version,
-                            cultureName: cultureName,
-                            publicKeyOrToken: publicKeyOrToken,
-                            hasPublicKey: hasPublicKey,
-                            isRetargetable: (assemblyDef.Flags & AssemblyFlags.Retargetable) != 0,
-                            contentType: (AssemblyContentType)((int)(assemblyDef.Flags & AssemblyFlags.ContentTypeMask) >> 9));
-
-                        return new AssemblyName(identity.GetDisplayName());
-                    }
-                }
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/IWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -11,5 +11,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// This includes the analyzers included through VSIX installations.
         /// </summary>
         IEnumerable<HostDiagnosticAnalyzerPackage> GetHostDiagnosticAnalyzerPackages();
+
+        /// <summary>
+        /// Gets the loader for VSIX based analyzer assemblies.
+        /// </summary>
+        /// <returns></returns>
+        IAnalyzerAssemblyLoader GetAnalyzerAssemblyLoader();
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.AnalyzerAssemblyLoader.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.AnalyzerAssemblyLoader.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
+{
+    internal partial class VisualStudioWorkspaceDiagnosticAnalyzerProviderService : IWorkspaceDiagnosticAnalyzerProviderService
+    {
+        private sealed class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+        {
+            private readonly IAnalyzerAssemblyLoader _fallbackLoader;
+
+            public AnalyzerAssemblyLoader()
+            {
+                _fallbackLoader = new SimpleAnalyzerAssemblyLoader();
+            }
+
+            public void AddDependencyLocation(string fullPath)
+            {
+                _fallbackLoader.AddDependencyLocation(fullPath);
+            }
+
+            public Assembly LoadFromPath(string fullPath)
+            {
+                try
+                {
+                    // We want to load the analyzer assembly assets in default context.
+                    // Use Assembly.Load instead of Assembly.LoadFrom to ensure that if the assembly is ngen'ed, then the native image gets loaded.
+                    return Assembly.Load(AssemblyName.GetAssemblyName(fullPath));
+                }
+                catch (Exception)
+                {
+                    // Use the fallback loader if we fail to load the assembly in the default context.
+                    return _fallbackLoader.LoadFromPath(fullPath);
+                }
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.ExtensionManager;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -19,11 +20,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
     /// These analyzers are used across this workspace session.
     /// </summary>
     [Export(typeof(IWorkspaceDiagnosticAnalyzerProviderService))]
-    internal class VisualStudioWorkspaceDiagnosticAnalyzerProviderService : IWorkspaceDiagnosticAnalyzerProviderService
+    internal partial class VisualStudioWorkspaceDiagnosticAnalyzerProviderService : IWorkspaceDiagnosticAnalyzerProviderService
     {
         private const string AnalyzerContentTypeName = "Microsoft.VisualStudio.Analyzer";
 
         private readonly ImmutableArray<HostDiagnosticAnalyzerPackage> _hostDiagnosticAnalyzerInfo;
+
+        /// <summary>
+        /// Loader for VSIX-based analyzers.
+        /// </summary>
+        private static readonly AnalyzerAssemblyLoader s_analyzerAssemblyLoader = new AnalyzerAssemblyLoader();
 
         [ImportingConstructor]
         public VisualStudioWorkspaceDiagnosticAnalyzerProviderService(VisualStudioWorkspaceImpl workspace)
@@ -47,6 +53,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
         public IEnumerable<HostDiagnosticAnalyzerPackage> GetHostDiagnosticAnalyzerPackages()
         {
             return _hostDiagnosticAnalyzerInfo;
+        }
+
+        public IAnalyzerAssemblyLoader GetAnalyzerAssemblyLoader()
+        {
+            return s_analyzerAssemblyLoader;
+        }
+
+        // internal for testing purposes.
+        internal static IAnalyzerAssemblyLoader GetLoader()
+        {
+            return s_analyzerAssemblyLoader;
         }
 
         // internal for testing purpose

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Implementation\AnalyzerDependency\IgnorableAssemblyNamePrefixList.cs" />
     <Compile Include="Implementation\CompilationErrorTelemetry\CompilationErrorTelemetryIncrementalAnalyzer.cs" />
     <Compile Include="Implementation\Diagnostics\VisualStudioVenusSpanMappingService.cs" />
+    <Compile Include="Implementation\Diagnostics\VisualStudioWorkspaceDiagnosticAnalyzerProviderService.AnalyzerAssemblyLoader.cs" />
     <Compile Include="Implementation\EditAndContinue\Interop\NativeMethods.cs" />
     <Compile Include="Implementation\AnalyzerDependency\IIgnorableAssemblyList.cs" />
     <Compile Include="Implementation\AnalyzerDependency\IBindingRedirectionService.cs" />

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderServiceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderServiceTests.vb
@@ -1,8 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 Imports Roslyn.Test.Utilities
+Imports Roslyn.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
     Public Class VisualStudioWorkspaceDiagnosticAnalyzerProviderServiceTests
@@ -38,6 +42,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Assert.Equal(packages(0).Assemblies(0), "installPath1")
             Assert.Equal(packages(0).Assemblies(1), "installPath2")
             Assert.Equal(packages(0).Assemblies(2), "installPath3")
+        End Sub
+
+        <WpfFact, WorkItem(6285, "https://github.com/dotnet/roslyn/issues/6285")>
+        Public Sub TestHostAnalyzerAssemblyLoader()
+            Using tempRoot = New TempRoot
+                Dim dir = tempRoot.CreateDirectory
+                Dim analyzerFile = TestHelpers.CreateCSharpAnalyzerAssemblyWithTestAnalyzer(dir, "TestAnalyzer")
+                Dim analyzerPackage = New HostDiagnosticAnalyzerPackage("MyPackage", ImmutableArray.Create(analyzerFile.Path))
+                Dim analyzerPackages = SpecializedCollections.SingletonEnumerable(analyzerPackage)
+                Dim analyzerLoader = VisualStudioWorkspaceDiagnosticAnalyzerProviderService.GetLoader()
+                Dim hostAnalyzerManager = New HostAnalyzerManager(analyzerPackages, analyzerLoader, hostDiagnosticUpdateSource:=Nothing)
+                Dim analyzerReferenceMap = hostAnalyzerManager.GetHostDiagnosticAnalyzersPerReference(LanguageNames.CSharp)
+                Assert.Single(analyzerReferenceMap)
+                Dim analyzers = analyzerReferenceMap.Single().Value
+                Assert.Single(analyzers)
+                Assert.Equal("TestAnalyzer", analyzers(0).ToString)
+            End Using
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
**Customer scenario:** User installs any VSIX based analyzer into their extensions hive, but the analyzers and fixers from the installed extension don't work.

**Reason:** While making the features layer portable, we changed the analyzer assembly loader for VSIX based analyzers to use the PEReader to get the assembly name for loading the assembly. Prior to that, we used to invoke the desktop API "AssemblyName.GetAssemblyName", which sets the CodeBase property of the returned assembly name to be full path of the assembly. Assembly.Load would attempt to load the ngen'ed image of the assembly, and if it doesn't exist then search will eventually fall back to loading the managed assembly at the CodeBase location. We lost the latter functionality when we made the above change, which causes the assembly loader to fail loading the assembly at the specified full path.

**Fix:** Move the analyzer assembly loader to the non-portable VS diagnostic analyzer provider service. Any host which needs to support VSIX based analyzers must also implement the assembly loader for VSIX analyzers.

**Testing:** Verified that assemblies from VSIX based analyzer extensions get loaded successfully and the diagnostics/code fixes work fine. Also added a unit test to verify that host analyzer manager can load assemblies from custom install paths - verified that test fails prior to this change.

**Fixes #6285**