### PR TITLE
Syntactically classify buffers without a workspace

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Implementation.Classification;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
@@ -32,8 +36,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
                     subjectBuffer,
                     workspace.GetService<IForegroundNotificationService>(),
                     AggregateAsynchronousOperationListener.CreateEmptyListener(),
-                    null,
-                    new SyntacticClassificationTaggerProvider(null, null, null));
+                    typeMap: null,
+                    taggerProvider: new SyntacticClassificationTaggerProvider(
+                        notificationService: null,
+                        typeMap: null,
+                        viewSupportsClassificationServiceOpt: null,
+                        associatedViewService: null,
+                        allLanguageServices: ImmutableArray<Lazy<ILanguageService, LanguageServiceMetadata>>.Empty,
+                        contentTypes: ImmutableArray<Lazy<ILanguageService, ContentTypeLanguageMetadata>>.Empty,
+                        asyncListeners: ImmutableArray<Lazy<IAsynchronousOperationListener, FeatureMetadata>>.Empty),
+                    viewSupportsClassificationServiceOpt: null,
+                    associatedViewService: null,
+                    editorClassificationService: null,
+                    languageName: null);
 
                 SnapshotSpan span = default(SnapshotSpan);
                 tagComputer.TagsChanged += (s, e) =>

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Implementation\Classification\ClassificationTypeDefinitions.cs" />
     <Compile Include="Implementation\Classification\ClassificationUtilities.cs" />
     <Compile Include="Implementation\Classification\IEditorClassificationService.cs" />
+    <Compile Include="Implementation\Classification\IViewSupportsClassificationService.cs" />
     <Compile Include="Implementation\Classification\SemanticClassificationTaggerProvider.cs" />
     <Compile Include="Implementation\Classification\SyntacticClassificationTaggerProvider.cs" />
     <Compile Include="Implementation\Classification\SyntacticClassificationTaggerProvider.TagComputer.cs" />

--- a/src/EditorFeatures/Core/Implementation/Classification/IViewSupportsClassificationService.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/IViewSupportsClassificationService.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
+{
+    /// <summary>
+    /// Determines whether a set of <see cref="ITextView"/>s that are not backed by a 
+    /// workspace should be classified.
+    /// </summary>
+    internal interface IViewSupportsClassificationService
+    {
+        /// <returns>The return value must be consistent.</returns>
+        bool CanClassifyViews(IEnumerable<ITextView> views);
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.cs
@@ -3,10 +3,13 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -23,6 +26,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
     internal partial class SyntacticClassificationTaggerProvider : ITaggerProvider
     {
         private readonly IForegroundNotificationService _notificationService;
+        private readonly IViewSupportsClassificationService _viewSupportsClassificationServiceOpt;
+        private readonly ITextBufferAssociatedViewService _associatedViewService;
+        private readonly IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> _editorClassificationLanguageServices;
+        private readonly IEnumerable<Lazy<ILanguageService, ContentTypeLanguageMetadata>> _contentTypesToLanguageNames;
         private readonly IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> _asyncListeners;
         private readonly ClassificationTypeMap _typeMap;
 
@@ -32,10 +39,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         public SyntacticClassificationTaggerProvider(
             IForegroundNotificationService notificationService,
             ClassificationTypeMap typeMap,
+            [Import(AllowDefault = true)] IViewSupportsClassificationService viewSupportsClassificationServiceOpt,
+            ITextBufferAssociatedViewService associatedViewService,
+            [ImportMany] IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> allLanguageServices,
+            [ImportMany] IEnumerable<Lazy<ILanguageService, ContentTypeLanguageMetadata>> contentTypes,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {
             _notificationService = notificationService;
             _typeMap = typeMap;
+            _viewSupportsClassificationServiceOpt = viewSupportsClassificationServiceOpt;
+            _associatedViewService = associatedViewService;
+            _editorClassificationLanguageServices = allLanguageServices.Where(s => s.Metadata.ServiceType == typeof(IEditorClassificationService).AssemblyQualifiedName);
+            _contentTypesToLanguageNames = contentTypes.Where(x => x.Metadata.DefaultContentType != null);
             _asyncListeners = asyncListeners;
         }
 
@@ -50,7 +65,26 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             if (!_tagComputers.TryGetValue(buffer, out tagComputer))
             {
                 var asyncListener = new AggregateAsynchronousOperationListener(_asyncListeners, FeatureAttribute.Classification);
-                tagComputer = new TagComputer(buffer, _notificationService, asyncListener, _typeMap, this);
+
+                var languageName = _contentTypesToLanguageNames.FirstOrDefault(x => buffer.ContentType.MatchesAny(x.Metadata.DefaultContentType))?.Metadata.Language;
+                var editorClassificationService = _editorClassificationLanguageServices.FirstOrDefault(x => x.Metadata.Language == languageName).Value as IEditorClassificationService;
+
+                if (editorClassificationService == null)
+                {
+                    return null;
+                }
+
+                tagComputer = new TagComputer(
+                    buffer,
+                    _notificationService,
+                    asyncListener,
+                    _typeMap,
+                    this,
+                    _viewSupportsClassificationServiceOpt,
+                    _associatedViewService, 
+                    editorClassificationService,
+                    languageName);
+
                 _tagComputers.Add(buffer, tagComputer);
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Classification/ViewSupportsClassificationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Classification/ViewSupportsClassificationService.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Implementation.Classification;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Utilities;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text.Editor;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Classification
+{
+    [Export(typeof(IViewSupportsClassificationService))]
+    internal class ViewSupportsClassificationService : IViewSupportsClassificationService
+    {
+        private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
+        private readonly SVsServiceProvider _serviceProvider;
+
+        [ImportingConstructor]
+        public ViewSupportsClassificationService(
+            ITextBufferAssociatedViewService viewService,
+            IVsEditorAdaptersFactoryService editorAdaptersFactoryService, 
+            SVsServiceProvider serviceProvider)
+        {
+            _editorAdaptersFactoryService = editorAdaptersFactoryService;
+            _serviceProvider = serviceProvider;
+        }
+
+        public bool CanClassifyViews(IEnumerable<ITextView> views)
+        {
+            var vsTextViews = views.Select(view => _editorAdaptersFactoryService.GetViewAdapter(view)).WhereNotNull();
+            return !vsTextViews.ContainsImmediateWindow((IVsUIShell)_serviceProvider.GetService(typeof(SVsUIShell)), _editorAdaptersFactoryService);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -1,23 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
-using TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 {
@@ -60,7 +54,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             _contentType = contentType;
             this.ProjectionBufferFactoryService = componentModel.GetService<IProjectionBufferFactoryService>();
             _bufferGraphFactoryService = componentModel.GetService<IBufferGraphFactoryService>();
-            _isImmediateWindow = IsImmediateWindow((IVsUIShell)serviceProvider.GetService(typeof(SVsUIShell)), vsTextView);
+            var _editorAdaptersFactoryService = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+
+            _isImmediateWindow = vsTextView.IsImmediateWindow(
+                (IVsUIShell)serviceProvider.GetService(typeof(SVsUIShell)),
+                _editorAdaptersFactoryService);
         }
 
         // Constructor for testing
@@ -265,41 +263,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             }
 
             return -1;
-        }
-
-        private bool IsImmediateWindow(IVsUIShell shellService, IVsTextView textView)
-        {
-            IEnumWindowFrames windowEnum = null;
-            IVsTextLines buffer = null;
-            Marshal.ThrowExceptionForHR(shellService.GetToolWindowEnum(out windowEnum));
-            Marshal.ThrowExceptionForHR(textView.GetBuffer(out buffer));
-
-            IVsWindowFrame[] frame = new IVsWindowFrame[1];
-            uint value;
-
-            var immediateWindowGuid = Guid.Parse(ToolWindowGuids80.ImmediateWindow);
-
-            while (windowEnum.Next(1, frame, out value) == VSConstants.S_OK)
-            {
-                Guid toolWindowGuid;
-                Marshal.ThrowExceptionForHR(frame[0].GetGuidProperty((int)__VSFPROPID.VSFPROPID_GuidPersistenceSlot, out toolWindowGuid));
-                if (toolWindowGuid == immediateWindowGuid)
-                {
-                    IntPtr frameTextView;
-                    Marshal.ThrowExceptionForHR(frame[0].QueryViewInterface(typeof(IVsTextView).GUID, out frameTextView));
-                    try
-                    {
-                        var immediateWindowTextView = Marshal.GetObjectForIUnknown(frameTextView) as IVsTextView;
-                        return textView == immediateWindowTextView;
-                    }
-                    finally
-                    {
-                        Marshal.Release(frameTextView);
-                    }
-                }
-            }
-
-            return false;
         }
 
         public void Dispose()

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Implementation\AnalyzerDependency\IgnorableAssemblyIdentityList.cs" />
     <Compile Include="Implementation\AnalyzerDependency\IgnorableAssemblyNameList.cs" />
     <Compile Include="Implementation\AnalyzerDependency\IgnorableAssemblyNamePrefixList.cs" />
+    <Compile Include="Implementation\Classification\ViewSupportsClassificationService.cs" />
     <Compile Include="Implementation\CompilationErrorTelemetry\CompilationErrorTelemetryIncrementalAnalyzer.cs" />
     <Compile Include="Implementation\Diagnostics\VisualStudioVenusSpanMappingService.cs" />
     <Compile Include="Implementation\Diagnostics\VisualStudioWorkspaceDiagnosticAnalyzerProviderService.AnalyzerAssemblyLoader.cs" />
@@ -117,6 +118,7 @@
       <DependentUpon>ServicesVSResources.resx</DependentUpon>
     </Compile>
     <Compile Include="SolutionEventMonitor.cs" />
+    <Compile Include="Utilities\IVsTextViewExtensions.cs" />
     <Compile Include="Utilities\VSCodeAnalysisColors.cs" />
     <Compile Include="Implementation\WorkspaceCacheService.cs" />
     <Compile Include="Implementation\Workspace\WorkspaceFailureOutputPane.cs" />

--- a/src/VisualStudio/Core/Def/Utilities/IVsTextViewExtensions.cs
+++ b/src/VisualStudio/Core/Def/Utilities/IVsTextViewExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Utilities
+{
+    internal static class IVsTextViewExtensions
+    {
+        internal static bool IsImmediateWindow(this IVsTextView vsTextView, IVsUIShell shellService, IVsEditorAdaptersFactoryService _editorAdaptersFactoryService)
+        {
+            return ContainsImmediateWindow(SpecializedCollections.SingletonEnumerable(vsTextView), shellService, _editorAdaptersFactoryService);
+        }
+
+        internal static bool ContainsImmediateWindow(this IEnumerable<IVsTextView> vsTextViews, IVsUIShell shellService, IVsEditorAdaptersFactoryService _editorAdaptersFactoryService)
+        {
+            IEnumWindowFrames windowEnum = null;
+            Marshal.ThrowExceptionForHR(shellService.GetToolWindowEnum(out windowEnum));
+
+            IVsWindowFrame[] frame = new IVsWindowFrame[1];
+            uint value;
+
+            var immediateWindowGuid = Guid.Parse(ToolWindowGuids80.ImmediateWindow);
+
+            while (windowEnum.Next(1, frame, out value) == VSConstants.S_OK)
+            {
+                Guid toolWindowGuid;
+                Marshal.ThrowExceptionForHR(frame[0].GetGuidProperty((int)__VSFPROPID.VSFPROPID_GuidPersistenceSlot, out toolWindowGuid));
+                if (toolWindowGuid == immediateWindowGuid)
+                {
+                    IntPtr frameTextView;
+                    Marshal.ThrowExceptionForHR(frame[0].QueryViewInterface(typeof(IVsTextView).GUID, out frameTextView));
+                    try
+                    {
+                        var immediateWindowTextView = Marshal.GetObjectForIUnknown(frameTextView) as IVsTextView;
+                        var immediateWindowWpfTextView = _editorAdaptersFactoryService.GetWpfTextView(immediateWindowTextView);
+                        return vsTextViews.Any(vsTextView => _editorAdaptersFactoryService.GetWpfTextView(vsTextView) == immediateWindowWpfTextView);
+                    }
+                    finally
+                    {
+                        Marshal.Release(frameTextView);
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #873

Sometimes there are buffers with our C#/VB content types that are not added to the Running Document Table and therefore never end up in the MiscellaneousFilesWorkspace (or any workspace), such as the Source Control "Annotate" view. This updates the Syntactic Classifier to handle such cases by creating a document for it in an AdhocWorkspace that lives for the lifetime of the tagger.