### PR TITLE
[AskMode] Fix `GetOverlap` method of `SortedSpans`

### DIFF
--- a/src/InteractiveWindow/Editor/Output/SortedSpans.cs
+++ b/src/InteractiveWindow/Editor/Output/SortedSpans.cs
@@ -62,19 +62,16 @@ namespace Microsoft.VisualStudio.InteractiveWindow
 
                 // If span is not found in _span, BinarySearch returns a negative number that is the 
                 // bitwise complement of the index of the next span with larger starting index, or if
-                // there is no such span, the bitwise complement of _span.Count.
-
-                // Try get next span in _span with larger starting index, in case the span starts 
-                // before the first one in _span, e.g. span starts within the logo of interactive window.
-                // If there's truly no overlap, then the for-loop will stop before first iteration.
+                // there is no such span, the bitwise complement of _span.Count.   
+                
+                // Try get the span before the one with next larger starting index on in the list,
+                // unless the first span is the next larger one, then we just get the first one. 
                 if (startIndex < 0)
                 {
                     startIndex = ~startIndex;
                 }
-
-                // It still possible that the it overlaps with last span in _span,
-                // so we will only check the last one.
-                if (startIndex == count)
+                                                       
+                if (startIndex > 0)
                 {
                     startIndex = startIndex - 1;
                 }

--- a/src/InteractiveWindow/Editor/Output/SortedSpans.cs
+++ b/src/InteractiveWindow/Editor/Output/SortedSpans.cs
@@ -69,11 +69,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 if (startIndex < 0)
                 {
                     startIndex = ~startIndex;
-                }
-                                                       
-                if (startIndex > 0)
-                {
-                    startIndex = startIndex - 1;
+
+                    if (startIndex > 0)
+                    {
+                        startIndex = startIndex - 1;
+                    }
                 }
 
                 Debug.Assert(startIndex >= 0);

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTest.csproj
@@ -79,6 +79,7 @@
     <Compile Include="HistoryTests.cs" />
     <Compile Include="InteractiveWindowHistoryTests.cs" />
     <Compile Include="InteractiveWindowTests.cs" />
+    <Compile Include="SortedSpansTests.cs" />
     <Compile Include="TestClipboard.cs" />
     <Compile Include="TestContentTypeDefinition.cs" />
     <Compile Include="TestInteractiveEngine.cs" />

--- a/src/InteractiveWindow/EditorTest/SortedSpansTests.cs
+++ b/src/InteractiveWindow/EditorTest/SortedSpansTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+using Xunit;
+
+namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
+{
+    public class SortedSpansTests
+    {
+        [Fact]
+        public void CheckOverlap()
+        {
+            var spans = new SortedSpans();
+
+            // no overlap with empty span list 
+            Assert.Empty(spans.GetOverlap(new Span(0, 10)));
+
+            // add span [10, 20)
+            spans.Add(new Span(10, 10));
+            // no overlap with [0, 5)
+            Assert.Empty(spans.GetOverlap(new Span(0, 5))); 
+            // no overlap with [25, 30)
+            Assert.Empty(spans.GetOverlap(new Span(25, 5)));
+            // no overlap with [0, 10)
+            Assert.Empty(spans.GetOverlap(new Span(0, 10)));
+            // no overlap with [20, 30)
+            Assert.Empty(spans.GetOverlap(new Span(20, 10)));
+            // overlap with [5, 15)
+            Assert.Equal(new Span[] { new Span(10, 5) },
+                         spans.GetOverlap(new Span(5, 10)));
+            // overlap with [0, 11)
+            Assert.Equal(new Span[] { new Span(10, 1) }, 
+                         spans.GetOverlap(new Span(0, 11)));
+            // overlap with [15, 25)
+            Assert.Equal(new Span[] { new Span(15, 5) },
+                         spans.GetOverlap(new Span(15, 10)));
+            // overlap with [11, 15]
+            Assert.Equal(new Span[] { new Span(11, 5) },
+                         spans.GetOverlap(new Span(11, 5)));
+            // overlap with [10, 20)
+            Assert.Equal(new Span[] { new Span(10, 10) },
+                         spans.GetOverlap(new Span(10, 10)));
+            // overlap with [0, 30)
+            Assert.Equal(new Span[] { new Span(10, 10) },
+                         spans.GetOverlap(new Span(0, 30)));
+
+            // now has both [10, 20) and [30, 40)
+            spans.Add(new Span(30, 10));
+
+            // no overlap with [20, 30)
+            Assert.Empty(spans.GetOverlap(new Span(20, 10)));
+            // no overlap with [0, 10)
+            Assert.Empty(spans.GetOverlap(new Span(0, 10)));
+            // no overlap with [40, 50)
+            Assert.Empty(spans.GetOverlap(new Span(40, 10)));
+
+            // overlap with [0, 15)
+            Assert.Equal(new Span[] { new Span(10, 5) },
+                         spans.GetOverlap(new Span(0, 15)));
+            // overlap with [20, 35)   
+            Assert.Equal(new Span[] { new Span(30, 5) },
+                         spans.GetOverlap(new Span(20, 15)));
+
+            // overlap with [0, 35) 
+            Assert.Equal(new Span[] { new Span(10, 10), new Span(30, 5) },
+                         spans.GetOverlap(new Span(0, 35)));
+            // overlap with [15, 35)  
+            Assert.Equal(new Span[] { new Span(15, 5), new Span(30, 5) },
+                         spans.GetOverlap(new Span(15, 20)));
+            // overlap with [15, 50)
+            Assert.Equal(new Span[] { new Span(15, 5), new Span(30, 10) },
+                         spans.GetOverlap(new Span(15, 35)));
+            // overlap with [0, 25) 
+            Assert.Equal(new Span[] { new Span(10, 10) },
+                         spans.GetOverlap(new Span(0, 25)));
+            // overlap with [25, 45) 
+            Assert.Equal(new Span[] { new Span(30, 10) },
+                         spans.GetOverlap(new Span(25, 20)));
+            // overlap with [0, 50)
+            Assert.Equal(new Span[] { new Span(10, 10), new Span(30, 10) },
+                         spans.GetOverlap(new Span(0, 50)));
+        }
+    }
+}

--- a/src/InteractiveWindow/EditorTest/SortedSpansTests.cs
+++ b/src/InteractiveWindow/EditorTest/SortedSpansTests.cs
@@ -42,7 +42,14 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
                          spans.GetOverlap(new Span(10, 10)));
             // overlap with [0, 30)
             Assert.Equal(new Span[] { new Span(10, 10) },
-                         spans.GetOverlap(new Span(0, 30)));
+                         spans.GetOverlap(new Span(0, 30))); 
+
+            // no overlap with [0, 0]
+            Assert.Empty(spans.GetOverlap(new Span(0, 0)));
+            // no overlap with [10, 10]
+            Assert.Empty(spans.GetOverlap(new Span(10, 0)));
+            // no overlap with [15, 15]
+            Assert.Empty(spans.GetOverlap(new Span(15, 0)));
 
             // now has both [10, 20) and [30, 40)
             spans.Add(new Span(30, 10));


### PR DESCRIPTION
The result is correctly preserved color for error message when copied from interactive window.
Fix https://github.com/dotnet/roslyn/issues/6100.

@dotnet/interactive 