### PR TITLE
Implement metadata version supersession for script compilation

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
+using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -307,6 +308,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             private bool CreateAndSetSourceAssemblyFullBind(CSharpCompilation compilation)
             {
                 var resolutionDiagnostics = DiagnosticBag.GetInstance();
+                var assemblyReferencesBySimpleName = PooledDictionary<string, List<ReferencedAssemblyIdentity>>.GetInstance();
+                bool supersedeLowerVersions = compilation.IsSubmission;
 
                 try
                 {
@@ -318,6 +321,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     ImmutableArray<ResolvedReference> referenceMap = ResolveMetadataReferences(
                         compilation,
+                        assemblyReferencesBySimpleName,
                         out references,
                         out boundReferenceDirectiveMap,
                         out boundReferenceDirectives,
@@ -342,6 +346,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         referenceMap,
                         compilation.Options.MetadataReferenceResolver,
                         compilation.Options.MetadataImportOptions,
+                        supersedeLowerVersions,
+                        assemblyReferencesBySimpleName,
                         out allAssemblyData,
                         out implicitlyResolvedReferences,
                         out implicitlyResolvedReferenceMap,
@@ -361,6 +367,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         references,
                         referenceMap,
                         modules.Length,
+                        referencedAssemblies.Length,
+                        assemblyReferencesBySimpleName,
+                        supersedeLowerVersions,
                         out referencedAssembliesMap,
                         out referencedModulesMap,
                         out aliasesOfReferencedAssemblies);
@@ -473,6 +482,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 finally
                 {
                     resolutionDiagnostics.Free();
+                    assemblyReferencesBySimpleName.Free();
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -2176,6 +2176,110 @@ public class Source
         }
 
         [Fact]
+        public void ReferenceSupersession_FxUnification1()
+        {
+            var c = CreateSubmission("System.Diagnostics.Process.GetCurrentProcess()", new[]
+            {
+                TestReferences.NetFx.v2_0_50727.mscorlib,
+                TestReferences.NetFx.v2_0_50727.System,
+                TestReferences.NetFx.v4_0_30319.mscorlib,
+                TestReferences.NetFx.v4_0_30319.System,
+            });
+
+            c.VerifyDiagnostics();
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=2.0.0.0: <superseded>",
+                "System, Version=2.0.0.0: <superseded>",
+                "mscorlib, Version=4.0.0.0",
+                "System, Version=4.0.0.0");
+        }
+
+        [Fact]
+        public void ReferenceSupersession_StrongNames1()
+        {
+            var c = CreateSubmission("new C()", new[]
+            {
+                TestReferences.SymbolsTests.Versioning.C2,
+                TestReferences.SymbolsTests.Versioning.C1,
+            });
+
+            c.VerifyDiagnostics();
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "C, Version=2.0.0.0",
+                "C, Version=1.0.0.0: <superseded>");
+        }
+
+        [Fact]
+        public void ReferenceSupersession_WeakNames1()
+        {
+            var c = CreateSubmission("new C()", new[]
+            {
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").EmitToImageReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+            });
+
+            c.VerifyDiagnostics();
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "C, Version=1.0.0.0: <superseded>",
+                "C, Version=2.0.0.0");
+        }
+
+        [Fact]
+        public void ReferenceSupersession_AliasesErased()
+        {
+            var c = CreateSubmission("new C()", new[]
+            {
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""0.0.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.1"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.1.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference().
+                    WithProperties(MetadataReferenceProperties.Assembly.WithAliases(ImmutableArray.Create("Z")).WithRecursiveAliases(true)),
+            });
+
+            c.VerifyDiagnostics();
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0: global,Z",
+                "C, Version=0.0.0.0: <superseded>",
+                "C, Version=2.0.0.1",
+                "C, Version=1.0.0.0: <superseded>",
+                "C, Version=2.0.0.0: <superseded>",
+                "C, Version=1.1.0.0: <superseded>");
+        }
+
+        [Fact]
+        public void ReferenceSupersession_NoUnaliasedAssembly()
+        {
+            var c = CreateSubmission("new C()", new[]
+            {
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""0.0.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.1"")] public class C {}", assemblyName: "C").ToMetadataReference(aliases: ImmutableArray.Create("X", "Y")),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference(),
+                CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.1.0.0"")] public class C {}", assemblyName: "C").ToMetadataReference().
+                    WithProperties(MetadataReferenceProperties.Assembly.WithAliases(ImmutableArray.Create("Z")).WithRecursiveAliases(true)),
+            });
+
+            c.VerifyDiagnostics(
+                // (1,5): error CS0246: The type or namespace name 'C' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "C").WithArguments("C"));
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0: global,Z",
+                "C, Version=0.0.0.0: <superseded>",
+                "C, Version=2.0.0.1: X,Y",
+                "C, Version=1.0.0.0: <superseded>",
+                "C, Version=2.0.0.0: <superseded>",
+                "C, Version=1.1.0.0: <superseded>");
+        }
+
+        [Fact]
         public void ReferenceDirective_RecursiveReferenceWithNoAliases()
         {
             // c - b (alias X) 
@@ -2478,6 +2582,12 @@ public class C : A
             resolver.VerifyResolutionAttempts(
                 "D -> B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=0.0.0.0",
+                "D, Version=0.0.0.0",
+                "B, Version=3.0.0.0: Y,X");
         }
 
         [Fact]
@@ -2499,16 +2609,21 @@ public class C : A
                 { "B, 2.0.0.0", b2Ref },
             });
 
-            var c = CreateCompilationWithMscorlib(@"public interface C : A, D {  }", new[] { aRef, dRef },
+            var c = CreateSubmission(@"public interface C : A, D {  }", new[] { aRef, dRef },
                 TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver));
 
-            c.VerifyEmitDiagnostics(
-                // error CS1704: An assembly with the same simple name 'B' has already been imported. Try removing one of the references (e.g. 'B') or sign them to enable side-by-side.
-                Diagnostic(ErrorCode.ERR_DuplicateImportSimple).WithArguments("B", "B"));
+            c.VerifyEmitDiagnostics();
 
             resolver.VerifyResolutionAttempts(
                 "D -> B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null",
                 "A -> B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=0.0.0.0",
+                "D, Version=0.0.0.0",
+                "B, Version=2.0.0.0",
+                "B, Version=1.0.0.0: <superseded>");
         }
 
         [Fact]
@@ -2530,16 +2645,21 @@ public class C : A
                 { "B, 2.0.0.0", b4Ref },
             });
 
-            var c = CreateCompilationWithMscorlib(@"public interface C : A, D {  }", new[] { aRef, dRef },
+            var c = CreateSubmission(@"public interface C : A, D {  }", new[] { aRef, dRef },
                 TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver));
 
-            c.VerifyEmitDiagnostics(
-                // error CS1704: An assembly with the same simple name 'B' has already been imported. Try removing one of the references (e.g. 'B') or sign them to enable side-by-side.
-                Diagnostic(ErrorCode.ERR_DuplicateImportSimple).WithArguments("B", "B"));
+            c.VerifyEmitDiagnostics();
 
             resolver.VerifyResolutionAttempts(
                 "D -> B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null",
                 "A -> B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=0.0.0.0",
+                "D, Version=0.0.0.0",
+                "B, Version=4.0.0.0",
+                "B, Version=3.0.0.0: <superseded>");
         }
 
         [Fact]
@@ -2765,6 +2885,13 @@ public class C : A
             resolverC.VerifyResolutionAttempts(
                 "A -> D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=1.0.0.0",
+                "B, Version=1.0.0.0",
+                "D, Version=1.0.0.0",
+                "E, Version=1.0.0.0");
         }
 
         /// <summary>
@@ -2820,6 +2947,13 @@ public class C : A
             resolverC.VerifyResolutionAttempts(
                 "A -> D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=1.0.0.0",
+                "B, Version=2.0.0.0",
+                "D, Version=1.0.0.0",
+                "E, Version=1.0.0.0");
         }
 
         [Fact]
@@ -2846,26 +2980,24 @@ public class C : A
                 { "B, 2.0.0.0", b2Ref },
             });
 
-            var c = CreateCompilationWithMscorlib("public class C : A { }", new[] { aRef },
-                s_signedDll.WithMetadataReferenceResolver(resolverC));
+            var c = CreateSubmission("public class C : A { }", new[] { aRef },
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolverC));
 
             c.VerifyEmitDiagnostics();
-
-            Assert.Equal(4, resolverC.ResolutionAttempts.Count);
-
-            Assert.Equal(
-               "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
-               ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b1Ref)).Identity.GetDisplayName());
-
-            Assert.Equal(
-               "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
-               ((AssemblySymbol)c.GetAssemblyOrModuleSymbol(b2Ref)).Identity.GetDisplayName());
 
             resolverC.VerifyResolutionAttempts(
                 "A -> D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=1.0.0.0",
+                "D, Version=1.0.0.0",
+                "B, Version=2.0.0.0",
+                "E, Version=1.0.0.0",
+                "B, Version=1.0.0.0: <superseded>");
         }
 
         [Fact]
@@ -2902,38 +3034,181 @@ public class C : A
                 // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity 
                 // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
                 Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
-                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", 
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A",
                     "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"),
 
                 // (1,14): warning CS1701: Assuming assembly reference 
                 // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'D' matches identity
                 // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
                 Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
-                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "D", 
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "D",
                     "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"),
 
                 // (1,14): warning CS1701: Assuming assembly reference 
                 // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'E' matches identity 
                 // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
                 Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
-                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "E", 
+                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "E",
                     "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
 
-            AssertEx.Equal(new[]
-            {
-                "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
-                "D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
-                "B, Version=4.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
-                "E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
-                "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2"
-            }, c.GetBoundReferenceManager().ReferencedAssemblies.Select(a => a.Identity.GetDisplayName()));
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=1.0.0.0",
+                "D, Version=1.0.0.0",
+                "B, Version=4.0.0.0",
+                "E, Version=1.0.0.0",
+                "B, Version=3.0.0.0");
 
             resolverC.VerifyResolutionAttempts(
                 "A -> D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
                 "A -> B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2");
+        }
+
+        [Fact]
+        public void MissingAssemblyResolution_BindingToImplicitReference3()
+        {
+            // c - a -> d -> "b,v2"
+            //          e -> "b,v1"
+            //          "b,v1"
+            //          "b,v2"
+            var b1Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b2Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b3Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""3.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+            var b4Ref = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""4.0.0.0"")] public interface B { }", options: s_signedDll, assemblyName: "B").EmitToImageReference();
+
+            var dRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface D : B { }", new[] { b2Ref }, options: s_signedDll, assemblyName: "D").EmitToImageReference();
+            var eRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface E : B { }", new[] { b1Ref }, options: s_signedDll, assemblyName: "E").EmitToImageReference();
+
+            var aRef = CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public interface A : D, E { }", new[] { dRef, eRef, b1Ref, b2Ref },
+                s_signedDll, assemblyName: "A").EmitToImageReference();
+
+            var resolverC = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "D, 1.0.0.0", dRef },
+                { "E, 1.0.0.0", eRef },
+                { "B, 1.0.0.0", b3Ref },
+                { "B, 2.0.0.0", b4Ref },
+            });
+
+            var c = CreateSubmission("public class C : A { }", new[] { aRef },
+                TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolverC));
+
+            c.VerifyEmitDiagnostics(
+                // (1,14): warning CS1701: Assuming assembly reference 
+                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity 
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A",
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"),
+
+                // (1,14): warning CS1701: Assuming assembly reference 
+                // 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'D' matches identity
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "D",
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"),
+
+                // (1,14): warning CS1701: Assuming assembly reference 
+                // 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'E' matches identity 
+                // 'B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
+                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin, "C").WithArguments(
+                    "B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "E",
+                    "B, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B"));
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=1.0.0.0",
+                "D, Version=1.0.0.0",
+                "B, Version=4.0.0.0",
+                "E, Version=1.0.0.0",
+                "B, Version=3.0.0.0: <superseded>");
+
+            resolverC.VerifyResolutionAttempts(
+                "A -> D, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "A -> B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "A -> E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2",
+                "A -> B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2");
+        }
+
+        [Fact]
+        public void MissingAssemblyResolution_Supersession_FxUnification()
+        {
+            var options = TestOptions.ReleaseDll.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default);
+
+            // c - "mscorlib, v4"
+            //     a -> "mscorlib, v2"
+            //          "System, v2"
+            //     b -> "mscorlib, v4"
+            //          "System, v4"
+            var aRef = CreateCompilation(@"public interface A { System.Diagnostics.Process PA { get; } }", new[] { TestReferences.NetFx.v2_0_50727.mscorlib, TestReferences.NetFx.v2_0_50727.System }, 
+                options: options, assemblyName: "A").EmitToImageReference();
+
+            var bRef = CreateCompilation(@"public interface B { System.Diagnostics.Process PB { get; } }", new[] { MscorlibRef_v4_0_30316_17626, TestReferences.NetFx.v4_0_30319.System },
+                options: options, assemblyName: "B").EmitToImageReference();
+
+            var resolverC = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "System, 2.0.0.0", TestReferences.NetFx.v2_0_50727.System },
+                { "System, 4.0.0.0", TestReferences.NetFx.v4_0_30319.System },
+            });
+
+            var c = CreateSubmissionWithExactReferences("public interface C : A, B { System.Diagnostics.Process PC { get; } }", new[] { MscorlibRef_v4_0_30316_17626, aRef, bRef },
+                options.WithMetadataReferenceResolver(resolverC));
+
+            c.VerifyEmitDiagnostics();
+
+            resolverC.VerifyResolutionAttempts(
+                "B -> System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "System.dll -> System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                "System.dll -> System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "A -> System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "System.dll -> System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                "System.dll -> System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=0.0.0.0",
+                "B, Version=0.0.0.0",
+                "System, Version=4.0.0.0",
+                "System, Version=2.0.0.0: <superseded>");
+        }
+
+        [Fact]
+        public void MissingAssemblyResolution_Supersession_StrongNames()
+        {
+            var options = TestOptions.ReleaseDll.WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default);
+
+            // c - a -> "C, v2"
+            //     b -> "C, v1"
+            var aRef = CreateCompilationWithMscorlib(@"public interface A { C CA { get; } }", new[] { TestReferences.SymbolsTests.Versioning.C2 },
+                options: options, assemblyName: "A").EmitToImageReference();
+
+            var bRef = CreateCompilationWithMscorlib(@"public interface B { C CB { get; } }", new[] { TestReferences.SymbolsTests.Versioning.C1 },
+                options: options, assemblyName: "B").EmitToImageReference();
+
+            var resolverC = new TestMissingMetadataReferenceResolver(new Dictionary<string, MetadataReference>
+            {
+                { "C, 1.0.0.0", TestReferences.SymbolsTests.Versioning.C1 },
+                { "C, 2.0.0.0", TestReferences.SymbolsTests.Versioning.C2 },
+            });
+
+            var c = CreateSubmission("public interface D : A, B { C CC { get; } }", new[] { aRef, bRef },
+                options.WithMetadataReferenceResolver(resolverC));
+
+            c.VerifyEmitDiagnostics();
+
+            resolverC.VerifyResolutionAttempts(
+                "B -> C, Version=1.0.0.0, Culture=neutral, PublicKeyToken=374d0c2befcd8cc9",
+                "A -> C, Version=2.0.0.0, Culture=neutral, PublicKeyToken=374d0c2befcd8cc9");
+
+            c.VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "A, Version=0.0.0.0",
+                "B, Version=0.0.0.0",
+                "C, Version=1.0.0.0: <superseded>",
+                "C, Version=2.0.0.0");
         }
     }
 }

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -147,15 +149,25 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private struct ReferencedAssemblyIdentity
+        protected struct ReferencedAssemblyIdentity
         {
             public readonly AssemblyIdentity Identity;
-            public readonly MetadataReference MetadataReference;
+            public readonly MetadataReference Reference;
 
-            public ReferencedAssemblyIdentity(AssemblyIdentity identity, MetadataReference metadataReference)
+            /// <summary>
+            /// non-negative: Index into the array of ReferencedAssemblies (not including the assembly being built).
+            /// negative: ReferencedAssemblies.Count + RelativeAssemblyIndex is an index into the array of assemblies (not including the assembly being built).
+            /// </summary>
+            public readonly int RelativeAssemblyIndex;
+
+            public int GetAssemblyIndex(int explicitlyReferencedAssemblyCount) => 
+                RelativeAssemblyIndex >= 0 ? RelativeAssemblyIndex : explicitlyReferencedAssemblyCount + RelativeAssemblyIndex;
+
+            public ReferencedAssemblyIdentity(AssemblyIdentity identity, MetadataReference reference, int relativeAssemblyIndex)
             {
                 Identity = identity;
-                MetadataReference = metadataReference;
+                Reference = reference;
+                RelativeAssemblyIndex = relativeAssemblyIndex;
             }
         }
 
@@ -163,6 +175,10 @@ namespace Microsoft.CodeAnalysis
         /// Resolves given metadata references to assemblies and modules.
         /// </summary>
         /// <param name="compilation">The compilation whose references are being resolved.</param>
+        /// <param name="assemblyReferencesBySimpleName">
+        /// Used to filter out assemblies that have the same strong or weak identity.
+        /// Maps simple name to a list of identities. The highest version of each name is the first.
+        /// </param>
         /// <param name="references">List where to store resolved references. References from #r directives will follow references passed to the compilation constructor.</param>
         /// <param name="boundReferenceDirectiveMap">Maps #r values to successfully resolved metadata references. Does not contain values that failed to resolve.</param>
         /// <param name="boundReferenceDirectives">Unique metadata references resolved from #r directives.</param>
@@ -174,6 +190,7 @@ namespace Microsoft.CodeAnalysis
         ///</returns>
         protected ImmutableArray<ResolvedReference> ResolveMetadataReferences(
             TCompilation compilation,
+            [Out] Dictionary<string, List<ReferencedAssemblyIdentity>> assemblyReferencesBySimpleName,
             out ImmutableArray<MetadataReference> references,
             out IDictionary<string, MetadataReference> boundReferenceDirectiveMap,
             out ImmutableArray<MetadataReference> boundReferenceDirectives,
@@ -197,14 +214,12 @@ namespace Microsoft.CodeAnalysis
 
             // Used to filter out duplicate references that reference the same file (resolve to the same full normalized path).
             var boundReferences = new Dictionary<MetadataReference, MetadataReference>(MetadataReferenceEqualityComparer.Instance);
-
-            // Used to filter out assemblies that have the same strong or weak identity.
-            // Maps simple name to a list of full names.
-            Dictionary<string, List<ReferencedAssemblyIdentity>> assemblyReferencesBySimpleName = null;
-
+            
             ArrayBuilder<MetadataReference> uniqueDirectiveReferences = (referenceDirectiveLocations != null) ? ArrayBuilder<MetadataReference>.GetInstance() : null;
-            ArrayBuilder<AssemblyData> assembliesBuilder = null;
-            ArrayBuilder<PEModule> modulesBuilder = null;
+            var assembliesBuilder = ArrayBuilder<AssemblyData>.GetInstance();
+            ArrayBuilder<PEModule> lazyModulesBuilder = null;
+
+            bool supersedeLowerVersions = compilation.IsSubmission;
 
             // When duplicate references with conflicting EmbedInteropTypes flag are encountered,
             // VB uses the flag from the last one, C# reports an error. We need to enumerate in reverse order
@@ -252,11 +267,13 @@ namespace Microsoft.CodeAnalysis
                     {
                         case MetadataImageKind.Assembly:
                             existingReference = TryAddAssembly(
-                                compilationReference.Compilation.Assembly.Identity,
+                                compilationReference.Compilation.Assembly.Identity, 
                                 boundReference,
+                                -assembliesBuilder.Count - 1,
                                 diagnostics,
                                 location,
-                                ref assemblyReferencesBySimpleName);
+                                assemblyReferencesBySimpleName,
+                                supersedeLowerVersions);
 
                             if (existingReference != null)
                             {
@@ -269,7 +286,7 @@ namespace Microsoft.CodeAnalysis
                             // right now. Conveniently, this constructor will trigger creation of the 
                             // SourceAssemblySymbol.
                             var asmData = CreateAssemblyDataForCompilation(compilationReference);
-                            AddAssembly(asmData, referenceIndex, referenceMap, ref assembliesBuilder);
+                            AddAssembly(asmData, referenceIndex, referenceMap, assembliesBuilder);
                             break;
 
                         default:
@@ -299,11 +316,13 @@ namespace Microsoft.CodeAnalysis
                             {
                                 PEAssembly assembly = assemblyMetadata.GetAssembly();
                                 existingReference = TryAddAssembly(
-                                    assembly.Identity,
-                                    peReference,
+                                    assembly.Identity, 
+                                    peReference, 
+                                    -assembliesBuilder.Count - 1,
                                     diagnostics,
                                     location,
-                                    ref assemblyReferencesBySimpleName);
+                                    assemblyReferencesBySimpleName,
+                                    supersedeLowerVersions);
 
                                 if (existingReference != null)
                                 {
@@ -319,7 +338,7 @@ namespace Microsoft.CodeAnalysis
                                     compilation.Options.MetadataImportOptions,
                                     peReference.Properties.EmbedInteropTypes);
 
-                                AddAssembly(asmData, referenceIndex, referenceMap, ref assembliesBuilder);
+                                AddAssembly(asmData, referenceIndex, referenceMap, assembliesBuilder);
                             }
                             else
                             {
@@ -341,7 +360,7 @@ namespace Microsoft.CodeAnalysis
                                     diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_LinkedNetmoduleMetadataMustProvideFullPEImage, location, peReference.Display));
                                 }
 
-                                AddModule(moduleMetadata.Module, referenceIndex, referenceMap, ref modulesBuilder);
+                                AddModule(moduleMetadata.Module, referenceIndex, referenceMap, ref lazyModulesBuilder);
                             }
                             else
                             {
@@ -376,33 +395,24 @@ namespace Microsoft.CodeAnalysis
             {
                 if (!referenceMap[i].IsSkipped)
                 {
-                    int count = referenceMap[i].Kind == MetadataImageKind.Assembly
-                        ? ((object)assembliesBuilder == null ? 0 : assembliesBuilder.Count)
-                        : ((object)modulesBuilder == null ? 0 : modulesBuilder.Count);
+                    int count = (referenceMap[i].Kind == MetadataImageKind.Assembly) ? assembliesBuilder.Count : lazyModulesBuilder?.Count ?? 0;
 
                     int reversedIndex = count - 1 - referenceMap[i].Index;
                     referenceMap[i] = GetResolvedReferenceAndFreePropertyMapEntry(references[i], reversedIndex, referenceMap[i].Kind, lazyAliasMap);
                 }
             }
 
-            if (assembliesBuilder == null)
-            {
-                assemblies = ImmutableArray<AssemblyData>.Empty;
-            }
-            else
-            {
-                assembliesBuilder.ReverseContents();
-                assemblies = assembliesBuilder.ToImmutableAndFree();
-            }
+            assembliesBuilder.ReverseContents();
+            assemblies = assembliesBuilder.ToImmutableAndFree();
             
-            if (modulesBuilder == null)
+            if (lazyModulesBuilder == null)
             {
                 modules = ImmutableArray<PEModule>.Empty;
             }
             else
             {
-                modulesBuilder.ReverseContents();
-                modules = modulesBuilder.ToImmutableAndFree();
+                lazyModulesBuilder.ReverseContents();
+                modules = lazyModulesBuilder.ToImmutableAndFree();
             }
 
             return ImmutableArray.CreateRange(referenceMap);
@@ -581,13 +591,8 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Caller is responsible for freeing any allocated ArrayBuilders.
         /// </remarks>
-        private static void AddAssembly(AssemblyData data, int referenceIndex, ResolvedReference[] referenceMap, ref ArrayBuilder<AssemblyData> assemblies)
+        private static void AddAssembly(AssemblyData data, int referenceIndex, ResolvedReference[] referenceMap, ArrayBuilder<AssemblyData> assemblies)
         {
-            if (assemblies == null)
-            {
-                assemblies = ArrayBuilder<AssemblyData>.GetInstance();
-            }
-
             // aliases will be filled in later:
             referenceMap[referenceIndex] = new ResolvedReference(assemblies.Count, MetadataImageKind.Assembly);
             assemblies.Add(data);
@@ -614,22 +619,44 @@ namespace Microsoft.CodeAnalysis
         /// - both assembly names are weak (no keys) and have the same simple name.
         /// </summary>
         private MetadataReference TryAddAssembly(
-            AssemblyIdentity identity,
-            MetadataReference boundReference,
+            AssemblyIdentity identity, 
+            MetadataReference reference, 
+            int assemblyIndex, 
             DiagnosticBag diagnostics, 
             Location location,
-            ref Dictionary<string, List<ReferencedAssemblyIdentity>> referencesBySimpleName)
+            Dictionary<string, List<ReferencedAssemblyIdentity>> referencesBySimpleName,
+            bool supersedeLowerVersions)
         {
-            if (referencesBySimpleName == null)
-            {
-                referencesBySimpleName = new Dictionary<string, List<ReferencedAssemblyIdentity>>(StringComparer.OrdinalIgnoreCase);
-            }
+            var referencedAssembly = new ReferencedAssemblyIdentity(identity, reference, assemblyIndex);
 
             List<ReferencedAssemblyIdentity> sameSimpleNameIdentities;
-            string simpleName = identity.Name;
-            if (!referencesBySimpleName.TryGetValue(simpleName, out sameSimpleNameIdentities))
+            if (!referencesBySimpleName.TryGetValue(identity.Name, out sameSimpleNameIdentities))
             {
-                referencesBySimpleName.Add(simpleName, new List<ReferencedAssemblyIdentity> { new ReferencedAssemblyIdentity(identity, boundReference) });
+                referencesBySimpleName.Add(identity.Name, new List<ReferencedAssemblyIdentity> { referencedAssembly });
+                return null;
+            }
+            
+            if (supersedeLowerVersions)
+            {
+                foreach (var other in sameSimpleNameIdentities)
+                {
+                    if (identity.Version == other.Identity.Version)
+                    {
+                        return other.Reference;
+                    }
+                }
+
+                // Keep all versions of the assembly and the first identity in the list the one with the highest version:
+                if (sameSimpleNameIdentities[0].Identity.Version > identity.Version)
+                {
+                    sameSimpleNameIdentities.Add(referencedAssembly);
+                }
+                else
+                {
+                    sameSimpleNameIdentities.Add(sameSimpleNameIdentities[0]);
+                    sameSimpleNameIdentities[0] = referencedAssembly;
+                }
+
                 return null;
             }
 
@@ -666,7 +693,7 @@ namespace Microsoft.CodeAnalysis
 
             if (equivalent.Identity == null)
             {
-                sameSimpleNameIdentities.Add(new ReferencedAssemblyIdentity(identity, boundReference));
+                sameSimpleNameIdentities.Add(referencedAssembly);
                 return null;
             }
 
@@ -684,7 +711,7 @@ namespace Microsoft.CodeAnalysis
                     // BREAKING CHANGE in VB: we report an error for both languages
 
                     // Multiple assemblies with equivalent identity have been imported: '{0}' and '{1}'. Remove one of the duplicate references.
-                    MessageProvider.ReportDuplicateMetadataReferenceStrong(diagnostics, location, boundReference, identity, equivalent.MetadataReference, equivalent.Identity);
+                    MessageProvider.ReportDuplicateMetadataReferenceStrong(diagnostics, location, reference, identity, equivalent.Reference, equivalent.Identity);
                 }
                 // If the versions match exactly we ignore duplicates w/o reporting errors while 
                 // Dev12 C# reports:
@@ -705,12 +732,12 @@ namespace Microsoft.CodeAnalysis
 
                 if (identity != equivalent.Identity)
                 {
-                    MessageProvider.ReportDuplicateMetadataReferenceWeak(diagnostics, location, boundReference, identity, equivalent.MetadataReference, equivalent.Identity);
+                    MessageProvider.ReportDuplicateMetadataReferenceWeak(diagnostics, location, reference, identity, equivalent.Reference, equivalent.Identity);
                 }
             }
 
-            Debug.Assert(equivalent.MetadataReference != null);
-            return equivalent.MetadataReference;
+            Debug.Assert(equivalent.Reference != null);
+            return equivalent.Reference;
         }
 
         protected void GetCompilationReferences(

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -155,8 +155,8 @@ namespace Microsoft.CodeAnalysis
             public readonly MetadataReference Reference;
 
             /// <summary>
-            /// non-negative: Index into the array of ReferencedAssemblies (not including the assembly being built).
-            /// negative: ReferencedAssemblies.Count + RelativeAssemblyIndex is an index into the array of assemblies (not including the assembly being built).
+            /// non-negative: Index into the array of all (explicitly and implicitly) referenced assemblies.
+            /// negative: ExplicitlyReferencedAssemblies.Count + RelativeAssemblyIndex is an index into the array of assemblies.
             /// </summary>
             public readonly int RelativeAssemblyIndex;
 

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -493,6 +493,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return c;
         }
 
+        public static CSharpCompilation CreateSubmissionWithExactReferences(
+           string code,
+           IEnumerable<MetadataReference> references = null,
+           CSharpCompilationOptions options = null,
+           CSharpParseOptions parseOptions = null,
+           CSharpCompilation previous = null,
+           Type returnType = null,
+           Type hostObjectType = null)
+        {
+            return CSharpCompilation.CreateScriptCompilation(
+                GetUniqueName(),
+                references: references,
+                options: options,
+                syntaxTree: Parse(code, options: parseOptions ?? TestOptions.Script),
+                previousScriptCompilation: previous,
+                returnType: returnType,
+                globalsType: hostObjectType);
+        }
+
         public static CSharpCompilation CreateSubmission(
            string code,
            IEnumerable<MetadataReference> references = null,

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
@@ -257,6 +258,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Friend Function CreateAndSetSourceAssemblyFullBind(compilation As VisualBasicCompilation) As Boolean
 
                 Dim resolutionDiagnostics = DiagnosticBag.GetInstance()
+                Dim supersedeLowerVersions = compilation.IsSubmission
+                Dim assemblyReferencesBySimpleName = PooledDictionary(Of String, List(Of ReferencedAssemblyIdentity)).GetInstance()
 
                 Try
                     Dim boundReferenceDirectiveMap As IDictionary(Of String, MetadataReference) = Nothing
@@ -267,6 +270,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Dim referenceMap As ImmutableArray(Of ResolvedReference) = ResolveMetadataReferences(
                         compilation,
+                        assemblyReferencesBySimpleName,
                         references,
                         boundReferenceDirectiveMap,
                         boundReferenceDirectives,
@@ -290,6 +294,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                      referenceMap,
                                                                      compilation.Options.MetadataReferenceResolver,
                                                                      compilation.Options.MetadataImportOptions,
+                                                                     supersedeLowerVersions,
+                                                                     assemblyReferencesBySimpleName,
                                                                      allAssemblyData,
                                                                      implicitlyResolvedReferences,
                                                                      implicitlyResolvedReferenceMap,
@@ -311,6 +317,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         references,
                         referenceMap,
                         modules.Length,
+                        referencedAssemblies.Length,
+                        assemblyReferencesBySimpleName,
+                        supersedeLowerVersions,
                         referencedAssembliesMap,
                         referencedModulesMap,
                         aliasesOfReferencedAssemblies)

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -417,6 +417,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return True
                 Finally
                     resolutionDiagnostics.Free()
+                    assemblyReferencesBySimpleName.Free()
                 End Try
             End Function
 

--- a/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
@@ -24,6 +24,7 @@ using AssertEx = PortableTestUtils::Roslyn.Test.Utilities.AssertEx;
 namespace Microsoft.CodeAnalysis.Scripting.CSharpTest
 {
     using static TestCompilationFactory;
+    using DiagnosticExtensions = PortableTestUtils::Microsoft.CodeAnalysis.DiagnosticExtensions;
 
     public class InteractiveSessionTests : TestBase
     {
@@ -226,6 +227,188 @@ System.Diagnostics.Process.GetCurrentProcess()
 ", options).Result;
 
             Assert.NotNull(process);
+        }
+
+        [Fact]
+        public void References_Versioning_FxUnification1()
+        {
+            var script = CSharpScript.Create($@"
+#r ""System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089""
+#r ""System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089""
+
+System.Diagnostics.Process.GetCurrentProcess()
+");
+            script.GetCompilation().VerifyAssemblyVersionsAndAliases(
+                "System, Version=2.0.0.0: <superseded>",
+                "System, Version=4.0.0.0",
+                "mscorlib, Version=4.0.0.0",
+                "System.Configuration, Version=4.0.0.0: <implicit>,global",
+                "System.Xml, Version=4.0.0.0: <implicit>,global",
+                "System.Data.SqlXml, Version=4.0.0.0: <implicit>,global",
+                "System.Security, Version=4.0.0.0: <implicit>,global",
+                "System.Core, Version=4.0.0.0: <implicit>,global",
+                "System.Numerics, Version=4.0.0.0: <implicit>,global",
+                "System.Configuration, Version=2.0.0.0: <superseded>",
+                "System.Xml, Version=2.0.0.0: <superseded>",
+                "System.Data.SqlXml, Version=2.0.0.0: <superseded>",
+                "System.Security, Version=2.0.0.0: <superseded>");
+
+            Assert.NotNull(script.RunAsync().Result.ReturnValue);
+        }
+
+        [Fact]
+        public void References_Versioning_FxUnification2()
+        {
+            var script0 = CSharpScript.Create($@"
+#r ""System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089""
+");
+            var script1 = script0.ContinueWith($@"
+#r ""System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089""
+");
+            var script2 = script1.ContinueWith(@"
+System.Diagnostics.Process.GetCurrentProcess()
+");
+            script0.GetCompilation().VerifyAssemblyVersionsAndAliases(
+                "System, Version=2.0.0.0",
+                "mscorlib, Version=4.0.0.0",
+                "System.Configuration, Version=2.0.0.0: <implicit>,global",
+                "System.Xml, Version=2.0.0.0: <implicit>,global",
+                "System.Data.SqlXml, Version=2.0.0.0: <implicit>,global",
+                "System.Security, Version=2.0.0.0: <implicit>,global");
+
+            script1.GetCompilation().VerifyAssemblyVersionsAndAliases(
+                "System, Version=4.0.0.0",
+                "mscorlib, Version=4.0.0.0",
+                "System, Version=2.0.0.0: <superseded>",
+                "System.Configuration, Version=2.0.0.0: <superseded>",
+                "System.Xml, Version=2.0.0.0: <superseded>",
+                "System.Data.SqlXml, Version=2.0.0.0: <superseded>",
+                "System.Security, Version=2.0.0.0: <superseded>",
+                "System.Configuration, Version=4.0.0.0: <implicit>",
+                "System.Xml, Version=4.0.0.0: <implicit>",
+                "System.Data.SqlXml, Version=4.0.0.0: <implicit>",
+                "System.Security, Version=4.0.0.0: <implicit>",
+                "System.Core, Version=4.0.0.0: <implicit>",
+                "System.Numerics, Version=4.0.0.0: <implicit>");
+
+            script2.GetCompilation().VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "System, Version=2.0.0.0: <superseded>",
+                "System, Version=4.0.0.0",
+                "System.Configuration, Version=4.0.0.0: <implicit>,global",
+                "System.Xml, Version=4.0.0.0: <implicit>,global",
+                "System.Data.SqlXml, Version=4.0.0.0: <implicit>,global",
+                "System.Security, Version=4.0.0.0: <implicit>,global",
+                "System.Core, Version=4.0.0.0: <implicit>,global",
+                "System.Numerics, Version=4.0.0.0: <implicit>,global",
+                "System.Configuration, Version=2.0.0.0: <superseded>",
+                "System.Xml, Version=2.0.0.0: <superseded>",
+                "System.Data.SqlXml, Version=2.0.0.0: <superseded>",
+                "System.Security, Version=2.0.0.0: <superseded>");
+
+            Assert.NotNull(script2.EvaluateAsync().Result);
+        }
+
+        [Fact]
+        public void References_Versioning_StrongNames1()
+        {
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(TestResources.General.C1);
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(TestResources.General.C2);
+
+            var result = CSharpScript.EvaluateAsync($@"
+#r ""{c1.Path}""
+#r ""{c2.Path}""
+
+new C()
+").Result;
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void References_Versioning_StrongNames2()
+        {
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(TestResources.General.C1);
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(TestResources.General.C2);
+
+            var result = CSharpScript.Create($@"
+#r ""{c1.Path}""
+").ContinueWith($@"
+#r ""{c2.Path}""
+").ContinueWith(@"
+new C()
+").EvaluateAsync().Result;
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void References_Versioning_WeakNames1()
+        {
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+
+            var result = CSharpScript.EvaluateAsync($@"
+#r ""{c1.Path}""
+#r ""{c2.Path}""
+
+new C()
+").Result;
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void References_Versioning_WeakNames2()
+        {
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+
+            var result = CSharpScript.Create($@"
+#r ""{c1.Path}""
+").ContinueWith($@"
+#r ""{c2.Path}""
+").ContinueWith(@"
+new C()
+").EvaluateAsync().Result;
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void References_Versioning_WeakNames3()
+        {
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+
+            var script0 = CSharpScript.Create($@"
+#r ""{c1.Path}""
+var c1 = new C();
+");
+            script0.GetCompilation().VerifyAssemblyVersionsAndAliases(
+            "C, Version=1.0.0.0",
+            "mscorlib, Version=4.0.0.0");
+
+            var script1 = script0.ContinueWith($@"
+#r ""{c2.Path}""
+var c2 = new C();
+");
+            script1.GetCompilation().VerifyAssemblyVersionsAndAliases(
+                "C, Version=2.0.0.0",
+                "mscorlib, Version=4.0.0.0",
+                "C, Version=1.0.0.0: <superseded>");
+
+            var script2 = script1.ContinueWith(@"
+c1 = c2;
+");
+            script2.GetCompilation().VerifyAssemblyVersionsAndAliases(
+                "mscorlib, Version=4.0.0.0",
+                "C, Version=1.0.0.0: <superseded>",
+                "C, Version=2.0.0.0");
+
+            DiagnosticExtensions.VerifyEmitDiagnostics(script2.GetCompilation(),
+                // (2,6): error CS0029: Cannot implicitly convert type 'C [{c2.Path}]' to 'C [{c1.Path}]'
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "c2").WithArguments($"C [{c2.Path}]", $"C [{c1.Path}]"));
         }
 
         [Fact]

--- a/src/Test/Utilities/Shared/Compilation/CompilationExtensions.cs
+++ b/src/Test/Utilities/Shared/Compilation/CompilationExtensions.cs
@@ -134,6 +134,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
+        internal static void VerifyAssemblyVersionsAndAliases(this Compilation compilation, params string[] expectedAssembliesAndAliases)
+        {
+            var actual = compilation.GetBoundReferenceManager().GetReferencedAssemblyAliases().
+               Select(t => $"{t.Item1.Identity.Name}, Version={t.Item1.Identity.Version}{(t.Item2.IsEmpty ? "" : ": " + string.Join(",", t.Item2))}");
+
+            AssertEx.Equal(expectedAssembliesAndAliases, actual, itemInspector: s => '"' + s + '"');
+        }
+
         internal static void VerifyAssemblyAliases(this Compilation compilation, params string[] expectedAssembliesAndAliases)
         {
             var actual = compilation.GetBoundReferenceManager().GetReferencedAssemblyAliases().

--- a/src/Test/Utilities/Shared/Mocks/TestReferences.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestReferences.cs
@@ -2465,6 +2465,34 @@ public static class TestReferences
                     return s_EN_US;
                 }
             }
+
+            private static PortableExecutableReference s_C1;
+            public static PortableExecutableReference C1
+            {
+                get
+                {
+                    if (s_C1 == null)
+                    {
+                        s_C1 = AssemblyMetadata.CreateFromImage(TestResources.General.C1).GetReference(display: "C1");
+                    }
+
+                    return s_C1;
+                }
+            }
+
+            private static PortableExecutableReference s_C2;
+            public static PortableExecutableReference C2
+            {
+                get
+                {
+                    if (s_C2 == null)
+                    {
+                        s_C2 = AssemblyMetadata.CreateFromImage(TestResources.General.C2).GetReference(display: "C2");
+                    }
+
+                    return s_C2;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Improves handling #r of assemblies that directly or indirectly reference multiple versions of libraries.

For example, #r on xunit reported errors:
```
> #r "C:\Users\tomat\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.x86.exe"
error CS1703: Multiple assemblies with equivalent identity have been imported: 'C:\WINDOWS\assembly\GAC_MSIL\System.Xml\2.0.0.0__b77a5c561934e089\System.Xml.dll' and 'C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Xml\v4.0_4.0.0.0__b77a5c561934e089\System.Xml.dll'. Remove one of the duplicate references.
error CS1703: Multiple assemblies with equivalent identity have been imported: 'C:\WINDOWS\assembly\GAC_MSIL\System.Configuration\2.0.0.0__b03f5f7f11d50a3a\System.Configuration.dll' and 'C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Configuration\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Configuration.dll'. Remove one of the duplicate references.
error CS1703: Multiple assemblies with equivalent identity have been imported: 'C:\WINDOWS\assembly\GAC_MSIL\System.Security\2.0.0.0__b03f5f7f11d50a3a\System.Security.dll' and 'C:\WINDOWS\Microsoft.Net\assembly\GAC_MSIL\System.Security\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Security.dll'. Remove one of the duplicate references.
```

This is because #r transitively adds references to all dependencies and includes all their versions.

This change still imports all the versions of the dependencies but only exposes the global namespace of the highest version to the script source. The other versions are imported under an alias ```<superseded>```. As a result all metadata assembly references resolve to the right versions (as they did before) but identifiers in the source only bind to the highest version.

This feature is only enabled for script compilation. We may consider using it for regular compilation as well in future.
