### PR TITLE
Properly handle VB WithEvents fields in metadata code model elements

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -976,6 +976,19 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
 
         public override bool IsValidExternalSymbol(ISymbol symbol)
         {
+            var methodSymbol = symbol as IMethodSymbol;
+            if (methodSymbol != null)
+            {
+                if (methodSymbol.MethodKind == MethodKind.PropertyGet ||
+                    methodSymbol.MethodKind == MethodKind.PropertySet ||
+                    methodSymbol.MethodKind == MethodKind.EventAdd ||
+                    methodSymbol.MethodKind == MethodKind.EventRemove ||
+                    methodSymbol.MethodKind == MethodKind.EventRaise)
+                {
+                    return false;
+                }
+            }
+
             return symbol.DeclaredAccessibility == Accessibility.Public
                 || symbol.DeclaredAccessibility == Accessibility.Protected
                 || symbol.DeclaredAccessibility == Accessibility.ProtectedOrInternal;

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -56,7 +56,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        private static readonly SymbolDisplayFormat s_fullNameFormat =
+        private static readonly SymbolDisplayFormat s_externalNameFormat =
+            new SymbolDisplayFormat(
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
+
+        private static readonly SymbolDisplayFormat s_externalFullNameFormat =
             new SymbolDisplayFormat(
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
                 memberOptions: SymbolDisplayMemberOptions.IncludeContainingType | SymbolDisplayMemberOptions.IncludeExplicitInterface,
@@ -943,17 +947,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 ? semanticModel.GetTypeInfo(node).Type
                 : semanticModel.GetDeclaredSymbol(node);
 
-            return GetFullName(symbol);
-        }
-
-        public override string GetFullName(ISymbol symbol)
-        {
-            if (symbol == null)
-            {
-                throw Exceptions.ThrowEFail();
-            }
-
-            return symbol.ToDisplayString(s_fullNameFormat);
+            return GetExternalSymbolFullName(symbol);
         }
 
         public override string GetFullyQualifiedName(string name, int position, SemanticModel semanticModel)
@@ -978,6 +972,33 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             }
 
             return name;
+        }
+
+        public override bool IsValidExternalSymbol(ISymbol symbol)
+        {
+            return symbol.DeclaredAccessibility == Accessibility.Public
+                || symbol.DeclaredAccessibility == Accessibility.Protected
+                || symbol.DeclaredAccessibility == Accessibility.ProtectedOrInternal;
+        }
+
+        public override string GetExternalSymbolName(ISymbol symbol)
+        {
+            if (symbol == null)
+            {
+                throw Exceptions.ThrowEFail();
+            }
+
+            return symbol.ToDisplayString(s_externalNameFormat);
+        }
+
+        public override string GetExternalSymbolFullName(ISymbol symbol)
+        {
+            if (symbol == null)
+            {
+                throw Exceptions.ThrowEFail();
+            }
+
+            return symbol.ToDisplayString(s_externalFullNameFormat);
         }
 
         public override EnvDTE.vsCMAccess GetAccess(ISymbol symbol)

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService_Prototype.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService_Prototype.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 }
 
                 // The unique signature is simply the node key.
-                return GetFullName(symbol);
+                return GetExternalSymbolFullName(symbol);
             }
 
             var builder = new StringBuilder();

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -519,7 +519,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         public abstract SyntaxNode SetName(SyntaxNode node, string name);
 
         public abstract string GetFullName(SyntaxNode node, SemanticModel semanticModel);
-        public abstract string GetFullName(ISymbol symbol);
 
         public abstract string GetFullyQualifiedName(string name, int position, SemanticModel semanticModel);
 
@@ -567,6 +566,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             // Update the node keys.
             nodeKeyValidation.RestoreKeys();
         }
+
+        public abstract bool IsValidExternalSymbol(ISymbol symbol);
+        public abstract string GetExternalSymbolName(ISymbol symbol);
+        public abstract string GetExternalSymbolFullName(ISymbol symbol);
 
         public VirtualTreePoint? GetStartPoint(SyntaxNode node, EnvDTE.vsCMPart? part)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -260,7 +260,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                     }
 
                 case SymbolKind.Property:
-                    return (EnvDTE.CodeElement)ExternalCodeProperty.Create(state, projectId, (IPropertySymbol)symbol);
+                    var propertySymbol = (IPropertySymbol)symbol;
+                    return propertySymbol.IsWithEvents
+                        ? (EnvDTE.CodeElement)ExternalCodeVariable.Create(state, projectId, propertySymbol)
+                        : (EnvDTE.CodeElement)ExternalCodeProperty.Create(state, projectId, (IPropertySymbol)symbol);
                 default:
                     throw Exceptions.ThrowEFail();
             }

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalMemberCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalMemberCollection.cs
@@ -55,7 +55,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
 
                 foreach (var member in typeSymbol.GetMembers())
                 {
-                    childrenBuilder.Add(this.State.CodeModelService.CreateExternalCodeElement(this.State, _projectId, member));
+                    if (this.CodeModelService.IsValidExternalSymbol(member))
+                    {
+                        childrenBuilder.Add(this.State.CodeModelService.CreateExternalCodeElement(this.State, _projectId, member));
+                    }
                 }
 
                 foreach (var typeMember in typeSymbol.GetTypeMembers())

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/AbstractExternalCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/AbstractExternalCodeElement.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
 
         protected virtual string GetFullName()
         {
-            return CodeModelService.GetFullName(LookupSymbol());
+            return CodeModelService.GetExternalSymbolFullName(LookupSymbol());
         }
 
         protected virtual bool GetIsShared()
@@ -72,8 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
 
         protected virtual string GetName()
         {
-            var symbol = LookupSymbol();
-            return symbol.Name;
+            return CodeModelService.GetExternalSymbolName(LookupSymbol());
         }
 
         protected virtual object GetParent()

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeClass.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeClass.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Collections;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeVariable.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeVariable.cs
@@ -11,20 +11,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
     [ComDefaultInterface(typeof(EnvDTE.CodeVariable))]
     public sealed class ExternalCodeVariable : AbstractExternalCodeMember, EnvDTE.CodeVariable, EnvDTE80.CodeVariable2
     {
-        internal static EnvDTE.CodeVariable Create(CodeModelState state, ProjectId projectId, IFieldSymbol symbol)
+        internal static EnvDTE.CodeVariable Create(CodeModelState state, ProjectId projectId, ISymbol symbol)
         {
             var element = new ExternalCodeVariable(state, projectId, symbol);
             return (EnvDTE.CodeVariable)ComAggregate.CreateAggregatedObject(element);
         }
 
-        private ExternalCodeVariable(CodeModelState state, ProjectId projectId, IFieldSymbol symbol)
+        private ExternalCodeVariable(CodeModelState state, ProjectId projectId, ISymbol symbol)
             : base(state, projectId, symbol)
         {
         }
 
-        private IFieldSymbol FieldSymbol
+        private ITypeSymbol GetSymbolType()
         {
-            get { return (IFieldSymbol)LookupSymbol(); }
+            var symbol = LookupSymbol();
+            if (symbol != null)
+            {
+                switch (symbol.Kind)
+                {
+                    case SymbolKind.Field:
+                        return ((IFieldSymbol)symbol).Type;
+                    case SymbolKind.Property:
+                        // Note: VB WithEvents fields are represented as properties
+                        return ((IPropertySymbol)symbol).Type;
+                }
+            }
+
+            return null;
         }
 
         public override EnvDTE.vsCMElement Kind
@@ -49,10 +62,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
             get
             {
-                // TODO: Verify VB implementation
-                var symbol = FieldSymbol;
-                return symbol.IsConst
-                    || symbol.IsReadOnly;
+                var fieldSymbol = LookupSymbol() as IFieldSymbol;
+                if (fieldSymbol == null)
+                {
+                    return false;
+                }
+
+                return fieldSymbol.IsConst
+                    || fieldSymbol.IsReadOnly;
             }
 
             set
@@ -65,7 +82,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
             get
             {
-                return CodeTypeRef.Create(this.State, this, this.ProjectId, FieldSymbol.Type);
+                var type = GetSymbolType();
+                if (type == null)
+                {
+                    throw Exceptions.ThrowEFail();
+                }
+
+                return CodeTypeRef.Create(this.State, this, this.ProjectId, type);
             }
 
             set
@@ -78,13 +101,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
             get
             {
-                // TODO: Verify VB Implementation
-                var symbol = FieldSymbol;
-                if (symbol.IsConst)
+                var fieldSymbol = LookupSymbol() as IFieldSymbol;
+                if (fieldSymbol == null)
+                {
+                    return EnvDTE80.vsCMConstKind.vsCMConstKindNone;
+                }
+
+                if (fieldSymbol.IsConst)
                 {
                     return EnvDTE80.vsCMConstKind.vsCMConstKindConst;
                 }
-                else if (symbol.IsReadOnly)
+                else if (fieldSymbol.IsReadOnly)
                 {
                     return EnvDTE80.vsCMConstKind.vsCMConstKindReadOnly;
                 }
@@ -105,7 +132,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             get
             {
                 // TODO: C# checks whether the field Type is generic. What does VB do?
-                var namedType = FieldSymbol.Type as INamedTypeSymbol;
+                var namedType = GetSymbolType() as INamedTypeSymbol;
                 return namedType != null
                     ? namedType.IsGenericType
                     : false;

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -115,16 +115,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         string GetFullName(SyntaxNode node, SemanticModel semanticModel);
 
         /// <summary>
-        /// Retrieves the value to be returned from the EnvDTE.CodeElement.FullName property for external code elements
-        /// </summary>
-        string GetFullName(ISymbol symbol);
-
-        /// <summary>
         /// Given a name, attempts to convert it to a fully qualified name.
         /// </summary>
         string GetFullyQualifiedName(string name, int position, SemanticModel semanticModel);
 
         void Rename(ISymbol symbol, string newName, Solution solution);
+
+        /// <summary>
+        /// Returns true if the given <paramref name="symbol"/> can be used to create an external code element; otherwise, false.
+        /// </summary>
+        bool IsValidExternalSymbol(ISymbol symbol);
+
+        /// <summary>
+        /// Returns the value to be returned from <see cref="EnvDTE.CodeElement.Name"/> for external code elements.
+        /// </summary>
+        string GetExternalSymbolName(ISymbol symbol);
+
+        /// <summary>
+        /// Retrieves the value to be returned from <see cref="EnvDTE.CodeElement.FullName"/> for external code elements.
+        /// </summary>
+        string GetExternalSymbolFullName(ISymbol symbol);
 
         SyntaxNode GetNodeWithModifiers(SyntaxNode node);
         SyntaxNode GetNodeWithType(SyntaxNode node);

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeAttributeTests.vb
@@ -56,106 +56,69 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestAttributeArguments(code As XElement, ParamArray expectedAttributeArguments() As Action(Of Object))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim attributes = GetAttributeArguments(codeElement)
+                    Assert.Equal(expectedAttributeArguments.Length, attributes.Count)
 
-                Dim attributes = GetAttributeArguments(codeElement)
-                Assert.Equal(expectedAttributeArguments.Length, attributes.Count)
-
-                For i = 1 To attributes.Count
-                    expectedAttributeArguments(i - 1)(attributes.Item(i))
-                Next
-            End Using
+                    For i = 1 To attributes.Count
+                        expectedAttributeArguments(i - 1)(attributes.Item(i))
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestTarget(code As XElement, expectedTarget As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
-
-                Dim target = GetTarget(codeElement)
-                Assert.Equal(expectedTarget, target)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim target = GetTarget(codeElement)
+                    Assert.Equal(expectedTarget, target)
+                End Sub)
         End Sub
 
         Protected Sub TestSetTarget(code As XElement, expectedCode As XElement, target As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeAttribute = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeAttribute)
-
-                codeAttribute.Target = target
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue().Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Sub TestSetValue(code As XElement, expectedCode As XElement, value As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeAttribute = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeAttribute)
-
-                codeAttribute.Value = value
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue().Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    codeElement.Target = target
+                End Sub)
         End Sub
 
         Protected Sub TestValue(code As XElement, expectedValue As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim target = GetValue(codeElement)
+                    Assert.Equal(expectedValue, target)
+                End Sub)
+        End Sub
 
-                Dim target = GetValue(codeElement)
-                Assert.Equal(expectedValue, target)
-            End Using
+        Protected Sub TestSetValue(code As XElement, expectedCode As XElement, value As String)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    codeElement.Value = value
+                End Sub)
         End Sub
 
         Protected Sub TestAddAttributeArgument(code As XElement, expectedCode As XElement, data As AttributeArgumentData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
-
-                Dim attributeArgument = AddAttributeArgument(codeElement, data)
-                Assert.NotNull(attributeArgument)
-                Assert.Equal(data.Name, attributeArgument.Name)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim attributeArgument = AddAttributeArgument(codeElement, data)
+                    Assert.NotNull(attributeArgument)
+                    Assert.Equal(data.Name, attributeArgument.Name)
+                End Sub)
         End Sub
 
         Protected Sub TestDelete(code As XElement, expectedCode As XElement)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
-
-                codeElement.Delete()
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    codeElement.Delete()
+                End Sub)
         End Sub
 
         Protected Sub TestDeleteAttributeArgument(code As XElement, expectedCode As XElement, indexToDelete As Integer)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
-
-                Dim argument = CType(codeElement.Arguments.Item(indexToDelete), EnvDTE80.CodeAttributeArgument)
-
-                argument.Delete()
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim argument = CType(codeElement.Arguments.Item(indexToDelete), EnvDTE80.CodeAttributeArgument)
+                    argument.Delete()
+                End Sub)
         End Sub
 
         Protected Function IsAttributeArgument(Optional name As String = Nothing, Optional value As String = Nothing) As Action(Of Object)
@@ -175,33 +138,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestAttributeArgumentStartPoint(code As XElement, index As Integer, ParamArray expectedParts() As Action(Of Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint)))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim arg = CType(codeElement.Arguments.Item(index), EnvDTE80.CodeAttributeArgument)
 
-                Dim arg = CType(codeElement.Arguments.Item(index), EnvDTE80.CodeAttributeArgument)
+                    Dim startPointGetter = Function(part As EnvDTE.vsCMPart) arg.GetStartPoint(part)
 
-                Dim startPointGetter = Function(part As EnvDTE.vsCMPart) arg.GetStartPoint(part)
-
-                For Each action In expectedParts
-                    action(startPointGetter)
-                Next
-            End Using
+                    For Each action In expectedParts
+                        action(startPointGetter)
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestAttributeArgumentEndPoint(code As XElement, index As Integer, ParamArray expectedParts() As Action(Of Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint)))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeAttribute2)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim arg = CType(codeElement.Arguments.Item(index), EnvDTE80.CodeAttributeArgument)
 
-                Dim arg = CType(codeElement.Arguments.Item(index), EnvDTE80.CodeAttributeArgument)
+                    Dim endPointGetter = Function(part As EnvDTE.vsCMPart) arg.GetEndPoint(part)
 
-                Dim endPointGetter = Function(part As EnvDTE.vsCMPart) arg.GetEndPoint(part)
-
-                For Each action In expectedParts
-                    action(endPointGetter)
-                Next
-            End Using
+                    For Each action In expectedParts
+                        action(endPointGetter)
+                    Next
+                End Sub)
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeDelegateTests.vb
@@ -77,13 +77,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestBaseClass(code As XElement, expectedFullName As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeDelegate2)()
-                Assert.NotNull(codeElement)
-                Assert.NotNull(codeElement.BaseClass)
-
-                Assert.Equal(expectedFullName, codeElement.BaseClass.FullName)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.NotNull(codeElement.BaseClass)
+                    Assert.Equal(expectedFullName, codeElement.BaseClass.FullName)
+                End Sub)
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
@@ -8,6 +8,53 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Partial Public MustInherit Class AbstractCodeElementTests(Of TCodeElement As Class)
         Inherits AbstractCodeModelObjectTests(Of TCodeElement)
 
+        Protected Overridable ReadOnly Property TargetExternalCodeElements As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        Private Function GetCodeElement(state As CodeModelTestState) As TCodeElement
+            Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)
+
+            Return If(codeElement IsNot Nothing AndAlso TargetExternalCodeElements,
+                      codeElement.AsExternal(),
+                      codeElement)
+        End Function
+
+        Protected Sub TestElement(code As XElement, expected As Action(Of TCodeElement))
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim codeElement = GetCodeElement(state)
+                Assert.NotNull(codeElement)
+
+                expected(codeElement)
+            End Using
+        End Sub
+
+        Protected Overloads Sub TestElementUpdate(code As XElement, expectedCode As XElement, updater As Action(Of TCodeElement))
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim codeElement = GetCodeElement(state)
+                Assert.NotNull(codeElement)
+
+                updater(codeElement)
+
+                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
+                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
+            End Using
+        End Sub
+
+        Friend Overloads Sub TestElementUpdate(code As XElement, expectedCode As XElement, updater As Action(Of CodeModelTestState, TCodeElement))
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim codeElement = GetCodeElement(state)
+                Assert.NotNull(codeElement)
+
+                updater(state, codeElement)
+
+                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
+                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
+            End Using
+        End Sub
+
         Protected Delegate Sub PartAction(part As EnvDTE.vsCMPart, textPointGetter As Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint))
 
         Protected Function Part(p As EnvDTE.vsCMPart, action As PartAction) As Action(Of Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint))
@@ -364,482 +411,359 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestPropertyDescriptors(code As XElement, ParamArray expectedPropertyNames As String())
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim propertyDescriptors = ComponentModel.TypeDescriptor.GetProperties(codeElement)
-                Dim propertyNames = propertyDescriptors _
+            TestElement(code,
+                Sub(codeElement)
+                    Dim propertyDescriptors = ComponentModel.TypeDescriptor.GetProperties(codeElement)
+                    Dim propertyNames = propertyDescriptors _
                     .OfType(Of ComponentModel.PropertyDescriptor) _
                     .Select(Function(pd) pd.Name) _
                     .ToArray()
 
-                Assert.Equal(expectedPropertyNames, propertyNames)
-            End Using
-        End Sub
-
-        Protected Sub TestElement(code As XElement, expected As Action(Of TCodeElement))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                expected(codeElement)
-            End Using
+                    Assert.Equal(expectedPropertyNames, propertyNames)
+                End Sub)
         End Sub
 
         Protected Sub TestGetStartPoint(code As XElement, ParamArray expectedParts() As Action(Of Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint)))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim textPointGetter = GetStartPointFunc(codeElement)
 
-                Dim textPointGetter = GetStartPointFunc(codeElement)
-
-                For Each action In expectedParts
-                    action(textPointGetter)
-                Next
-            End Using
+                    For Each action In expectedParts
+                        action(textPointGetter)
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestGetEndPoint(code As XElement, ParamArray expectedParts() As Action(Of Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint)))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim textPointGetter = GetEndPointFunc(codeElement)
 
-                Dim textPointGetter = GetEndPointFunc(codeElement)
-
-                For Each action In expectedParts
-                    action(textPointGetter)
-                Next
-            End Using
+                    For Each action In expectedParts
+                        action(textPointGetter)
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestAccess(code As XElement, expectedAccess As EnvDTE.vsCMAccess)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim access = GetAccess(codeElement)
-                Assert.Equal(expectedAccess, access)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim access = GetAccess(codeElement)
+                    Assert.Equal(expectedAccess, access)
+                End Sub)
         End Sub
 
         Protected Sub TestAttributes(code As XElement, ParamArray expectedAttributes() As Action(Of Object))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim attributes = GetAttributes(codeElement)
+                    Assert.Equal(expectedAttributes.Length, attributes.Count)
 
-                Dim attributes = GetAttributes(codeElement)
-                Assert.Equal(expectedAttributes.Length, attributes.Count)
-
-                For i = 1 To attributes.Count
-                    expectedAttributes(i - 1)(attributes.Item(i))
-                Next
-            End Using
+                    For i = 1 To attributes.Count
+                        expectedAttributes(i - 1)(attributes.Item(i))
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestBases(code As XElement, ParamArray expectedBases() As Action(Of Object))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim bases = GetBases(codeElement)
+                    Assert.Equal(expectedBases.Length, bases.Count)
 
-                Dim bases = GetBases(codeElement)
-                Assert.Equal(expectedBases.Length, bases.Count)
-
-                For i = 1 To bases.Count
-                    expectedBases(i - 1)(bases.Item(i))
-                Next
-            End Using
+                    For i = 1 To bases.Count
+                        expectedBases(i - 1)(bases.Item(i))
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestChildren(code As XElement, ParamArray expectedChildren() As Action(Of Object))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim element = CType(codeElement, EnvDTE.CodeElement)
+                    Assert.True(element IsNot Nothing, "Could not cast " & GetType(TCodeElement).FullName & " to " & GetType(EnvDTE.CodeElement).FullName & ".")
 
-                Dim element = CType(codeElement, EnvDTE.CodeElement)
-                Assert.True(element IsNot Nothing, "Could not cast " & GetType(TCodeElement).FullName & " to " & GetType(EnvDTE.CodeElement).FullName & ".")
+                    Dim children = element.Children
+                    Assert.Equal(expectedChildren.Length, children.Count)
 
-                Dim children = element.Children
-                Assert.Equal(expectedChildren.Length, children.Count)
-
-                For i = 1 To children.Count
-                    expectedChildren(i - 1)(children.Item(i))
-                Next
-            End Using
+                    For i = 1 To children.Count
+                        expectedChildren(i - 1)(children.Item(i))
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestClassKind(code As XElement, expectedClassKind As EnvDTE80.vsCMClassKind)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim classKind = GetClassKind(codeElement)
-                Assert.Equal(expectedClassKind, classKind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim classKind = GetClassKind(codeElement)
+                    Assert.Equal(expectedClassKind, classKind)
+                End Sub)
         End Sub
 
         Protected Sub TestComment(code As XElement, expectedComment As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim comment = GetComment(codeElement)
-                Assert.Equal(expectedComment, comment)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim comment = GetComment(codeElement)
+                    Assert.Equal(expectedComment, comment)
+                End Sub)
         End Sub
 
         Protected Sub TestConstKind(code As XElement, expectedConstKind As EnvDTE80.vsCMConstKind)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim constKind = GetConstKind(codeElement)
-                Assert.Equal(expectedConstKind, constKind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim constKind = GetConstKind(codeElement)
+                    Assert.Equal(expectedConstKind, constKind)
+                End Sub)
         End Sub
 
         Protected Sub TestDataTypeKind(code As XElement, expectedDataTypeKind As EnvDTE80.vsCMDataTypeKind)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim dataTypeKind = GetDataTypeKind(codeElement)
-                Assert.Equal(expectedDataTypeKind, dataTypeKind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim dataTypeKind = GetDataTypeKind(codeElement)
+                    Assert.Equal(expectedDataTypeKind, dataTypeKind)
+                End Sub)
         End Sub
 
         Protected Sub TestDocComment(code As XElement, expectedDocComment As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim docComment = GetDocComment(codeElement)
-                Assert.Equal(expectedDocComment, docComment)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim docComment = GetDocComment(codeElement)
+                    Assert.Equal(expectedDocComment, docComment)
+                End Sub)
         End Sub
 
         Protected Sub TestFullName(code As XElement, expectedFullName As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim fullName = GetFullName(codeElement)
-                Assert.Equal(expectedFullName, fullName)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim fullName = GetFullName(codeElement)
+                    Assert.Equal(expectedFullName, fullName)
+                End Sub)
         End Sub
 
         Protected Sub TestImplementedInterfaces(code As XElement, ParamArray expectedBases() As Action(Of Object))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim implementedInterfaces = GetImplementedInterfaces(codeElement)
+                    Assert.Equal(expectedBases.Length, implementedInterfaces.Count)
 
-                Dim implementedInterfaces = GetImplementedInterfaces(codeElement)
-                Assert.Equal(expectedBases.Length, implementedInterfaces.Count)
-
-                For i = 1 To implementedInterfaces.Count
-                    expectedBases(i - 1)(implementedInterfaces.Item(i))
-                Next
-            End Using
+                    For i = 1 To implementedInterfaces.Count
+                        expectedBases(i - 1)(implementedInterfaces.Item(i))
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestInheritanceKind(code As XElement, expectedInheritanceKind As EnvDTE80.vsCMInheritanceKind)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim inheritanceKind = GetInheritanceKind(codeElement)
-                Assert.Equal(expectedInheritanceKind, inheritanceKind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim inheritanceKind = GetInheritanceKind(codeElement)
+                    Assert.Equal(expectedInheritanceKind, inheritanceKind)
+                End Sub)
         End Sub
 
         Protected Sub TestIsAbstract(code As XElement, expectedValue As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim value = GetIsAbstract(codeElement)
-                Assert.Equal(expectedValue, value)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim value = GetIsAbstract(codeElement)
+                    Assert.Equal(expectedValue, value)
+                End Sub)
         End Sub
 
         Protected Sub TestIsDefault(code As XElement, expectedValue As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim value = GetIsDefault(codeElement)
-                Assert.Equal(expectedValue, value)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim value = GetIsDefault(codeElement)
+                    Assert.Equal(expectedValue, value)
+                End Sub)
         End Sub
 
         Protected Sub TestIsGeneric(code As XElement, expectedValue As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim value = GetIsGeneric(codeElement)
-                Assert.Equal(expectedValue, value)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim value = GetIsGeneric(codeElement)
+                    Assert.Equal(expectedValue, value)
+                End Sub)
         End Sub
 
         Protected Sub TestIsShared(code As XElement, expectedValue As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim value = GetIsShared(codeElement)
-                Assert.Equal(expectedValue, value)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim value = GetIsShared(codeElement)
+                    Assert.Equal(expectedValue, value)
+                End Sub)
         End Sub
 
         Protected Sub TestKind(code As XElement, expectedKind As EnvDTE.vsCMElement)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)(expectedKind)
-                Assert.NotNull(codeElement)
-
-                Dim kind = GetKind(codeElement)
-
-                Assert.Equal(expectedKind, kind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim kind = GetKind(codeElement)
+                    Assert.Equal(expectedKind, kind)
+                End Sub)
         End Sub
 
         Protected Sub TestMustImplement(code As XElement, expectedValue As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim value = GetMustImplement(codeElement)
-                Assert.Equal(expectedValue, value)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim value = GetMustImplement(codeElement)
+                    Assert.Equal(expectedValue, value)
+                End Sub)
         End Sub
 
         Protected Sub TestName(code As XElement, expectedName As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim name = GetName(codeElement)
-                Assert.Equal(expectedName, name)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim name = GetName(codeElement)
+                    Assert.Equal(expectedName, name)
+                End Sub)
         End Sub
 
         Protected Sub TestOverrideKind(code As XElement, expectedOverrideKind As EnvDTE80.vsCMOverrideKind)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim overrideKind = GetOverrideKind(codeElement)
-                Assert.Equal(expectedOverrideKind, overrideKind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim overrideKind = GetOverrideKind(codeElement)
+                    Assert.Equal(expectedOverrideKind, overrideKind)
+                End Sub)
         End Sub
 
         Protected Sub TestParts(code As XElement, expectedPartCount As Integer)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim parts = GetParts(codeElement)
 
-                Dim parts = GetParts(codeElement)
-
-                ' TODO: Test the elements themselves, not just the count (PartialTypeCollection.Item is not 
-                ' fully implemented)
-                Assert.Equal(expectedPartCount, parts.Count)
-            End Using
+                    ' TODO: Test the elements themselves, not just the count (PartialTypeCollection.Item is not fully implemented)
+                    Assert.Equal(expectedPartCount, parts.Count)
+                End Sub)
         End Sub
 
         Protected Sub TestParent(code As XElement, expectedParent As Action(Of Object))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim parent = GetParent(codeElement)
-
-                expectedParent(parent)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim parent = GetParent(codeElement)
+                    expectedParent(parent)
+                End Sub)
         End Sub
 
         Protected Sub TestPrototype(code As XElement, flags As EnvDTE.vsCMPrototype, expectedPrototype As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim prototype = GetPrototype(codeElement, flags)
-
-                Assert.Equal(expectedPrototype, prototype)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim prototype = GetPrototype(codeElement, flags)
+                    Assert.Equal(expectedPrototype, prototype)
+                End Sub)
         End Sub
 
         Protected Sub TestPrototypeThrows(Of TException As Exception)(code As XElement, flags As EnvDTE.vsCMPrototype)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Throws(Of TException)(Sub() GetPrototype(codeElement, flags))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Throws(Of TException)(Sub() GetPrototype(codeElement, flags))
+                End Sub)
         End Sub
 
         Protected Sub TestReadWrite(code As XElement, expectedOverrideKind As EnvDTE80.vsCMPropertyKind)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim readWrite = GetReadWrite(codeElement)
-                Assert.Equal(expectedOverrideKind, readWrite)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim readWrite = GetReadWrite(codeElement)
+                    Assert.Equal(expectedOverrideKind, readWrite)
+                End Sub)
         End Sub
 
         Protected Sub TestIsDerivedFrom(code As XElement, baseFullName As String, expectedIsDerivedFrom As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim actualIsDerivedFrom = IsDerivedFrom(codeElement, baseFullName)
-
-                Assert.Equal(expectedIsDerivedFrom, actualIsDerivedFrom)
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestAddAttribute(code As XElement, expectedCode As XElement, data As AttributeData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim attribute = AddAttribute(codeElement, data)
-                Assert.NotNull(attribute)
-                Assert.Equal(data.Name, attribute.Name)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestAddEnumMember(code As XElement, expectedCode As XElement, data As EnumMemberData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim enumMember = AddEnumMember(codeElement, data)
-                Assert.NotNull(enumMember)
-                Assert.Equal(data.Name, enumMember.Name)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestAddEvent(code As XElement, expectedCode As XElement, data As EventData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim ev = AddEvent(codeElement, data)
-                Assert.NotNull(ev)
-                Assert.Equal(data.Name, ev.Name)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestAddFunction(code As XElement, expectedCode As XElement, data As FunctionData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim func = AddFunction(codeElement, data)
-                Assert.NotNull(func)
-
-                If data.Kind <> EnvDTE.vsCMFunction.vsCMFunctionDestructor Then
-                    Assert.Equal(data.Name, func.Name)
-                End If
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestAddParameter(code As XElement, expectedCode As XElement, data As ParameterData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim name = GetName(codeElement)
-
-                Dim parameter = AddParameter(codeElement, data)
-                Assert.NotNull(parameter)
-                Assert.Equal(data.Name, parameter.Name)
-
-                ' Verify we haven't screwed up any node keys by checking that we
-                ' can still access the parent element after adding the parameter.
-                Assert.Equal(name, GetName(codeElement))
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestAddProperty(code As XElement, expectedCode As XElement, data As PropertyData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim prop = AddProperty(codeElement, data)
-                Assert.NotNull(prop)
-                Assert.True(data.GetterName = prop.Name OrElse data.PutterName = prop.Name)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestAddVariable(code As XElement, expectedCode As XElement, data As VariableData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim variable = AddVariable(codeElement, data)
-                Assert.NotNull(variable)
-                Assert.Equal(data.Name, variable.Name)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync(CancellationToken.None).Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
-        End Sub
-
-        Protected Overrides Sub TestRemoveChild(code As XElement, expectedCode As XElement, child As Object)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim name = GetName(codeElement)
-
-                RemoveChild(codeElement, child)
-
-                ' Verify we haven't screwed up any node keys by checking that we
-                ' can still access the parent element after deleting the child.
-                Assert.Equal(name, GetName(codeElement))
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim actualIsDerivedFrom = IsDerivedFrom(codeElement, baseFullName)
+                    Assert.Equal(expectedIsDerivedFrom, actualIsDerivedFrom)
+                End Sub)
         End Sub
 
         Protected Sub TestTypeProp(code As XElement, data As CodeTypeRefData)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim codeTypeRef = GetTypeProp(codeElement)
+                    TestCodeTypeRef(codeTypeRef, data)
+                End Sub)
+        End Sub
 
-                Dim codeTypeRef = GetTypeProp(codeElement)
+        Protected Overrides Sub TestAddAttribute(code As XElement, expectedCode As XElement, data As AttributeData)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim attribute = AddAttribute(codeElement, data)
+                    Assert.NotNull(attribute)
+                    Assert.Equal(data.Name, attribute.Name)
+                End Sub)
+        End Sub
 
-                TestCodeTypeRef(codeTypeRef, data)
-            End Using
+        Protected Overrides Sub TestAddEnumMember(code As XElement, expectedCode As XElement, data As EnumMemberData)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim enumMember = AddEnumMember(codeElement, data)
+                    Assert.NotNull(enumMember)
+                    Assert.Equal(data.Name, enumMember.Name)
+                End Sub)
+        End Sub
+
+        Protected Overrides Sub TestAddEvent(code As XElement, expectedCode As XElement, data As EventData)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim ev = AddEvent(codeElement, data)
+                    Assert.NotNull(ev)
+                    Assert.Equal(data.Name, ev.Name)
+                End Sub)
+        End Sub
+
+        Protected Overrides Sub TestAddFunction(code As XElement, expectedCode As XElement, data As FunctionData)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim func = AddFunction(codeElement, data)
+                    Assert.NotNull(func)
+
+                    If data.Kind <> EnvDTE.vsCMFunction.vsCMFunctionDestructor Then
+                        Assert.Equal(data.Name, func.Name)
+                    End If
+                End Sub)
+        End Sub
+
+        Protected Overrides Sub TestAddParameter(code As XElement, expectedCode As XElement, data As ParameterData)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim name = GetName(codeElement)
+
+                    Dim parameter = AddParameter(codeElement, data)
+                    Assert.NotNull(parameter)
+                    Assert.Equal(data.Name, parameter.Name)
+
+                    ' Verify we haven't screwed up any node keys by checking that we
+                    ' can still access the parent element after adding the parameter.
+                    Assert.Equal(name, GetName(codeElement))
+                End Sub)
+        End Sub
+
+        Protected Overrides Sub TestAddProperty(code As XElement, expectedCode As XElement, data As PropertyData)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim prop = AddProperty(codeElement, data)
+                    Assert.NotNull(prop)
+                    Assert.True(data.GetterName = prop.Name OrElse data.PutterName = prop.Name)
+                End Sub)
+        End Sub
+
+        Protected Overrides Sub TestAddVariable(code As XElement, expectedCode As XElement, data As VariableData)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim variable = AddVariable(codeElement, data)
+                    Assert.NotNull(variable)
+                    Assert.Equal(data.Name, variable.Name)
+                End Sub)
+        End Sub
+
+        Protected Overrides Sub TestRemoveChild(code As XElement, expectedCode As XElement, child As Object)
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim name = GetName(codeElement)
+
+                    RemoveChild(codeElement, child)
+
+                    ' Verify we haven't screwed up any node keys by checking that we
+                    ' can still access the parent element after deleting the child.
+                    Assert.Equal(name, GetName(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestSetAccess(code As XElement, expectedCode As XElement, access As EnvDTE.vsCMAccess)
@@ -847,18 +771,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetAccess(code As XElement, expectedCode As XElement, access As EnvDTE.vsCMAccess, action As SetterAction(Of EnvDTE.vsCMAccess))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim accessSetter = GetAccessSetter(codeElement)
-
-                action(access, accessSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim accessSetter = GetAccessSetter(codeElement)
+                    action(access, accessSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetClassKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMClassKind)
@@ -866,18 +783,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetClassKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMClassKind, action As SetterAction(Of EnvDTE80.vsCMClassKind))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim classKindSetter = GetClassKindSetter(codeElement)
-
-                action(kind, classKindSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim classKindSetter = GetClassKindSetter(codeElement)
+                    action(kind, classKindSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetComment(code As XElement, expectedCode As XElement, value As String)
@@ -885,18 +795,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetComment(code As XElement, expectedCode As XElement, value As String, action As SetterAction(Of String))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim commentSetter = GetCommentSetter(codeElement)
-
-                action(value, commentSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim commentSetter = GetCommentSetter(codeElement)
+                    action(value, commentSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetConstKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMConstKind)
@@ -904,18 +807,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetConstKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMConstKind, action As SetterAction(Of EnvDTE80.vsCMConstKind))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim constKindSetter = GetConstKindSetter(codeElement)
-
-                action(kind, constKindSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim constKindSetter = GetConstKindSetter(codeElement)
+                    action(kind, constKindSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetDataTypeKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMDataTypeKind)
@@ -923,18 +819,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetDataTypeKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMDataTypeKind, action As SetterAction(Of EnvDTE80.vsCMDataTypeKind))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim dataTypeKindSetter = GetDataTypeKindSetter(codeElement)
-
-                action(kind, dataTypeKindSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim dataTypeKindSetter = GetDataTypeKindSetter(codeElement)
+                    action(kind, dataTypeKindSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetDocComment(code As XElement, expectedCode As XElement, value As String)
@@ -942,18 +831,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetDocComment(code As XElement, expectedCode As XElement, value As String, action As SetterAction(Of String))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim docCommentSetter = GetDocCommentSetter(codeElement)
-
-                action(value, docCommentSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim docCommentSetter = GetDocCommentSetter(codeElement)
+                    action(value, docCommentSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetInheritanceKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMInheritanceKind)
@@ -961,18 +843,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetInheritanceKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMInheritanceKind, action As SetterAction(Of EnvDTE80.vsCMInheritanceKind))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim inheritanceKindSetter = GetInheritanceKindSetter(codeElement)
-
-                action(kind, inheritanceKindSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim inheritanceKindSetter = GetInheritanceKindSetter(codeElement)
+                    action(kind, inheritanceKindSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetIsAbstract(code As XElement, expectedCode As XElement, value As Boolean)
@@ -980,18 +855,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetIsAbstract(code As XElement, expectedCode As XElement, value As Boolean, action As SetterAction(Of Boolean))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim isAbstractSetter = GetIsAbstractSetter(codeElement)
-
-                action(value, isAbstractSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim isAbstractSetter = GetIsAbstractSetter(codeElement)
+                    action(value, isAbstractSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetIsDefault(code As XElement, expectedCode As XElement, value As Boolean)
@@ -999,18 +867,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetIsDefault(code As XElement, expectedCode As XElement, value As Boolean, action As SetterAction(Of Boolean))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim isDefaultSetter = GetIsDefaultSetter(codeElement)
-
-                action(value, isDefaultSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim isDefaultSetter = GetIsDefaultSetter(codeElement)
+                    action(value, isDefaultSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetIsShared(code As XElement, expectedCode As XElement, value As Boolean)
@@ -1018,18 +879,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetIsShared(code As XElement, expectedCode As XElement, value As Boolean, action As SetterAction(Of Boolean))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim isSharedSetter = GetIsSharedSetter(codeElement)
-
-                action(value, isSharedSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim isSharedSetter = GetIsSharedSetter(codeElement)
+                    action(value, isSharedSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetMustImplement(code As XElement, expectedCode As XElement, value As Boolean)
@@ -1037,18 +891,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetMustImplement(code As XElement, expectedCode As XElement, value As Boolean, action As SetterAction(Of Boolean))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim mustImplementSetter = GetMustImplementSetter(codeElement)
-
-                action(value, mustImplementSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim mustImplementSetter = GetMustImplementSetter(codeElement)
+                    action(value, mustImplementSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetOverrideKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMOverrideKind)
@@ -1056,47 +903,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetOverrideKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMOverrideKind, action As SetterAction(Of EnvDTE80.vsCMOverrideKind))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim overrideKindSetter = GetOverrideKindSetter(codeElement)
-
-                action(kind, overrideKindSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim overrideKindSetter = GetOverrideKindSetter(codeElement)
+                    action(kind, overrideKindSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetName(code As XElement, expectedCode As XElement, name As String, action As SetterAction(Of String))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim nameSetter = GetNameSetter(codeElement)
-
-                action(name, nameSetter)
-
-                Assert.Equal(name, GetName(codeElement))
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim nameSetter = GetNameSetter(codeElement)
+                    action(name, nameSetter)
+                End Sub)
         End Sub
 
-        Protected Sub TestNamespaceName(Code As XElement, name As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(Code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+        Protected Sub TestNamespaceName(code As XElement, name As String)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim codeNamespaceElement = GetNamespace(codeElement)
+                    Assert.NotNull(codeNamespaceElement)
 
-                Dim codeNamespaceElement = GetNamespace(codeElement)
-                Assert.NotNull(codeNamespaceElement)
-
-                Assert.Equal(name, codeNamespaceElement.Name)
-            End Using
+                    Assert.Equal(name, codeNamespaceElement.Name)
+                End Sub)
         End Sub
 
         Protected Sub TestSetTypeProp(code As XElement, expectedCode As XElement, codeTypeRef As EnvDTE.CodeTypeRef)
@@ -1104,18 +933,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetTypeProp(code As XElement, expectedCode As XElement, codeTypeRef As EnvDTE.CodeTypeRef, action As SetterAction(Of EnvDTE.CodeTypeRef))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim typePropSetter = GetTypePropSetter(codeElement)
-
-                action(codeTypeRef, typePropSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim typePropSetter = GetTypePropSetter(codeElement)
+                    action(codeTypeRef, typePropSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetTypeProp(code As XElement, expectedCode As XElement, typeName As String)
@@ -1123,178 +945,124 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetTypeProp(code As XElement, expectedCode As XElement, typeName As String, action As SetterAction(Of EnvDTE.CodeTypeRef))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeTypeRef = state.RootCodeModel.CreateCodeTypeRef(typeName)
-
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Dim typePropSetter = GetTypePropSetter(codeElement)
-
-                action(codeTypeRef, typePropSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(state, codeElement)
+                    Dim codeTypeRef = state.RootCodeModel.CreateCodeTypeRef(typeName)
+                    Dim typePropSetter = GetTypePropSetter(codeElement)
+                    action(codeTypeRef, typePropSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestGenericNameExtender_GetBaseTypesCount(code As XElement, expected As Integer)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, GenericNameExtender_GetBaseTypesCount(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, GenericNameExtender_GetBaseTypesCount(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestGenericNameExtender_GetImplementedTypesCount(code As XElement, expected As Integer)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, GenericNameExtender_GetImplementedTypesCount(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, GenericNameExtender_GetImplementedTypesCount(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestGenericNameExtender_GetImplementedTypesCountThrows(Of TException As Exception)(code As XElement)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Throws(Of TException)(Sub() GenericNameExtender_GetImplementedTypesCount(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Throws(Of TException)(Sub() GenericNameExtender_GetImplementedTypesCount(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestGenericNameExtender_GetBaseGenericName(code As XElement, index As Integer, expected As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, GenericNameExtender_GetBaseGenericName(codeElement, index))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, GenericNameExtender_GetBaseGenericName(codeElement, index))
+                End Sub)
         End Sub
 
         Protected Sub TestGenericNameExtender_GetImplTypeGenericName(code As XElement, index As Integer, expected As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, GenericNameExtender_GetImplTypeGenericName(codeElement, index))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, GenericNameExtender_GetImplTypeGenericName(codeElement, index))
+                End Sub)
         End Sub
 
         Protected Sub TestGenericNameExtender_GetImplTypeGenericNameThrows(Of TException As Exception)(code As XElement, index As Integer)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Throws(Of TException)(Sub() GenericNameExtender_GetImplTypeGenericName(codeElement, index))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Throws(Of TException)(Sub() GenericNameExtender_GetImplTypeGenericName(codeElement, index))
+                End Sub)
         End Sub
 
         Protected Sub TestAddBase(code As XElement, base As Object, position As Object, expectedCode As XElement)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                AddBase(codeElement, base, position)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    AddBase(codeElement, base, position)
+                End Sub)
         End Sub
 
         Protected Sub TestAddBaseThrows(Of TException As Exception)(code As XElement, base As Object, position As Object)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Throws(Of TException)(Sub() AddBase(codeElement, base, position))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Throws(Of TException)(Sub() AddBase(codeElement, base, position))
+                End Sub)
         End Sub
 
         Protected Sub TestRemoveBase(code As XElement, element As Object, expectedCode As XElement)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                RemoveBase(codeElement, element)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    RemoveBase(codeElement, element)
+                End Sub)
         End Sub
 
         Protected Sub TestRemoveBaseThrows(Of TException As Exception)(code As XElement, element As Object)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Throws(Of TException)(Sub() RemoveBase(codeElement, element))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Throws(Of TException)(Sub() RemoveBase(codeElement, element))
+                End Sub)
         End Sub
 
         Protected Sub TestAddImplementedInterface(code As XElement, base As Object, position As Object, expectedCode As XElement)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                AddImplementedInterface(codeElement, base, position)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    AddImplementedInterface(codeElement, base, position)
+                End Sub)
         End Sub
 
         Protected Sub TestAddImplementedInterfaceThrows(Of TException As Exception)(code As XElement, base As Object, position As Object)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Throws(Of TException)(Sub() AddImplementedInterface(codeElement, base, position))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Throws(Of TException)(Sub() AddImplementedInterface(codeElement, base, position))
+                End Sub)
         End Sub
 
         Protected Sub TestRemoveImplementedInterface(code As XElement, element As Object, expectedCode As XElement)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                RemoveImplementedInterface(codeElement, element)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    RemoveImplementedInterface(codeElement, element)
+                End Sub)
         End Sub
 
         Protected Sub TestRemoveImplementedInterfaceThrows(Of TException As Exception)(code As XElement, element As Object)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
-
-                Assert.Throws(Of TException)(Sub() RemoveImplementedInterface(codeElement, element))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Throws(Of TException)(Sub() RemoveImplementedInterface(codeElement, element))
+                End Sub)
         End Sub
 
         Protected Sub TestAllParameterNames(code As XElement, ParamArray expectedParameterNames() As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of TCodeElement)()
-                Assert.NotNull(codeElement)
+            TestElement(code,
+                Sub(codeElement)
+                    Dim parameters = GetParameters(codeElement)
+                    Assert.NotNull(parameters)
 
-                Dim parameters = GetParameters(codeElement)
-                Assert.NotNull(parameters)
-
-                Assert.Equal(parameters.Count(), expectedParameterNames.Count())
-                If (expectedParameterNames.Any()) Then
-                    TestAllParameterNamesByIndex(parameters, expectedParameterNames)
-                    TestAllParameterNamesByName(parameters, expectedParameterNames)
-                End If
-            End Using
+                    Assert.Equal(parameters.Count(), expectedParameterNames.Count())
+                    If (expectedParameterNames.Any()) Then
+                        TestAllParameterNamesByIndex(parameters, expectedParameterNames)
+                        TestAllParameterNamesByName(parameters, expectedParameterNames)
+                    End If
+                End Sub)
         End Sub
 
         Private Sub TestAllParameterNamesByName(parameters As EnvDTE.CodeElements, expectedParameterNames() As String)

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeEventTests.vb
@@ -73,12 +73,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestIsPropertyStyleEvent(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeEvent)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, codeElement.IsPropertyStyleEvent)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, codeElement.IsPropertyStyleEvent)
+                End Sub)
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeFunctionTests.vb
@@ -131,12 +131,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestCanOverride(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, codeElement.CanOverride)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, codeElement.CanOverride)
+                End Sub)
         End Sub
 
         Protected Sub TestSetCanOverride(code As XElement, expectedCode As XElement, value As Boolean)
@@ -144,95 +142,73 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetCanOverride(code As XElement, expectedCode As XElement, value As Boolean, action As SetterAction(Of Boolean))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                action(value, Sub(v) codeElement.CanOverride = v)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    action(value, Sub(v) codeElement.CanOverride = v)
+                End Sub)
         End Sub
 
         Protected Sub TestIsOverloaded(code As XElement, expectedOverloaded As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Dim overloaded = GetIsOverloaded(codeElement)
-                Assert.Equal(expectedOverloaded, overloaded)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim overloaded = GetIsOverloaded(codeElement)
+                    Assert.Equal(expectedOverloaded, overloaded)
+                End Sub)
         End Sub
 
         Protected Sub TestOverloadsUniqueSignatures(code As XElement, ParamArray expectedOverloadNames As String())
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Dim actualOverloads = GetOverloads(codeElement)
-                Assert.Equal(expectedOverloadNames.Count, actualOverloads.Count)
-                For index = 1 To actualOverloads.Count
-                    Dim codeFunction = CType(actualOverloads.Item(index), EnvDTE80.CodeFunction2)
-                    Dim signature = GetPrototype(codeFunction, EnvDTE.vsCMPrototype.vsCMPrototypeUniqueSignature)
-                    Assert.True(expectedOverloadNames.Contains(signature))
-                Next
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Dim actualOverloads = GetOverloads(codeElement)
+                    Assert.Equal(expectedOverloadNames.Count, actualOverloads.Count)
+                    For index = 1 To actualOverloads.Count
+                        Dim codeFunction = CType(actualOverloads.Item(index), EnvDTE80.CodeFunction2)
+                        Dim signature = GetPrototype(codeFunction, EnvDTE.vsCMPrototype.vsCMPrototypeUniqueSignature)
+                        Assert.True(expectedOverloadNames.Contains(signature))
+                    Next
+                End Sub)
         End Sub
 
         Protected Sub TestFunctionKind(code As XElement, expected As EnvDTE.vsCMFunction)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, codeElement.FunctionKind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, codeElement.FunctionKind)
+                End Sub)
         End Sub
 
         Protected Sub TestFunctionKind(code As XElement, expected As EnvDTE80.vsCMFunction2)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, CType(codeElement.FunctionKind, EnvDTE80.vsCMFunction2))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, CType(codeElement.FunctionKind, EnvDTE80.vsCMFunction2))
+                End Sub)
         End Sub
 
         Protected Sub TestExtensionMethodExtender_IsExtension(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, ExtensionMethodExtender_GetIsExtension(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, ExtensionMethodExtender_GetIsExtension(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestPartialMethodExtender_IsPartial(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, PartialMethodExtender_GetIsPartial(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, PartialMethodExtender_GetIsPartial(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestPartialMethodExtender_IsDeclaration(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, PartialMethodExtender_GetIsDeclaration(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, PartialMethodExtender_GetIsDeclaration(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestPartialMethodExtender_HasOtherPart(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeFunction2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, PartialMethodExtender_GetHasOtherPart(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, PartialMethodExtender_GetHasOtherPart(codeElement))
+                End Sub)
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeImportTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeImportTests.vb
@@ -37,12 +37,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestNamespace(code As XElement, expectedNamespace As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeImport)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expectedNamespace, codeElement.Namespace)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expectedNamespace, codeElement.Namespace)
+                End Sub)
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
@@ -65,21 +65,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestParameterKind(code As XElement, kind As vsCMParameterKind)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of CodeParameter2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(kind, codeElement.ParameterKind)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(kind, codeElement.ParameterKind)
+                End Sub)
         End Sub
 
         Protected Sub TestDefaultValue(code As XElement, expectedValue As String)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of CodeParameter2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expectedValue, codeElement.DefaultValue)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expectedValue, codeElement.DefaultValue)
+                End Sub)
         End Sub
 
         Protected Sub TestSetParameterKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMParameterKind)
@@ -87,18 +83,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetParameterKind(code As XElement, expectedCode As XElement, kind As EnvDTE80.vsCMParameterKind, action As SetterAction(Of EnvDTE80.vsCMParameterKind))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of CodeParameter2)()
-                Assert.NotNull(codeElement)
-
-                Dim parameterKindSetter = GetParameterKindSetter(codeElement)
-
-                action(kind, parameterKindSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim parameterKindSetter = GetParameterKindSetter(codeElement)
+                    action(kind, parameterKindSetter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetDefaultValue(code As XElement, expected As XElement, defaultValue As String)
@@ -106,18 +95,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetDefaultValue(code As XElement, expectedCode As XElement, defaultValue As String, action As SetterAction(Of String))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of CodeParameter2)()
-                Assert.NotNull(codeElement)
-
-                Dim defaultValueSetter = GetDefaultValueSetter(codeElement)
-
-                action(defaultValue, defaultValueSetter)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim defaultValueSetter = GetDefaultValueSetter(codeElement)
+                    action(defaultValue, defaultValueSetter)
+                End Sub)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodePropertyTests.vb
@@ -101,30 +101,24 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestAutoImplementedPropertyExtender_IsAutoImplemented(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeProperty2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, AutoImplementedPropertyExtender_GetIsAutoImplemented(codeElement))
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, AutoImplementedPropertyExtender_GetIsAutoImplemented(codeElement))
+                End Sub)
         End Sub
 
         Protected Sub TestGetter(code As XElement, verifier As Action(Of EnvDTE.CodeFunction))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeProperty2)()
-                Assert.NotNull(codeElement)
-
-                verifier(codeElement.Getter)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    verifier(codeElement.Getter)
+                End Sub)
         End Sub
 
         Protected Sub TestSetter(code As XElement, verifier As Action(Of EnvDTE.CodeFunction))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeProperty2)()
-                Assert.NotNull(codeElement)
-
-                verifier(codeElement.Setter)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    verifier(codeElement.Setter)
+                End Sub)
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeVariableTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeVariableTests.vb
@@ -95,12 +95,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Sub TestIsConstant(code As XElement, expected As Boolean)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeVariable2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, codeElement.IsConstant)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, codeElement.IsConstant)
+                End Sub)
         End Sub
 
         Protected Sub TestSetIsConstant(code As XElement, expectedCode As XElement, value As Boolean)
@@ -108,25 +106,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetIsConstant(code As XElement, expectedCode As XElement, value As Boolean, action As SetterAction(Of Boolean))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeVariable2)()
-                Assert.NotNull(codeElement)
-
-                action(value, Sub(v) codeElement.IsConstant = v)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    action(value, Sub(v) codeElement.IsConstant = v)
+                End Sub)
         End Sub
 
         Protected Sub TestInitExpression(code As XElement, expected As Object)
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeVariable2)()
-                Assert.NotNull(codeElement)
-
-                Assert.Equal(expected, codeElement.InitExpression)
-            End Using
+            TestElement(code,
+                Sub(codeElement)
+                    Assert.Equal(expected, codeElement.InitExpression)
+                End Sub)
         End Sub
 
         Protected Sub TestSetInitExpression(code As XElement, expectedCode As XElement, value As Object)
@@ -134,16 +124,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Sub
 
         Protected Sub TestSetInitExpression(code As XElement, expectedCode As XElement, value As Object, action As SetterAction(Of Object))
-            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeElement = state.GetCodeElementAtCursor(Of EnvDTE80.CodeVariable2)()
-                Assert.NotNull(codeElement)
-
-                action(value, Sub(v) codeElement.InitExpression = v)
-
-                Dim text = state.GetDocumentAtCursor().GetTextAsync().Result.ToString()
-
-                Assert.Equal(expectedCode.NormalizedValue.Trim(), text.Trim())
-            End Using
+            TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    action(value, Sub(v) codeElement.InitExpression = v)
+                End Sub)
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
@@ -618,7 +618,7 @@ class C { }
 
         End Sub
 
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttributeArgument3()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeClassTests.vb
@@ -1,0 +1,79 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
+    Public Class ExternalCodeClassTests
+        Inherits AbstractCodeClassTests
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ExpectedClassMembers()
+            Dim code =
+<Code>
+class C$$
+{
+    // fields
+    private int _privateX;
+    protected int ProtectedX;
+    internal int InternalX;
+    protected internal int ProtectedInternalX;
+    public int PublicX;
+
+    // methods
+    private void PrivateM() { }
+    protected void ProtectedM() { }
+    internal void InternalM() { }
+    protected internal void ProtectedInternalM() { }
+    public void PublicM() { }
+}
+</Code>
+
+            TestElement(code,
+                Sub(codeElement)
+                    Dim members = codeElement.Members
+                    Assert.Equal(7, members.Count)
+
+                    Dim member1 = members.Item(1)
+                    Assert.Equal("ProtectedX", member1.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member1.Kind)
+
+                    Dim member2 = members.Item(2)
+                    Assert.Equal("ProtectedInternalX", member2.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member2.Kind)
+
+                    Dim member3 = members.Item(3)
+                    Assert.Equal("PublicX", member3.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member3.Kind)
+
+                    Dim member4 = members.Item(4)
+                    Assert.Equal("ProtectedM", member4.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member4.Kind)
+
+                    Dim member5 = members.Item(5)
+                    Assert.Equal("ProtectedInternalM", member5.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member5.Kind)
+
+                    Dim member6 = members.Item(6)
+                    Assert.Equal("PublicM", member6.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member6.Kind)
+
+                    Dim member7 = members.Item(7)
+                    Assert.Equal("C", member7.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member7.Kind)
+                End Sub)
+        End Sub
+
+        Protected Overrides ReadOnly Property LanguageName As String
+            Get
+                Return LanguageNames.CSharp
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean
+            Get
+                Return True
+            End Get
+        End Property
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -949,14 +949,14 @@ class $$C
     void M() { }
 }
 </Code>
-            Using workspaceAndFileCodeModel = CreateCodeModelTestState(GetWorkspaceDefinition(code))
-                Dim codeClass = workspaceAndFileCodeModel.GetCodeElementAtCursor(Of EnvDTE80.CodeClass2)
+            Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim codeClass = state.GetCodeElementAtCursor(Of EnvDTE80.CodeClass2)
                 Assert.Equal(1, codeClass.Members.OfType(Of EnvDTE80.CodeFunction2)().Count())
-                Dim project = workspaceAndFileCodeModel.VisualStudioWorkspace.CurrentSolution.Projects.First()
+                Dim project = state.VisualStudioWorkspace.CurrentSolution.Projects.First()
                 Dim documentId = project.DocumentIds.First()
-                workspaceAndFileCodeModel.VisualStudioWorkspace.CloseDocument(documentId)
-                Dim newSolution = workspaceAndFileCodeModel.VisualStudioWorkspace.CurrentSolution.RemoveDocument(documentId)
-                workspaceAndFileCodeModel.VisualStudioWorkspace.TryApplyChanges(newSolution)
+                state.VisualStudioWorkspace.CloseDocument(documentId)
+                Dim newSolution = state.VisualStudioWorkspace.CurrentSolution.RemoveDocument(documentId)
+                state.VisualStudioWorkspace.TryApplyChanges(newSolution)
                 ' throws COMException with HResult = E_FAIL
                 Assert.Throws(Of System.Runtime.InteropServices.COMException)(
                     Sub()

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
@@ -798,7 +798,7 @@ End Class
 
         End Sub
 
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub AddAttributeArgument2()
             Dim code =
 <Code>
@@ -822,7 +822,7 @@ End Class
 
         End Sub
 
-        <ConditionalWpfFact(GetType(x86), Skip:="https://github.com/dotnet/roslyn/issues/5800"), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub TestAddArgument3()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -3142,6 +3142,39 @@ End Class
         End Sub
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ClassMembersForWithEventsField()
+            Dim code =
+<Code>
+Class C
+    Event E(x As Integer)
+End Class
+
+Class D$$
+    Inherits C
+
+    Private WithEvents x As C
+
+    Private Sub D_E(x As Integer) Handles Me.E
+    End Sub
+End Class
+</Code>
+
+            TestElement(code,
+                Sub(codeElement)
+                    Dim members = codeElement.Members
+                    Assert.Equal(2, members.Count)
+
+                    Dim member1 = members.Item(1)
+                    Assert.Equal("x", member1.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member1.Kind)
+
+                    Dim member2 = members.Item(2)
+                    Assert.Equal("D_E", member2.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member2.Kind)
+                End Sub)
+        End Sub
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub ClassIncludedDeclareMethods()
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
@@ -77,7 +77,7 @@ End Class
         End Sub
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Sub ClassMembersForWithEventsField()
+        Public Sub ClassMembersForWithEventsField_Private()
             Dim code =
 <Code>
 Class C
@@ -102,10 +102,52 @@ End Class
                     Dim member1 = members.Item(1)
                     Assert.Equal("New", member1.Name)
                     Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member1.Kind)
+                    Assert.Equal(EnvDTE.vsCMAccess.vsCMAccessPublic, CType(member1, EnvDTE.CodeFunction).Access)
 
                     Dim member2 = members.Item(2)
                     Assert.Equal("_x", member2.Name)
                     Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member2.Kind)
+                    Assert.Equal(EnvDTE.vsCMAccess.vsCMAccessPrivate, CType(member2, EnvDTE.CodeVariable).Access)
+                End Sub)
+        End Sub
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ClassMembersForWithEventsField_Protected()
+            Dim code =
+<Code>
+Class C
+    Event E(x As Integer)
+End Class
+
+Class D$$
+    Inherits C
+
+    Protected WithEvents x As C
+
+    Private Sub D_E(x As Integer) Handles Me.E
+    End Sub
+End Class
+</Code>
+
+            TestElement(code,
+                Sub(codeElement)
+                    Dim members = codeElement.Members
+                    Assert.Equal(3, members.Count)
+
+                    Dim member1 = members.Item(1)
+                    Assert.Equal("New", member1.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member1.Kind)
+                    Assert.Equal(EnvDTE.vsCMAccess.vsCMAccessPublic, CType(member1, EnvDTE.CodeFunction).Access)
+
+                    Dim member2 = members.Item(2)
+                    Assert.Equal("_x", member2.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member2.Kind)
+                    Assert.Equal(EnvDTE.vsCMAccess.vsCMAccessPrivate, CType(member2, EnvDTE.CodeVariable).Access)
+
+                    Dim member3 = members.Item(3)
+                    Assert.Equal("x", member3.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member3.Kind)
+                    Assert.Equal(EnvDTE.vsCMAccess.vsCMAccessProtected Or EnvDTE.vsCMAccess.vsCMAccessWithEvents, CType(member3, EnvDTE.CodeVariable).Access)
                 End Sub)
         End Sub
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
@@ -7,7 +7,76 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasi
     Public Class ExternalCodeClassTests
         Inherits AbstractCodeClassTests
 
-        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ExpectedClassMembers()
+            Dim code =
+<Code>
+Class C$$
+    ' fields
+    Private _privateX As Integer
+    Protected ProtectedX As Integer
+    Friend InternalX As Integer
+    Protected Friend ProtectedInternalX As Integer
+    Public PublicX As Integer
+
+    ' methods
+    Private Sub PrivateM()
+    End Sub
+    Protected Sub ProtectedM()
+    End Sub
+    Friend Sub InternalM()
+    End Sub
+    Protected Friend Sub ProtectedInternalM()
+    End Sub
+    Public Sub PublicM()
+    End Sub
+End Class
+</Code>
+
+            TestElement(code,
+                Sub(codeElement)
+                    Dim members = codeElement.Members
+                    Assert.Equal(9, members.Count)
+
+                    Dim member1 = members.Item(1)
+                    Assert.Equal("New", member1.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member1.Kind)
+
+                    Dim member2 = members.Item(2)
+                    Assert.Equal("ProtectedX", member2.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member2.Kind)
+
+                    Dim member3 = members.Item(3)
+                    Assert.Equal("InternalX", member3.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member3.Kind)
+
+                    Dim member4 = members.Item(4)
+                    Assert.Equal("ProtectedInternalX", member4.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member4.Kind)
+
+                    Dim member5 = members.Item(5)
+                    Assert.Equal("PublicX", member5.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member5.Kind)
+
+                    Dim member6 = members.Item(6)
+                    Assert.Equal("ProtectedM", member6.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member6.Kind)
+
+                    Dim member7 = members.Item(7)
+                    Assert.Equal("InternalM", member7.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member7.Kind)
+
+                    Dim member8 = members.Item(8)
+                    Assert.Equal("ProtectedInternalM", member8.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member8.Kind)
+
+                    Dim member9 = members.Item(9)
+                    Assert.Equal("PublicM", member9.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member9.Kind)
+                End Sub)
+        End Sub
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub ClassMembersForWithEventsField()
             Dim code =
 <Code>
@@ -26,18 +95,18 @@ End Class
 </Code>
 
             TestElement(code,
-                    Sub(codeElement)
-                        Dim members = codeElement.Members
-                        Assert.Equal(2, members.Count)
+                Sub(codeElement)
+                    Dim members = codeElement.Members
+                    Assert.Equal(2, members.Count)
 
-                        Dim member1 = members.Item(1)
-                        Assert.Equal("x", member1.Name)
-                        Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member1.Kind)
+                    Dim member1 = members.Item(1)
+                    Assert.Equal("New", member1.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member1.Kind)
 
-                        Dim member2 = members.Item(2)
-                        Assert.Equal("D_E", member2.Name)
-                        Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member2.Kind)
-                    End Sub)
+                    Dim member2 = members.Item(2)
+                    Assert.Equal("_x", member2.Name)
+                    Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member2.Kind)
+                End Sub)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
@@ -1,0 +1,55 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasic
+    Public Class ExternalCodeClassTests
+        Inherits AbstractCodeClassTests
+
+        <ConditionalFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub ClassMembersForWithEventsField()
+            Dim code =
+<Code>
+Class C
+    Event E(x As Integer)
+End Class
+
+Class D$$
+    Inherits C
+
+    Private WithEvents x As C
+
+    Private Sub D_E(x As Integer) Handles Me.E
+    End Sub
+End Class
+</Code>
+
+            TestElement(code,
+                    Sub(codeElement)
+                        Dim members = codeElement.Members
+                        Assert.Equal(2, members.Count)
+
+                        Dim member1 = members.Item(1)
+                        Assert.Equal("x", member1.Name)
+                        Assert.Equal(EnvDTE.vsCMElement.vsCMElementVariable, member1.Kind)
+
+                        Dim member2 = members.Item(2)
+                        Assert.Equal("D_E", member2.Name)
+                        Assert.Equal(EnvDTE.vsCMElement.vsCMElementFunction, member2.Kind)
+                    End Sub)
+        End Sub
+
+        Protected Overrides ReadOnly Property LanguageName As String
+            Get
+                Return LanguageNames.VisualBasic
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean
+            Get
+                Return True
+            End Get
+        End Property
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -317,6 +317,7 @@
     <Compile Include="CodeModel\VisualBasic\CodeStructTests.vb" />
     <Compile Include="CodeModel\VisualBasic\CodeVariableTests.vb" />
     <Compile Include="CodeModel\VisualBasic\EventCollectorTests.vb" />
+    <Compile Include="CodeModel\VisualBasic\ExternalCodeClassTests.vb" />
     <Compile Include="CodeModel\VisualBasic\FileCodeModelTests.vb" />
     <Compile Include="CodeModel\VisualBasic\ImplementsStatementTests.vb" />
     <Compile Include="CodeModel\VisualBasic\InheritsStatementTests.vb" />

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -284,6 +284,7 @@
     <Compile Include="CodeModel\CSharp\CodeStructTests.vb" />
     <Compile Include="CodeModel\CSharp\CodeVariableTests.vb" />
     <Compile Include="CodeModel\CSharp\EventCollectorTests.vb" />
+    <Compile Include="CodeModel\CSharp\ExternalCodeClassTests.vb" />
     <Compile Include="CodeModel\CSharp\FileCodeModelTests.vb" />
     <Compile Include="CodeModel\CSharp\RootCodeModelTests.vb" />
     <Compile Include="CodeModel\CSharp\SyntaxNodeKeyTests.vb" />

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -53,7 +53,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
 
-        Private Shared ReadOnly s_fullNameFormat As SymbolDisplayFormat =
+        Private Shared ReadOnly s_externalNameFormat As SymbolDisplayFormat =
+            New SymbolDisplayFormat(
+                genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.ExpandNullable)
+
+        Private Shared ReadOnly s_externalfullNameFormat As SymbolDisplayFormat =
             New SymbolDisplayFormat(
                 typeQualificationStyle:=SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
                 genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
@@ -430,15 +435,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 For Each member In DirectCast(container, CompilationUnitSyntax).Members
                     Yield member
                 Next
-            ElseIf TypeOf container Is NamespaceBlockSyntax
+            ElseIf TypeOf container Is NamespaceBlockSyntax Then
+
                 For Each member In DirectCast(container, NamespaceBlockSyntax).Members
                     Yield member
                 Next
-            ElseIf TypeOf container Is TypeBlockSyntax
+            ElseIf TypeOf container Is TypeBlockSyntax Then
+
                 For Each member In DirectCast(container, TypeBlockSyntax).Members
                     Yield member
                 Next
-            ElseIf TypeOf container Is EnumBlockSyntax
+            ElseIf TypeOf container Is EnumBlockSyntax Then
+
                 For Each member In DirectCast(container, EnumBlockSyntax).Members
                     Yield member
                 Next
@@ -491,12 +499,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                             Next
                         Next
 
-                    ElseIf Not onlySupportedNodes
+                    ElseIf Not onlySupportedNodes Then
                         ' Only return fields if the supported flag Is false.
                         Yield member
                     End If
 
-                ElseIf NodeIsSupported(onlySupportedNodes, member)
+                ElseIf NodeIsSupported(onlySupportedNodes, member) Then
                     Yield member
                 End If
 
@@ -1023,15 +1031,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                             semanticModel.GetTypeInfo(node).Type,
                             semanticModel.GetDeclaredSymbol(node))
 
-            Return GetFullName(symbol)
-        End Function
-
-        Public Overrides Function GetFullName(symbol As ISymbol) As String
-            If symbol Is Nothing Then
-                Throw Exceptions.ThrowEFail()
-            End If
-
-            Return symbol.ToDisplayString(s_fullNameFormat)
+            Return GetExternalSymbolFullName(symbol)
         End Function
 
         Public Overrides Function IsAccessorNode(node As SyntaxNode) As Boolean
@@ -1341,20 +1341,50 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                            .WaitAndGetResult(CancellationToken.None)
         End Function
 
+        Public Overrides Function IsValidExternalSymbol(symbol As ISymbol) As Boolean
+            Dim fieldSymbol = TryCast(symbol, IFieldSymbol)
+            If fieldSymbol IsNot Nothing Then
+                Dim propertySymbol = TryCast(fieldSymbol.AssociatedSymbol, IPropertySymbol)
+                If propertySymbol?.IsWithEvents Then
+                    Return True
+                End If
+            End If
+
+            Return symbol.DeclaredAccessibility = Accessibility.Public OrElse
+                   symbol.DeclaredAccessibility = Accessibility.Protected OrElse
+                   symbol.DeclaredAccessibility = Accessibility.ProtectedOrFriend OrElse
+                   symbol.DeclaredAccessibility = Accessibility.Friend
+        End Function
+
+        Public Overrides Function GetExternalSymbolName(symbol As ISymbol) As String
+            If symbol Is Nothing Then
+                Throw Exceptions.ThrowEFail()
+            End If
+
+            Return symbol.ToDisplayString(s_externalNameFormat)
+        End Function
+
+        Public Overrides Function GetExternalSymbolFullName(symbol As ISymbol) As String
+            If symbol Is Nothing Then
+                Throw Exceptions.ThrowEFail()
+            End If
+
+            Return symbol.ToDisplayString(s_externalfullNameFormat)
+        End Function
+
         Public Overrides Function GetAccess(symbol As ISymbol) As EnvDTE.vsCMAccess
             Debug.Assert(symbol IsNot Nothing)
 
             Dim access As EnvDTE.vsCMAccess = 0
 
-            ' TODO: Add vsCMAccessWithEvents for fields symbols defined as WithEvents
             Select Case symbol.DeclaredAccessibility
                 Case Accessibility.Private
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessPrivate
                 Case Accessibility.Protected
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessProtected
-                Case Accessibility.Internal
+                Case Accessibility.Internal, Accessibility.Friend
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessProject
-                Case Accessibility.ProtectedOrInternal
+                Case Accessibility.ProtectedOrInternal, Accessibility.ProtectedOrFriend
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessProjectOrProtected
                 Case Accessibility.Public
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessPublic
@@ -1362,8 +1392,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                     Throw Exceptions.ThrowEFail()
             End Select
 
-            If symbol.IsKind(SymbolKind.Property) AndAlso
-               DirectCast(symbol, IPropertySymbol).IsWithEvents Then
+            If TryCast(symbol, IPropertySymbol)?.IsWithEvents Then
                 access = access Or EnvDTE.vsCMAccess.vsCMAccessWithEvents
             End If
 
@@ -2853,7 +2882,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
             If propertyStatement IsNot Nothing Then
                 If propertyStatement.Modifiers.Any(SyntaxKind.WriteOnlyKeyword) Then
                     Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly
-                ElseIf propertyStatement.Modifiers.Any(SyntaxKind.ReadOnlyKeyword)
+                ElseIf propertyStatement.Modifiers.Any(SyntaxKind.ReadOnlyKeyword) Then
                     Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly
                 Else
                     Return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite
@@ -3778,7 +3807,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Dim enumMember = DirectCast(container, EnumMemberDeclarationSyntax)
                 Dim attributeLists = enumMember.AttributeLists.Insert(index, attributeList)
                 Return enumMember.WithAttributeLists(attributeLists)
-            ElseIf TypeOf container Is DelegateStatementSyntax
+            ElseIf TypeOf container Is DelegateStatementSyntax Then
                 Dim delegateStatement = DirectCast(container, DelegateStatementSyntax)
                 Dim attributeLists = delegateStatement.AttributeLists.Insert(index, attributeList)
                 Return delegateStatement.WithAttributeLists(attributeLists)
@@ -3817,7 +3846,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Dim eventStatement = DirectCast(container, EventStatementSyntax)
                 Dim attributeLists = eventStatement.AttributeLists.Insert(index, attributeList)
                 Return eventStatement.WithAttributeLists(attributeLists)
-            ElseIf TypeOf container Is EventBlockSyntax
+            ElseIf TypeOf container Is EventBlockSyntax Then
                 Dim eventBlock = DirectCast(container, EventBlockSyntax)
                 Dim attributeLists = eventBlock.EventStatement.AttributeLists.Insert(index, attributeList)
                 Return eventBlock.WithEventStatement(eventBlock.EventStatement.WithAttributeLists(attributeLists))

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -1342,6 +1342,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
         End Function
 
         Public Overrides Function IsValidExternalSymbol(symbol As ISymbol) As Boolean
+            Dim methodSymbol = TryCast(symbol, IMethodSymbol)
+            If methodSymbol IsNot Nothing Then
+                If methodSymbol.MethodKind = MethodKind.PropertyGet OrElse
+                   methodSymbol.MethodKind = MethodKind.PropertySet OrElse
+                   methodSymbol.MethodKind = MethodKind.EventAdd OrElse
+                   methodSymbol.MethodKind = MethodKind.EventRemove OrElse
+                   methodSymbol.MethodKind = MethodKind.EventRaise Then
+
+                    Return False
+                End If
+            End If
+
             Dim fieldSymbol = TryCast(symbol, IFieldSymbol)
             If fieldSymbol IsNot Nothing Then
                 Dim propertySymbol = TryCast(fieldSymbol.AssociatedSymbol, IPropertySymbol)


### PR DESCRIPTION
**Customer Scenario**:

When inheriting a VB WebForm from another VB WebForm that was compiled into a different assembly, the designer will generate duplicate field declarations for inherited controls, producing warnings in inherited WebForm. There is a workaround in that the user can manually delete the duplicated field declarations from the generated code in the *.designer.vb file. However, if the user makes any change to the designer, the field declarations will be re-generated, requiring them to be deleted again.

Filed on Connect [here](https://connect.microsoft.com/VisualStudio/feedback/details/1695089/the-designer-vb-for-inherited-web-forms-are-automatically-filled-up-with-duplicate-declarations).

**Issue Description**:

The issue here is that VB WithEvents fields are not represented properly "external" code model elements -- that is, code model elements created from metadata. The WebForm designer walks all of the inherited fields to determine which fields need to be generated, and VB WithEvents fields are simply get missed because they don't appear in a form that the WebForm designer expects them to.

**Fix Description**

Because VB WithEvents fields are actually properties under the hood, Code Model needs to handle them specially. This was already done for "internal" code elements (i.e. elements defined in source) but wasn't done for "external" code elements. This change rectifies that.

Additionally, there was no good unit test infrastructure for testing external code model elements. This change adds that infrastructure plus new tests for both C# and VB.

**Testing Done**:
* Verified customer scenario
* Added unit test coverage specific to VB WithEvents fields in "external" code elements

Tagging @dotnet/roslyn-ide 