### PR TITLE
Add expansion rule to add cast to lambda expression bodies

### DIFF
--- a/src/EditorFeatures/Test2/Expansion/AbstractExpansionTest.vb
+++ b/src/EditorFeatures/Test2/Expansion/AbstractExpansionTest.vb
@@ -1,18 +1,16 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Simplification
-Imports Microsoft.CodeAnalysis.Text
 Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Expansion
     Public MustInherit Class AbstractExpansionTest
 
-        Protected Sub Test(definition As XElement, expected As XElement, Optional useLastProject As Boolean = False)
+        Protected Sub Test(definition As XElement, expected As XElement, Optional useLastProject As Boolean = False, Optional expandParameter As Boolean = False)
             Using workspace = TestWorkspaceFactory.CreateWorkspace(definition)
                 Dim hostDocument = If(Not useLastProject, workspace.Documents.Single(), workspace.Documents.Last())
 
@@ -28,12 +26,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Expansion
                 If (hostDocument.AnnotatedSpans.ContainsKey("Expand")) Then
                     For Each span In hostDocument.AnnotatedSpans("Expand")
                         Dim node = GetExpressionSyntaxWithSameSpan(root.FindToken(span.Start).Parent, span.End)
-                        root = root.ReplaceNode(node, Simplifier.ExpandAsync(node, document, Nothing).Result)
+                        root = root.ReplaceNode(node, Simplifier.ExpandAsync(node, document, expandInsideNode:=Nothing, expandParameter:=expandParameter).Result)
                     Next
                 ElseIf (hostDocument.AnnotatedSpans.ContainsKey("ExpandAndSimplify")) Then
                     For Each span In hostDocument.AnnotatedSpans("ExpandAndSimplify")
                         Dim node = GetExpressionSyntaxWithSameSpan(root.FindToken(span.Start).Parent, span.End)
-                        root = root.ReplaceNode(node, Simplifier.ExpandAsync(node, document, Nothing).Result)
+                        root = root.ReplaceNode(node, Simplifier.ExpandAsync(node, document, expandInsideNode:=Nothing, expandParameter:=expandParameter).Result)
                         document = document.WithSyntaxRoot(root)
                         document = Simplifier.ReduceAsync(document, Simplifier.Annotation).Result
                         root = document.GetSyntaxRootAsync().Result

--- a/src/EditorFeatures/Test2/Expansion/NameExpansionTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/NameExpansionTests.vb
@@ -148,6 +148,119 @@ namespace NS
             Test(input, expected)
         End Sub
 
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Sub CSharp_GenericNameExpansion_DontExpandAnonymousTypes()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    static void Mumble&lt;T&gt;(T anonymousType) { }
+
+    static void M()
+    {
+        {|Expand:Mumble|}(new { x = 42 });
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+class C
+{
+    static void Mumble&lt;T&gt;(T anonymousType) { }
+
+    static void M()
+    {
+        global::C.Mumble(new { x = 42 });
+    }
+}
+</code>
+
+            Test(input, expected)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Sub CSharp_LambdaParameter_DontExpandAnonymousTypes1()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+class C
+{
+    static void Mumble&lt;T&gt;(T anonymousType, Action&lt;T, int&gt; lambda) { }
+
+    static void M()
+    {
+        Mumble(new { x = 42 }, {|Expand:a => a.x|});
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+using System;
+class C
+{
+    static void Mumble&lt;T&gt;(T anonymousType, Action&lt;T, int&gt; lambda) { }
+
+    static void M()
+    {
+        Mumble(new { x = 42 }, a => a.x);
+    }
+}
+</code>
+
+            Test(input, expected, expandParameter:=True)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Sub CSharp_LambdaParameter_DontExpandAnonymousTypes2()
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+class C
+{
+    static void Mumble&lt;T&gt;(T anonymousType, Action&lt;T, int, int&gt; lambda) { }
+
+    static void M()
+    {
+        Mumble(new { x = 42 }, {|Expand:(a, y) => a.x|});
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+using System;
+class C
+{
+    static void Mumble&lt;T&gt;(T anonymousType, Action&lt;T, int, int&gt; lambda) { }
+
+    static void M()
+    {
+        Mumble(new { x = 42 }, (a, y) => a.x);
+    }
+}
+</code>
+
+            Test(input, expected, expandParameter:=True)
+        End Sub
+
+#End Region
+
+#Region "Visual Basic tests"
+
         <WorkItem(1913, "https://github.com/dotnet/roslyn/issues/1913")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Expansion)>
         Public Sub VisualBasic_SimpleIdentifierAliasExpansion_AliasBinds()
@@ -237,6 +350,7 @@ End Namespace
 
             Test(input, expected)
         End Sub
+
 #End Region
 
     End Class

--- a/src/EditorFeatures/Test2/Rename/CSharp/DeclarationConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/DeclarationConflictTests.vb
@@ -546,5 +546,29 @@ class C
                 result.AssertLabeledSpansAre("second", "DefaultValue(C.Method)", type:=RelatedLocationType.ResolvedReferenceConflict)
             End Using
         End Sub
+
+        <WorkItem(6306, "https://github.com/dotnet/roslyn/issues/6306")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub ResolveConflictInAnonymousTypeProperty()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document><![CDATA[
+using System;
+class C
+{
+    void X<T>(T t, Func<T, long> e) { {|first:X|}(new { a = 1 }, a => a.a); }
+
+    [Obsolete]
+    void {|second:$$Y|}<T>(T t, Func<T, int> e) { }
+}
+                        ]]></Document>
+                    </Project>
+                </Workspace>, renameTo:="X")
+
+                result.AssertLabeledSpansAre("first", "X(new { a = 1 }, a => (long)a.a);", type:=RelatedLocationType.ResolvedNonReferenceConflict)
+                result.AssertLabeledSpansAre("second", "X", type:=RelatedLocationType.NoConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/CSharp/DeclarationConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/DeclarationConflictTests.vb
@@ -560,14 +560,40 @@ class C
     void X<T>(T t, Func<T, long> e) { {|first:X|}(new { a = 1 }, a => a.a); }
 
     [Obsolete]
-    void {|second:$$Y|}<T>(T t, Func<T, int> e) { }
+    void {|origin:$$Y|}<T>(T t, Func<T, int> e) { }
 }
                         ]]></Document>
                     </Project>
                 </Workspace>, renameTo:="X")
 
                 result.AssertLabeledSpansAre("first", "X(new { a = 1 }, a => (long)a.a);", type:=RelatedLocationType.ResolvedNonReferenceConflict)
-                result.AssertLabeledSpansAre("second", "X", type:=RelatedLocationType.NoConflict)
+                result.AssertLabeledSpansAre("origin", "X", type:=RelatedLocationType.NoConflict)
+            End Using
+        End Sub
+
+        <WorkItem(6308, "https://github.com/dotnet/roslyn/issues/6308")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub ResolveConflictWhenAnonymousTypeIsUsedAsGenericArgument()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document><![CDATA[
+using System;
+class C
+{
+    void M<T>(T t, Func<T, int, int> e) { }
+    int M<T>(T t, Func<T, long, long> e) => {|first:M|}(new { }, (_, a) => {|second:X|}(a));
+
+    long X(long a) => a;
+    int {|origin:$$Y|}(int a) => a;
+}
+                        ]]></Document>
+                    </Project>
+                </Workspace>, renameTo:="X")
+
+                result.AssertLabeledSpansAre("first", "M(new { }, (_, a) => (long)X(a))", type:=RelatedLocationType.ResolvedNonReferenceConflict)
+                result.AssertLabeledSpansAre("second", "M(new { }, (_, a) => (long)X(a))", type:=RelatedLocationType.ResolvedNonReferenceConflict)
+                result.AssertLabeledSpansAre("origin", "X", type:=RelatedLocationType.NoConflict)
             End Using
         End Sub
     End Class

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -451,10 +451,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
             var newVariableDeclarator = await FindDeclaratorAsync(updatedDocument, cancellationToken).ConfigureAwait(false);
             localSymbol = (ILocalSymbol)semanticModel.GetDeclaredSymbol(newVariableDeclarator, cancellationToken);
 
-            bool wasCastAdded;
-            var explicitCastExpression = newExpression.CastIfPossible(localSymbol.Type, newVariableDeclarator.SpanStart, semanticModel, out wasCastAdded);
-
-            if (wasCastAdded)
+            var explicitCastExpression = newExpression.CastIfPossible(localSymbol.Type, newVariableDeclarator.SpanStart, semanticModel);
+            if (explicitCastExpression != newExpression)
             {
                 updatedDocument = await updatedDocument.ReplaceNodeAsync(newExpression, explicitCastExpression, cancellationToken).ConfigureAwait(false);
                 semanticModel = await updatedDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -80,11 +80,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             this ExpressionSyntax expression,
             ITypeSymbol targetType,
             int position,
-            SemanticModel semanticModel,
-            out bool wasCastAdded)
+            SemanticModel semanticModel)
         {
-            wasCastAdded = false;
-
             if (targetType.ContainsAnonymousType())
             {
                 return expression;
@@ -122,7 +119,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return expression;
             }
 
-            wasCastAdded = true;
             return castExpression;
         }
 

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationHelpers.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationHelpers.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 


### PR DESCRIPTION
Fixes #6306
Fixes #6308

This change also fixes two outstanding (though not yet reported) bugs in the expansion engine:

* Generic type arguments should *not* be addded to a name if they contain anonymous types
* A lambda parameter should not be expanded if its type is an anonymous type

Tagging @dotnet/roslyn-ide 