### PR TITLE
[AskMode] Fix crash in DirectiveTriviaSyntax.DirectiveNameToken...

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/DirectiveTriviaSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/DirectiveTriviaSyntax.cs
@@ -48,6 +48,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                         return ((PragmaChecksumDirectiveTriviaSyntax)this).PragmaKeyword;
                     case SyntaxKind.ReferenceDirectiveTrivia:
                         return ((ReferenceDirectiveTriviaSyntax)this).ReferenceKeyword;
+                    case SyntaxKind.LoadDirectiveTrivia:
+                        return ((LoadDirectiveTriviaSyntax)this).LoadKeyword;
+                    case SyntaxKind.ShebangDirectiveTrivia:
+                        return ((ShebangDirectiveTriviaSyntax)this).ExclamationToken;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(this.Kind());
                 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
@@ -131,6 +131,15 @@ class C
             VerifySendEnterThroughToEnter("$$", "SnippetShortcut", sendThroughEnterEnabled: false, expected: false);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(6405, "https://github.com/dotnet/roslyn/issues/6405")]
+        public void SnippetsNotInPreProcessorContextForScriptDirectives()
+        {
+            VerifyItemIsAbsent(@"#r f$$", MockSnippetInfoService.SnippetShortcut, sourceCodeKind: SourceCodeKind.Script);
+            VerifyItemIsAbsent(@"#load f$$", MockSnippetInfoService.SnippetShortcut, sourceCodeKind: SourceCodeKind.Script);
+            VerifyItemIsAbsent(@"#!$$", MockSnippetInfoService.SnippetShortcut, sourceCodeKind: SourceCodeKind.Script);
+        }
+
         private class MockSnippetInfoService : ISnippetInfoService
         {
             internal const string SnippetShortcut = "SnippetShortcut";


### PR DESCRIPTION
This helper was never updated to include ```#load``` or ```#!```.

(fixes #6405)