### PR TITLE
Fix Crash from Analyzers node context menu invocation #6006

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -137,8 +137,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         private void UpdateAnalyzerFolderContextMenu()
         {
-            _addMenuItem.Visible = SelectedProjectSupportsAnalyzers();
-            _addMenuItem.Enabled = _allowProjectSystemOperations;
+            if (_addMenuItem != null)
+            {
+                _addMenuItem.Visible = SelectedProjectSupportsAnalyzers();
+                _addMenuItem.Enabled = _allowProjectSystemOperations;
+            }
         }
 
         public IContextMenuController AnalyzerContextMenuController


### PR DESCRIPTION
Fix for #6006 

Right-clicking the 'Analyzer' node (under References) while other projects in the solution are still loading led to VS crash. This is because ```AnalyzersCommandHandler.Initialize```, a method that hook's up context menu handlers, has not been called yet and hence the relevant menu command is still null. This simple fix has been verified.