### PR TITLE
When a project or document is removed/closed, clear out all the squiggles we currently have for them.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -200,12 +200,11 @@ class Program
             {
                 var document = workspace.Documents.First();
 
-                var updateArgs = new DiagnosticsUpdatedArgs(
+                var updateArgs = DiagnosticsUpdatedArgs.DiagnosticsCreated(
                         new object(), workspace, workspace.CurrentSolution, document.Project.Id, document.Id,
                         ImmutableArray.Create(
                             CreateDiagnosticData(workspace, document, new TextSpan(0, 0)),
-                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))),
-                        DiagnosticsUpdatedKind.DiagnosticsCreated);
+                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))));
 
                 var spans = await GetErrorsFromUpdateSource(workspace, document, updateArgs).ConfigureAwait(true);
 
@@ -234,12 +233,11 @@ class Program
             {
                 var document = workspace.Documents.First();
 
-                var updateArgs = new DiagnosticsUpdatedArgs(
+                var updateArgs = DiagnosticsUpdatedArgs.DiagnosticsCreated(
                         new LiveId(), workspace, workspace.CurrentSolution, document.Project.Id, document.Id,
                         ImmutableArray.Create(
                             CreateDiagnosticData(workspace, document, new TextSpan(0, 0)),
-                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))),
-                        DiagnosticsUpdatedKind.DiagnosticsCreated);
+                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))));
 
                 var spans = await GetErrorsFromUpdateSource(workspace, document, updateArgs).ConfigureAwait(true);
 

--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -204,7 +204,8 @@ class Program
                         new object(), workspace, workspace.CurrentSolution, document.Project.Id, document.Id,
                         ImmutableArray.Create(
                             CreateDiagnosticData(workspace, document, new TextSpan(0, 0)),
-                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))));
+                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))),
+                        DiagnosticsUpdatedKind.DiagnosticsCreated);
 
                 var spans = await GetErrorsFromUpdateSource(workspace, document, updateArgs).ConfigureAwait(true);
 
@@ -237,7 +238,8 @@ class Program
                         new LiveId(), workspace, workspace.CurrentSolution, document.Project.Id, document.Id,
                         ImmutableArray.Create(
                             CreateDiagnosticData(workspace, document, new TextSpan(0, 0)),
-                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))));
+                            CreateDiagnosticData(workspace, document, new TextSpan(0, 1))),
+                        DiagnosticsUpdatedKind.DiagnosticsCreated);
 
                 var spans = await GetErrorsFromUpdateSource(workspace, document, updateArgs).ConfigureAwait(true);
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -110,6 +110,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
             private void DisconnectFromTagger(IAccurateTagger<TTag> tagger)
             {
+                this.AssertIsForeground();
+
                 tagger.TagsChanged -= OnUnderlyingTaggerTagsChanged;
                 var disposable = tagger as IDisposable;
                 if (disposable != null)

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     foreach (var updateArgs in _owner._diagnosticService.GetDiagnosticsUpdatedEventArgs(workspace, project.Id, document.Id, cancellationToken))
                     {
                         var diagnostics = _owner._diagnosticService.GetDiagnostics(updateArgs.Workspace, updateArgs.ProjectId, updateArgs.DocumentId, updateArgs.Id, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken);
-                        OnDiagnosticsUpdated(new DiagnosticsUpdatedArgs(updateArgs.Id, updateArgs.Workspace, project.Solution, updateArgs.ProjectId, updateArgs.DocumentId, diagnostics.AsImmutableOrEmpty(), DiagnosticsUpdatedKind.DiagnosticsCreated));
+                        OnDiagnosticsUpdated(DiagnosticsUpdatedArgs.DiagnosticsCreated(updateArgs.Id, updateArgs.Workspace, project.Solution, updateArgs.ProjectId, updateArgs.DocumentId, diagnostics.AsImmutableOrEmpty()));
                     }
                 }
             }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     foreach (var updateArgs in _owner._diagnosticService.GetDiagnosticsUpdatedEventArgs(workspace, project.Id, document.Id, cancellationToken))
                     {
                         var diagnostics = _owner._diagnosticService.GetDiagnostics(updateArgs.Workspace, updateArgs.ProjectId, updateArgs.DocumentId, updateArgs.Id, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken);
-                        OnDiagnosticsUpdated(new DiagnosticsUpdatedArgs(updateArgs.Id, updateArgs.Workspace, project.Solution, updateArgs.ProjectId, updateArgs.DocumentId, diagnostics.AsImmutableOrEmpty()));
+                        OnDiagnosticsUpdated(new DiagnosticsUpdatedArgs(updateArgs.Id, updateArgs.Workspace, project.Solution, updateArgs.ProjectId, updateArgs.DocumentId, diagnostics.AsImmutableOrEmpty(), DiagnosticsUpdatedKind.DiagnosticsCreated));
                     }
                 }
             }
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             {
                 // First see if this is a document/project removal.  If so, clear out any state we
                 // have associated with any analyzers we have for that document/project.
-                ProcessDocumentOrProjectRemoval(e);
+                ProcessRemovedDiagnostics(e);
 
                 // Do some quick checks to avoid doing any further work for diagnostics  we don't
                 // care about.
@@ -210,13 +210,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 }
             }
 
-            private void ProcessDocumentOrProjectRemoval(DiagnosticsUpdatedArgs e)
+            private void ProcessRemovedDiagnostics(DiagnosticsUpdatedArgs e)
             {
-                if (e.Solution != null)
+                if (e.Kind != DiagnosticsUpdatedKind.DiagnosticsRemoved)
                 {
-                    // Wasn't a removal.  See DiagnosticIncrementalAnalyzer.RemoveDocument and RemoveProject.
-                    // In the cases where we're removing a document or project, the solution, projectId and
-                    // documentId are all null.
+                    // Wasn't a removal.  We don't need to do anything here.
                     return;
                 }
 

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -49,7 +49,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
 
         public void ClearDiagnostics(DebuggingSession session, Workspace workspace, object errorId, ProjectId projectId, DocumentId documentId)
         {
-            RaiseDiagnosticsUpdated(MakeArgs(session, workspace, errorId, projectId, documentId, ImmutableArray.Create<DiagnosticData>()));
+            RaiseDiagnosticsUpdated(MakeArgs(session, workspace, errorId, projectId, documentId, ImmutableArray.Create<DiagnosticData>(),
+                DiagnosticsUpdatedKind.DiagnosticsRemoved));
         }
 
         public ImmutableArray<DocumentId> ReportDiagnostics(DebuggingSession session, object errorId, ProjectId projectId, Solution solution, IEnumerable<Diagnostic> diagnostics)
@@ -60,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                 where document != null
                 let item = MakeDiagnosticData(projectId, document, solution, diagnostic)
                 group item by document.Id into itemsByDocumentId
-                select MakeArgs(session, errorId, solution.Workspace, solution, projectId, itemsByDocumentId.Key, ImmutableArray.CreateRange(itemsByDocumentId)));
+                select MakeArgs(session, errorId, solution.Workspace, solution, projectId, itemsByDocumentId.Key, ImmutableArray.CreateRange(itemsByDocumentId), DiagnosticsUpdatedKind.DiagnosticsCreated));
 
             foreach (var args in argsByDocument)
             {
@@ -85,13 +86,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
         }
 
         private DiagnosticsUpdatedArgs MakeArgs(
-            DebuggingSession session, Workspace workspace, object errorId, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items)
+            DebuggingSession session, Workspace workspace, object errorId, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items,
+            DiagnosticsUpdatedKind kind)
         {
-            return MakeArgs(session, errorId, workspace, solution: null, projectId: projectId, documentId: documentId, items: items);
+            return MakeArgs(session, errorId, workspace, solution: null, projectId: projectId, documentId: documentId, items: items, kind: kind);
         }
 
         private DiagnosticsUpdatedArgs MakeArgs(
-            DebuggingSession session, object errorId, Workspace workspace, Solution solution, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items)
+            DebuggingSession session, object errorId, Workspace workspace, Solution solution, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items,
+            DiagnosticsUpdatedKind kind)
         {
             return new DiagnosticsUpdatedArgs(
                 id: new EnCId(session, errorId),
@@ -99,7 +102,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                 solution: solution,
                 projectId: projectId,
                 documentId: documentId,
-                diagnostics: items);
+                diagnostics: items,
+                kind: kind);
         }
 
         private void RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs args)

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
@@ -97,7 +97,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var diagnostic = CreateDiagnosticData(workspace, project, document);
 
             source.RaiseUpdateEvent(
-                new DiagnosticsUpdatedArgs(id, workspace, workspace.CurrentSolution, project, document, ImmutableArray.Create(diagnostic)));
+                new DiagnosticsUpdatedArgs(id, workspace, workspace.CurrentSolution, project, document, ImmutableArray.Create(diagnostic),
+                DiagnosticsUpdatedKind.DiagnosticsCreated));
 
             set.WaitOne();
 

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
@@ -97,8 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var diagnostic = CreateDiagnosticData(workspace, project, document);
 
             source.RaiseUpdateEvent(
-                new DiagnosticsUpdatedArgs(id, workspace, workspace.CurrentSolution, project, document, ImmutableArray.Create(diagnostic),
-                DiagnosticsUpdatedKind.DiagnosticsCreated));
+                DiagnosticsUpdatedArgs.DiagnosticsCreated(id, workspace, workspace.CurrentSolution, project, document, ImmutableArray.Create(diagnostic)));
 
             set.WaitOne();
 

--- a/src/EditorFeatures/Test/Squiggles/AbstractSquiggleProducerTests.cs
+++ b/src/EditorFeatures/Test/Squiggles/AbstractSquiggleProducerTests.cs
@@ -7,17 +7,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
-using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             if (raiseDiagnosticsUpdated)
             {
-                RaiseDiagnosticsUpdated(MakeArgs(analyzer, dxs, project, DiagnosticsUpdatedKind.DiagnosticsCreated));
+                RaiseDiagnosticsUpdated(MakeCreatedArgs(analyzer, dxs, project));
             }
         }
 
@@ -115,36 +115,34 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     ImmutableInterlocked.TryUpdate(ref _analyzerHostDiagnosticsMap, analyzer, newDiags, existing))
                 {
                     var project = this.Workspace.CurrentSolution.GetProject(projectId);
-                    RaiseDiagnosticsUpdated(MakeArgs(analyzer, ImmutableHashSet<DiagnosticData>.Empty, project,
-                        DiagnosticsUpdatedKind.DiagnosticsRemoved));
+                    RaiseDiagnosticsUpdated(MakeRemovedArgs(analyzer, project));
                 }
             }
             else if (ImmutableInterlocked.TryRemove(ref _analyzerHostDiagnosticsMap, analyzer, out existing))
             {
                 var project = this.Workspace.CurrentSolution.GetProject(projectId);
-                RaiseDiagnosticsUpdated(MakeArgs(analyzer, ImmutableHashSet<DiagnosticData>.Empty, project,
-                    DiagnosticsUpdatedKind.DiagnosticsRemoved));
+                RaiseDiagnosticsUpdated(MakeRemovedArgs(analyzer, project));
 
                 if (existing.Any(d => d.ProjectId == null))
                 {
-                    RaiseDiagnosticsUpdated(MakeArgs(analyzer, ImmutableHashSet<DiagnosticData>.Empty, project: null,
-                        kind: DiagnosticsUpdatedKind.DiagnosticsRemoved));
+                    RaiseDiagnosticsUpdated(MakeRemovedArgs(analyzer, project: null));
                 }
             }
         }
 
-        private DiagnosticsUpdatedArgs MakeArgs(DiagnosticAnalyzer analyzer, ImmutableHashSet<DiagnosticData> items, Project project,
-            DiagnosticsUpdatedKind kind)
+        private DiagnosticsUpdatedArgs MakeCreatedArgs(DiagnosticAnalyzer analyzer, ImmutableHashSet<DiagnosticData> items, Project project)
         {
-            return new DiagnosticsUpdatedArgs(
-                kind: kind,
-                id: new HostArgsId(this, analyzer, project?.Id),
-                workspace: this.Workspace,
-                solution: project?.Solution,
-                projectId: project?.Id,
-                documentId: null,
-                diagnostics: items.ToImmutableArray());
+            return DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                CreateId(analyzer, project), this.Workspace, project?.Solution, project?.Id, documentId: null, diagnostics: items.ToImmutableArray());
         }
+
+        private DiagnosticsUpdatedArgs MakeRemovedArgs(DiagnosticAnalyzer analyzer, Project project)
+        {
+            return DiagnosticsUpdatedArgs.DiagnosticsRemoved(
+                CreateId(analyzer, project), this.Workspace, project?.Solution, project?.Id, documentId: null);
+        }
+
+        private HostArgsId CreateId(DiagnosticAnalyzer analyzer, Project project) => new HostArgsId(this, analyzer, project?.Id);
 
         internal ImmutableArray<DiagnosticData> TestOnly_GetReportedDiagnostics()
         {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticsUpdatedArgs.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticsUpdatedArgs.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ProjectId projectId,
             DocumentId documentId)
         {
-            return new DiagnosticsUpdatedArgs(id, workspace, solution, projectId, documentId, ImmutableArray<DiagnosticData>.Empty, DiagnosticsUpdatedKind.DiagnosticsCreated);
+            return new DiagnosticsUpdatedArgs(id, workspace, solution, projectId, documentId, ImmutableArray<DiagnosticData>.Empty, DiagnosticsUpdatedKind.DiagnosticsRemoved);
         }
     }
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticsUpdatedArgs.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticsUpdatedArgs.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Common;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public Solution Solution { get; }
         public ImmutableArray<DiagnosticData> Diagnostics { get; }
 
-        public DiagnosticsUpdatedArgs(
+        private DiagnosticsUpdatedArgs(
             object id,
             Workspace workspace,
             Solution solution,
@@ -25,6 +26,32 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Solution = solution;
             Diagnostics = diagnostics;
             Kind = kind;
+
+            if (kind == DiagnosticsUpdatedKind.DiagnosticsRemoved)
+            {
+                Debug.Assert(diagnostics.IsEmpty);
+            }
+        }
+
+        public static DiagnosticsUpdatedArgs DiagnosticsCreated(
+            object id,
+            Workspace workspace,
+            Solution solution,
+            ProjectId projectId,
+            DocumentId documentId,
+            ImmutableArray<DiagnosticData> diagnostics)
+        {
+            return new DiagnosticsUpdatedArgs(id, workspace, solution, projectId, documentId, diagnostics, DiagnosticsUpdatedKind.DiagnosticsCreated);
+        }
+
+        public static DiagnosticsUpdatedArgs DiagnosticsRemoved(
+            object id,
+            Workspace workspace,
+            Solution solution,
+            ProjectId projectId,
+            DocumentId documentId)
+        {
+            return new DiagnosticsUpdatedArgs(id, workspace, solution, projectId, documentId, ImmutableArray<DiagnosticData>.Empty, DiagnosticsUpdatedKind.DiagnosticsCreated);
         }
     }
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticsUpdatedArgs.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticsUpdatedArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Common;
 
@@ -7,15 +8,42 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal class DiagnosticsUpdatedArgs : UpdatedEventArgs
     {
+        public DiagnosticsUpdatedKind Kind { get; }
         public Solution Solution { get; }
         public ImmutableArray<DiagnosticData> Diagnostics { get; }
 
         public DiagnosticsUpdatedArgs(
-            object id, Workspace workspace, Solution solution, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics) :
-                base(id, workspace, projectId, documentId)
+            object id,
+            Workspace workspace,
+            Solution solution,
+            ProjectId projectId,
+            DocumentId documentId,
+            ImmutableArray<DiagnosticData> diagnostics,
+            DiagnosticsUpdatedKind kind)
+                : base(id, workspace, projectId, documentId)
         {
-            this.Solution = solution;
-            this.Diagnostics = diagnostics;
+            Solution = solution;
+            Diagnostics = diagnostics;
+            Kind = kind;
         }
+    }
+
+    internal enum DiagnosticsUpdatedKind
+    {
+        /// <summary>
+        /// Called when the diagnostic analyzer engine decides to remove existing diagnostics.
+        /// For example, this can happen when a document is removed from a solution.  In that
+        /// case the analyzer engine will delete all diagnostics associated with that document.
+        /// Any layers caching diagnostics should listen for these events to know when to 
+        /// delete their cached items entirely.
+        /// </summary>
+        DiagnosticsRemoved,
+
+        /// <summary>
+        /// Called when a new set of (possibly empty) diagnostics have been produced.  This
+        /// happens through normal editing and processing of files as diagnostic analyzers
+        /// produce new diagnostics for documents and projects.
+        /// </summary>
+        DiagnosticsCreated,
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.NestedTypes.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.NestedTypes.cs
@@ -109,8 +109,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             public ArgumentKey(DiagnosticAnalyzer analyzer, StateType stateType, object key) : base(analyzer)
             {
-                this.StateType = stateType;
-                this.Key = key;
+                StateType = stateType;
+                Key = key;
             }
 
             public override bool Equals(object obj)
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return false;
                 }
 
-                return StateType == other.StateType && Key == other.Key && base.Equals(obj);
+                return StateType == other.StateType && Equals(Key, other.Key) && base.Equals(obj);
             }
 
             public override int GetHashCode()

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var data = await _executor.GetSyntaxAnalysisDataAsync(userDiagnosticDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticsUpdated(StateType.Syntax, document.Id, stateSet, new SolutionArgument(document), data.Items, DiagnosticsUpdatedKind.DiagnosticsCreated);
+                            RaiseDiagnosticsCreated(StateType.Syntax, document.Id, stateSet, new SolutionArgument(document), data.Items);
                             continue;
                         }
 
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticsUpdated(StateType.Document, document.Id, stateSet, new SolutionArgument(document), data.Items, DiagnosticsUpdatedKind.DiagnosticsCreated);
+                            RaiseDiagnosticsCreated(StateType.Document, document.Id, stateSet, new SolutionArgument(document), data.Items);
                             continue;
                         }
 
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var data = await _executor.GetDocumentAnalysisDataAsync(userDiagnosticDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticsUpdated(StateType.Document, document.Id, stateSet, new SolutionArgument(document), data.Items, DiagnosticsUpdatedKind.DiagnosticsCreated);
+                            RaiseDiagnosticsCreated(StateType.Document, document.Id, stateSet, new SolutionArgument(document), data.Items);
                             continue;
                         }
 
@@ -434,8 +434,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     var solutionArgs = new SolutionArgument(null, documentId.ProjectId, documentId);
                     for (var stateType = 0; stateType < s_stateTypeCount; stateType++)
                     {
-                        RaiseDiagnosticsUpdated((StateType)stateType, documentId, stateSet, solutionArgs, ImmutableArray<DiagnosticData>.Empty,
-                            DiagnosticsUpdatedKind.DiagnosticsRemoved);
+                        RaiseDiagnosticsRemoved((StateType)stateType, documentId, stateSet, solutionArgs);
                     }
                 }
             }
@@ -450,8 +449,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     stateSet.Remove(projectId);
 
                     var solutionArgs = new SolutionArgument(null, projectId, null);
-                    RaiseDiagnosticsUpdated(StateType.Project, projectId, stateSet, solutionArgs, ImmutableArray<DiagnosticData>.Empty,
-                        DiagnosticsUpdatedKind.DiagnosticsRemoved);
+                    RaiseDiagnosticsRemoved(StateType.Project, projectId, stateSet, solutionArgs);
                 }
             }
 
@@ -603,8 +601,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return;
             }
 
-            RaiseDiagnosticsUpdated(type, document.Id, stateSet, new SolutionArgument(document), newItems,
-                DiagnosticsUpdatedKind.DiagnosticsCreated);
+            RaiseDiagnosticsCreated(type, document.Id, stateSet, new SolutionArgument(document), newItems);
         }
 
         private void RaiseProjectDiagnosticsUpdatedIfNeeded(
@@ -633,15 +630,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             {
                 if (documentId == null)
                 {
-                    RaiseDiagnosticsUpdated(StateType.Project, project.Id, stateSet, new SolutionArgument(project), ImmutableArray<DiagnosticData>.Empty,
-                        DiagnosticsUpdatedKind.DiagnosticsRemoved);
+                    RaiseDiagnosticsRemoved(StateType.Project, project.Id, stateSet, new SolutionArgument(project));
                     continue;
                 }
 
                 var document = project.GetDocument(documentId);
                 var argument = documentId == null ? new SolutionArgument(null, documentId.ProjectId, documentId) : new SolutionArgument(document);
-                RaiseDiagnosticsUpdated(StateType.Project, documentId, stateSet, argument, ImmutableArray<DiagnosticData>.Empty,
-                    DiagnosticsUpdatedKind.DiagnosticsRemoved);
+                RaiseDiagnosticsRemoved(StateType.Project, documentId, stateSet, argument);
             }
         }
 
@@ -652,13 +647,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             {
                 if (kv.Key == null)
                 {
-                    RaiseDiagnosticsUpdated(StateType.Project, project.Id, stateSet, new SolutionArgument(project), kv.ToImmutableArrayOrEmpty(),
-                        DiagnosticsUpdatedKind.DiagnosticsCreated);
+                    RaiseDiagnosticsCreated(StateType.Project, project.Id, stateSet, new SolutionArgument(project), kv.ToImmutableArrayOrEmpty());
                     continue;
                 }
 
-                RaiseDiagnosticsUpdated(StateType.Project, kv.Key, stateSet, new SolutionArgument(project.GetDocument(kv.Key)), kv.ToImmutableArrayOrEmpty(),
-                    DiagnosticsUpdatedKind.DiagnosticsCreated);
+                RaiseDiagnosticsCreated(StateType.Project, kv.Key, stateSet, new SolutionArgument(project.GetDocument(kv.Key)), kv.ToImmutableArrayOrEmpty());
             }
         }
 
@@ -667,9 +660,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             return lookup.Contains(documentId) ? lookup[documentId].ToImmutableArrayOrEmpty() : ImmutableArray<DiagnosticData>.Empty;
         }
 
-        private void RaiseDiagnosticsUpdated(
-            StateType type, object key, StateSet stateSet, SolutionArgument solution, ImmutableArray<DiagnosticData> diagnostics,
-            DiagnosticsUpdatedKind kind)
+        private void RaiseDiagnosticsCreated(
+            StateType type, object key, StateSet stateSet, SolutionArgument solution, ImmutableArray<DiagnosticData> diagnostics)
         {
             if (Owner == null)
             {
@@ -677,11 +669,32 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             }
 
             // get right arg id for the given analyzer
-            var id = stateSet.ErrorSourceName != null ?
-                new HostAnalyzerKey(stateSet.Analyzer, type, key, stateSet.ErrorSourceName) : (object)new ArgumentKey(stateSet.Analyzer, type, key);
+            var id = CreateArgumentKey(type, key, stateSet);
 
             Owner.RaiseDiagnosticsUpdated(this,
-                new DiagnosticsUpdatedArgs(id, Workspace, solution.Solution, solution.ProjectId, solution.DocumentId, diagnostics, kind));
+                DiagnosticsUpdatedArgs.DiagnosticsCreated(id, Workspace, solution.Solution, solution.ProjectId, solution.DocumentId, diagnostics));
+        }
+
+        private static ArgumentKey CreateArgumentKey(StateType type, object key, StateSet stateSet)
+        {
+            return stateSet.ErrorSourceName != null
+                ? new HostAnalyzerKey(stateSet.Analyzer, type, key, stateSet.ErrorSourceName)
+                : new ArgumentKey(stateSet.Analyzer, type, key);
+        }
+
+        private void RaiseDiagnosticsRemoved(
+            StateType type, object key, StateSet stateSet, SolutionArgument solution)
+        {
+            if (Owner == null)
+            {
+                return;
+            }
+
+            // get right arg id for the given analyzer
+            var id = CreateArgumentKey(type, key, stateSet);
+
+            Owner.RaiseDiagnosticsUpdated(this,
+                DiagnosticsUpdatedArgs.DiagnosticsRemoved(id, Workspace, solution.Solution, solution.ProjectId, solution.DocumentId));
         }
 
         private ImmutableArray<DiagnosticData> UpdateDocumentDiagnostics(
@@ -928,8 +941,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 var documentId = document.Id;
                 var solutionArgs = new SolutionArgument(document);
 
-                RaiseDiagnosticsUpdated(type, document.Id, stateSet, solutionArgs, ImmutableArray<DiagnosticData>.Empty,
-                    DiagnosticsUpdatedKind.DiagnosticsRemoved);
+                RaiseDiagnosticsRemoved(type, document.Id, stateSet, solutionArgs);
             }
         }
 
@@ -956,8 +968,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             // raise diagnostic updated event
             var solutionArgs = new SolutionArgument(project);
-            RaiseDiagnosticsUpdated(StateType.Project, project.Id, stateSet, solutionArgs, ImmutableArray<DiagnosticData>.Empty,
-                DiagnosticsUpdatedKind.DiagnosticsRemoved);
+            RaiseDiagnosticsRemoved(StateType.Project, project.Id, stateSet, solutionArgs);
         }
 
         private async Task ClearExistingDiagnostics(Document document, StateSet stateSet, StateType type, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -39,8 +39,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                     var mergedDiagnostics = MergeDiagnostics(liveDiagnostics, GetExistingDiagnostics(existingDiagnostics));
                     await state.PersistAsync(project, new AnalysisData(projectTextVersion, semanticVersion, mergedDiagnostics), CancellationToken.None).ConfigureAwait(false);
-                    RaiseDiagnosticsUpdated(StateType.Project, project.Id, stateSet, new SolutionArgument(project), mergedDiagnostics,
-                        DiagnosticsUpdatedKind.DiagnosticsCreated);
+                    RaiseDiagnosticsCreated(StateType.Project, project.Id, stateSet, new SolutionArgument(project), mergedDiagnostics);
                 }
             }
         }
@@ -106,8 +105,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             var mergedDiagnostics = MergeDiagnostics(diagnostics, GetExistingDiagnostics(existingDiagnostics));
             await state.PersistAsync(document, new AnalysisData(textVersion, semanticVersion, mergedDiagnostics), CancellationToken.None).ConfigureAwait(false);
-            RaiseDiagnosticsUpdated(stateType, document.Id, stateSet, new SolutionArgument(document), mergedDiagnostics,
-                DiagnosticsUpdatedKind.DiagnosticsCreated);
+            RaiseDiagnosticsCreated(stateType, document.Id, stateSet, new SolutionArgument(document), mergedDiagnostics);
         }
 
         private static ImmutableArray<DiagnosticData> GetExistingDiagnostics(AnalysisData analysisData)

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -39,7 +39,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                     var mergedDiagnostics = MergeDiagnostics(liveDiagnostics, GetExistingDiagnostics(existingDiagnostics));
                     await state.PersistAsync(project, new AnalysisData(projectTextVersion, semanticVersion, mergedDiagnostics), CancellationToken.None).ConfigureAwait(false);
-                    RaiseDiagnosticsUpdated(StateType.Project, project.Id, stateSet, new SolutionArgument(project), mergedDiagnostics);
+                    RaiseDiagnosticsUpdated(StateType.Project, project.Id, stateSet, new SolutionArgument(project), mergedDiagnostics,
+                        DiagnosticsUpdatedKind.DiagnosticsCreated);
                 }
             }
         }
@@ -105,7 +106,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             var mergedDiagnostics = MergeDiagnostics(diagnostics, GetExistingDiagnostics(existingDiagnostics));
             await state.PersistAsync(document, new AnalysisData(textVersion, semanticVersion, mergedDiagnostics), CancellationToken.None).ConfigureAwait(false);
-            RaiseDiagnosticsUpdated(stateType, document.Id, stateSet, new SolutionArgument(document), mergedDiagnostics);
+            RaiseDiagnosticsUpdated(stateType, document.Id, stateSet, new SolutionArgument(document), mergedDiagnostics,
+                DiagnosticsUpdatedKind.DiagnosticsCreated);
         }
 
         private static ImmutableArray<DiagnosticData> GetExistingDiagnostics(AnalysisData analysisData)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -61,18 +61,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         public override void RemoveDocument(DocumentId documentId)
         {
-            Owner.RaiseDiagnosticsUpdated(
-                this, new DiagnosticsUpdatedArgs(
-                    ValueTuple.Create(this, documentId), Workspace, null, null, null, ImmutableArray<DiagnosticData>.Empty,
-                    DiagnosticsUpdatedKind.DiagnosticsRemoved));
+            Owner.RaiseDiagnosticsUpdated(this, DiagnosticsUpdatedArgs.DiagnosticsRemoved(
+                ValueTuple.Create(this, documentId), Workspace, null, null, null));
         }
 
         public override void RemoveProject(ProjectId projectId)
         {
-            Owner.RaiseDiagnosticsUpdated(
-                this, new DiagnosticsUpdatedArgs(
-                    ValueTuple.Create(this, projectId), Workspace, null, null, null, ImmutableArray<DiagnosticData>.Empty,
-                    DiagnosticsUpdatedKind.DiagnosticsRemoved));
+            Owner.RaiseDiagnosticsUpdated(this, DiagnosticsUpdatedArgs.DiagnosticsRemoved(
+                ValueTuple.Create(this, projectId), Workspace, null, null, null));
         }
         #endregion
 
@@ -218,16 +214,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 if (kv.Key == null)
                 {
                     Owner.RaiseDiagnosticsUpdated(
-                        this, new DiagnosticsUpdatedArgs(
-                            ValueTuple.Create(this, project.Id), workspace, solution, project.Id, null, kv.ToImmutableArrayOrEmpty(),
-                            kind: DiagnosticsUpdatedKind.DiagnosticsCreated));
+                        this, DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                            ValueTuple.Create(this, project.Id), workspace, solution, project.Id, null, kv.ToImmutableArrayOrEmpty()));
                     continue;
                 }
 
                 Owner.RaiseDiagnosticsUpdated(
-                    this, new DiagnosticsUpdatedArgs(
-                        ValueTuple.Create(this, kv.Key), workspace, solution, project.Id, kv.Key, kv.ToImmutableArrayOrEmpty(),
-                        kind: DiagnosticsUpdatedKind.DiagnosticsCreated));
+                    this, DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                        ValueTuple.Create(this, kv.Key), workspace, solution, project.Id, kv.Key, kv.ToImmutableArrayOrEmpty()));
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -62,13 +62,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         public override void RemoveDocument(DocumentId documentId)
         {
             Owner.RaiseDiagnosticsUpdated(
-                this, new DiagnosticsUpdatedArgs(ValueTuple.Create(this, documentId), Workspace, null, null, null, ImmutableArray<DiagnosticData>.Empty));
+                this, new DiagnosticsUpdatedArgs(
+                    ValueTuple.Create(this, documentId), Workspace, null, null, null, ImmutableArray<DiagnosticData>.Empty,
+                    DiagnosticsUpdatedKind.DiagnosticsRemoved));
         }
 
         public override void RemoveProject(ProjectId projectId)
         {
             Owner.RaiseDiagnosticsUpdated(
-                this, new DiagnosticsUpdatedArgs(ValueTuple.Create(this, projectId), Workspace, null, null, null, ImmutableArray<DiagnosticData>.Empty));
+                this, new DiagnosticsUpdatedArgs(
+                    ValueTuple.Create(this, projectId), Workspace, null, null, null, ImmutableArray<DiagnosticData>.Empty,
+                    DiagnosticsUpdatedKind.DiagnosticsRemoved));
         }
         #endregion
 
@@ -215,13 +219,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     Owner.RaiseDiagnosticsUpdated(
                         this, new DiagnosticsUpdatedArgs(
-                            ValueTuple.Create(this, project.Id), workspace, solution, project.Id, null, kv.ToImmutableArrayOrEmpty()));
+                            ValueTuple.Create(this, project.Id), workspace, solution, project.Id, null, kv.ToImmutableArrayOrEmpty(),
+                            kind: DiagnosticsUpdatedKind.DiagnosticsCreated));
                     continue;
                 }
 
                 Owner.RaiseDiagnosticsUpdated(
                     this, new DiagnosticsUpdatedArgs(
-                        ValueTuple.Create(this, kv.Key), workspace, solution, project.Id, kv.Key, kv.ToImmutableArrayOrEmpty()));
+                        ValueTuple.Create(this, kv.Key), workspace, solution, project.Id, kv.Key, kv.ToImmutableArrayOrEmpty(),
+                        kind: DiagnosticsUpdatedKind.DiagnosticsCreated));
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -536,7 +536,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     solution: null,
                     projectId: null,
                     documentId: null,
-                    diagnostics: ImmutableArray.Create<DiagnosticData>(diagnostic));
+                    diagnostics: ImmutableArray.Create<DiagnosticData>(diagnostic),
+                    kind: DiagnosticsUpdatedKind.DiagnosticsCreated);
 
                 _hostUpdateSource.RaiseDiagnosticsUpdated(args);
             }

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -530,14 +530,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var diagnostic = AnalyzerHelper.CreateAnalyzerLoadFailureDiagnostic(reference.FullPath, e);
 
                 // diagnostic from host analyzer can never go away
-                var args = new DiagnosticsUpdatedArgs(
+                var args = DiagnosticsUpdatedArgs.DiagnosticsCreated(
                     id: Tuple.Create(this, reference.FullPath, e.ErrorCode, e.TypeName),
                     workspace: PrimaryWorkspace.Workspace,
                     solution: null,
                     projectId: null,
                     documentId: null,
-                    diagnostics: ImmutableArray.Create<DiagnosticData>(diagnostic),
-                    kind: DiagnosticsUpdatedKind.DiagnosticsCreated);
+                    diagnostics: ImmutableArray.Create<DiagnosticData>(diagnostic));
 
                 _hostUpdateSource.RaiseDiagnosticsUpdated(args);
             }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -92,9 +92,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
                 var diagnosticData = diagnostics == null ? ImmutableArray<DiagnosticData>.Empty : diagnostics.Select(d => DiagnosticData.Create(document, d)).ToImmutableArrayOrEmpty();
                 _service.RaiseDiagnosticsUpdated(
-                    new DiagnosticsUpdatedArgs(new MiscUpdateArgsId(document.Id),
-                    _workspace, document.Project.Solution, document.Project.Id, document.Id, diagnosticData,
-                    DiagnosticsUpdatedKind.DiagnosticsCreated));
+                    DiagnosticsUpdatedArgs.DiagnosticsCreated(new MiscUpdateArgsId(document.Id),
+                    _workspace, document.Project.Solution, document.Project.Id, document.Id, diagnosticData));
             }
 
             public void RemoveDocument(DocumentId documentId)
@@ -121,8 +120,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             private void RaiseEmptyDiagnosticUpdated(DocumentId documentId)
             {
-                _service.RaiseDiagnosticsUpdated(new DiagnosticsUpdatedArgs(ValueTuple.Create(this, documentId), _workspace, null, documentId.ProjectId, documentId, ImmutableArray<DiagnosticData>.Empty,
-                    DiagnosticsUpdatedKind.DiagnosticsRemoved));
+                _service.RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs.DiagnosticsRemoved(
+                    ValueTuple.Create(this, documentId), _workspace, null, documentId.ProjectId, documentId));
             }
 
             // method we don't care. misc project only supports syntax errors

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -93,7 +93,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 var diagnosticData = diagnostics == null ? ImmutableArray<DiagnosticData>.Empty : diagnostics.Select(d => DiagnosticData.Create(document, d)).ToImmutableArrayOrEmpty();
                 _service.RaiseDiagnosticsUpdated(
                     new DiagnosticsUpdatedArgs(new MiscUpdateArgsId(document.Id),
-                    _workspace, document.Project.Solution, document.Project.Id, document.Id, diagnosticData));
+                    _workspace, document.Project.Solution, document.Project.Id, document.Id, diagnosticData,
+                    DiagnosticsUpdatedKind.DiagnosticsCreated));
             }
 
             public void RemoveDocument(DocumentId documentId)
@@ -120,7 +121,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             private void RaiseEmptyDiagnosticUpdated(DocumentId documentId)
             {
-                _service.RaiseDiagnosticsUpdated(new DiagnosticsUpdatedArgs(ValueTuple.Create(this, documentId), _workspace, null, documentId.ProjectId, documentId, ImmutableArray<DiagnosticData>.Empty));
+                _service.RaiseDiagnosticsUpdated(new DiagnosticsUpdatedArgs(ValueTuple.Create(this, documentId), _workspace, null, documentId.ProjectId, documentId, ImmutableArray<DiagnosticData>.Empty,
+                    DiagnosticsUpdatedKind.DiagnosticsRemoved));
             }
 
             // method we don't care. misc project only supports syntax errors

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -282,13 +282,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             var project = item as Project;
             if (project != null)
             {
-                RaiseDiagnosticsUpdated(project.Id, project.Id, null, buildErrors);
+                RaiseDiagnosticsUpdated(project.Id, project.Id, null, buildErrors, DiagnosticsUpdatedKind.DiagnosticsCreated);
                 return;
             }
 
             // must be not null
             var document = item as Document;
-            RaiseDiagnosticsUpdated(document.Id, document.Project.Id, document.Id, buildErrors);
+            RaiseDiagnosticsUpdated(document.Id, document.Project.Id, document.Id, buildErrors, DiagnosticsUpdatedKind.DiagnosticsCreated);
         }
 
         private Dictionary<ProjectId, HashSet<string>> GetSupportedLiveDiagnosticId(Solution solution, InprogressState state)
@@ -308,7 +308,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         private void ClearProjectErrors(ProjectId projectId, Solution solution = null)
         {
             // remove all project errors
-            RaiseDiagnosticsUpdated(projectId, projectId, null, ImmutableArray<DiagnosticData>.Empty);
+            RaiseDiagnosticsUpdated(projectId, projectId, null, ImmutableArray<DiagnosticData>.Empty, DiagnosticsUpdatedKind.DiagnosticsRemoved);
 
             var project = (solution ?? _workspace.CurrentSolution).GetProject(projectId);
             if (project == null)
@@ -325,7 +325,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
         private void ClearDocumentErrors(ProjectId projectId, DocumentId documentId)
         {
-            RaiseDiagnosticsUpdated(documentId, projectId, documentId, ImmutableArray<DiagnosticData>.Empty);
+            RaiseDiagnosticsUpdated(documentId, projectId, documentId, ImmutableArray<DiagnosticData>.Empty, DiagnosticsUpdatedKind.DiagnosticsRemoved);
         }
 
         public void AddNewErrors(DocumentId documentId, DiagnosticData diagnostic)
@@ -363,10 +363,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             return _state;
         }
 
-        private void RaiseDiagnosticsUpdated(object id, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items)
+        private void RaiseDiagnosticsUpdated(object id, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items,
+            DiagnosticsUpdatedKind kind)
         {
             DiagnosticsUpdated?.Invoke(this, new DiagnosticsUpdatedArgs(
-                   new ArgumentKey(id), _workspace, _workspace.CurrentSolution, projectId, documentId, items));
+                   new ArgumentKey(id), _workspace, _workspace.CurrentSolution, projectId, documentId, items, kind));
         }
 
         private void RaiseBuildStarted(bool started)

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
@@ -37,7 +37,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             }
         }
 
-        private void RaiseDiagnosticsUpdatedForProject(ProjectId projectId, object key, IEnumerable<DiagnosticData> items)
+        private void RaiseDiagnosticsUpdatedForProject(ProjectId projectId, object key, IEnumerable<DiagnosticData> items,
+            DiagnosticsUpdatedKind kind)
         {
             var args = new DiagnosticsUpdatedArgs(
                 id: Tuple.Create(this, projectId, key),
@@ -45,7 +46,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 solution: null,
                 projectId: projectId,
                 documentId: null,
-                diagnostics: items.AsImmutableOrEmpty());
+                diagnostics: items.AsImmutableOrEmpty(),
+                kind: kind);
 
             RaiseDiagnosticsUpdated(args);
         }
@@ -61,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 _diagnosticMap.GetOrAdd(projectId, id => new HashSet<object>()).Add(key);
             }
 
-            RaiseDiagnosticsUpdatedForProject(projectId, key, items);
+            RaiseDiagnosticsUpdatedForProject(projectId, key, items, DiagnosticsUpdatedKind.DiagnosticsCreated);
         }
 
         public void ClearAllDiagnosticsForProject(ProjectId projectId)
@@ -81,7 +83,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             {
                 foreach (var key in projectDiagnosticKeys)
                 {
-                    RaiseDiagnosticsUpdatedForProject(projectId, key, SpecializedCollections.EmptyEnumerable<DiagnosticData>());
+                    RaiseDiagnosticsUpdatedForProject(projectId, key, SpecializedCollections.EmptyEnumerable<DiagnosticData>(), 
+                        DiagnosticsUpdatedKind.DiagnosticsRemoved);
                 }
             }
         }
@@ -103,7 +106,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
             if (raiseEvent)
             {
-                RaiseDiagnosticsUpdatedForProject(projectId, key, SpecializedCollections.EmptyEnumerable<DiagnosticData>());
+                RaiseDiagnosticsUpdatedForProject(projectId, key, SpecializedCollections.EmptyEnumerable<DiagnosticData>(),
+                    DiagnosticsUpdatedKind.DiagnosticsRemoved);
             }
         }
     }

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -737,33 +737,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim item = items(0)
 
                 Dim id = If(CObj(item.DocumentId), item.ProjectId)
-                RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                        New ErrorId(Me, id), workspace, workspace.CurrentSolution, item.ProjectId, item.DocumentId, items.ToImmutableArray(),
-                        DiagnosticsUpdatedKind.DiagnosticsCreated))
+                RaiseEvent DiagnosticsUpdated(Me, DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                        New ErrorId(Me, id), workspace, workspace.CurrentSolution, item.ProjectId, item.DocumentId, items.ToImmutableArray()))
             End Sub
 
             Public Sub RaiseDiagnosticsUpdated(workspace As Workspace)
                 Dim documentMap = Items.Where(Function(t) t.DocumentId IsNot Nothing).Where(Function(t) t.Workspace Is workspace).ToLookup(Function(t) t.DocumentId)
 
                 For Each group In documentMap
-                    RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key.ProjectId, group.Key, group.ToImmutableArrayOrEmpty(),
-                        DiagnosticsUpdatedKind.DiagnosticsCreated))
+                    RaiseEvent DiagnosticsUpdated(Me, DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key.ProjectId, group.Key, group.ToImmutableArrayOrEmpty()))
                 Next
 
                 Dim projectMap = Items.Where(Function(t) t.DocumentId Is Nothing).Where(Function(t) t.Workspace Is workspace).ToLookup(Function(t) t.ProjectId)
 
                 For Each group In projectMap
-                    RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key, Nothing, group.ToImmutableArrayOrEmpty(),
-                        DiagnosticsUpdatedKind.DiagnosticsCreated))
+                    RaiseEvent DiagnosticsUpdated(Me, DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key, Nothing, group.ToImmutableArrayOrEmpty()))
                 Next
             End Sub
 
             Public Sub RaiseClearDiagnosticsUpdated(workspace As Workspace, projectId As ProjectId, documentId As DocumentId)
-                RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                    New ErrorId(Me, documentId), workspace, workspace.CurrentSolution, projectId, documentId, ImmutableArray(Of DiagnosticData).Empty,
-                    DiagnosticsUpdatedKind.DiagnosticsRemoved))
+                RaiseEvent DiagnosticsUpdated(Me, DiagnosticsUpdatedArgs.DiagnosticsRemoved(
+                    New ErrorId(Me, documentId), workspace, workspace.CurrentSolution, projectId, documentId))
             End Sub
 
             Private Class ErrorId

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -738,7 +738,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim id = If(CObj(item.DocumentId), item.ProjectId)
                 RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                        New ErrorId(Me, id), workspace, workspace.CurrentSolution, item.ProjectId, item.DocumentId, items.ToImmutableArray()))
+                        New ErrorId(Me, id), workspace, workspace.CurrentSolution, item.ProjectId, item.DocumentId, items.ToImmutableArray(),
+                        DiagnosticsUpdatedKind.DiagnosticsCreated))
             End Sub
 
             Public Sub RaiseDiagnosticsUpdated(workspace As Workspace)
@@ -746,20 +747,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 For Each group In documentMap
                     RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key.ProjectId, group.Key, group.ToImmutableArrayOrEmpty()))
+                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key.ProjectId, group.Key, group.ToImmutableArrayOrEmpty(),
+                        DiagnosticsUpdatedKind.DiagnosticsCreated))
                 Next
 
                 Dim projectMap = Items.Where(Function(t) t.DocumentId Is Nothing).Where(Function(t) t.Workspace Is workspace).ToLookup(Function(t) t.ProjectId)
 
                 For Each group In projectMap
                     RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key, Nothing, group.ToImmutableArrayOrEmpty()))
+                        New ErrorId(Me, group.Key), workspace, workspace.CurrentSolution, group.Key, Nothing, group.ToImmutableArrayOrEmpty(),
+                        DiagnosticsUpdatedKind.DiagnosticsCreated))
                 Next
             End Sub
 
             Public Sub RaiseClearDiagnosticsUpdated(workspace As Workspace, projectId As ProjectId, documentId As DocumentId)
                 RaiseEvent DiagnosticsUpdated(Me, New DiagnosticsUpdatedArgs(
-                    New ErrorId(Me, documentId), workspace, workspace.CurrentSolution, projectId, documentId, ImmutableArray(Of DiagnosticData).Empty))
+                    New ErrorId(Me, documentId), workspace, workspace.CurrentSolution, projectId, documentId, ImmutableArray(Of DiagnosticData).Empty,
+                    DiagnosticsUpdatedKind.DiagnosticsRemoved))
             End Sub
 
             Private Class ErrorId


### PR DESCRIPTION
This affects TS as they routlinely close/open projects behind the scenes, while still using the
current editor buffer.