### PR TITLE
[Compiler VB Scanner] Tweaks

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -127,13 +127,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 s_wslTablePool.Free(_wslTable)
                 s_wsTablePool.Free(_wsTable)
 
-                For Each p As Page In Me._pages
+                For Each p As Page In _pages
                     If p IsNot Nothing Then
                         p.Free()
                     End If
                 Next
 
-                Array.Clear(Me._pages, 0, Me._pages.Length)
+                Array.Clear(_pages, 0, _pages.Length)
             End If
         End Sub
         Friend ReadOnly Property Options As VisualBasicParseOptions
@@ -165,8 +165,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 If token IsNot Nothing Then
                     AdvanceChar(quickToken.Length)
                     If quickToken.TerminatorLength <> 0 Then
-                        Me._endOfTerminatorTrivia = Me._lineBufferOffset
-                        Me._lineBufferOffset -= quickToken.TerminatorLength
+                        _endOfTerminatorTrivia = _lineBufferOffset
+                        _lineBufferOffset -= quickToken.TerminatorLength
                     End If
 
                     Return token
@@ -720,7 +720,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Sub ScanSingleLineTrivia(tList As SyntaxListBuilder)
-            If Me.IsScanningXmlDoc Then
+            If IsScanningXmlDoc Then
                 ScanSingleLineTriviaInXmlDoc(tList)
             Else
                 ScanWhitespaceAndLineContinuations(tList)
@@ -1380,7 +1380,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 ch = Peek(len)
 
                 Dim code = Convert.ToUInt16(ch)
-                If code < 128 AndAlso IsNarrowIdentifierCharacter(code) OrElse
+                If code < 128US AndAlso IsNarrowIdentifierCharacter(code) OrElse
                     IsWideIdentifierCharacter(ch) Then
 
                     len += 1
@@ -2376,7 +2376,7 @@ baddate:
                     Return result
 
                 ElseIf IsNewLine(ch) Then
-                    If Me._isScanningDirective Then
+                    If _isScanningDirective Then
                         Exit While
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerBuffer.vb
@@ -28,13 +28,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Private ReadOnly _pool As ObjectPool(Of Page)
             Private Sub New(pool As ObjectPool(Of Page))
-                Me._pageStart = -1
-                Me._arr = New Char(s_PAGE_SIZE - 1) {}
-                Me._pool = pool
+                _pageStart = -1
+                _arr = New Char(s_PAGE_SIZE - 1) {}
+                _pool = pool
             End Sub
 
             Friend Sub Free()
-                Me._pageStart = -1
+                _pageStart = -1
                 _pool.Free(Me)
             End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
@@ -290,7 +290,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Function ScanXmlContent() As SyntaxToken
             ' SHIM
-            If Me.IsScanningXmlDoc Then
+            If IsScanningXmlDoc Then
                 Return ScanXmlContentInXmlDoc()
             End If
 


### PR DESCRIPTION
 - Remove redundant `Me.` calls
 - Added an Unsigned Short literal identifier to remove a cast.