### PR TITLE
Add regression tests for #4264.

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -104,7 +104,6 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Test\Utilities\Shared\TestUtilities.projitems*{6ff42825-5464-4151-ac55-ed828168c192}*SharedItemsImports = 13
-		src\Test\Utilities\Shared\TestUtilities.projitems*{f7712928-1175-47b3-8819-ee086753dee2}*SharedItemsImports = 4
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -92,6 +92,26 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         }
 
         [Fact]
+        public void RunWithShiftJisFile()
+        {
+            var dir = Temp.CreateDirectory();
+            var src = dir.CreateFile("sjis.cs").WriteAllBytes(TestResources.General.ShiftJisSource);
+
+            var cmd = new MockCSharpCompiler(null, dir.Path, new[] { "/nologo", "/codepage:932", src.Path });
+
+            Assert.Equal(932, cmd.Arguments.Encoding?.WindowsCodePage);
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var exitCode = cmd.Run(outWriter);
+            Assert.Equal(0, exitCode);
+            Assert.Equal("", outWriter.ToString());
+
+            var result = ProcessUtilities.Run(Path.Combine(dir.Path, "sjis.exe"), arguments: "", workingDirectory: dir.Path);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("星野 八郎太", File.ReadAllText(Path.Combine(dir.Path, "output.txt"), Encoding.GetEncoding(932)));
+        }
+
+        [Fact]
         [WorkItem(946954)]
         public void CompilerBinariesAreAnyCPU()
         {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -91,6 +91,27 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             return CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
+        // This test should only run when the machine's default encoding is shift-JIS
+        [ConditionalFact(typeof(HasShiftJisDefaultEncoding))]
+        public void CompileShiftJisOnShiftJis()
+        {
+            var dir = Temp.CreateDirectory();
+            var src = dir.CreateFile("sjis.cs").WriteAllBytes(TestResources.General.ShiftJisSource);
+
+            var cmd = new MockCSharpCompiler(null, dir.Path, new[] { "/nologo", src.Path });
+
+            Assert.Null(cmd.Arguments.Encoding);
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var exitCode = cmd.Run(outWriter);
+            Assert.Equal(0, exitCode);
+            Assert.Equal("", outWriter.ToString());
+
+            var result = ProcessUtilities.Run(Path.Combine(dir.Path, "sjis.exe"), arguments: "", workingDirectory: dir.Path);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("星野 八郎太", File.ReadAllText(Path.Combine(dir.Path, "output.txt"), Encoding.GetEncoding(932)));
+        }
+
         [Fact]
         public void RunWithShiftJisFile()
         {

--- a/src/Compilers/Core/CodeAnalysisTest/Text/EncodedStringTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/EncodedStringTextTests.cs
@@ -32,6 +32,32 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
+        private static SourceText CreateMemoryStreamBasedEncodedText(byte[] bytes, 
+            Func<Encoding> getEncoding,
+            Encoding readEncodingOpt = null,
+            SourceHashAlgorithm algorithm = SourceHashAlgorithm.Sha1)
+        {
+            // For testing purposes, create a bigger buffer so that we verify 
+            // that the implementation only uses the part that's covered by the stream and not the entire array.
+            byte[] buffer = new byte[bytes.Length + 10];
+            bytes.CopyTo(buffer, 0);
+
+            using (var stream = new MemoryStream(buffer, 0, bytes.Length, writable: true, publiclyVisible: true))
+            {
+                return EncodedStringText.Create(stream, getEncoding, readEncodingOpt, algorithm);
+            }
+        }
+
+        [Fact]
+        public void ShiftJisGetEncoding()
+        {
+            var sjis = Encoding.GetEncoding(932);
+            var data = CreateMemoryStreamBasedEncodedText(TestResources.General.ShiftJisSource, () => sjis);
+
+            Assert.Equal(932, data.Encoding?.WindowsCodePage);
+            Assert.Equal(sjis.GetString(TestResources.General.ShiftJisSource), data.ToString());
+        }
+
         [Fact]
         public void ShiftJisFile()
         {

--- a/src/Compilers/Core/CodeAnalysisTest/Text/EncodedStringTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/EncodedStringTextTests.cs
@@ -16,6 +16,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             byte[] bytes = writeEncoding.GetBytesWithPreamble(text);
 
+            return CreateMemoryStreamBasedEncodedText(bytes, readEncodingOpt, algorithm);
+        }
+
+        private static SourceText CreateMemoryStreamBasedEncodedText(byte[] bytes, Encoding readEncodingOpt, SourceHashAlgorithm algorithm = SourceHashAlgorithm.Sha1)
+        {
             // For testing purposes, create a bigger buffer so that we verify 
             // that the implementation only uses the part that's covered by the stream and not the entire array.
             byte[] buffer = new byte[bytes.Length + 10];
@@ -25,6 +30,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 return EncodedStringText.Create(stream, readEncodingOpt, algorithm);
             }
+        }
+
+        [Fact]
+        public void ShiftJisFile()
+        {
+            var sjis = Encoding.GetEncoding(932);
+            var data = CreateMemoryStreamBasedEncodedText(TestResources.General.ShiftJisSource, sjis);
+
+            Assert.Equal(932, data.Encoding?.WindowsCodePage);
+            Assert.Equal(sjis.GetString(TestResources.General.ShiftJisSource), data.ToString());
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// Encoding to use when UTF-8 fails. We try to find the following, in order, if available:
         ///     1. The default ANSI codepage
-       ///      2. CodePage 1252.
-       ///      3. Latin1.
+        ///     2. CodePage 1252.
+        ///     3. Latin1.
         /// </summary>
         private static readonly Encoding s_fallbackEncoding = GetFallbackEncoding();
 
@@ -67,7 +67,20 @@ namespace Microsoft.CodeAnalysis.Text
         /// <paramref name="defaultEncoding"/> is null and the stream appears to be a binary file.
         /// </exception>
         /// <exception cref="IOException">An IO error occurred while reading from the stream.</exception>
-        internal static SourceText Create(Stream stream, Encoding defaultEncoding = null, SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
+        internal static SourceText Create(Stream stream,
+            Encoding defaultEncoding = null,
+            SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
+        {
+            return Create(stream,
+                () => s_fallbackEncoding,
+                defaultEncoding: defaultEncoding,
+                checksumAlgorithm: checksumAlgorithm);
+        }
+
+        // internal for testing
+        internal static SourceText Create(Stream stream, Func<Encoding> getEncoding,
+            Encoding defaultEncoding = null,
+            SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
         {
             Debug.Assert(stream != null);
             Debug.Assert(stream.CanRead && stream.CanSeek);
@@ -87,12 +100,13 @@ namespace Microsoft.CodeAnalysis.Text
 
             try
             {
-                return Decode(stream, defaultEncoding ?? s_fallbackEncoding, checksumAlgorithm, throwIfBinaryDetected: detectEncoding);
+                return Decode(stream, defaultEncoding ?? getEncoding(), checksumAlgorithm, throwIfBinaryDetected: detectEncoding);
             }
             catch (DecoderFallbackException e)
             {
                 throw new InvalidDataException(e.Message);
             }
+
         }
 
         /// <summary>

--- a/src/Compilers/Test/Resources/Core/CompilerTestResources.csproj
+++ b/src/Compilers/Test/Resources/Core/CompilerTestResources.csproj
@@ -83,6 +83,7 @@
     <EmbeddedResource Include="DiagnosticTests\ErrTestMod01.netmodule" />
     <Content Include="DiagnosticTests\ErrTestMod02.cs" />
     <EmbeddedResource Include="DiagnosticTests\ErrTestMod02.netmodule" />
+    <EmbeddedResource Include="Encoding\sjis.cs" />
     <Content Include="MetadataTests\InterfaceAndClass\CSClasses01.cs" />
     <EmbeddedResource Include="MetadataTests\InterfaceAndClass\CSClasses01.dll" />
     <Content Include="MetadataTests\InterfaceAndClass\CSInterfaces01.cs" />

--- a/src/Compilers/Test/Resources/Core/Encoding/sjis.cs
+++ b/src/Compilers/Test/Resources/Core/Encoding/sjis.cs
@@ -1,0 +1,10 @@
+using System.IO;
+using System.Text;
+
+class プラネテス
+{
+    public static void Main()
+    {
+        File.WriteAllText("output.txt", "星野 八郎太", Encoding.GetEncoding(932));
+    }
+}

--- a/src/Compilers/Test/Resources/Core/TestResources.cs
+++ b/src/Compilers/Test/Resources/Core/TestResources.cs
@@ -178,6 +178,9 @@ namespace TestResources
         private static byte[] _DelegatesWithoutInvoke;
         public static byte[] DelegatesWithoutInvoke => ResourceLoader.GetOrCreateResource(ref _DelegatesWithoutInvoke, "SymbolsTests.Delegates.DelegatesWithoutInvoke.dll");
 
+        private static byte[] _shiftJisSource;
+        public static byte[] ShiftJisSource => ResourceLoader.GetOrCreateResource(ref _shiftJisSource, "Encoding.sjis.cs");
+
         private static byte[] _Events;
         public static byte[] Events => ResourceLoader.GetOrCreateResource(ref _Events, "SymbolsTests.Events.dll");
 

--- a/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 using Xunit;
 
 namespace Roslyn.Test.Utilities
@@ -28,5 +29,12 @@ namespace Roslyn.Test.Utilities
         public override bool ShouldSkip { get { return IntPtr.Size != 4; } }
 
         public override string SkipReason { get { return "Target platform is not x86"; } }
+    }
+
+    public class HasShiftJisDefaultEncoding : ExecutionCondition
+    {
+        public override bool ShouldSkip => Encoding.GetEncoding(0)?.WindowsCodePage != 932;
+
+        public override string SkipReason => "OS default codepage is not Shift-JIS (932).";
     }
 }

--- a/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
@@ -33,7 +33,7 @@ namespace Roslyn.Test.Utilities
 
     public class HasShiftJisDefaultEncoding : ExecutionCondition
     {
-        public override bool ShouldSkip => Encoding.GetEncoding(0)?.WindowsCodePage != 932;
+        public override bool ShouldSkip => Encoding.GetEncoding(0)?.CodePage != 932;
 
         public override string SkipReason => "OS default codepage is not Shift-JIS (932).";
     }


### PR DESCRIPTION
This test verifies that the compiler will correctly compile a shift-JIS
encoded file, which fixes #6325. Unfortunately, there's no way to
completely guarantee that GetEncoding(0) is being called correctly,
since there is no way to mock that call without affecting other threads
or even programs on the system.