### PR TITLE
Fix VB incorrectly reported redundant casts in compound assignment statements

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -7687,7 +7687,7 @@ End Class
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
         <WorkItem(995855)>
-        Public Sub VisualBasic_Remove_UnnecessaryCastInTernaryExpression()
+        Public Sub VisualBasic_DontRemove_NecessaryCastInTernaryExpression1()
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -7696,7 +7696,109 @@ Class C
     Private Shared Sub Main(args As String())
         Dim s As Byte = 0
         Dim i As Integer = 0
-        s += If(i = 0, {|Simplify:CByte(0)|}, {|Simplify:CByte(0)|})
+        s += If(i = 0, CByte(0), {|Simplify:CByte(0)|})
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Class C
+    Private Shared Sub Main(args As String())
+        Dim s As Byte = 0
+        Dim i As Integer = 0
+        s += If(i = 0, CByte(0), CByte(0))
+    End Sub
+End Class
+]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(995855)>
+        Public Sub VisualBasic_DontRemove_NecessaryCastInTernaryExpression2()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Class C
+    Private Shared Sub Main(args As String())
+        Dim s As Byte = 0
+        Dim i As Integer = 0
+        s += If(i = 0, {|Simplify:CByte(0)|}, CByte(0))
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Class C
+    Private Shared Sub Main(args As String())
+        Dim s As Byte = 0
+        Dim i As Integer = 0
+        s += If(i = 0, CByte(0), CByte(0))
+    End Sub
+End Class
+]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(995855)>
+        Public Sub VisualBasic_Remove_UnnecessaryCastInTernaryExpression1()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Class C
+    Private Shared Sub Main(args As String())
+        Dim s As Byte = 0
+        Dim i As Integer = 0
+        s += If(i = 0, 0, {|Simplify:CByte(0)|})
+    End Sub
+End Class
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+Class C
+    Private Shared Sub Main(args As String())
+        Dim s As Byte = 0
+        Dim i As Integer = 0
+        s += If(i = 0, 0, 0)
+    End Sub
+End Class
+]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(995855)>
+        Public Sub VisualBasic_Remove_UnnecessaryCastInTernaryExpression2()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document><![CDATA[
+Class C
+    Private Shared Sub Main(args As String())
+        Dim s As Byte = 0
+        Dim i As Integer = 0
+        s += If(i = 0, {|Simplify:CByte(0)|}, 0)
     End Sub
 End Class
 ]]>
@@ -8201,6 +8303,165 @@ Class C
     End Sub
 End Class
 ]]>
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Sub VisualBasic_Remove_IntegerToByte_OptionStrictOff()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Option Strict Off
+Class C
+    Sub M()
+        Dim b As Byte
+        b += {|Simplify:CByte(1)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Option Strict Off
+Class C
+    Sub M()
+        Dim b As Byte
+        b += 1
+    End Sub
+End Class
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Sub VisualBasic_DontRemove_IntegerToByte_OptionStrictOn1()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        b += {|Simplify:CByte(1)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        b += CByte(1)
+    End Sub
+End Class
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Sub VisualBasic_DontRemove_IntegerToByte_OptionStrictOn2()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        Const x = 1
+        b += {|Simplify:CByte(x)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        Const x = 1
+        b += CByte(x)
+    End Sub
+End Class
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Sub VisualBasic_DontRemove_IntegerToByte_OptionStrictOn3()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        Dim x As Integer = 1
+        b += {|Simplify:CByte(x)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        Dim x As Integer = 1
+        b += CByte(x)
+    End Sub
+End Class
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Sub VisualBasic_DontRemove_IntegerToByte_OptionStrictOn4()
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        b = b + {|Simplify:CByte(1)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Option Strict On
+Class C
+    Sub M()
+        Dim b As Byte
+        b = b + CByte(1)
+    End Sub
+End Class
 </code>
 
             Test(input, expected)

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -618,7 +618,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             if (assignmentExpression.IsCompoundAssignExpression() &&
                 assignmentExpression.Kind() != SyntaxKind.LeftShiftAssignmentExpression &&
                 assignmentExpression.Kind() != SyntaxKind.RightShiftAssignmentExpression &&
-                ReplacementBreaksCompoundAssignExpression(assignmentExpression.Left, assignmentExpression.Right, newAssignmentExpression.Left, newAssignmentExpression.Right))
+                ReplacementBreaksCompoundAssignment(assignmentExpression.Left, assignmentExpression.Right, newAssignmentExpression.Left, newAssignmentExpression.Right))
             {
                 return true;
             }

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -744,7 +744,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return true;
         }
 
-        protected bool ReplacementBreaksCompoundAssignExpression(
+        protected bool ReplacementBreaksCompoundAssignment(
             TExpressionSyntax originalLeft,
             TExpressionSyntax originalRight,
             TExpressionSyntax newLeft,


### PR DESCRIPTION
Fixes #2560

**Customer Scenario**:

VB remove unnecessary cast reports false positives for common cases with compound assignment where applying the code fix can break the user's code.

*Redundant cast incorrectly reported*:

![image](https://cloud.githubusercontent.com/assets/116161/10768202/1871b0c4-7c9d-11e5-8801-576f489f85d4.png)

*Error after removing cast*:

![image](https://cloud.githubusercontent.com/assets/116161/10768173/eba339b4-7c9c-11e5-9136-39eb5ff26629.png)

**Issue Description**:

Consider the following code:

```VB
Dim b As Byte
b += CByte(1)
```

The `CByte` cast can be removed if the Option Strict is Off. However, if Option Strict is On, the compiler produces an error ("Option Strict On disallows implicit conversions from 'Integer' to 'Byte'").

The issue here is that compound statements are not considered by unnecessary cast detection. Unfortunately, supporting is not as straight forward as I'd hoped for a couple of reasons:

1. There is no compiler API to get the built-in operator used by a VB assignment statement. If there were, this would be a straightforward fix since removing the cast results in the compiler choosing `System.Int32.op_Add(Int32, Int32)` rather than `System.Byte.op_Add(Byte, Byte)`.

2. There is a hidden narrowing-numeric conversion of a constant value in the following code:

```VB
b += 1
```

Using the compiler API to classify conversion from the expression `1` to the type of `b` results in a widening-numeric conversion, which is misleading since the type of `1` is `System.Int32` and the type of `b` is `System.Byte`.

**Fix Description**:

Fixing the problem requires two changes:

1. Actually support assignment statements in the speculative analyzer and check to see if replacement would break the compound assignment.
2. Add a special case in the VB speculative analyzer in the case that Option Strict is not Off and the expression has a constant value. In that case, we use a different compiler API to classify *the type of the expression* `1` to the type of `b`, rather than classifying *the expression* `1` to the type of `b`.

**Testing Done**:
* Unit test coverage added for negative and positive cases.

Tagging @dotnet/roslyn-ide 