### PR TITLE
Added: Restore.cmd for restoring NuGet packages in open.

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,0 +1,8 @@
+@echo off
+set NuGetExe=%~dp0NuGet.exe
+
+echo Restoring packages: Toolsets (this may take some time)
+call %NugetExe% restore -verbosity quiet "%~dp0build\ToolsetPackages\project.json" -configfile "%~dp0nuget.config"
+
+echo Restoring packages: Roslyn.sln (this may take some time)
+call %NugetExe% restore -verbosity quiet "%~dp0Roslyn.sln" -configfile "%~dp0nuget.config"


### PR DESCRIPTION
We currently need to restore both Toolset and Rolsyn currently.
This is simplifies this, until we make end-to-end "just open Roslyn.sln
and build" work.