### PR TITLE
Remove PumpingWait

### DIFF
--- a/src/EditorFeatures/CSharpTest/EventHookup/EventHookupTestState.cs
+++ b/src/EditorFeatures/CSharpTest/EventHookup/EventHookupTestState.cs
@@ -43,13 +43,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EventHookup
             return new EventHookupTestState(XElement.Parse(workspaceXml));
         }
 
-        public void WaitForAsyncOperations()
-        {
-            var waiters = this.Workspace.ExportProvider.GetExportedValues<IAsynchronousOperationWaiter>();
-            var tasks = waiters.Select(w => w.CreateWaitTask()).ToList();
-            tasks.PumpingWaitAll();
-        }
-
         internal void AssertShowing(string expectedText)
         {
             Assert.NotNull(_commandHandler.EventHookupSessionManager.QuickInfoSession);

--- a/src/EditorFeatures/Test/AbstractCommandHandlerTestState.cs
+++ b/src/EditorFeatures/Test/AbstractCommandHandlerTestState.cs
@@ -270,13 +270,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
             await waiters.WaitAllAsync().ConfigureAwait(true);
         }
 
-        public void WaitForAsynchronousOperations()
-        {
-            var waiters = Workspace.ExportProvider.GetExportedValues<IAsynchronousOperationWaiter>();
-            var tasks = waiters.Select(w => w.CreateWaitTask()).ToList();
-            tasks.PumpingWaitAll();
-        }
-
         public void AssertMatchesTextStartingAtLine(int line, string text)
         {
             var lines = text.Split('\r');

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -826,9 +826,9 @@ End Class";
             {
                 foreach (var document in project.Documents)
                 {
-                    document.GetTextAsync().PumpingWait();
-                    document.GetSyntaxRootAsync().PumpingWait();
-                    document.GetSemanticModelAsync().PumpingWait();
+                    document.GetTextAsync().Wait();
+                    document.GetSyntaxRootAsync().Wait();
+                    document.GetSemanticModelAsync().Wait();
                 }
             }
         }

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -313,11 +313,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
                 service.Register(workspace);
 
                 // don't rely on background parser to have tree. explicitly do it here.
-                TouchEverything(workspace.CurrentSolution);
+                await TouchEverything(workspace.CurrentSolution).ConfigureAwait(true);
 
                 service.Reanalyze(workspace, worker, projectIds: null, documentIds: SpecializedCollections.SingletonEnumerable<DocumentId>(info.Id));
 
-                TouchEverything(workspace.CurrentSolution);
+                await TouchEverything(workspace.CurrentSolution).ConfigureAwait(true);
 
                 await WaitAsync(service, workspace).ConfigureAwait(true);
 
@@ -809,9 +809,9 @@ End Class";
             service.Register(workspace);
 
             // don't rely on background parser to have tree. explicitly do it here.
-            TouchEverything(workspace.CurrentSolution);
+            await TouchEverything(workspace.CurrentSolution).ConfigureAwait(true);
             operation(workspace);
-            TouchEverything(workspace.CurrentSolution);
+            await TouchEverything(workspace.CurrentSolution).ConfigureAwait(true);
 
             await WaitAsync(service, workspace).ConfigureAwait(true);
 
@@ -820,15 +820,15 @@ End Class";
             return worker;
         }
 
-        private void TouchEverything(Solution solution)
+        private async Task TouchEverything(Solution solution)
         {
             foreach (var project in solution.Projects)
             {
                 foreach (var document in project.Documents)
                 {
-                    document.GetTextAsync().Wait();
-                    document.GetSyntaxRootAsync().Wait();
-                    document.GetSemanticModelAsync().Wait();
+                    await document.GetTextAsync().ConfigureAwait(true);
+                    await document.GetSyntaxRootAsync().ConfigureAwait(true);
+                    await document.GetSemanticModelAsync().ConfigureAwait(true);
                 }
             }
         }

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -27,10 +27,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
                 state.SendTypeChars("using System.Ne")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Net", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Net", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars("x")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Net", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Net", isSoftSelected:=True).ConfigureAwait(True)
                 state.SendTab()
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 Assert.Contains("using System.Net", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -189,7 +189,7 @@ class MyException : $$]]></Document>)
 
                 state.SendTypeChars("Test")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:="class TestException" & vbCrLf & "TestDocComment")
+                Await state.AssertSelectedCompletionItem(description:="class TestException" & vbCrLf & "TestDocComment").ConfigureAwait(True)
             End Using
         End Function
 
@@ -209,19 +209,19 @@ class C
 
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True).ConfigureAwait(True)
                 Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList<>", "List<>", "System"}))
                 state.SendTypeChars("Li")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True).ConfigureAwait(True)
                 Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList<>", "List<>"}))
                 Assert.False(state.CompletionItemsContainsAny(displayText:={"System"}))
                 state.SendTypeChars("n")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="LinkedList<>", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="LinkedList<>", isHardSelected:=True).ConfigureAwait(True)
                 state.SendBackspace()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="List<int>", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTab()
                 Assert.Contains("new List<int>", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -242,7 +242,7 @@ partial class C
 
                 state.SendTypeChars("C")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars(" ")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
             End Using
@@ -285,7 +285,7 @@ class @return
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 state.SendTypeChars("r")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="@return", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="@return", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTab()
                 Assert.Contains("@return", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -341,7 +341,7 @@ class Program
 
                 state.SendTypeChars("using Sys")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars("(")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 Assert.Contains("using Sys(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -357,7 +357,7 @@ class Program
 
                 state.SendTypeChars("using Sys")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars(".")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
                 Assert.Contains("using System.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -373,7 +373,7 @@ class Program
 
                 state.SendTypeChars("using Sys")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars(";")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 state.AssertMatchesTextStartingAtLine(1, "using System;")
@@ -389,7 +389,7 @@ class Program
 
                 state.SendTypeChars("using Sys")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars(" ")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 Assert.Contains("using Sys ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -411,7 +411,7 @@ class C
 
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="string", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="string", isHardSelected:=True).ConfigureAwait(True)
                 Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(c) c.DisplayText = "int"))
             End Using
         End Function
@@ -461,7 +461,7 @@ class Foo
 
                 state.SendTypeChars(", ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True).ConfigureAwait(True)
                 Assert.Equal(1, state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(c) c.DisplayText = "Numeros").Count())
             End Using
         End Function
@@ -484,7 +484,7 @@ class Foo
 
                 state.SendTypeChars(", ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True).ConfigureAwait(True)
                 Assert.Equal(1, state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(c) c.DisplayText = "Numeros").Count())
             End Using
         End Function
@@ -532,7 +532,7 @@ class Foo
 
                 state.SendTypeChars("Nu")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars(c.ToString())
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 Assert.Contains(String.Format("Numeros num = Nu{0}", c), state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -558,11 +558,9 @@ class Program
                 Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "@int:"))
                 state.SendTypeChars("n")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "@int:"))
                 state.SendTypeChars("t")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "@int:"))
             End Using
         End Function
@@ -827,10 +825,10 @@ class C
                 Assert.Equal(12, state.TextView.Caret.Position.VirtualSpaces)
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("P", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem("P", isSoftSelected:=True).ConfigureAwait(True)
                 state.SendDownKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("P", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("P", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 Assert.Equal("            P", state.GetLineFromCurrentCaretPosition().GetText())
@@ -874,7 +872,7 @@ class Program
                 ' ensure we still select the named param even though 'string' is in the MRU.
                 state.SendTypeChars("Foo(s")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("s:")
+                Await state.AssertSelectedCompletionItem("s:").ConfigureAwait(True)
             End Using
         End Function
 
@@ -937,7 +935,7 @@ class C
             ]]></Document>)
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Numeros")
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros").ConfigureAwait(True)
             End Using
         End Function
 
@@ -959,7 +957,7 @@ class C
             ]]></Document>)
                 state.SendTypeChars("w")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="W")
+                Await state.AssertSelectedCompletionItem(displayText:="W").ConfigureAwait(True)
             End Using
         End Function
 
@@ -978,13 +976,13 @@ class C
             ]]></Document>)
                 state.SendTypeChars("Met")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Method")
+                Await state.AssertSelectedCompletionItem(displayText:="Method").ConfigureAwait(True)
                 state.SendLeftKey()
                 state.SendLeftKey()
                 state.SendLeftKey()
                 state.SendTypeChars("new")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Method", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Method", isSoftSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1005,7 +1003,7 @@ class TestException : Exception { }
                 Await state.AssertCompletionSession().ConfigureAwait(True)
                 state.SendTypeChars("!")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("!--")
+                Await state.AssertSelectedCompletionItem("!--").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1024,7 +1022,7 @@ class C
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("string")
+                Await state.AssertSelectedCompletionItem("string").ConfigureAwait(True)
                 state.CompletionItemsContainsAll({"integer", "Method"})
             End Using
         End Function
@@ -1044,7 +1042,7 @@ class C
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("AccessViolationException")
+                Await state.AssertSelectedCompletionItem("AccessViolationException").ConfigureAwait(True)
                 state.CompletionItemsContainsAll({"integer", "Method"})
             End Using
         End Function
@@ -1064,7 +1062,7 @@ class C
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("string")
+                Await state.AssertSelectedCompletionItem("string").ConfigureAwait(True)
                 state.CompletionItemsContainsAll({"integer", "Method"})
             End Using
         End Function
@@ -1115,7 +1113,7 @@ class Program
 
                 state.SendTypeChars("F")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("F<>")
+                Await state.AssertSelectedCompletionItem("F<>").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1179,10 +1177,9 @@ class Program
 
                 state.SendTypeChars(" ")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("List<int>")
+                Await state.AssertSelectedCompletionItem("List<int>").ConfigureAwait(True)
                 state.SendTypeChars("(")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 Assert.Equal(expected, state.GetDocumentText())
             End Using
         End Function
@@ -1228,7 +1225,7 @@ class C
                 state.SendTypeChars("str = @th")
 
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("@this")
+                Await state.AssertSelectedCompletionItem("@this").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1241,7 +1238,7 @@ class C
 class AtAttribute : System.Attribute { }]]></Document>)
                 state.SendTypeChars("At")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("At")
+                Await state.AssertSelectedCompletionItem("At").ConfigureAwait(True)
                 Assert.Equal("At", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
             End Using
         End Function
@@ -1260,7 +1257,7 @@ class C
 }]]></Document>)
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Exception")
+                Await state.AssertSelectedCompletionItem("Exception").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1306,7 +1303,7 @@ class C
                 Dim linkDocument = documents.Single(Function(d) d.IsLinkFile)
                 state.SendTypeChars("Thing1")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Thing1")
+                Await state.AssertSelectedCompletionItem("Thing1").ConfigureAwait(True)
                 state.SendBackspace()
                 state.SendBackspace()
                 state.SendBackspace()
@@ -1317,7 +1314,7 @@ class C
                 state.Workspace.SetDocumentContext(linkDocument.Id)
                 state.SendTypeChars("Thing1")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Thing1")
+                Await state.AssertSelectedCompletionItem("Thing1").ConfigureAwait(True)
                 Assert.True(state.CurrentCompletionPresenterSession.SelectedItem.ShowsWarningIcon)
                 state.SendBackspace()
                 state.SendBackspace()
@@ -1327,7 +1324,7 @@ class C
                 state.SendBackspace()
                 state.SendTypeChars("M")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("M")
+                Await state.AssertSelectedCompletionItem("M").ConfigureAwait(True)
                 Assert.False(state.CurrentCompletionPresenterSession.SelectedItem.ShowsWarningIcon)
             End Using
         End Function
@@ -1343,7 +1340,7 @@ class C
 }]]></Document>)
                 state.SendTypeChars("voi")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("void")
+                Await state.AssertSelectedCompletionItem("void").ConfigureAwait(True)
                 state.SendSave()
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 state.AssertMatchesTextStartingAtLine(3, "    voi")
@@ -1389,7 +1386,7 @@ class C
 }]]></Document>)
                 state.SendTypeChars("#reg")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("region")
+                Await state.AssertSelectedCompletionItem("region").ConfigureAwait(True)
                 state.SendReturn()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 state.AssertMatchesTextStartingAtLine(3, "    #region")
@@ -1407,7 +1404,7 @@ class C
 }]]></Document>)
                 state.SendTypeChars("#reg")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("region")
+                Await state.AssertSelectedCompletionItem("region").ConfigureAwait(True)
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 state.AssertMatchesTextStartingAtLine(3, "    #region ")
@@ -1426,7 +1423,7 @@ class C
 }]]></Document>)
                 state.SendTypeChars("#endreg")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("endregion")
+                Await state.AssertSelectedCompletionItem("endregion").ConfigureAwait(True)
                 state.SendReturn()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 state.AssertMatchesTextStartingAtLine(4, "    #endregion ")

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Projections.vb
@@ -27,7 +27,7 @@ public override void Execute() {
 
                 state.SendTypeChars(".Curr")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="CurrentDomain")
+                Await state.AssertSelectedCompletionItem(displayText:="CurrentDomain").ConfigureAwait(True)
                 state.SendTab()
                 Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -68,7 +68,7 @@ class C
 
                 state.SendTypeCharsToSpecificViewAndBuffer("Cons", view, buffer)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Console")
+                Await state.AssertSelectedCompletionItem(displayText:="Console").ConfigureAwait(True)
             End Using
         End Function
 
@@ -104,7 +104,7 @@ class C
 
                 state.SendTypeCharsToSpecificViewAndBuffer(" ", view, buffer)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="string", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="string", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -141,7 +141,7 @@ class C
 
                 state.SendTypeCharsToSpecificViewAndBuffer("#reg", view, buffer)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="region", shouldFormatOnCommit:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="region", shouldFormatOnCommit:=True).ConfigureAwait(True)
 
             End Using
         End Function

--- a/src/EditorFeatures/Test2/IntelliSense/TestState.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestState.vb
@@ -237,12 +237,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                        Function(i) i.DisplayText = v))
         End Function
 
-        Public Sub AssertSelectedCompletionItem(Optional displayText As String = Nothing,
+        Public Async Function AssertSelectedCompletionItem(Optional displayText As String = Nothing,
                                Optional description As String = Nothing,
                                Optional isSoftSelected As Boolean? = Nothing,
                                Optional isHardSelected As Boolean? = Nothing,
-                               Optional shouldFormatOnCommit As Boolean? = Nothing)
-            WaitForAsynchronousOperations()
+                               Optional shouldFormatOnCommit As Boolean? = Nothing) As Task
+            Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
             If isSoftSelected.HasValue Then
                 Assert.Equal(isSoftSelected.Value, Me.CurrentCompletionPresenterSession.IsSoftSelected)
             End If
@@ -268,7 +268,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             If description IsNot Nothing Then
                 Assert.Equal(description, Me.CurrentCompletionPresenterSession.SelectedItem.GetDescriptionAsync().Result.GetFullText())
             End If
-        End Sub
+        End Function
 
 #End Region
 
@@ -310,11 +310,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             MyBase.SendInvokeSignatureHelp(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
         End Sub
 
-        Public Sub SendSelectSignatureHelpItemThroughPresenterSession(item As SignatureHelpItem)
-            WaitForAsynchronousOperations()
-            CurrentSignatureHelpPresenterSession.SetSelectedItem(item)
-        End Sub
-
         Public Async Function AssertNoSignatureHelpSession(Optional block As Boolean = True) As Task
             If block Then
                 Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
@@ -347,13 +342,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Function
 
         Public Function SignatureHelpItemsContainsAll(displayText As String()) As Boolean
-            WaitForAsynchronousOperations()
+            AssertNoAsynchronousOperationsRunning()
             Return displayText.All(Function(v) CurrentSignatureHelpPresenterSession.SignatureHelpItems.Any(
                                        Function(i) GetDisplayText(i, CurrentSignatureHelpPresenterSession.SelectedParameter.Value) = v))
         End Function
 
         Public Function SignatureHelpItemsContainsAny(displayText As String()) As Boolean
-            WaitForAsynchronousOperations()
+            AssertNoAsynchronousOperationsRunning()
             Return displayText.Any(Function(v) CurrentSignatureHelpPresenterSession.SignatureHelpItems.Any(
                                        Function(i) GetDisplayText(i, CurrentSignatureHelpPresenterSession.SelectedParameter.Value) = v))
         End Function

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -25,10 +25,10 @@ End Class
                               </Document>)
                 state.SendTypeChars("on")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("On Error GoTo", description:=String.Format(FeaturesResources.Keyword, "On Error GoTo") + vbCrLf + VBFeaturesResources.OnErrorGotoKeywordToolTip)
+                Await state.AssertSelectedCompletionItem("On Error GoTo", description:=String.Format(FeaturesResources.Keyword, "On Error GoTo") + vbCrLf + VBFeaturesResources.OnErrorGotoKeywordToolTip).ConfigureAwait(True)
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Error GoTo", description:=String.Format(FeaturesResources.Keyword, "Error GoTo") + vbCrLf + VBFeaturesResources.OnErrorGotoKeywordToolTip)
+                Await state.AssertSelectedCompletionItem("Error GoTo", description:=String.Format(FeaturesResources.Keyword, "Error GoTo") + vbCrLf + VBFeaturesResources.OnErrorGotoKeywordToolTip).ConfigureAwait(True)
             End Using
         End Function
 
@@ -46,7 +46,7 @@ End Class
 
                 state.SendTypeChars("next")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("On Error Resume Next", description:=String.Format(FeaturesResources.Keyword, "On Error Resume Next") + vbCrLf + VBFeaturesResources.OnErrorResumeNextKeywordToolTip)
+                Await state.AssertSelectedCompletionItem("On Error Resume Next", description:=String.Format(FeaturesResources.Keyword, "On Error Resume Next") + vbCrLf + VBFeaturesResources.OnErrorResumeNextKeywordToolTip).ConfigureAwait(True)
                 state.SendTypeChars(" ")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
             End Using
@@ -191,7 +191,7 @@ End Module
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Equals", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem("Equals", isSoftSelected:=True).ConfigureAwait(True)
                 Dim caretPos = state.GetCaretPoint().BufferPosition.Position
                 state.SendReturn()
                 state.Workspace.Documents.First().GetTextView().Caret.MoveTo(New SnapshotPoint(state.Workspace.Documents.First().TextBuffer.CurrentSnapshot, caretPos))
@@ -233,7 +233,7 @@ End Module
                               </document>)
                 state.SendTypeChars("Progra.")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Equals", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Equals", isSoftSelected:=True).ConfigureAwait(True)
                 Assert.Contains("Program.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
@@ -279,22 +279,22 @@ End Class
                               </document>)
                 state.SendTypeChars(".A")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True).ConfigureAwait(True)
                 state.SendDownKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="B", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="B", isHardSelected:=True).ConfigureAwait(True)
                 state.SendDownKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True).ConfigureAwait(True)
                 state.SendDownKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True).ConfigureAwait(True)
                 state.SendPageUp()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True).ConfigureAwait(True)
                 state.SendUpKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -344,11 +344,9 @@ End Class
                               </document>)
                 state.SendTypeChars(".A")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 Assert.Equal(4, state.CurrentCompletionPresenterSession.CompletionItems.Count)
                 state.SendTypeChars("A")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 Assert.Equal(2, state.CurrentCompletionPresenterSession.CompletionItems.Count)
             End Using
         End Function
@@ -366,10 +364,10 @@ End Class
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Equals", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Equals", isSoftSelected:=True).ConfigureAwait(True)
                 state.SendUpKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Equals", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Equals", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -508,10 +506,10 @@ End Class
                               </document>)
                 state.SendTypeChars(".A")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True).ConfigureAwait(True)
                 state.SendDownKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="B", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="B", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 Assert.Contains(".B", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -538,7 +536,7 @@ End Class
                               </document>)
                 state.SendTypeChars(".A")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="A", isHardSelected:=True).ConfigureAwait(True)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 state.SendSelectCompletionItemThroughPresenterSession(state.CurrentCompletionPresenterSession.CompletionItems.First(
                                                            Function(i) i.DisplayText = "B"))
@@ -598,7 +596,7 @@ Class MyException
 End Class]]></document>)
                 state.SendTypeChars("TestEx")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:="Class TestException" & vbCrLf & "TestDoc")
+                Await state.AssertSelectedCompletionItem(description:="Class TestException" & vbCrLf & "TestDoc").ConfigureAwait(True)
             End Using
         End Function
 
@@ -618,19 +616,19 @@ End Module]]></Document>)
 
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True).ConfigureAwait(True)
                 Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList(Of " & ChrW(&H2026) & ")", "List(Of " & ChrW(&H2026) & ")", "System"}))
                 state.SendTypeChars("Li")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True).ConfigureAwait(True)
                 Assert.True(state.CompletionItemsContainsAll(displayText:={"LinkedList(Of " & ChrW(&H2026) & ")", "List(Of " & ChrW(&H2026) & ")"}))
                 Assert.False(state.CompletionItemsContainsAny(displayText:={"System"}))
                 state.SendTypeChars("n")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="LinkedList(Of " & ChrW(&H2026) & ")", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="LinkedList(Of " & ChrW(&H2026) & ")", isHardSelected:=True).ConfigureAwait(True)
                 state.SendBackspace()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="List(Of Integer)", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTab()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 Assert.Contains("New List(Of Integer)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -655,7 +653,7 @@ End Class]]></Document>)
 
                 state.SendBackspace()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="b", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="b", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -735,7 +733,7 @@ End Module</Document>)
                 ' Could match Int32
                 state.SendTypeChars(" I3")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Int32", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Int32", isHardSelected:=True).ConfigureAwait(True)
                 state.SendReturn()
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 Assert.Equal(<Document>
@@ -845,7 +843,7 @@ end class
 
                 state.SendTypeChars("Imports Sys")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars("(")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 Assert.Contains("Imports Sys(", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -861,7 +859,7 @@ end class
 
                 state.SendTypeChars("Imports Sys")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars(".")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
                 Assert.Contains("Imports System.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -877,7 +875,7 @@ end class
 
                 state.SendTypeChars("Imports Sys")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="System", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars(" ")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
                 Assert.Contains("Imports Sys ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -962,7 +960,7 @@ class Foo
 
                 state.SendTypeChars(", ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Numeros.Dos", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros.Dos", isSoftSelected:=True).ConfigureAwait(True)
                 Assert.Equal(1, state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(c) c.DisplayText = "Numeros").Count())
             End Using
         End Function
@@ -992,7 +990,6 @@ End Class
                 Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "string:="))
                 state.SendTypeChars("t")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 Assert.True(state.CurrentCompletionPresenterSession.CompletionItems.Any(Function(i) i.DisplayText = "string:="))
             End Using
         End Function
@@ -1079,7 +1076,7 @@ End Module
 
                 state.SendTypeChars("z")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("#Const", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem("#Const", isSoftSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1097,6 +1094,7 @@ End Class
 
                 state.SendTypeChars("(")
                 Await state.AssertSignatureHelpSession().ConfigureAwait(True)
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 Assert.True(state.SignatureHelpItemsContainsAll({"Object.Finalize()"}))
             End Using
         End Function
@@ -1116,10 +1114,10 @@ End Module
 
                 state.SendTypeChars("a")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("args", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("args", isHardSelected:=True).ConfigureAwait(True)
                 state.SendDownKey()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("args:=", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("args:=", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1138,7 +1136,7 @@ End Module
 
                 state.SendTypeChars("_")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("_AppDomain", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem("_AppDomain", isHardSelected:=False).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1211,7 +1209,7 @@ End Module|}          </Document>)
                 Await state.AssertCompletionSession().ConfigureAwait(True)
                 state.SendTypeCharsToSpecificViewAndBuffer("a", view, subjectBuffer)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="arg")
+                Await state.AssertSelectedCompletionItem(displayText:="arg").ConfigureAwait(True)
 
                 Dim text = view.TextSnapshot.GetText()
                 Dim projection = DirectCast(topProjectionBuffer.TextBuffer, IProjectionBuffer)
@@ -1225,7 +1223,7 @@ End Module|}          </Document>)
                 editorOperations.Backspace()
                 editorOperations.InsertText("b")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="bbb")
+                Await state.AssertSelectedCompletionItem(displayText:="bbb").ConfigureAwait(True)
 
                 ' prepare to remap our subject buffer
                 Dim subjectBufferText = subjectDocument.TextBuffer.CurrentSnapshot.GetText()
@@ -1246,10 +1244,10 @@ End Module|}          </Document>)
 
                 ' the same completion session should still be active after the remapping.
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="bbb")
+                Await state.AssertSelectedCompletionItem(displayText:="bbb").ConfigureAwait(True)
                 state.SendTypeCharsToSpecificViewAndBuffer("b", view, subjectBuffer)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="bbb")
+                Await state.AssertSelectedCompletionItem(displayText:="bbb").ConfigureAwait(True)
 
                 ' verify we can commit even when unmapped
                 projection.ReplaceSpans(0, projection.CurrentSnapshot.GetSourceSpans.Count, {projection.CurrentSnapshot.GetText()}, EditOptions.DefaultMinimalChange, editTag:=Nothing)
@@ -1282,7 +1280,7 @@ End Class
                 Await state.AssertCompletionSession().ConfigureAwait(True)
                 state.SendTypeChars("!")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("!--")
+                Await state.AssertSelectedCompletionItem("!--").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1382,7 +1380,7 @@ End Class
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("End", description:=String.Format(FeaturesResources.Keyword, "End") + vbCrLf + VBFeaturesResources.EndKeywordToolTip)
+                Await state.AssertSelectedCompletionItem("End", description:=String.Format(FeaturesResources.Keyword, "End") + vbCrLf + VBFeaturesResources.EndKeywordToolTip).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1448,7 +1446,7 @@ End Class
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("String")
+                Await state.AssertSelectedCompletionItem("String").ConfigureAwait(True)
                 state.CompletionItemsContainsAll({"Integer", "G"})
             End Using
         End Function
@@ -1466,7 +1464,7 @@ End Class
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("String")
+                Await state.AssertSelectedCompletionItem("String").ConfigureAwait(True)
                 state.CompletionItemsContainsAll({"Integer", "G"})
             End Using
         End Function
@@ -1484,7 +1482,7 @@ End Class
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("AccessViolationException")
+                Await state.AssertSelectedCompletionItem("AccessViolationException").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1501,7 +1499,7 @@ End Class
             ]]></Document>)
                 state.SendBackspace()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("String")
+                Await state.AssertSelectedCompletionItem("String").ConfigureAwait(True)
                 state.CompletionItemsContainsAll({"Integer", "G"})
             End Using
         End Function
@@ -1519,7 +1517,7 @@ End Class
             ]]></Document>)
                 state.SendTypeChars("str")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("String", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("String", isHardSelected:=True).ConfigureAwait(True)
                 state.SendTypeChars("gg")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
             End Using
@@ -1574,7 +1572,7 @@ End Class
             ]]></Document>)
                 state.SendBackspace()
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Integer")
+                Await state.AssertSelectedCompletionItem("Integer").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1652,7 +1650,6 @@ End Class
             ]]></Document>)
                 state.SendTypeChars("selec")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 Assert.Equal(state.CurrentCompletionPresenterSession.CompletionItems.Count, 2)
             End Using
         End Function
@@ -1730,7 +1727,7 @@ End Class]]></Document>)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("summary")
+                Await state.AssertSelectedCompletionItem("summary").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1757,7 +1754,7 @@ End Module</Document>)
 
                 state.SendTypeChars("sub")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Sub")
+                Await state.AssertSelectedCompletionItem("Sub").ConfigureAwait(True)
                 Assert.True(state.CurrentCompletionPresenterSession.Builder IsNot Nothing)
             End Using
         End Function
@@ -1772,7 +1769,7 @@ End Module</Document>)
 
                 state.SendTypeChars("prop")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Property", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem("Property", isSoftSelected:=True).ConfigureAwait(True)
                 Assert.True(state.CurrentCompletionPresenterSession.Builder IsNot Nothing)
             End Using
         End Function
@@ -1818,9 +1815,9 @@ End Class
 
                 state.SendTypeChars("GetType")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("GetType", VBFeaturesResources.GettypeFunction + vbCrLf +
+                Await state.AssertSelectedCompletionItem("GetType", VBFeaturesResources.GettypeFunction + vbCrLf +
                     ReturnsSystemTypeObject + vbCrLf +
-                    $"GetType({Typename}) As Type")
+                    $"GetType({Typename}) As Type").ConfigureAwait(True)
             End Using
         End Function
 
@@ -1844,7 +1841,7 @@ End Class
 
                 state.SendTypeChars("New")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("New", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("New", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1861,7 +1858,7 @@ End Class
                               </Document>)
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("AccessViolationException", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem("AccessViolationException", isSoftSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1884,7 +1881,7 @@ Public Class C
 End Class</Document>)
                 state.SendTypeChars("f")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("E.Foo", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem("E.Foo", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
 
@@ -1903,7 +1900,6 @@ End Class
                               </Document>)
                 state.SendTypeChars("Task")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 state.SendDownKey()
                 state.SendTypeChars(" ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
@@ -1986,7 +1982,7 @@ End Class
 
                 state.SendTypeChars("Thi")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Thing1")
+                Await state.AssertSelectedCompletionItem("Thing1").ConfigureAwait(True)
                 state.SendBackspace()
                 state.SendBackspace()
                 state.SendBackspace()
@@ -1994,7 +1990,7 @@ End Class
                 state.Workspace.SetDocumentContext(linkDocument.Id)
                 state.SendTypeChars("Thi")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Thing1")
+                Await state.AssertSelectedCompletionItem("Thing1").ConfigureAwait(True)
             End Using
         End Function
 
@@ -2044,7 +2040,7 @@ Class C
 End Class]]></Document>)
                 state.SendTypeChars("Su")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Sub")
+                Await state.AssertSelectedCompletionItem("Sub").ConfigureAwait(True)
                 state.SendSave()
                 Await state.AssertNoCompletionSession(block:=True).ConfigureAwait(True)
                 state.AssertMatchesTextStartingAtLine(2, "    Su")
@@ -2065,7 +2061,7 @@ End Class
             ]]></Document>)
                 state.SendDelete()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("String")
+                Await state.AssertSelectedCompletionItem("String").ConfigureAwait(True)
             End Using
         End Function
 
@@ -2082,7 +2078,7 @@ End Class
             ]]></Document>)
                 state.SendBackspace()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("ReadOnly")
+                Await state.AssertSelectedCompletionItem("ReadOnly").ConfigureAwait(True)
                 state.SendTypeChars("a")
                 Await state.AssertNoCompletionSession().ConfigureAwait(True)
             End Using
@@ -2118,7 +2114,6 @@ End Class
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 ' Should only have one item called 'Double' and it should have a keyword glyph
                 Dim doubleItem = state.CurrentCompletionPresenterSession.CompletionItems.Single(Function(c) c.DisplayText = "Double")
                 Assert.True(doubleItem.Glyph.Value = Glyph.Keyword)
@@ -2139,7 +2134,6 @@ End Class
             ]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.WaitForAsynchronousOperations()
                 ' We should have gotten the item corresponding to [Double] and the item for the Double keyword
                 Dim doubleItems = state.CurrentCompletionPresenterSession.CompletionItems.Where(Function(c) c.DisplayText = "Double")
                 Assert.Equal(2, doubleItems.Count())
@@ -2201,7 +2195,7 @@ Module Program
 End Module]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("Table")
+                Await state.AssertSelectedCompletionItem("Table").ConfigureAwait(True)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_Projections.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_Projections.vb
@@ -36,7 +36,7 @@ End Namespace
                 Await state.AssertCompletionSession().ConfigureAwait(True)
                 state.SendTypeChars("Curr")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="CurrentDomain")
+                Await state.AssertSelectedCompletionItem(displayText:="CurrentDomain").ConfigureAwait(True)
                 state.SendTab()
                 Assert.Contains("__o = AppDomain.CurrentDomain", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -75,7 +75,7 @@ End Class
 
                 state.SendTypeCharsToSpecificViewAndBuffer("Cons", view, buffer)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="Console")
+                Await state.AssertSelectedCompletionItem(displayText:="Console").ConfigureAwait(True)
             End Using
         End Function
 
@@ -112,7 +112,7 @@ End Class
 
                 state.SendTypeCharsToSpecificViewAndBuffer("Str", view, buffer)
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(displayText:="String", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="String", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/TestUtilities/Async/WaitHelper.cs
+++ b/src/EditorFeatures/TestUtilities/Async/WaitHelper.cs
@@ -13,67 +13,10 @@ namespace Roslyn.Test.Utilities
 {
     public static class WaitHelper
     {
-        /// <summary>
-        /// This is a hueristic for checking to see if we are in a deadlock state because
-        /// we are waiting on a Task that may be in the StaTaskScheduler queue from the 
-        /// main thread.
-        /// </summary>
-        /// <param name="tasks"></param>
-        private static void CheckForStaDeadlockInPumpingWait(IEnumerable<Task> tasks)
-        {
-            var sta = StaTaskScheduler.DefaultSta;
-            Debug.Assert(sta.Threads.Length == 1);
-
-            if (Thread.CurrentThread != sta.Threads[0])
-            {
-                return;
-            }
-
-            if (tasks.Any(x => x.Status == TaskStatus.WaitingForActivation) && sta.IsAnyQueued())
-            {
-                throw new InvalidOperationException("PumingWait is likely in a deadlock");
-            }
-        }
-
         public static void WaitForDispatchedOperationsToComplete(DispatcherPriority priority)
         {
             Action action = delegate { };
             new FrameworkElement().Dispatcher.Invoke(action, priority);
-        }
-
-        public static void PumpingWait(this Task task)
-        {
-            PumpingWaitAll(new[] { task });
-        }
-
-        public static T PumpingWaitResult<T>(this Task<T> task)
-        {
-            PumpingWait(task);
-            return task.Result;
-        }
-
-        public static void PumpingWaitAll(this IEnumerable<Task> tasks)
-        {
-            var smallTimeout = TimeSpan.FromMilliseconds(10);
-            var taskArray = tasks.ToArray();
-            var done = false;
-            while (!done)
-            {
-                done = Task.WaitAll(taskArray, smallTimeout);
-                if (!done)
-                {
-                    WaitForDispatchedOperationsToComplete(DispatcherPriority.ApplicationIdle);
-                    CheckForStaDeadlockInPumpingWait(tasks);
-                }
-            }
-
-            foreach (var task in tasks)
-            {
-                if (task.Exception != null)
-                {
-                    throw task.Exception;
-                }
-            }
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/Async/WaitHelper.cs
+++ b/src/EditorFeatures/TestUtilities/Async/WaitHelper.cs
@@ -13,10 +13,67 @@ namespace Roslyn.Test.Utilities
 {
     public static class WaitHelper
     {
+        /// <summary>
+        /// This is a hueristic for checking to see if we are in a deadlock state because
+        /// we are waiting on a Task that may be in the StaTaskScheduler queue from the 
+        /// main thread.
+        /// </summary>
+        /// <param name="tasks"></param>
+        private static void CheckForStaDeadlockInPumpingWait(IEnumerable<Task> tasks)
+        {
+            var sta = StaTaskScheduler.DefaultSta;
+            Debug.Assert(sta.Threads.Length == 1);
+
+            if (Thread.CurrentThread != sta.Threads[0])
+            {
+                return;
+            }
+
+            if (tasks.Any(x => x.Status == TaskStatus.WaitingForActivation) && sta.IsAnyQueued())
+            {
+                throw new InvalidOperationException("PumingWait is likely in a deadlock");
+            }
+        }
+
         public static void WaitForDispatchedOperationsToComplete(DispatcherPriority priority)
         {
             Action action = delegate { };
             new FrameworkElement().Dispatcher.Invoke(action, priority);
+        }
+
+        public static void PumpingWait(this Task task)
+        {
+            PumpingWaitAll(new[] { task });
+        }
+
+        public static T PumpingWaitResult<T>(this Task<T> task)
+        {
+            PumpingWait(task);
+            return task.Result;
+        }
+
+        public static void PumpingWaitAll(this IEnumerable<Task> tasks)
+        {
+            var smallTimeout = TimeSpan.FromMilliseconds(10);
+            var taskArray = tasks.ToArray();
+            var done = false;
+            while (!done)
+            {
+                done = Task.WaitAll(taskArray, smallTimeout);
+                if (!done)
+                {
+                    WaitForDispatchedOperationsToComplete(DispatcherPriority.ApplicationIdle);
+                    CheckForStaDeadlockInPumpingWait(tasks);
+                }
+            }
+
+            foreach (var task in tasks)
+            {
+                if (task.Exception != null)
+                {
+                    throw task.Exception;
+                }
+            }
         }
     }
 }

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -39,24 +40,24 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             }
         }
 
-        private void InsertAndExecuteInputs(params string[] inputs)
+        private async Task InsertAndExecuteInputs(params string[] inputs)
         {
             foreach (var input in inputs)
             {
-                InsertAndExecuteInput(input);
+                await InsertAndExecuteInput(input).ConfigureAwait(true);
             }
         }
 
-        private void InsertAndExecuteInput(string input)
+        private async Task InsertAndExecuteInput(string input)
         {
             _window.InsertCode(input);
             AssertCurrentSubmission(input);
-            ExecuteInput();
+            await ExecuteInput().ConfigureAwait(true);
         }
 
-        private void ExecuteInput()
+        private async Task ExecuteInput()
         {
-            ((InteractiveWindow)_window).ExecuteInputAsync().PumpingWait();
+            await ((InteractiveWindow)_window).ExecuteInputAsync().ConfigureAwait(true);
         }
 
         private void AssertCurrentSubmission(string expected)
@@ -67,22 +68,22 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         #endregion Helpers
 
         [WpfFact]
-        public void CheckHistoryPrevious()
+        public async Task CheckHistoryPrevious()
         {
             const string inputString = "1 ";
-            InsertAndExecuteInput(inputString);
+            await InsertAndExecuteInput(inputString).ConfigureAwait(true);
             _operations.HistoryPrevious();
             AssertCurrentSubmission(inputString);
         }
 
         [WpfFact]
-        public void CheckHistoryPreviousNotCircular()
+        public async Task CheckHistoryPreviousNotCircular()
         {
             //submit, submit, up, up, up
             const string inputString1 = "1 ";
             const string inputString2 = "2 ";
-            InsertAndExecuteInput(inputString1);
-            InsertAndExecuteInput(inputString2);
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
 
             _operations.HistoryPrevious();
             AssertCurrentSubmission(inputString2);
@@ -94,16 +95,16 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CheckHistoryPreviousAfterSubmittingEntryFromHistory()
+        public async Task CheckHistoryPreviousAfterSubmittingEntryFromHistory()
         {
             //submit, submit, submit, up, up, submit, up, up, up
             const string inputString1 = "1 ";
             const string inputString2 = "2 ";
             const string inputString3 = "3 ";
 
-            InsertAndExecuteInput(inputString1);
-            InsertAndExecuteInput(inputString2);
-            InsertAndExecuteInput(inputString3);
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString3).ConfigureAwait(true);
 
             _operations.HistoryPrevious();
             AssertCurrentSubmission(inputString3);
@@ -111,7 +112,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             _operations.HistoryPrevious();
             AssertCurrentSubmission(inputString2);
 
-            ExecuteInput();
+            await ExecuteInput().ConfigureAwait(true);
 
             //history navigation should start from the last history pointer
             _operations.HistoryPrevious();
@@ -126,15 +127,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CheckHistoryPreviousAfterSubmittingNewEntryWhileNavigatingHistory()
+        public async Task CheckHistoryPreviousAfterSubmittingNewEntryWhileNavigatingHistory()
         {
             //submit, submit, up, up, submit new, up, up, up
             const string inputString1 = "1 ";
             const string inputString2 = "2 ";
             const string inputString3 = "3 ";
 
-            InsertAndExecuteInput(inputString1);
-            InsertAndExecuteInput(inputString2);
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
 
             _operations.HistoryPrevious();
             AssertCurrentSubmission(inputString2);
@@ -144,7 +145,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
 
             SetActiveCode(inputString3);
             AssertCurrentSubmission(inputString3);
-            ExecuteInput();
+            await ExecuteInput().ConfigureAwait(true);
 
             //History pointer should be reset. Previous should now bring up last entry
             _operations.HistoryPrevious();
@@ -162,14 +163,14 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CheckHistoryNextNotCircular()
+        public async Task CheckHistoryNextNotCircular()
         {
             //submit, submit, down, up, down, down
             const string inputString1 = "1 ";
             const string inputString2 = "2 ";
             const string empty = "";
-            InsertAndExecuteInput(inputString1);
-            InsertAndExecuteInput(inputString2);
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
 
             //Next should do nothing as history pointer is uninitialized and there is
             //no next entry. Buffer should be empty
@@ -190,21 +191,21 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             AssertCurrentSubmission(inputString2);
 
             //This is to make sure the window doesn't crash
-            ExecuteInput();
+            await ExecuteInput().ConfigureAwait(true);
             AssertCurrentSubmission(empty);
         }
 
         [WpfFact]
-        public void CheckHistoryNextAfterSubmittingEntryFromHistory()
+        public async Task CheckHistoryNextAfterSubmittingEntryFromHistory()
         {
             //submit, submit, submit, up, up, submit, down, down, down
             const string inputString1 = "1 ";
             const string inputString2 = "2 ";
             const string inputString3 = "3 ";
 
-            InsertAndExecuteInput(inputString1);
-            InsertAndExecuteInput(inputString2);
-            InsertAndExecuteInput(inputString3);
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString3).ConfigureAwait(true);
 
             _operations.HistoryPrevious();
             AssertCurrentSubmission(inputString3);
@@ -213,7 +214,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             AssertCurrentSubmission(inputString2);
 
             //submit inputString2 again. Should be added at the end of history
-            ExecuteInput();
+            await ExecuteInput().ConfigureAwait(true);
 
             //history navigation should start from the last history pointer
             _operations.HistoryNext();
@@ -229,7 +230,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CheckHistoryNextAfterSubmittingNewEntryWhileNavigatingHistory()
+        public async Task CheckHistoryNextAfterSubmittingNewEntryWhileNavigatingHistory()
         {
             //submit, submit, up, up, submit new, down, up
             const string inputString1 = "1 ";
@@ -237,8 +238,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             const string inputString3 = "3 ";
             const string empty = "";
 
-            InsertAndExecuteInput(inputString1);
-            InsertAndExecuteInput(inputString2);
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
 
             _operations.HistoryPrevious();
             AssertCurrentSubmission(inputString2);
@@ -248,7 +249,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
 
             SetActiveCode(inputString3);
             AssertCurrentSubmission(inputString3);
-            ExecuteInput();
+            await ExecuteInput().ConfigureAwait(true);
 
             //History pointer should be reset. next should do nothing
             _operations.HistoryNext();
@@ -259,15 +260,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CheckUncommittedInputAfterNavigatingHistory()
+        public async Task CheckUncommittedInputAfterNavigatingHistory()
         {
             //submit, submit, up, up, submit new, down, up
             const string inputString1 = "1 ";
             const string inputString2 = "2 ";
             const string uncommittedInput = "uncommittedInput";
 
-            InsertAndExecuteInput(inputString1);
-            InsertAndExecuteInput(inputString2);
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
             //Add uncommitted input
             SetActiveCode(uncommittedInput);
             //Navigate history. This should save uncommitted input
@@ -279,21 +280,21 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CheckHistoryPreviousAfterReset()
+        public async Task CheckHistoryPreviousAfterReset()
         {
             const string resetCommand1 = "#reset";
             const string resetCommand2 = "#reset  ";
-            InsertAndExecuteInput(resetCommand1);
-            InsertAndExecuteInput(resetCommand2);
+            await InsertAndExecuteInput(resetCommand1).ConfigureAwait(true);
+            await InsertAndExecuteInput(resetCommand2).ConfigureAwait(true);
             _operations.HistoryPrevious();  AssertCurrentSubmission(resetCommand2);
             _operations.HistoryPrevious();  AssertCurrentSubmission(resetCommand1);
             _operations.HistoryPrevious();  AssertCurrentSubmission(resetCommand1);
         }
 
         [WpfFact]
-        public void TestHistoryPrevious()
+        public async Task TestHistoryPrevious()
         {
-            InsertAndExecuteInputs("1", "2", "3");
+            await InsertAndExecuteInputs("1", "2", "3").ConfigureAwait(true);
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("3");
             _operations.HistoryPrevious();  AssertCurrentSubmission("2");
@@ -303,9 +304,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryNext()
+        public async Task TestHistoryNext()
         {
-            InsertAndExecuteInputs("1", "2", "3");
+            await InsertAndExecuteInputs("1", "2", "3").ConfigureAwait(true);
 
             SetActiveCode("4");
 
@@ -322,18 +323,18 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryPreviousWithPattern_NoMatch()
+        public async Task TestHistoryPreviousWithPattern_NoMatch()
         {
-            InsertAndExecuteInputs("123", "12", "1");
+            await InsertAndExecuteInputs("123", "12", "1").ConfigureAwait(true);
 
             _operations.HistoryPrevious("4");   AssertCurrentSubmission("");
             _operations.HistoryPrevious("4");   AssertCurrentSubmission("");
         }
 
         [WpfFact]
-        public void TestHistoryPreviousWithPattern_PatternMaintained()
+        public async Task TestHistoryPreviousWithPattern_PatternMaintained()
         {
-            InsertAndExecuteInputs("123", "12", "1");
+            await InsertAndExecuteInputs("123", "12", "1").ConfigureAwait(true);
 
             _operations.HistoryPrevious("12");  AssertCurrentSubmission("12"); // Skip over non-matching entry.
             _operations.HistoryPrevious("12");  AssertCurrentSubmission("123");
@@ -341,9 +342,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryPreviousWithPattern_PatternDropped()
+        public async Task TestHistoryPreviousWithPattern_PatternDropped()
         {
-            InsertAndExecuteInputs("1", "2", "3");
+            await InsertAndExecuteInputs("1", "2", "3").ConfigureAwait(true);
 
             _operations.HistoryPrevious("2");   AssertCurrentSubmission("2"); // Skip over non-matching entry.
             _operations.HistoryPrevious(null);  AssertCurrentSubmission("1"); // Pattern isn't passed, so return to normal iteration.
@@ -351,9 +352,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryPreviousWithPattern_PatternChanged()
+        public async Task TestHistoryPreviousWithPattern_PatternChanged()
         {
-            InsertAndExecuteInputs("10", "20", "15", "25");
+            await InsertAndExecuteInputs("10", "20", "15", "25").ConfigureAwait(true);
 
             _operations.HistoryPrevious("1");   AssertCurrentSubmission("15"); // Skip over non-matching entry.
             _operations.HistoryPrevious("2");   AssertCurrentSubmission("20"); // Skip over non-matching entry.
@@ -361,9 +362,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryNextWithPattern_NoMatch()
+        public async Task TestHistoryNextWithPattern_NoMatch()
         {
-            InsertAndExecuteInputs("start", "1", "12", "123");
+            await InsertAndExecuteInputs("start", "1", "12", "123").ConfigureAwait(true);
             SetActiveCode("end");
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("123");
@@ -376,9 +377,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryNextWithPattern_PatternMaintained()
+        public async Task TestHistoryNextWithPattern_PatternMaintained()
         {
-            InsertAndExecuteInputs("start", "1", "12", "123");
+            await InsertAndExecuteInputs("start", "1", "12", "123").ConfigureAwait(true);
             SetActiveCode("end");
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("123");
@@ -392,9 +393,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryNextWithPattern_PatternDropped()
+        public async Task TestHistoryNextWithPattern_PatternDropped()
         {
-            InsertAndExecuteInputs("start", "3", "2", "1");
+            await InsertAndExecuteInputs("start", "3", "2", "1").ConfigureAwait(true);
             SetActiveCode("end");
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("1");
@@ -408,9 +409,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryNextWithPattern_PatternChanged()
+        public async Task TestHistoryNextWithPattern_PatternChanged()
         {
-            InsertAndExecuteInputs("start", "25", "15", "20", "10");
+            await InsertAndExecuteInputs("start", "25", "15", "20", "10").ConfigureAwait(true);
             SetActiveCode("end");
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("10");
@@ -425,9 +426,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistorySearchPrevious()
+        public async Task TestHistorySearchPrevious()
         {
-            InsertAndExecuteInputs("123", "12", "1");
+            await InsertAndExecuteInputs("123", "12", "1").ConfigureAwait(true);
 
             // Default search string is empty.
             _operations.HistorySearchPrevious();    AssertCurrentSubmission("1"); // Pattern is captured before this step.
@@ -437,9 +438,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistorySearchPreviousWithPattern()
+        public async Task TestHistorySearchPreviousWithPattern()
         {
-            InsertAndExecuteInputs("123", "12", "1");
+            await InsertAndExecuteInputs("123", "12", "1").ConfigureAwait(true);
             SetActiveCode("12");
 
             _operations.HistorySearchPrevious();    AssertCurrentSubmission("12"); // Pattern is captured before this step.
@@ -448,9 +449,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistorySearchNextWithPattern()
+        public async Task TestHistorySearchNextWithPattern()
         {
-            InsertAndExecuteInputs("12", "123", "12", "1");
+            await InsertAndExecuteInputs("12", "123", "12", "1").ConfigureAwait(true);
             SetActiveCode("end");
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("1");
@@ -464,9 +465,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryPreviousAndSearchPrevious()
+        public async Task TestHistoryPreviousAndSearchPrevious()
         {
-            InsertAndExecuteInputs("200", "100", "30", "20", "10", "2", "1");
+            await InsertAndExecuteInputs("200", "100", "30", "20", "10", "2", "1").ConfigureAwait(true);
 
             _operations.HistoryPrevious();          AssertCurrentSubmission("1");
             _operations.HistorySearchPrevious();    AssertCurrentSubmission("10"); // Pattern is captured before this step.
@@ -478,9 +479,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryPreviousAndSearchPrevious_ExplicitPattern()
+        public async Task TestHistoryPreviousAndSearchPrevious_ExplicitPattern()
         {
-            InsertAndExecuteInputs("200", "100", "30", "20", "10", "2", "1");
+            await InsertAndExecuteInputs("200", "100", "30", "20", "10", "2", "1").ConfigureAwait(true);
 
             _operations.HistoryPrevious();          AssertCurrentSubmission("1");
             _operations.HistorySearchPrevious();    AssertCurrentSubmission("10"); // Pattern is captured before this step.
@@ -492,9 +493,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryNextAndSearchNext()
+        public async Task TestHistoryNextAndSearchNext()
         {
-            InsertAndExecuteInputs("1", "2", "10", "20", "30", "100", "200");
+            await InsertAndExecuteInputs("1", "2", "10", "20", "30", "100", "200").ConfigureAwait(true);
             SetActiveCode("4");
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("200");
@@ -513,9 +514,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void TestHistoryNextAndSearchNext_ExplicitPattern()
+        public async Task TestHistoryNextAndSearchNext_ExplicitPattern()
         {
-            InsertAndExecuteInputs("1", "2", "10", "20", "30", "100", "200");
+            await InsertAndExecuteInputs("1", "2", "10", "20", "30", "100", "200").ConfigureAwait(true);
             SetActiveCode("4");
 
             _operations.HistoryPrevious();  AssertCurrentSubmission("200");

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTestHost.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTestHost.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Evaluator = new TestInteractiveEngine(contentTypeRegistryService);
             Window = ExportProvider.GetExport<IInteractiveWindowFactoryService>().Value.CreateWindow(Evaluator);
             ((InteractiveWindow)Window).StateChanged += stateChangedHandler;
-            Window.InitializeAsync().PumpingWait();
+            Window.InitializeAsync().Wait();
         }
 
         public static Type[] GetVisualStudioTypes()

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         private IInteractiveWindow Window => _testHost.Window;                                                                                                                                       
+
         private Task TaskRun(Action action)
         {
             return _factory.StartNew(action, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
@@ -182,9 +183,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
 
         [WorkItem(3970, "https://github.com/dotnet/roslyn/issues/3970")]
         [WpfFact]
-        public void ResetStateTransitions()
+        public async Task ResetStateTransitions()
         {
-            Window.Operations.ResetAsync().PumpingWait();
+            await Window.Operations.ResetAsync().ConfigureAwait(true);
             Assert.Equal(_states, new[]
             {
                 InteractiveWindow.State.Initializing,
@@ -195,16 +196,16 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void DoubleInitialize()
+        public async Task DoubleInitialize()
         {
             try
             {
-                Window.InitializeAsync().PumpingWait();
+                await Window.InitializeAsync().ConfigureAwait(true);
                 Assert.True(false);
             }
-            catch (AggregateException e)
+            catch (InvalidOperationException)
             {
-                Assert.IsType<InvalidOperationException>(e.InnerExceptions.Single());
+
             }
         }
 
@@ -221,12 +222,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void AccessPropertiesOnNonUIThread()
+        public async Task AccessPropertiesOnNonUIThread()
         {
             foreach (var property in typeof(IInteractiveWindow).GetProperties())
             {
                 Assert.Null(property.SetMethod);
-                TaskRun(() => property.GetMethod.Invoke(Window, Array.Empty<object>())).PumpingWait();
+                await TaskRun(() => property.GetMethod.Invoke(Window, Array.Empty<object>())).ConfigureAwait(true);
             }
 
             Assert.Empty(typeof(IInteractiveWindowOperations).GetProperties());
@@ -236,49 +237,49 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         /// Confirm that we are, in fact, running on a non-UI thread.
         /// </remarks>
         [WpfFact]
-        public void NonUIThread()
+        public async Task NonUIThread()
         {
-            TaskRun(() => Assert.False(((InteractiveWindow)Window).OnUIThread())).PumpingWait();
+            await TaskRun(() => Assert.False(((InteractiveWindow)Window).OnUIThread())).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallCloseOnNonUIThread()
+        public async Task CallCloseOnNonUIThread()
         {
-            TaskRun(() => Window.Close()).PumpingWait();
+            await TaskRun(() => Window.Close()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallInsertCodeOnNonUIThread()
+        public async Task CallInsertCodeOnNonUIThread()
         {
-            TaskRun(() => Window.InsertCode("1")).PumpingWait();
+            await TaskRun(() => Window.InsertCode("1")).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallSubmitAsyncOnNonUIThread()
+        public async Task CallSubmitAsyncOnNonUIThread()
         {
-            TaskRun(() => Window.SubmitAsync(Array.Empty<string>()).GetAwaiter().GetResult()).PumpingWait();
+            await TaskRun(() => Window.SubmitAsync(Array.Empty<string>()).GetAwaiter().GetResult()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallWriteOnNonUIThread()
+        public async Task CallWriteOnNonUIThread()
         {
-            TaskRun(() => Window.WriteLine("1")).PumpingWait();
-            TaskRun(() => Window.Write("1")).PumpingWait();
-            TaskRun(() => Window.WriteErrorLine("1")).PumpingWait();
-            TaskRun(() => Window.WriteError("1")).PumpingWait();
+            await TaskRun(() => Window.WriteLine("1")).ConfigureAwait(true);
+            await TaskRun(() => Window.Write("1")).ConfigureAwait(true);
+            await TaskRun(() => Window.WriteErrorLine("1")).ConfigureAwait(true);
+            await TaskRun(() => Window.WriteError("1")).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallFlushOutputOnNonUIThread()
+        public async Task CallFlushOutputOnNonUIThread()
         {
             Window.Write("1"); // Something to flush.
-            TaskRun(() => Window.FlushOutput()).PumpingWait();
+            await TaskRun(() => Window.FlushOutput()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallAddInputOnNonUIThread()
+        public async Task CallAddInputOnNonUIThread()
         {
-            TaskRun(() => Window.AddInput("1")).PumpingWait();
+            await TaskRun(() => Window.AddInput("1")).ConfigureAwait(true);
         }
 
         /// <remarks>
@@ -291,72 +292,72 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CallBackspaceOnNonUIThread()
+        public async Task CallBackspaceOnNonUIThread()
         {
             Window.InsertCode("1"); // Something to backspace.
-            TaskRun(() => Window.Operations.Backspace()).PumpingWait();
+            await TaskRun(() => Window.Operations.Backspace()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallBreakLineOnNonUIThread()
+        public async Task CallBreakLineOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.BreakLine()).PumpingWait();
+            await TaskRun(() => Window.Operations.BreakLine()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallClearHistoryOnNonUIThread()
+        public async Task CallClearHistoryOnNonUIThread()
         {
             Window.AddInput("1"); // Need a history entry.
-            TaskRun(() => Window.Operations.ClearHistory()).PumpingWait();
+            await TaskRun(() => Window.Operations.ClearHistory()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallClearViewOnNonUIThread()
+        public async Task CallClearViewOnNonUIThread()
         {
             Window.InsertCode("1"); // Something to clear.
-            TaskRun(() => Window.Operations.ClearView()).PumpingWait();
+            await TaskRun(() => Window.Operations.ClearView()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallHistoryNextOnNonUIThread()
+        public async Task CallHistoryNextOnNonUIThread()
         {
             Window.AddInput("1"); // Need a history entry.
-            TaskRun(() => Window.Operations.HistoryNext()).PumpingWait();
+            await TaskRun(() => Window.Operations.HistoryNext()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallHistoryPreviousOnNonUIThread()
+        public async Task CallHistoryPreviousOnNonUIThread()
         {
             Window.AddInput("1"); // Need a history entry.
-            TaskRun(() => Window.Operations.HistoryPrevious()).PumpingWait();
+            await TaskRun(() => Window.Operations.HistoryPrevious()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallHistorySearchNextOnNonUIThread()
+        public async Task CallHistorySearchNextOnNonUIThread()
         {
             Window.AddInput("1"); // Need a history entry.
-            TaskRun(() => Window.Operations.HistorySearchNext()).PumpingWait();
+            await TaskRun(() => Window.Operations.HistorySearchNext()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallHistorySearchPreviousOnNonUIThread()
+        public async Task CallHistorySearchPreviousOnNonUIThread()
         {
             Window.AddInput("1"); // Need a history entry.
-            TaskRun(() => Window.Operations.HistorySearchPrevious()).PumpingWait();
+            await TaskRun(() => Window.Operations.HistorySearchPrevious()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallHomeOnNonUIThread()
+        public async Task CallHomeOnNonUIThread()
         {
             Window.Operations.BreakLine(); // Distinguish Home from End.
-            TaskRun(() => Window.Operations.Home(true)).PumpingWait();
+            await TaskRun(() => Window.Operations.Home(true)).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallEndOnNonUIThread()
+        public async Task CallEndOnNonUIThread()
         {
             Window.Operations.BreakLine(); // Distinguish Home from End.
-            TaskRun(() => Window.Operations.End(true)).PumpingWait();
+            await TaskRun(() => Window.Operations.End(true)).ConfigureAwait(true);
         }
 
         [WpfFact]
@@ -375,58 +376,58 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CallSelectAllOnNonUIThread()
+        public async Task CallSelectAllOnNonUIThread()
         {
             Window.InsertCode("1"); // Something to select.
-            TaskRun(() => Window.Operations.SelectAll()).PumpingWait();
+            await TaskRun(() => Window.Operations.SelectAll()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallPasteOnNonUIThread()
+        public async Task CallPasteOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.Paste()).PumpingWait();
+            await TaskRun(() => Window.Operations.Paste()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallCutOnNonUIThread()
+        public async Task CallCutOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.Cut()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cut()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallDeleteOnNonUIThread()
+        public async Task CallDeleteOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.Delete()).PumpingWait();
+            await TaskRun(() => Window.Operations.Delete()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallReturnOnNonUIThread()
+        public async Task CallReturnOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.Return()).PumpingWait();
+            await TaskRun(() => Window.Operations.Return()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallTrySubmitStandardInputOnNonUIThread()
+        public async Task CallTrySubmitStandardInputOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.TrySubmitStandardInput()).PumpingWait();
+            await TaskRun(() => Window.Operations.TrySubmitStandardInput()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallResetAsyncOnNonUIThread()
+        public async Task CallResetAsyncOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.ResetAsync()).PumpingWait();
+            await TaskRun(() => Window.Operations.ResetAsync()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallExecuteInputOnNonUIThread()
+        public async Task CallExecuteInputOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.ExecuteInput()).PumpingWait();
+            await TaskRun(() => Window.Operations.ExecuteInput()).ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void CallCancelOnNonUIThread()
+        public async Task CallCancelOnNonUIThread()
         {
-            TaskRun(() => Window.Operations.Cancel()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cancel()).ConfigureAwait(true);
         }
 
         [WorkItem(4235, "https://github.com/dotnet/roslyn/issues/4235")]
@@ -608,17 +609,17 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
-        public void CopyInputAndOutput()
+        public async Task CopyInputAndOutput()
         {
             _testClipboard.Clear();
 
-            Submit(
+            await Submit(
 @"foreach (var o in new[] { 1, 2, 3 })
 System.Console.WriteLine();",
 @"1
 2
 3
-");
+").ConfigureAwait(true);
             var caret = Window.TextView.Caret;
             caret.MoveToPreviousCaretPosition();
             caret.MoveToPreviousCaretPosition();
@@ -679,17 +680,17 @@ System.Console.WriteLine()",
         }
 
         [WpfFact]
-        public void CutInputAndOutput()
+        public async Task CutInputAndOutput()
         {
             _testClipboard.Clear();
 
-            Submit(
+            await Submit(
 @"foreach (var o in new[] { 1, 2, 3 })
 System.Console.WriteLine();",
 @"1
 2
 3
-");
+").ConfigureAwait(true);
             var caret = Window.TextView.Caret;
             caret.MoveToPreviousCaretPosition();
             caret.MoveToPreviousCaretPosition();
@@ -705,15 +706,15 @@ System.Console.WriteLine();",
         /// should copy the current line.
         /// </summary>
         [WpfFact]
-        public void CopyNoSelection()
+        public async Task CopyNoSelection()
         {
-            Submit(
+            await Submit(
 @"s +
 
  t",
 @" 1
 
-2 ");
+2 ").ConfigureAwait(true);
             CopyNoSelectionAndVerify(0, 7, "> s +\r\n", @"> s +\par ", @"[{""content"":""> "",""kind"":0},{""content"":""s +\u000d\u000a"",""kind"":2}]");
             CopyNoSelectionAndVerify(7, 11, "> \r\n", @"> \par ", @"[{""content"":""> "",""kind"":0},{""content"":""\u000d\u000a"",""kind"":2}]");
             CopyNoSelectionAndVerify(11, 17, ">  t\r\n", @">  t\par ", @"[{""content"":""> "",""kind"":0},{""content"":"" t\u000d\u000a"",""kind"":2}]");
@@ -807,7 +808,7 @@ System.Console.WriteLine();",
         }
 
         [WpfFact]
-        public void CancelMultiLineInput()
+        public async Task CancelMultiLineInput()
         {
             ApplyChanges(
                 Window.CurrentLanguageBuffer,
@@ -818,7 +819,7 @@ System.Console.WriteLine();",
             var snapshot = buffer.CurrentSnapshot;
             Assert.Equal("> {\r\n>     {\r\n>     }\r\n> }", snapshot.GetText());
 
-            TaskRun(() => Window.Operations.Cancel()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cancel()).ConfigureAwait(true);
 
             // Text after cancel.
             snapshot = buffer.CurrentSnapshot;
@@ -841,12 +842,12 @@ System.Console.WriteLine();",
         }
 
         [WpfFact]
-        public void DeleteWithOutSelectionInReadOnlyArea()
+        public async Task DeleteWithOutSelectionInReadOnlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("2");                                              
 
             var caret = Window.TextView.Caret;
@@ -861,24 +862,24 @@ System.Console.WriteLine();",
             caret.MoveToPreviousCaretPosition();
             AssertCaretVirtualPosition(1, 1);
 
-            TaskRun(() => Window.Operations.Delete()).PumpingWait();
+            await TaskRun(() => Window.Operations.Delete()).ConfigureAwait(true);
             AssertCaretVirtualPosition(1, 1);
 
             // Delete() with caret in active prompt, move caret to 
             // closest editable buffer
             caret.MoveToNextCaretPosition();
             AssertCaretVirtualPosition(2, 0);
-            TaskRun(() => Window.Operations.Delete()).PumpingWait();
+            await TaskRun(() => Window.Operations.Delete()).ConfigureAwait(true);
             AssertCaretVirtualPosition(2, 2);
         }
         
         [WpfFact]
-        public void DeleteWithSelectionInReadonlyArea()
+        public async Task DeleteWithSelectionInReadonlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("23");
 
             var caret = Window.TextView.Caret;                                   
@@ -894,7 +895,7 @@ System.Console.WriteLine();",
 
             Window.Operations.SelectAll();
 
-            TaskRun(() => Window.Operations.Delete()).PumpingWait();
+            await TaskRun(() => Window.Operations.Delete()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot());
 
             // Delete() with selection in active prompt, no-op
@@ -906,7 +907,7 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Delete()).PumpingWait();
+            await TaskRun(() => Window.Operations.Delete()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot());
 
             // Delete() with selection overlaps with editable buffer, 
@@ -921,18 +922,18 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Delete()).PumpingWait();
+            await TaskRun(() => Window.Operations.Delete()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 3", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(2, 2);
         }
 
         [WpfFact]
-        public void BackspaceWithOutSelectionInReadOnlyArea()
+        public async Task BackspaceWithOutSelectionInReadOnlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("int x");
             Window.Operations.BreakLine();
             Window.InsertCode(";");
@@ -951,7 +952,7 @@ System.Console.WriteLine();",
             caret.MoveToPreviousCaretPosition();  
             AssertCaretVirtualPosition(1, 1);
 
-            TaskRun(() => Window.Operations.Backspace()).PumpingWait();
+            await TaskRun(() => Window.Operations.Backspace()).ConfigureAwait(true);
             AssertCaretVirtualPosition(1, 1);
             Assert.Equal("> 1\r\n1\r\n> int x\r\n> ;", GetTextFromCurrentSnapshot());
 
@@ -963,18 +964,18 @@ System.Console.WriteLine();",
             caret.MoveToNextCaretPosition();
             AssertCaretVirtualPosition(3, 1);
 
-            TaskRun(() => Window.Operations.Backspace()).PumpingWait();
+            await TaskRun(() => Window.Operations.Backspace()).ConfigureAwait(true);
             AssertCaretVirtualPosition(2, 7);
             Assert.Equal("> 1\r\n1\r\n> int x;", GetTextFromCurrentSnapshot());
         }
 
         [WpfFact]
-        public void BackspaceWithSelectionInReadonlyArea()
+        public async Task BackspaceWithSelectionInReadonlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("int x");
             Window.Operations.BreakLine();
             Window.InsertCode(";");
@@ -996,7 +997,7 @@ System.Console.WriteLine();",
 
             Window.Operations.SelectAll();
 
-            TaskRun(() => Window.Operations.Backspace()).PumpingWait();
+            await TaskRun(() => Window.Operations.Backspace()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> int x\r\n> ;", GetTextFromCurrentSnapshot());
 
             // Backspace() with selection in active prompt, no-op
@@ -1008,7 +1009,7 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Backspace()).PumpingWait();
+            await TaskRun(() => Window.Operations.Backspace()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> int x\r\n> ;", GetTextFromCurrentSnapshot());
 
             // Backspace() with selection overlaps with editable buffer
@@ -1022,18 +1023,18 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Backspace()).PumpingWait();
+            await TaskRun(() => Window.Operations.Backspace()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> int x;", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(2, 7);
         }
 
         [WpfFact]
-        public void ReturnWithOutSelectionInReadOnlyArea()
+        public async Task ReturnWithOutSelectionInReadOnlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             var caret = Window.TextView.Caret;      
 
             // Return() with caret in readonly area, no-op       
@@ -1042,7 +1043,7 @@ System.Console.WriteLine();",
             caret.MoveToPreviousCaretPosition();   
             AssertCaretVirtualPosition(1, 1);
 
-            TaskRun(() => Window.Operations.Return()).PumpingWait();
+            await TaskRun(() => Window.Operations.Return()).ConfigureAwait(true);
             AssertCaretVirtualPosition(1, 1);
 
             // Return() with caret in active prompt, move caret to 
@@ -1050,17 +1051,17 @@ System.Console.WriteLine();",
             caret.MoveToNextCaretPosition();
             AssertCaretVirtualPosition(2, 0);
 
-            TaskRun(() => Window.Operations.Return()).PumpingWait();
+            await TaskRun(() => Window.Operations.Return()).ConfigureAwait(true);
             AssertCaretVirtualPosition(3, 2);
         }
 
         [WpfFact]
-        public void ReturnWithSelectionInReadonlyArea()
+        public async Task ReturnWithSelectionInReadonlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("23");
 
             var caret = Window.TextView.Caret;
@@ -1076,7 +1077,7 @@ System.Console.WriteLine();",
 
             Window.Operations.SelectAll();
 
-            TaskRun(() => Window.Operations.Return()).PumpingWait();
+            await TaskRun(() => Window.Operations.Return()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot());
 
             // Return() with selection in active prompt, no-op
@@ -1088,7 +1089,7 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Return()).PumpingWait();
+            await TaskRun(() => Window.Operations.Return()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot());
 
             // Delete() with selection overlaps with editable buffer, 
@@ -1103,18 +1104,18 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Return()).PumpingWait();
+            await TaskRun(() => Window.Operations.Return()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> \r\n> 3", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(3, 2);
         }
 
         [WpfFact]
-        public void CutWithOutSelectionInReadOnlyArea()
+        public async Task CutWithOutSelectionInReadOnlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("2");
 
             var caret = Window.TextView.Caret;
@@ -1127,7 +1128,7 @@ System.Console.WriteLine();",
             caret.MoveToPreviousCaretPosition();
             AssertCaretVirtualPosition(1, 1);
 
-            TaskRun(() => Window.Operations.Cut()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cut()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 2", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(1, 1);
 
@@ -1136,7 +1137,7 @@ System.Console.WriteLine();",
             // Cut() with caret in active prompt
             caret.MoveToNextCaretPosition();
             AssertCaretVirtualPosition(2, 0);
-            TaskRun(() => Window.Operations.Cut()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cut()).ConfigureAwait(true);
 
             Assert.Equal("> 1\r\n1\r\n> ", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(2, 2);
@@ -1144,12 +1145,12 @@ System.Console.WriteLine();",
         }
 
         [WpfFact]
-        public void CutWithSelectionInReadonlyArea()
+        public async Task CutWithSelectionInReadonlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("23");
 
             var caret = Window.TextView.Caret;
@@ -1166,7 +1167,7 @@ System.Console.WriteLine();",
 
             Window.Operations.SelectAll();
 
-            TaskRun(() => Window.Operations.Cut()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cut()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot());
             VerifyClipboardData(null, null, null);
 
@@ -1179,7 +1180,7 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Cut()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cut()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot());
             VerifyClipboardData(null, null, null);
 
@@ -1195,19 +1196,19 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Cut()).PumpingWait();
+            await TaskRun(() => Window.Operations.Cut()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 3", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(2, 2);
             VerifyClipboardData("2", expectedRtf: null, expectedRepl: null);
         }
 
         [WpfFact]
-        public void PasteWithOutSelectionInReadOnlyArea()
+        public async Task PasteWithOutSelectionInReadOnlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("2");
 
             var caret = Window.TextView.Caret;
@@ -1224,26 +1225,26 @@ System.Console.WriteLine();",
             caret.MoveToPreviousCaretPosition();  
             AssertCaretVirtualPosition(1, 1);
 
-            TaskRun(() => Window.Operations.Paste()).PumpingWait();
+            await TaskRun(() => Window.Operations.Paste()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 2", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(1, 1);
 
             // Paste() with caret in active prompt
             caret.MoveToNextCaretPosition();
             AssertCaretVirtualPosition(2, 0);                                                                                                                     
-            TaskRun(() => Window.Operations.Paste()).PumpingWait();
+            await TaskRun(() => Window.Operations.Paste()).ConfigureAwait(true);
 
             Assert.Equal("> 1\r\n1\r\n> 22", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(2, 3);            
         }
 
         [WpfFact]    
-        public void PasteWithSelectionInReadonlyArea()
+        public async Task PasteWithSelectionInReadonlyArea()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             Window.InsertCode("23");
 
             var caret = Window.TextView.Caret;
@@ -1263,7 +1264,7 @@ System.Console.WriteLine();",
 
             Window.Operations.SelectAll();
 
-            TaskRun(() => Window.Operations.Paste()).PumpingWait();
+            await TaskRun(() => Window.Operations.Paste()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot());  
 
             // Paste() with selection in active prompt, no-op
@@ -1275,7 +1276,7 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Paste()).PumpingWait();
+            await TaskRun(() => Window.Operations.Paste()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 23", GetTextFromCurrentSnapshot()); 
 
             // Paste() with selection overlaps with editable buffer, 
@@ -1290,18 +1291,18 @@ System.Console.WriteLine();",
 
             selection.Select(start, end);
 
-            TaskRun(() => Window.Operations.Paste()).PumpingWait();
+            await TaskRun(() => Window.Operations.Paste()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> 233", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(2, 4);
         }
 
         [WpfFact]
-        public void DeleteLineWithOutSelection()
+        public async Task DeleteLineWithOutSelection()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");                                                                                                                        
+").ConfigureAwait(true);                                                                                                                        
             var caret = Window.TextView.Caret;                               
 
             // DeleteLine with caret in readonly area
@@ -1340,12 +1341,12 @@ System.Console.WriteLine();",
         }
 
         [WpfFact]
-        public void DeleteLineWithSelection()
+        public async Task DeleteLineWithSelection()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             var caret = Window.TextView.Caret;
             var selection = Window.TextView.Selection;
 
@@ -1353,8 +1354,8 @@ System.Console.WriteLine();",
             caret.MoveToPreviousCaretPosition();
             caret.MoveToPreviousCaretPosition();
             caret.MoveToPreviousCaretPosition();
-            TaskRun(() => Window.Operations.SelectAll()).PumpingWait();
-            TaskRun(() => Window.Operations.DeleteLine()).PumpingWait();
+            await TaskRun(() => Window.Operations.SelectAll()).ConfigureAwait(true);
+            await TaskRun(() => Window.Operations.DeleteLine()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> ", GetTextFromCurrentSnapshot());
 
             // DeleteLine with selection in active prompt
@@ -1371,7 +1372,7 @@ System.Console.WriteLine();",
             }
 
             selection.Select(caret.MoveToNextCaretPosition().VirtualBufferPosition, caret.MoveToNextCaretPosition().VirtualBufferPosition);
-            TaskRun(() => Window.Operations.DeleteLine()).PumpingWait();
+            await TaskRun(() => Window.Operations.DeleteLine()).ConfigureAwait(true);
             Assert.Equal("> 1\r\n1\r\n> ;", GetTextFromCurrentSnapshot());
             AssertCaretVirtualPosition(2, 2);
             Assert.True(selection.IsEmpty);
@@ -1397,12 +1398,12 @@ System.Console.WriteLine();",
         }
 
         [WpfFact]
-        public void CutLineWithOutSelection()
+        public async Task CutLineWithOutSelection()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             var caret = Window.TextView.Caret;
             _testClipboard.Clear();
 
@@ -1445,12 +1446,12 @@ System.Console.WriteLine();",
         }
 
         [WpfFact]
-        public void CutLineWithSelection()
+        public async Task CutLineWithSelection()
         {
-            Submit(
+            await Submit(
 @"1",
 @"1
-");
+").ConfigureAwait(true);
             var caret = Window.TextView.Caret;
             var selection = Window.TextView.Selection;
             _testClipboard.Clear();
@@ -1507,32 +1508,32 @@ System.Console.WriteLine();",
         }
 
         [WpfFact]
-        public void SubmitAsyncNone()
+        public async Task SubmitAsyncNone()
         {
-            SubmitAsync();
+            await SubmitAsync().ConfigureAwait(true);
         }
 
         [WpfFact]
-        public void SubmitAsyncSingle()
+        public async Task SubmitAsyncSingle()
         {
-            SubmitAsync("1");
+            await SubmitAsync("1").ConfigureAwait(true);
         }
 
         [WorkItem(5964)]
         [WpfFact]
-        public void SubmitAsyncMultiple()
+        public async Task SubmitAsyncMultiple()
         {
-            SubmitAsync("1", "2", "1 + 2");
+            await SubmitAsync("1", "2", "1 + 2").ConfigureAwait(true);
         }
 
-        private void SubmitAsync(params string[] submissions)
+        private async Task SubmitAsync(params string[] submissions)
         {
             var actualSubmissions = new List<string>();
             var evaluator = _testHost.Evaluator;
             EventHandler<string> onExecute = (_, s) => actualSubmissions.Add(s.TrimEnd());
 
             evaluator.OnExecute += onExecute;
-            TaskRun(() => Window.SubmitAsync(submissions)).PumpingWait();
+            await TaskRun(() => Window.SubmitAsync(submissions)).ConfigureAwait(true);
             evaluator.OnExecute -= onExecute;
 
             AssertEx.Equal(submissions, actualSubmissions);
@@ -1543,9 +1544,9 @@ System.Console.WriteLine();",
             return Window.TextView.TextBuffer.CurrentSnapshot.GetText();
         }    
 
-        private void Submit(string submission, string output)
+        private async Task Submit(string submission, string output)
         {
-            TaskRun(() => Window.SubmitAsync(new[] { submission })).PumpingWait();
+            await TaskRun(() => Window.SubmitAsync(new[] { submission })).ConfigureAwait(true);
             // TestInteractiveEngine.ExecuteCodeAsync() simply returns
             // success rather than executing the submission, so add the
             // expected output to the output buffer.

--- a/src/Test/Diagnostics/TestingOnly_WaitingService.cs
+++ b/src/Test/Diagnostics/TestingOnly_WaitingService.cs
@@ -118,10 +118,5 @@ namespace Roslyn.Hosting.Diagnostics.Waiters
                 waiter.Value.TrackActiveTokens = enable;
             }
         }
-
-        public void PumpingWait(Task task)
-        {
-            task.PumpingWait();
-        }
     }
 }

--- a/src/Test/Diagnostics/TestingOnly_WaitingService.cs
+++ b/src/Test/Diagnostics/TestingOnly_WaitingService.cs
@@ -118,5 +118,10 @@ namespace Roslyn.Hosting.Diagnostics.Waiters
                 waiter.Value.TrackActiveTokens = enable;
             }
         }
+
+        public void PumpingWait(Task task)
+        {
+            task.PumpingWait();
+        }
     }
 }

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -26,9 +26,9 @@ class C
             Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "interface").ConfigureAwait(True)
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:="title" & vbCrLf &
+                Await state.AssertSelectedCompletionItem(description:="title" & vbCrLf &
                     "description" & vbCrLf &
-                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "interface"))
+                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "interface")).ConfigureAwait(True)
             End Using
         End Function
 
@@ -38,8 +38,8 @@ class C
             Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "intErfaCE").ConfigureAwait(True)
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=$"{String.Format(FeaturesResources.Keyword, "interface")}
-{String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "interface")}")
+                Await state.AssertSelectedCompletionItem(description:=$"{String.Format(FeaturesResources.Keyword, "interface")}
+{String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "interface")}").ConfigureAwait(True)
             End Using
         End Function
 
@@ -49,9 +49,9 @@ class C
             Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "interfac").ConfigureAwait(True)
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:="title" & vbCrLf &
+                Await state.AssertSelectedCompletionItem(description:="title" & vbCrLf &
                     "description" & vbCrLf &
-                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "interfac"))
+                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "interfac")).ConfigureAwait(True)
             End Using
         End Sub
 
@@ -61,7 +61,7 @@ class C
             Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "interfaces").ConfigureAwait(True)
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "interface"))
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "interface")).ConfigureAwait(True)
             End Using
         End Sub
 
@@ -72,7 +72,7 @@ class C
 
                 state.SendTypeChars("DisplayTex")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "InsertionText"))
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "InsertionText")).ConfigureAwait(True)
             End Using
         End Sub
 
@@ -99,7 +99,7 @@ class C
 
                 state.SendTypeChars("for")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "for"))
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "for")).ConfigureAwait(True)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/Completion/VisualBasicCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/VisualBasicCompletionSnippetNoteTests.vb
@@ -22,9 +22,9 @@ End Class]]></document>
             Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interface").ConfigureAwait(True)
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
                     VBFeaturesResources.InterfaceKeywordToolTip & vbCrLf &
-                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "Interface"))
+                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "Interface")).ConfigureAwait(True)
             End Using
         End Function
 
@@ -33,9 +33,9 @@ End Class]]></document>
             Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "intErfaCE").ConfigureAwait(True)
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
                     VBFeaturesResources.InterfaceKeywordToolTip & vbCrLf &
-                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "Interface"))
+                    String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "Interface")).ConfigureAwait(True)
             End Using
         End Function
 
@@ -44,8 +44,8 @@ End Class]]></document>
             Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interfac").ConfigureAwait(True)
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
-                    VBFeaturesResources.InterfaceKeywordToolTip)
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
+                    VBFeaturesResources.InterfaceKeywordToolTip).ConfigureAwait(True)
             End Using
         End Function
 
@@ -54,8 +54,8 @@ End Class]]></document>
             Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interfaces").ConfigureAwait(True)
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
-                    VBFeaturesResources.InterfaceKeywordToolTip)
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
+                    VBFeaturesResources.InterfaceKeywordToolTip).ConfigureAwait(True)
             End Using
         End Function
 
@@ -65,7 +65,7 @@ End Class]]></document>
 
                 state.SendTypeChars("DisplayTex")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:="")
+                Await state.AssertSelectedCompletionItem(description:="").ConfigureAwait(True)
             End Using
         End Function
 
@@ -75,7 +75,7 @@ End Class]]></document>
 
                 state.SendTypeChars("DisplayTex")
                 Await state.AssertCompletionSession().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "InsertionText"))
+                Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.NoteTabTwiceToInsertTheSnippet, "InsertionText")).ConfigureAwait(True)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 state.SendTypeChars("arg")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 Assert.Equal("arg", state.GetCurrentViewLineText())
-                state.AssertCompletionSession()
+                Await state.AssertCompletionSession().ConfigureAwait(True)
                 state.SendTab()
                 Assert.Equal("args", state.GetCurrentViewLineText())
             End Using
@@ -53,7 +53,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                 state.SendTypeChars("arg")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 Assert.Equal("arg", state.GetCurrentViewLineText())
-                state.AssertCompletionSession()
+                Await state.AssertCompletionSession().ConfigureAwait(True)
                 state.SendTab()
                 Assert.Equal("args", state.GetCurrentViewLineText())
             End Using
@@ -78,12 +78,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, True)
                 state.SendTypeChars("x")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionSession()
-                state.AssertSelectedCompletionItem("x")
+                Await state.AssertCompletionSession().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("x").ConfigureAwait(True)
                 state.SendBackspace()
                 state.SendTypeChars("bar")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("bar")
+                Await state.AssertSelectedCompletionItem("bar").ConfigureAwait(True)
                 state.SendTab()
                 Assert.Equal("bar", state.GetCurrentViewLineText())
             End Using
@@ -108,14 +108,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, True)
                 state.SendTypeChars("bar")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("bar")
+                Await state.AssertSelectedCompletionItem("bar").ConfigureAwait(True)
                 state.SendTab()
                 Assert.Equal("bar", state.GetCurrentViewLineText())
                 state.SendReturn()
                 Assert.Equal("", state.GetCurrentViewLineText())
                 state.SendTypeChars("bar")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("bar")
+                Await state.AssertSelectedCompletionItem("bar").ConfigureAwait(True)
                 state.SendTab()
                 Assert.Equal("    bar", state.GetCurrentViewLineText())
             End Using
@@ -141,22 +141,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("foo")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("foo")
+                Await state.AssertSelectedCompletionItem("foo").ConfigureAwait(True)
                 state.SendTab()
                 state.SendTypeChars(".ToS")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("ToString")
+                Await state.AssertSelectedCompletionItem("ToString").ConfigureAwait(True)
                 For i As Integer = 0 To 7
                     state.SendBackspace()
                 Next
 
                 state.SendTypeChars("green")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("green")
+                Await state.AssertSelectedCompletionItem("green").ConfigureAwait(True)
                 state.SendTab()
                 state.SendTypeChars(".ToS")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("ToString")
+                Await state.AssertSelectedCompletionItem("ToString").ConfigureAwait(True)
             End Using
         End Function
 
@@ -182,7 +182,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("variable")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionItemsContainAll("variable1", "variable2")
+                Await state.AssertCompletionItemsContainAll("variable1", "variable2").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -208,7 +208,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("variable")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionItemsContainAll("variable1", "variable2")
+                Await state.AssertCompletionItemsContainAll("variable1", "variable2").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -234,8 +234,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("variable")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionItemsContainNone("variable1")
-                state.AssertCompletionItemsContainAll("variable2")
+                Await state.AssertCompletionItemsContainNone("variable1").ConfigureAwait(True)
+                Await state.AssertCompletionItemsContainAll("variable2").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -261,8 +261,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("variable")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionItemsContainNone("variable1")
-                state.AssertCompletionItemsContainAll("variable2")
+                Await state.AssertCompletionItemsContainNone("variable1").ConfigureAwait(True)
+                Await state.AssertCompletionItemsContainAll("variable2").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -288,8 +288,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("variable")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionItemsContainNone("variable1")
-                state.AssertCompletionItemsContainAll("variable2")
+                Await state.AssertCompletionItemsContainNone("variable1").ConfigureAwait(True)
+                Await state.AssertCompletionItemsContainAll("variable2").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -315,8 +315,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("variable")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionItemsContainNone("variable1")
-                state.AssertCompletionItemsContainNone("variable2")
+                Await state.AssertCompletionItemsContainNone("variable1").ConfigureAwait(True)
+                Await state.AssertCompletionItemsContainNone("variable2").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -340,7 +340,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("new string(")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSignatureHelpSession()
+                Await state.AssertSignatureHelpSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -368,7 +368,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("something(")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSignatureHelpSession()
+                Await state.AssertSignatureHelpSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -397,7 +397,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("something<int>(")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSignatureHelpSession()
+                Await state.AssertSignatureHelpSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -451,7 +451,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("STATICI")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionItemsContainNone("STATICINT")
+                Await state.AssertCompletionItemsContainNone("STATICINT").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -477,7 +477,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             Using state = TestState.CreateCSharpTestState(text, False)
                 state.SendTypeChars("1")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertNoCompletionSession()
+                Await state.AssertNoCompletionSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -632,7 +632,7 @@ $$</Document>
                 state.SendTypeChars("arg")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
                 Assert.Equal("arg", state.GetCurrentViewLineText())
-                state.AssertCompletionSession()
+                Await state.AssertCompletionSession().ConfigureAwait(True)
                 state.SendTab()
                 Assert.Equal("args", state.GetCurrentViewLineText())
             End Using
@@ -670,11 +670,11 @@ $$</Document>
         Private Async Function VerifyCompletionAndDotAfter(item As String, state As TestState) As Threading.Tasks.Task
             state.SendTypeChars(item)
             Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-            state.AssertSelectedCompletionItem(item)
+            Await state.AssertSelectedCompletionItem(item).ConfigureAwait(True)
             state.SendTab()
             state.SendTypeChars(".")
             Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-            state.AssertCompletionSession()
+            Await state.AssertCompletionSession().ConfigureAwait(True)
             For i As Integer = 0 To item.Length
                 state.SendBackspace()
             Next

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
+Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor
@@ -194,25 +195,25 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Sub
 
         Public Overloads Sub SendSelectCompletionItemThroughPresenterSession(item As CompletionItem)
-            WaitForAsynchronousOperations()
+            AssertNoAsynchronousOperationsRunning()
             CurrentCompletionPresenterSession.SetSelectedItem(item)
         End Sub
 
-        Public Sub AssertNoCompletionSession(Optional block As Boolean = True)
+        Public Async Function AssertNoCompletionSession(Optional block As Boolean = True) As Task
             If block Then
-                WaitForAsynchronousOperations()
+                Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
             End If
 
             Assert.Null(Me.CurrentCompletionPresenterSession)
-        End Sub
+        End Function
 
-        Public Sub AssertCompletionSession()
-            WaitForAsynchronousOperations()
+        Public Async Function AssertCompletionSession() As Task
+            Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
             Assert.NotNull(Me.CurrentCompletionPresenterSession)
-        End Sub
+        End Function
 
-        Public Sub AssertCompletionItemsContainAll(ParamArray displayTexts As String())
-            WaitForAsynchronousOperations()
+        Public Async Function AssertCompletionItemsContainAll(ParamArray displayTexts As String()) As Task
+            Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
 
             If Me.CurrentCompletionPresenterSession Is Nothing Then
                 Assert.False(True, "No completion session active")
@@ -223,10 +224,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                     Assert.False(True, "Didn't find '" & displayText & "' in completion.")
                 End If
             Next
-        End Sub
+        End Function
 
-        Public Sub AssertCompletionItemsContainNone(ParamArray displayTexts As String())
-            WaitForAsynchronousOperations()
+        Public Async Function AssertCompletionItemsContainNone(ParamArray displayTexts As String()) As Task
+            Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
 
             If Me.CurrentCompletionPresenterSession Is Nothing Then
                 Assert.False(True, "No completion session active")
@@ -237,16 +238,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                     Assert.False(True, "Found '" & displayText & "' in completion.")
                 End If
             Next
-        End Sub
+        End Function
 
-        Public Sub AssertSelectedCompletionItem(
+        Public Async Function AssertSelectedCompletionItem(
             Optional displayText As String = Nothing,
             Optional description As String = Nothing,
             Optional isSoftSelected As Boolean? = Nothing,
             Optional isHardSelected As Boolean? = Nothing
-        )
+        ) As Task
 
-            WaitForAsynchronousOperations()
+            Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
             If isSoftSelected.HasValue Then
                 Assert.Equal(isSoftSelected.Value, Me.CurrentCompletionPresenterSession.IsSoftSelected)
             End If
@@ -268,7 +269,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             If description IsNot Nothing Then
                 Assert.Equal(description, Me.CurrentCompletionPresenterSession.SelectedItem.GetDescriptionAsync().Result.GetFullText())
             End If
-        End Sub
+        End Function
 
 #End Region
 
@@ -294,22 +295,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Sub
 
         Public Sub SendSelectSignatureHelpItemThroughPresenterSession(item As SignatureHelpItem)
-            WaitForAsynchronousOperations()
+            AssertNoAsynchronousOperationsRunning()
             CurrentSignatureHelpPresenterSession.SetSelectedItem(item)
         End Sub
 
-        Public Sub AssertNoSignatureHelpSession(Optional block As Boolean = True)
+        Public Async Function AssertNoSignatureHelpSession(Optional block As Boolean = True) As Task
             If block Then
-                WaitForAsynchronousOperations()
+                Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
             End If
 
             Assert.Null(Me.CurrentSignatureHelpPresenterSession)
-        End Sub
+        End Function
 
-        Public Sub AssertSignatureHelpSession()
-            WaitForAsynchronousOperations()
+        Public Async Function AssertSignatureHelpSession() As Task
+            Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
             Assert.NotNull(Me.CurrentSignatureHelpPresenterSession)
-        End Sub
+        End Function
 
         Private Function GetDisplayText(item As SignatureHelpItem, selectedParameter As Integer) As String
             Dim suffix = If(selectedParameter < item.Parameters.Count,
@@ -330,21 +331,21 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Function
 
         Public Function SignatureHelpItemsContainsAll(displayText As String()) As Boolean
-            WaitForAsynchronousOperations()
+            AssertNoAsynchronousOperationsRunning()
             Return displayText.All(Function(v) CurrentSignatureHelpPresenterSession.SignatureHelpItems.Any(
                                        Function(i) GetDisplayText(i, CurrentSignatureHelpPresenterSession.SelectedParameter.Value) = v))
         End Function
 
         Public Function SignatureHelpItemsContainsAny(displayText As String()) As Boolean
-            WaitForAsynchronousOperations()
+            AssertNoAsynchronousOperationsRunning()
             Return displayText.Any(Function(v) CurrentSignatureHelpPresenterSession.SignatureHelpItems.Any(
                                        Function(i) GetDisplayText(i, CurrentSignatureHelpPresenterSession.SelectedParameter.Value) = v))
         End Function
 
-        Public Sub AssertSelectedSignatureHelpItem(Optional displayText As String = Nothing,
+        Public Async Function AssertSelectedSignatureHelpItem(Optional displayText As String = Nothing,
                                Optional documentation As String = Nothing,
-                               Optional selectedParameter As String = Nothing)
-            WaitForAsynchronousOperations()
+                               Optional selectedParameter As String = Nothing) As Task
+            Await WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
 
             If displayText IsNot Nothing Then
                 Assert.Equal(displayText, GetDisplayText(Me.CurrentSignatureHelpPresenterSession.SelectedItem, Me.CurrentSignatureHelpPresenterSession.SelectedParameter.Value))
@@ -359,7 +360,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
                     Me.CurrentSignatureHelpPresenterSession.SelectedItem.Parameters(
                         Me.CurrentSignatureHelpPresenterSession.SelectedParameter.Value).DisplayParts))
             End If
-        End Sub
+        End Function
 #End Region
 
         Public Function GetCurrentViewLineText() As String

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/VisualBasicDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/VisualBasicDebuggerIntellisenseTests.vb
@@ -169,11 +169,11 @@ End Module</Document>
                 For xx = 0 To 10
                     state.SendTypeChars("z")
                     Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                    state.AssertSelectedCompletionItem("z")
+                    Await state.AssertSelectedCompletionItem("z").ConfigureAwait(True)
                     state.SendTab()
                     state.SendTypeChars(".")
                     Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                    state.AssertCompletionSession()
+                    Await state.AssertCompletionSession().ConfigureAwait(True)
                     state.SendReturn()
                 Next
             End Using
@@ -197,7 +197,7 @@ End Module</Document>
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 state.SendTypeChars("new String(")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSignatureHelpSession()
+                Await state.AssertSignatureHelpSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -219,7 +219,7 @@ End Module</Document>
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 state.SendTypeChars("Main(")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSignatureHelpSession()
+                Await state.AssertSignatureHelpSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -245,7 +245,7 @@ End Module</Document>
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 state.SendTypeChars("Self(Of Integer)(")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSignatureHelpSession()
+                Await state.AssertSignatureHelpSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -271,7 +271,7 @@ End Module</Document>
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 state.SendTypeChars("new List(Of String) From { a")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionSession()
+                Await state.AssertCompletionSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -303,7 +303,7 @@ End Class
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 state.SendTypeChars("new AClass")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("AClass")
+                Await state.AssertSelectedCompletionItem("AClass").ConfigureAwait(True)
             End Using
         End Sub
 
@@ -329,7 +329,7 @@ End Module</Document>
             Using state = TestState.CreateVisualBasicTestState(text, False)
                 state.SendTypeChars("Self(Of ")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertCompletionSession()
+                Await state.AssertCompletionSession().ConfigureAwait(True)
             End Using
         End Sub
 
@@ -365,11 +365,11 @@ End Module</Document>
             End If
             state.SendTypeChars(item)
             Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-            state.AssertSelectedCompletionItem(item)
+            Await state.AssertSelectedCompletionItem(item).ConfigureAwait(True)
             state.SendTab()
             state.SendTypeChars(".")
             Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-            state.AssertCompletionSession()
+            Await state.AssertCompletionSession().ConfigureAwait(True)
             For i As Integer = 0 To item.Length
                 state.SendBackspace()
             Next

--- a/src/VisualStudio/Core/Test/Diagnostics/MiscDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/MiscDiagnosticUpdateSourceTests.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Immutable
 Imports System.Threading
+Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor
@@ -47,7 +48,7 @@ class 123 { }
                 Dim tagger = provider.CreateTagger(Of IErrorTag)(buffer)
                 Using disposable = TryCast(tagger, IDisposable)
                     Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
-                    analyzer.AnalyzeSyntaxAsync(workspace.CurrentSolution.Projects.First().Documents.First(), CancellationToken.None).PumpingWait()
+                    Await analyzer.AnalyzeSyntaxAsync(workspace.CurrentSolution.Projects.First().Documents.First(), CancellationToken.None).ConfigureAwait(True)
 
                     Await listener.CreateWaitTask().ConfigureAwait(True)
 
@@ -61,7 +62,7 @@ class 123 { }
         End Function
 
         <WpfFact>
-        Public Sub TestMiscCSharpErrorSource()
+        Public Async Function TestMiscCSharpErrorSource() As Tasks.Task
             Dim code = <code>
 class 123 { }
                        </code>
@@ -78,14 +79,14 @@ class 123 { }
                                                            End Sub
 
                 Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
-                analyzer.AnalyzeSyntaxAsync(workspace.CurrentSolution.Projects.First().Documents.First(), CancellationToken.None).PumpingWait()
+                Await analyzer.AnalyzeSyntaxAsync(workspace.CurrentSolution.Projects.First().Documents.First(), CancellationToken.None).ConfigureAwait(True)
 
                 Assert.Equal(PredefinedBuildTools.Live, buildTool)
             End Using
-        End Sub
+        End Function
 
         <WpfFact>
-        Public Sub TestMiscVBErrorSource()
+        Public Async Function TestMiscVBErrorSource() As Task
             Dim code = <code>
 Class 123
 End Class
@@ -103,10 +104,10 @@ End Class
                                                            End Sub
 
                 Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
-                analyzer.AnalyzeSyntaxAsync(workspace.CurrentSolution.Projects.First().Documents.First(), CancellationToken.None).PumpingWait()
+                Await analyzer.AnalyzeSyntaxAsync(workspace.CurrentSolution.Projects.First().Documents.First(), CancellationToken.None).ConfigureAwait(True)
 
                 Assert.Equal(PredefinedBuildTools.Live, buildTool)
             End Using
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
@@ -41,7 +41,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
 
                 testState.SendBackspace()
                 Await testState.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                testState.WaitForAsynchronousOperations()
                 Assert.Equal(testState.CurrentCompletionPresenterSession.SelectedItem.DisplayText, "Shortcut")
 
                 testState.SendTabToCompletion()
@@ -63,7 +62,6 @@ End Class</File>.Value
             Using testState
                 testState.SendTabToCompletion()
                 Await testState.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                testState.WaitForAsynchronousOperations()
                 Assert.Null(testState.CurrentCompletionPresenterSession)
             End Using
         End Function


### PR DESCRIPTION
This removes PumpingWait from our test infrastructure and replaces it with proper await calls on the Task(s) in question.