### PR TITLE
Adds support for event add-handler accessors.

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
@@ -27,6 +27,7 @@ Public Class TestOptions
 
     Public Shared ReadOnly ReleaseModule As New VisualBasicCompilationOptions(OutputKind.NetModule, optimizationLevel:=OptimizationLevel.Release)
     Public Shared ReadOnly ReleaseWinMD As New VisualBasicCompilationOptions(OutputKind.WindowsRuntimeMetadata, optimizationLevel:=OptimizationLevel.Release)
+    Public Shared ReadOnly DebugWinMD As New VisualBasicCompilationOptions(OutputKind.WindowsRuntimeMetadata, optimizationLevel:=OptimizationLevel.Debug)
 End Class
 
 Friend Module TestOptionExtensions

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
@@ -499,6 +499,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         If node.IsKind(SyntaxKind.PropertyStatement) Then
                             Dim propertyBlock = DirectCast(node.Parent, PropertyBlockSyntax)
                             Return propertyBlock.Accessors.Where(Function(a) a.IsKind(SyntaxKind.GetAccessorBlock)).Single().BlockStatement
+                        ElseIf node.IsKind(SyntaxKind.EventStatement) Then
+                            Dim eventBlock = DirectCast(node.Parent, EventBlockSyntax)
+                            Return eventBlock.Accessors.Where(Function(a) a.IsKind(SyntaxKind.AddHandlerAccessorBlock)).Single().BlockStatement
                         End If
 
                         Debug.Assert(node.IsKind(SyntaxKind.FunctionStatement))

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWinMdEvents.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWinMdEvents.vb
@@ -896,6 +896,35 @@ End Class
 ]]>)
         End Sub
 
+        <Fact(), WorkItem(6313, "https://github.com/dotnet/roslyn/issues/6313")>
+        Public Sub CustomEventWinMd()
+            Dim source =
+<compilation>
+    <file name="a.vb">
+Imports System.Runtime.InteropServices.WindowsRuntime
+
+Class Test
+    Public Custom Event CustomEvent As System.Action(Of Integer)
+        AddHandler(value As System.Action(Of Integer))
+            Return Nothing		
+        End AddHandler
+
+        RemoveHandler(value As EventRegistrationToken)
+
+        End RemoveHandler
+
+        RaiseEvent()
+
+        End RaiseEvent
+    End Event
+End Class
+    </file>
+</compilation>
+
+            Dim comp = CreateCompilationWithReferences(source, WinRtRefs, options:=TestOptions.DebugWinMD)
+            Dim verifier = CompileAndVerify(comp)
+        End Sub
+
         ' Field-like and custom events are not treated differently.
         <Fact(), WorkItem(1003209)>
         Public Sub HandlesClauses_EventKinds()

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
@@ -135,6 +135,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
                        ElseIf s.IsKind(SyntaxKind.PropertyStatement) Then
                            Assert.True(sourceMethod0.BlockSyntax.IsKind(SyntaxKind.GetAccessorBlock))
                            Return DirectCast(sourceMethod0.BlockSyntax.Parent, PropertyBlockSyntax).PropertyStatement
+                       ElseIf s.IsKind(SyntaxKind.EventStatement) Then
+                           Assert.True(sourceMethod0.BlockSyntax.IsKind(SyntaxKind.AddHandlerAccessorBlock))
+                           Return DirectCast(sourceMethod0.BlockSyntax.Parent, PropertyBlockSyntax).PropertyStatement
                        End If
 
                        For Each s0 In locals0


### PR DESCRIPTION
Closes #6313 

This is a PR that is based against the stabilization branch, not master like the [old one](https://github.com/dotnet/roslyn/pull/6433#issuecomment-152358869).  Old pull request went through review already.