### PR TITLE
Add logging to find all reference command handler

### DIFF
--- a/src/EditorFeatures/Core/Implementation/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/FindReferences/FindReferencesCommandHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.Navigation;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.SymbolMapping;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -51,12 +52,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.FindReferences
                     var service = document.Project.LanguageServices.GetService<IFindReferencesService>();
                     if (service != null)
                     {
-                        if (!service.TryFindReferences(document, caretPosition, context))
+                        using (Logger.LogBlock(FunctionId.CommandHandler_FindAllReference, context.CancellationToken))
                         {
-                            foreach (var presenter in _presenters)
+                            if (!service.TryFindReferences(document, caretPosition, context))
                             {
-                                presenter.DisplayResult(document.Project.Solution, SpecializedCollections.EmptyEnumerable<ReferencedSymbol>());
-                                return;
+                                foreach (var presenter in _presenters)
+                                {
+                                    presenter.DisplayResult(document.Project.Solution, SpecializedCollections.EmptyEnumerable<ReferencedSymbol>());
+                                    return;
+                                }
                             }
                         }
                     }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -311,5 +311,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         NonFatalWatson,
         GlobalOperationRegistration,
+        CommandHandler_FindAllReference,
     }
 }


### PR DESCRIPTION
this logging itself doesn't do anything. our logging system separate logger and the listener. if there is no listener for this data point, logging itself becomes no-op.