### PR TITLE
always use the 'en-US' culture for `.ToUpper()` when creating the new property name

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -1003,5 +1003,165 @@ enum E
     [|x|] = 1;
 }");
         }
+
+        [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishDottedI()
+        {
+            using (new CultureContext("tr-TR"))
+            {
+                Test(@"
+class C
+{
+    int [|iyi|];
+}
+", @"
+class C
+{
+    int iyi;
+
+    public int Iyi
+    {
+        get
+        {
+            return iyi;
+        }
+        set
+        {
+            iyi = value;
+        }
+    }
+}
+");
+            }
+        }
+
+        [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishUndottedI()
+        {
+            using (new CultureContext("tr-TR"))
+            {
+                Test(@"
+class C
+{
+    int [|ırak|];
+}
+", @"
+class C
+{
+    int ırak;
+
+    public int Irak
+    {
+        get
+        {
+            return ırak;
+        }
+        set
+        {
+            ırak = value;
+        }
+    }
+}
+");
+            }
+        }
+
+        [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_Arabic()
+        {
+            using (new CultureContext("ar-EG"))
+            {
+                Test(@"
+class C
+{
+    int [|بيت|];
+}
+", @"
+class C
+{
+    int بيت;
+
+    public int بيت1
+    {
+        get
+        {
+            return بيت;
+        }
+        set
+        {
+            بيت = value;
+        }
+    }
+}
+");
+            }
+        }
+
+        [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_Spanish()
+        {
+            using (new CultureContext("es-ES"))
+            {
+                Test(@"
+class C
+{
+    int [|árbol|];
+}
+", @"
+class C
+{
+    int árbol;
+
+    public int Árbol
+    {
+        get
+        {
+            return árbol;
+        }
+        set
+        {
+            árbol = value;
+        }
+    }
+}
+");
+            }
+        }
+
+        [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_Greek()
+        {
+            using (new CultureContext("el-GR"))
+            {
+                Test(@"
+class C
+{
+    int [|σκύλος|];
+}
+", @"
+class C
+{
+    int σκύλος;
+
+    public int Σκύλος
+    {
+        get
+        {
+            return σκύλος;
+        }
+        set
+        {
+            σκύλος = value;
+        }
+    }
+}
+");
+            }
+        }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionRules.cs
+++ b/src/Features/Core/Portable/Completion/CompletionRules.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Completion
         private readonly AbstractCompletionService _completionService;
         private readonly Dictionary<string, PatternMatcher> _patternMatcherMap = new Dictionary<string, PatternMatcher>();
         private readonly Dictionary<string, PatternMatcher> _fallbackPatternMatcherMap = new Dictionary<string, PatternMatcher>();
-        private static readonly CultureInfo EnUSCultureInfo = new CultureInfo("en-US");
+        internal static readonly CultureInfo EnUSCultureInfo = new CultureInfo("en-US");
 
         public CompletionRules(AbstractCompletionService completionService)
         {

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -7,11 +7,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Rename;
-using Microsoft.CodeAnalysis.Rename.ConflictEngine;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
@@ -358,8 +358,10 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 baseName = fieldName;
             }
 
-            // Make uppercase the first letter
-            return char.ToUpper(baseName[0]).ToString() + baseName.Substring(1);
+            // Make the first character upper case using the "en-US" culture.  See discussion at
+            // https://github.com/dotnet/roslyn/issues/5524.
+            var firstCharacter = CompletionRules.EnUSCultureInfo.TextInfo.ToUpper(baseName[0]);
+            return firstCharacter.ToString() + baseName.Substring(1);
         }
 
         protected abstract Task<SyntaxNode> RewriteFieldNameAndAccessibility(string originalFieldName, bool makePrivate, Document document, SyntaxAnnotation declarationAnnotation, CancellationToken cancellationToken);


### PR DESCRIPTION
As per an internal discussion, it was decided that it was best to use the "en-US" culture when calling `char.ToUpper()` to create the new property's name.  C# and VB share the same code path so only C# tests were added.

Fixes #5524.