### PR TITLE
Fixes /pathmap for the unix root ("/") directory.  Adds diagnostics for pathmap failed parsing.

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -104,7 +104,6 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Test\Utilities\Shared\TestUtilities.projitems*{6ff42825-5464-4151-ac55-ed828168c192}*SharedItemsImports = 13
-		src\Test\Utilities\Shared\TestUtilities.projitems*{f7712928-1175-47b3-8819-ee086753dee2}*SharedItemsImports = 4
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5246,6 +5246,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The pathmap option was incorrectly formatted.
+        /// </summary>
+        internal static string ERR_InvalidPathMap {
+            get {
+                return ResourceManager.GetString("ERR_InvalidPathMap", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid preprocessor expression.
         /// </summary>
         internal static string ERR_InvalidPreprocExpr {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4657,4 +4657,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_SourceFileReferencesNotSupported" xml:space="preserve">
     <value>Source file references are not supported.</value>
   </data>
+  <data name="ERR_InvalidPathMap" xml:space="preserve">
+    <value>The pathmap option was incorrectly formatted.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -932,7 +932,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 if (value == null)
                                     break;
 
-                                pathMap = pathMap.Concat(ParsePathMap(value));
+                                pathMap = pathMap.Concat(ParsePathMap(value, diagnostics));
                             }
                             continue;
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1316,5 +1316,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_PPLoadFollowsToken = 8098,
         ERR_SourceFileReferencesNotSupported = 8099,
         ERR_BadAwaitInStaticVariableInitializer = 8100,
+        ERR_InvalidPathMap = 8101,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -126,6 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // command line:
         public override int ERR_ExpectedSingleScript { get { return (int)ErrorCode.ERR_ExpectedSingleScript; } }
         public override int ERR_OpenResponseFile { get { return (int)ErrorCode.ERR_OpenResponseFile; } }
+        public override int ERR_InvalidPathMap { get { return (int)ErrorCode.ERR_InvalidPathMap; } }
         public override int FTL_InputFileNameTooLong { get { return (int)ErrorCode.FTL_InputFileNameTooLong; } }
         public override int ERR_FileNotFound { get { return (int)ErrorCode.ERR_FileNotFound; } }
         public override int ERR_NoSourceFile { get { return (int)ErrorCode.ERR_NoSourceFile; } }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7931,8 +7931,9 @@ class C {
             Assert.Equal(0, parsedArgs.PathMap.Length);
 
             parsedArgs = DefaultParse(new [] { "/pathmap:k=,=v", "a.cs" }, _baseDirectory);
-            parsedArgs.Errors.Verify();
-            Assert.Equal(0, parsedArgs.PathMap.Length);
+            Assert.Equal(2, parsedArgs.Errors.Count());
+            Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[0].Code);
+            Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[1].Code);
         }
     }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7927,13 +7927,20 @@ class C {
             Assert.Equal(KeyValuePair.Create("K2", "V2"), parsedArgs.PathMap[1]);
 
             parsedArgs = DefaultParse(new [] { "/pathmap:,,,", "a.cs" }, _baseDirectory);
-            parsedArgs.Errors.Verify();
-            Assert.Equal(0, parsedArgs.PathMap.Length);
+            Assert.Equal(4, parsedArgs.Errors.Count());
+            Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[0].Code);
+            Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[1].Code);
+            Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[2].Code);
+            Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[3].Code);
 
             parsedArgs = DefaultParse(new [] { "/pathmap:k=,=v", "a.cs" }, _baseDirectory);
             Assert.Equal(2, parsedArgs.Errors.Count());
             Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[0].Code);
             Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[1].Code);
+
+            parsedArgs = DefaultParse(new [] { "/pathmap:k=v=bad", "a.cs" }, _baseDirectory);
+            Assert.Equal(1, parsedArgs.Errors.Count());
+            Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[0].Code);
         }
     }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -191,10 +191,19 @@ namespace Microsoft.CodeAnalysis
         protected ImmutableArray<KeyValuePair<string, string>> ParsePathMap(string pathMap, IList<Diagnostic> errors)
         {
             var pathMapBuilder = ArrayBuilder<KeyValuePair<string, string>>.GetInstance();
+            if (pathMap.IsEmpty())
+            {
+                return pathMapBuilder.ToImmutableAndFree();
+            }
+
             foreach (var kEqualsV in pathMap.Split(','))
             {
                 var kv = kEqualsV.Split('=');
-                if (kv.Length != 2) continue;
+                if (kv.Length != 2)
+                {
+                    errors.Add(Diagnostic.Create(_messageProvider, _messageProvider.ERR_InvalidPathMap, kEqualsV));
+                    continue;
+                }
                 var from = PathUtilities.TrimTrailingSeparators(kv[0]);
                 var to = PathUtilities.TrimTrailingSeparators(kv[1]);
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis
             return string.Empty;
         }
 
-        protected ImmutableArray<KeyValuePair<string, string>> ParsePathMap(string pathMap)
+        protected ImmutableArray<KeyValuePair<string, string>> ParsePathMap(string pathMap, IList<Diagnostic> errors)
         {
             var pathMapBuilder = ArrayBuilder<KeyValuePair<string, string>>.GetInstance();
             foreach (var kEqualsV in pathMap.Split(','))
@@ -197,8 +197,15 @@ namespace Microsoft.CodeAnalysis
                 if (kv.Length != 2) continue;
                 var from = PathUtilities.TrimTrailingSeparators(kv[0]);
                 var to = PathUtilities.TrimTrailingSeparators(kv[1]);
-                if (from.Length == 0 || to.Length == 0) continue;
-                pathMapBuilder.Add(new KeyValuePair<string, string>(from, to));
+
+                if (from.Length == 0 || (to.Length == 0 && kv[1] != "/"))
+                {
+                    errors.Add(Diagnostic.Create(_messageProvider, _messageProvider.ERR_InvalidPathMap, kEqualsV));
+                }
+                else
+                {
+                    pathMapBuilder.Add(new KeyValuePair<string, string>(from, to));
+                }
             }
 
             return pathMapBuilder.ToImmutableAndFree();

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -138,6 +138,7 @@ namespace Microsoft.CodeAnalysis
         // command line:
         public abstract int ERR_ExpectedSingleScript { get; }
         public abstract int ERR_OpenResponseFile { get; }
+        public abstract int ERR_InvalidPathMap { get; }
         public abstract int FTL_InputFileNameTooLong { get; }
         public abstract int ERR_FileNotFound { get; }
         public abstract int ERR_NoSourceFile { get; }

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -989,7 +989,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 Exit Select
                             End If
 
-                            pathMap = pathMap.Concat(ParsePathMap(value))
+                            pathMap = pathMap.Concat(ParsePathMap(value, diagnostics))
                             Continue For
 
                         Case "reportanalyzer"

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1679,6 +1679,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_InterpolationAlignmentOutOfRange = 37250
         ERR_InterpolatedStringFactoryError = 37251
         ERR_DebugEntryPointNotSourceMethodDefinition = 37252
+        ERR_InvalidPathMap = 37253
 
         ERR_LastPlusOne
 

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -160,6 +160,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Public Overrides ReadOnly Property ERR_InvalidPathMap As Integer
+            Get
+                Return ERRID.ERR_InvalidPathMap
+            End Get
+        End Property
+
         Public Overrides ReadOnly Property FTL_InputFileNameTooLong As Integer
             Get
                 Return ERRID.FTL_InputFileNameTooLong

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -6108,6 +6108,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to The pathmap option was incorrectly formatted.
+        '''</summary>
+        Friend ReadOnly Property ERR_InvalidPathMap() As String
+            Get
+                Return ResourceManager.GetString("ERR_InvalidPathMap", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Invalid signature public key specified in AssemblySignatureKeyAttribute..
         '''</summary>
         Friend ReadOnly Property ERR_InvalidSignaturePublicKey() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5332,4 +5332,7 @@
   <data name="ERR_DebugEntryPointNotSourceMethodDefinition" xml:space="preserve">
     <value>Debug entry point must be a definition of a method declared in the current compilation.</value>
   </data>
+  <data name="ERR_InvalidPathMap" xml:space="preserve">
+    <value>The pathmap option was incorrectly formatted.</value>
+  </data>
 </root>

--- a/src/Test/Utilities/Shared/Mocks/TestMessageProvider.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestMessageProvider.cs
@@ -29,6 +29,11 @@ namespace Roslyn.Test.Utilities
             throw new NotImplementedException();
         }
 
+        public override int ERR_InvalidPathMap
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         public override int ERR_FailedToCreateTempFile
         {
             get { throw new NotImplementedException(); }


### PR DESCRIPTION
This PR does three things, all of which are related to the `/pathmap` feature.

1. Adds a test for pathmap by using the CallerFilePath attribute.
2. Fixes the pathmap parser which used to parse `"/"` as `""` which it dropped on the floor without reporting any diagnostics.
3. Adds diagnostics to the pathmap parser.  Anything that it can't parse will make the build fail.