### PR TITLE
Preselect "True" and "False" keywords in VB

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2211,11 +2211,11 @@ Module Program
 End Module]]></Document>)
                 state.SendTypeChars("f")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("False")
+                Await state.AssertSelectedCompletionItem("False").ConfigureAwait(True)
                 state.SendBackspace()
                 state.SendTypeChars("t")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("True")
+                Await state.AssertSelectedCompletionItem("True").ConfigureAwait(True)
             End Using
         End Function
 
@@ -2232,14 +2232,13 @@ Module Program
     Sub foo (x as boolean)
     End Sub
 End Module]]></Document>)
-                state.SendTypeChars("fa")
+                state.SendTypeChars("f")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("False")
-                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem("False").ConfigureAwait(True)
                 state.SendBackspace()
                 state.SendTypeChars("t")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("True")
+                Await state.AssertSelectedCompletionItem("True").ConfigureAwait(True)
             End Using
         End Function
 
@@ -2248,19 +2247,24 @@ End Module]]></Document>)
         Public Async Function BooleanPreselection3() As Task
             Using state = TestState.CreateVisualBasicTestState(
                 <Document><![CDATA[
-Imports System
+
 Module Program
+    Class F
+    End Class
+    Class T
+    End Class
+
     Sub Main(args As String())
         $$
     End Sub
 End Module]]></Document>)
                 state.SendTypeChars("f")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("FieldAccessExpression")
+                Await state.AssertSelectedCompletionItem("F").ConfigureAwait(True)
                 state.SendBackspace()
                 state.SendTypeChars("t")
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                state.AssertSelectedCompletionItem("TAB")
+                Await state.AssertSelectedCompletionItem("T").ConfigureAwait(True)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2198,5 +2198,70 @@ End Module]]></Document>)
                 Await state.AssertSelectedCompletionItem("Table").ConfigureAwait(True)
             End Using
         End Function
+
+        <WorkItem(4892, "https://github.com/dotnet/roslyn/issues/4892")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BooleanPreselection1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim x as boolean = $$
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("f")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertSelectedCompletionItem("False")
+                state.SendBackspace()
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertSelectedCompletionItem("True")
+            End Using
+        End Function
+
+        <WorkItem(4892, "https://github.com/dotnet/roslyn/issues/4892")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BooleanPreselection2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Module Program
+    Sub Main(args As String())
+        foo($$
+    End Sub
+
+    Sub foo (x as boolean)
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("fa")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertSelectedCompletionItem("False")
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertSelectedCompletionItem("True")
+            End Using
+        End Function
+
+        <WorkItem(4892, "https://github.com/dotnet/roslyn/issues/4892")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BooleanPreselection3() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                <Document><![CDATA[
+Imports System
+Module Program
+    Sub Main(args As String())
+        $$
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("f")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertSelectedCompletionItem("FieldAccessExpression")
+                state.SendBackspace()
+                state.SendTypeChars("t")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertSelectedCompletionItem("TAB")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
@@ -77,7 +77,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 filterSpan: filterSpan,
                 descriptionFactory: c => Task.FromResult(keyword.DescriptionFactory(c)),
                 glyph: Glyph.Keyword,
-                isIntrinsic: keyword.IsIntrinsic);
+                isIntrinsic: keyword.IsIntrinsic,
+                preselect: keyword.ShouldPreselect);
         }
 
         protected virtual async Task<IEnumerable<RecommendedKeyword>> RecommendKeywordsAsync(

--- a/src/Features/Core/Portable/Completion/Providers/KeywordCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/KeywordCompletionItem.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 {
     internal class KeywordCompletionItem : CompletionItem
     {
-        public KeywordCompletionItem(CompletionListProvider completionProvider, string displayText, TextSpan filterSpan, Func<CancellationToken, Task<ImmutableArray<SymbolDisplayPart>>> descriptionFactory, Glyph? glyph, bool isIntrinsic, bool shouldFormatOnCommit = false)
-            : base(completionProvider, displayText, filterSpan, descriptionFactory, glyph, shouldFormatOnCommit: shouldFormatOnCommit, rules: KeywordCompletionItemRules.Instance)
+        public KeywordCompletionItem(CompletionListProvider completionProvider, string displayText, TextSpan filterSpan, Func<CancellationToken, Task<ImmutableArray<SymbolDisplayPart>>> descriptionFactory, Glyph? glyph, bool isIntrinsic, bool preselect, bool shouldFormatOnCommit = false)
+            : base(completionProvider, displayText, filterSpan, descriptionFactory, glyph, shouldFormatOnCommit: shouldFormatOnCommit, rules: KeywordCompletionItemRules.Instance, preselect: preselect)
         {
             this.IsIntrinsic = isIntrinsic;
         }

--- a/src/Features/Core/Portable/Completion/Providers/RecommendedKeyword.cs
+++ b/src/Features/Core/Portable/Completion/Providers/RecommendedKeyword.cs
@@ -14,9 +14,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         public Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> DescriptionFactory { get; }
         public bool IsIntrinsic { get; }
         public bool ShouldFormatOnCommit { get; }
+        public bool ShouldPreselect { get; }
 
-        public RecommendedKeyword(string keyword, string toolTip = "", Glyph glyph = Glyph.Keyword, bool isIntrinsic = false, bool shouldFormatOnCommit = false)
-            : this(keyword, glyph, _ => CreateDisplayParts(keyword, toolTip), isIntrinsic, shouldFormatOnCommit)
+        public RecommendedKeyword(string keyword, string toolTip = "", Glyph glyph = Glyph.Keyword, bool isIntrinsic = false, bool shouldFormatOnCommit = false, bool shouldPreselect = false)
+            : this(keyword, glyph, _ => CreateDisplayParts(keyword, toolTip), isIntrinsic, shouldFormatOnCommit, shouldPreselect)
         {
         }
 
@@ -39,13 +40,15 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
              Glyph glyph,
               Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> descriptionFactory,
               bool isIntrinsic = false,
-              bool shouldFormatOnCommit = false)
+              bool shouldFormatOnCommit = false,
+              bool shouldPreselect = false)
         {
             this.Keyword = keyword;
             this.Glyph = glyph;
             this.DescriptionFactory = descriptionFactory;
             this.IsIntrinsic = isIntrinsic;
             this.ShouldFormatOnCommit = shouldFormatOnCommit;
+            this.ShouldPreselect = shouldPreselect;
         }
     }
 }

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
         End Function
 
         Private Function ShouldPreselect(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As Boolean
-            Dim documentId = context?.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(context.SyntaxTree.FilePath).FirstOrDefault()
+            Dim documentId = context?.Workspace?.CurrentSolution.GetDocumentIdsWithFilePath(context.SyntaxTree.FilePath).FirstOrDefault()
             If documentId Is Nothing Then
                 Return False
             End If

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
@@ -2,6 +2,7 @@
 
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion.Providers
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expressions
@@ -12,12 +13,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
         Inherits AbstractKeywordRecommender
 
         Protected Overrides Function RecommendKeywords(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As IEnumerable(Of RecommendedKeyword)
+            Dim preselect As Boolean = ShouldPreselect(context, cancellationToken)
+
             If context.IsAnyExpressionContext Then
-                Return {New RecommendedKeyword("True", VBFeaturesResources.TrueKeywordToolTip),
-                        New RecommendedKeyword("False", VBFeaturesResources.FalseKeywordToolTip)}
+                Return {New RecommendedKeyword("True", VBFeaturesResources.TrueKeywordToolTip, shouldPreselect:=preselect),
+                        New RecommendedKeyword("False", VBFeaturesResources.FalseKeywordToolTip, shouldPreselect:=preselect)}
             End If
 
             Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()
+        End Function
+
+        Private Function ShouldPreselect(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As Boolean
+            Dim documentId = context.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(context.SyntaxTree.FilePath).First()
+            Dim document = context.Workspace.CurrentSolution.GetDocument(documentId)
+            Dim typeInferenceService = document.Project.LanguageServices.GetService(Of ITypeInferenceService)()
+            Dim types = typeInferenceService.InferTypes(context.SemanticModel, context.Position, cancellationToken)
+
+            Return types.Any(Function(t) t.SpecialType = SpecialType.System_Boolean)
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
@@ -24,7 +24,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
         End Function
 
         Private Function ShouldPreselect(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As Boolean
-            Dim documentId = context.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(context.SyntaxTree.FilePath).First()
+            Dim documentId = context?.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(context.SyntaxTree.FilePath).FirstOrDefault()
+            If documentId Is Nothing Then
+                Return False
+            End If
+
             Dim document = context.Workspace.CurrentSolution.GetDocument(documentId)
             Dim typeInferenceService = document.Project.LanguageServices.GetService(Of ITypeInferenceService)()
             Dim types = typeInferenceService.InferTypes(context.SemanticModel, context.Position, cancellationToken)

--- a/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionRules.vb
+++ b/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionRules.vb
@@ -36,6 +36,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
                     Return -1
                 End If
 
+                ' Furthermore, preselection is more important than case sensitivity
+                If leftItem.Preselect AndAlso Not rightItem.Preselect Then
+                    Return -1
+                ElseIf rightItem.Preselect AndAlso Not leftItem.Preselect
+                    Return 1
+                End If
+
                 diff = PatternMatch.CompareCase(leftMatch, rightMatch)
                 If diff <> 0 Then
                     Return diff


### PR DESCRIPTION
This is a redo of https://github.com/dotnet/roslyn/pull/6318.

* VB completion item matching now prefers preselected matches over case sensitive matches
