### PR TITLE
Added Restore.cmd to simplify restore for contributors

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,0 +1,11 @@
+@echo off
+set NuGetExe="%~dp0NuGet.exe"
+
+echo Restoring packages: Toolsets
+call %NugetExe% restore -verbosity quiet "%~dp0build\ToolsetPackages\project.json" -configfile "%~dp0nuget.config"
+
+echo Restoring packages: Samples
+call %NugetExe% restore -verbosity quiet "%~dp0src\Samples\Samples.sln" -configfile "%~dp0nuget.config"
+
+echo Restoring packages: Roslyn (this may take some time)
+call %NugetExe% restore -verbosity quiet "%~dp0Roslyn.sln" -configfile "%~dp0nuget.config"

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -40,11 +40,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd
 
 REM Restore the NuGet packages 
 if "%BuildRestore%" == "true" (
-    nuget.exe restore -nocache -verbosity quiet %RoslynRoot%build/ToolsetPackages/project.json
-    nuget.exe restore -nocache -verbosity quiet %RoslynRoot%build/Toolset.sln
-    nuget.exe restore -nocache %RoslynRoot%build\ToolsetPackages\project.json
-    nuget.exe restore -nocache %RoslynRoot%Roslyn.sln
-    nuget.exe restore -nocache %RoslynRoot%src\Samples\Samples.sln
+    call "%RoslynRoot%\Restore.cmd"
 ) else (
     powershell -noprofile -executionPolicy RemoteSigned -command "%RoslynRoot%\build\scripts\restore.ps1 %NugetZipUrl%"
 )
@@ -67,10 +63,6 @@ if defined Perf (
 ) else (
   set Target=BuildAndTest
 )
-
-nuget.exe restore -nocache %RoslynRoot%build\ToolsetPackages\project.json
-nuget.exe restore -nocache %RoslynRoot%Roslyn.sln
-nuget.exe restore -nocache %RoslynRoot%src\Samples\Samples.sln
 
 msbuild %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath=%RoslynRoot%Binaries\Bootstrap BuildAndTest.proj /t:%Target% /p:Configuration=%BuildConfiguration% /p:Test64=%Test64%
 if ERRORLEVEL 1 (


### PR DESCRIPTION
This replaces #6335.

Restore.cmd can now be called to simplify the number of
projects you need to restore until we've resolved #6336.

This also reduces the number of restores we do during CI
builds, as we were restoring Roslyn and the samples twice
and the toolset 3 times.

Make note, I removed -nocache. This does *nothing*
for project.json projects, it does not stop NuGet from
using the Global Packages folder
(%USERPROFILE%\.nuget\packages) and it does not
validate this folder's contents with what's in the source.