### PR TITLE
For experimental builds, set the bit that will override binding redirects

### DIFF
--- a/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
+++ b/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
@@ -53,11 +53,22 @@ namespace Roslyn.VisualStudio.Setup
         public override void Register(RegistrationContext context)
         {
             _redirectionAttribute.Register(context);
+
+#if !OFFICIAL_BUILD
+
+            // If we're not an official build, we need to opt into overriding the devenv.exe.config binding redirect
+            using (var key = context.CreateKey(@"RuntimeConfiguration\dependentAssembly\bindingRedirection\" + _redirectionAttribute.Guid.ToString("B").ToUpperInvariant()))
+            {
+                key.SetValue("isPkgDefOverrideEnabled", true);
+            }
+
+#endif
         }
 
         public override void Unregister(RegistrationContext context)
         {
             _redirectionAttribute.Unregister(context);
         }
+
     }
 }


### PR DESCRIPTION
In Update 1, devenv.exe.config specifies the binding redirects for
the Roslyn assemblies, in addition to us specifying them in the pkgdef.
If you're building an experimental VSIX, we need to specify a temporary
flag which will enable the shell to ignore the other redirects in
the .exe.config in favor of our pkgdef ones.