### PR TITLE
Remove equivalenceKey from CodeAction.Create overload

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionCodeAction.cs
@@ -9,24 +9,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
     internal sealed class SuppressionCodeAction : CodeAction.SimpleCodeAction
     {
         public SuppressionCodeAction(Diagnostic diagnostic, IEnumerable<CodeAction> nestedActions)
-            : base(string.Format(FeaturesResources.SuppressionCodeActionTitle, diagnostic.Id), nestedActions.AsImmutableOrEmpty(), ComputeEquivalenceKey(nestedActions))
+            : base(string.Format(FeaturesResources.SuppressionCodeActionTitle, diagnostic.Id), nestedActions.AsImmutableOrEmpty())
         {
-        }
-
-        private static string ComputeEquivalenceKey(IEnumerable<CodeAction> nestedActions)
-        {
-            if (nestedActions == null)
-            {
-                return null;
-            }
-
-            var equivalenceKey = string.Empty;
-            foreach (var action in nestedActions)
-            {
-                equivalenceKey += (action.EquivalenceKey ?? action.GetHashCode().ToString() + ";");
-            }
-
-            return equivalenceKey;
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         // Wrap the generate type actions into a single top level suggestion
                         // so as to not clutter the list.
                         return SpecializedCollections.SingletonEnumerable(
-                            new MyCodeAction(FeaturesResources.Generate_type, actions.AsImmutable(), actions[0].EquivalenceKey));
+                            new MyCodeAction(FeaturesResources.Generate_type, actions.AsImmutable()));
                     }
                     else
                     {
@@ -295,8 +295,8 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
         private class MyCodeAction : CodeAction.SimpleCodeAction
         {
-            public MyCodeAction(string title, ImmutableArray<CodeAction> nestedActions, string equivalenceKey)
-                : base(title, nestedActions, equivalenceKey)
+            public MyCodeAction(string title, ImmutableArray<CodeAction> nestedActions)
+                : base(title, nestedActions)
             {
             }
         }

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -293,19 +293,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
             return new SolutionChangeAction(title, createChangedSolution, equivalenceKey);
         }
 
-        /// <summary>
-        /// Creates a top level code action with multiple code action choices a user can invoke.
-        /// </summary>
-        public static CodeAction Create(string title, IEnumerable<CodeAction> nestedActions)
-        {
-            if (title == null)
-            {
-                throw new ArgumentNullException(nameof(title));
-            }
-
-            return new SimpleCodeAction(title, nestedActions.AsImmutableOrEmpty());
-        }
-
         internal class SimpleCodeAction : CodeAction
         {
             private readonly string _title;

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -296,14 +296,14 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <summary>
         /// Creates a top level code action with multiple code action choices a user can invoke.
         /// </summary>
-        public static CodeAction Create(string title, IEnumerable<CodeAction> nestedActions, string equivalenceKey = null)
+        public static CodeAction Create(string title, IEnumerable<CodeAction> nestedActions)
         {
             if (title == null)
             {
                 throw new ArgumentNullException(nameof(title));
             }
 
-            return new SimpleCodeAction(title, nestedActions.AsImmutableOrEmpty(), equivalenceKey);
+            return new SimpleCodeAction(title, nestedActions.AsImmutableOrEmpty());
         }
 
         internal class SimpleCodeAction : CodeAction
@@ -312,11 +312,18 @@ namespace Microsoft.CodeAnalysis.CodeActions
             private readonly string _equivalenceKey;
             private readonly ImmutableArray<CodeAction> _nestedActions;
 
-            public SimpleCodeAction(string title, ImmutableArray<CodeAction> nestedActions, string equivalenceKey)
+            public SimpleCodeAction(string title, ImmutableArray<CodeAction> nestedActions)
             {
                 _title = title;
                 _nestedActions = nestedActions;
+                _equivalenceKey = ComputeEquivalenceKey(nestedActions);
+            }
+
+            public SimpleCodeAction(string title, string equivalenceKey)
+            {
+                _title = title;
                 _equivalenceKey = equivalenceKey;
+                _nestedActions = ImmutableArray<CodeAction>.Empty;
             }
 
             public sealed override string Title => _title;
@@ -334,6 +341,29 @@ namespace Microsoft.CodeAnalysis.CodeActions
             {
                 return Task.FromResult<Document>(null);
             }
+
+            private static string ComputeEquivalenceKey(IEnumerable<CodeAction> nestedActions)
+            {
+                if (nestedActions == null)
+                {
+                    return null;
+                }
+
+                var equivalenceKey = StringBuilderPool.Allocate();
+                try
+                {
+                    foreach (var action in nestedActions)
+                    {
+                        equivalenceKey.Append(action.EquivalenceKey ?? action.GetHashCode().ToString() + ";");
+                    }
+
+                    return equivalenceKey.Length > 0 ? equivalenceKey.ToString() : null;
+                }
+                finally
+                {
+                    StringBuilderPool.ReturnAndFree(equivalenceKey);
+                }
+            }
         }
 
         internal class DocumentChangeAction : SimpleCodeAction
@@ -341,7 +371,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
             private readonly Func<CancellationToken, Task<Document>> _createChangedDocument;
 
             public DocumentChangeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey = null)
-                : base(title, nestedActions: ImmutableArray<CodeAction>.Empty, equivalenceKey: equivalenceKey)
+                : base(title, equivalenceKey)
             {
                 _createChangedDocument = createChangedDocument;
             }
@@ -359,7 +389,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
             private readonly Func<CancellationToken, Task<Solution>> _createChangedSolution;
 
             public SolutionChangeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution, string equivalenceKey = null)
-                : base(title, nestedActions: ImmutableArray<CodeAction>.Empty, equivalenceKey: equivalenceKey)
+                : base(title, equivalenceKey)
             {
                 _createChangedSolution = createChangedSolution;
             }

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,6 +3,6 @@ Microsoft.CodeAnalysis.Project.IsSubmission.get -> bool
 Microsoft.CodeAnalysis.Workspace.UpdateReferencesAfterAdd() -> void
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ArrayCreationExpression(Microsoft.CodeAnalysis.SyntaxNode elementType, Microsoft.CodeAnalysis.SyntaxNode size) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ArrayCreationExpression(Microsoft.CodeAnalysis.SyntaxNode elementType, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> elements) -> Microsoft.CodeAnalysis.SyntaxNode
-static Microsoft.CodeAnalysis.CodeActions.CodeAction.Create(string title, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeAction> nestedActions, string equivalenceKey = null) -> Microsoft.CodeAnalysis.CodeActions.CodeAction
+static Microsoft.CodeAnalysis.CodeActions.CodeAction.Create(string title, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeAction> nestedActions) -> Microsoft.CodeAnalysis.CodeActions.CodeAction
 static Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetGenerator(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Editing.SyntaxGenerator
 virtual Microsoft.CodeAnalysis.Editing.SyntaxGenerator.RemoveNode(Microsoft.CodeAnalysis.SyntaxNode root, Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.SyntaxRemoveOptions options) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,6 +3,5 @@ Microsoft.CodeAnalysis.Project.IsSubmission.get -> bool
 Microsoft.CodeAnalysis.Workspace.UpdateReferencesAfterAdd() -> void
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ArrayCreationExpression(Microsoft.CodeAnalysis.SyntaxNode elementType, Microsoft.CodeAnalysis.SyntaxNode size) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ArrayCreationExpression(Microsoft.CodeAnalysis.SyntaxNode elementType, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> elements) -> Microsoft.CodeAnalysis.SyntaxNode
-static Microsoft.CodeAnalysis.CodeActions.CodeAction.Create(string title, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeActions.CodeAction> nestedActions) -> Microsoft.CodeAnalysis.CodeActions.CodeAction
 static Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetGenerator(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Editing.SyntaxGenerator
 virtual Microsoft.CodeAnalysis.Editing.SyntaxGenerator.RemoveNode(Microsoft.CodeAnalysis.SyntaxNode root, Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.SyntaxRemoveOptions options) -> Microsoft.CodeAnalysis.SyntaxNode


### PR DESCRIPTION
Automatically calculate equivalence keys from nested actions.

Fixes #5975.