### PR TITLE
Fix too aggressive #load Assert...

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.cs
@@ -181,8 +181,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var path = (string)fileToken.Value;
                 if (path == null)
                 {
-                    // If there is no path, the parser should have some Diagnostics to report.
-                    Debug.Assert(tree.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error));
+                    // If there is no path, the parser should have some Diagnostics to report (if we're in an active region).
+                    Debug.Assert(!directive.IsActive || tree.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error));
                     continue;
                 }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -72,5 +72,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // #load "test"
                 Diagnostic(ErrorCode.ERR_SourceFileReferencesNotSupported, @"#load ""test""").WithLocation(1, 1));
         }
+
+        [Fact, WorkItem(6439, "https://github.com/dotnet/roslyn/issues/6439")]
+        public void ErrorInInactiveRegion()
+        {
+            var code = @"
+#if undefined
+#load nothing
+#endif";
+            var compilation = CreateCompilationWithMscorlib45(code, parseOptions: TestOptions.Script);
+
+            Assert.Single(compilation.SyntaxTrees);
+            compilation.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
It's okay for malformed #loads to not report Diagnostics if they're in an inactive region.

Fixes #6439