### PR TITLE
Fix unit test that was mistakenly changed in PR 6434

### DIFF
--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -175,10 +175,10 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             var commands = interactiveCommands.GetCommands();
 
             Assert.NotEmpty(commands);
-            Assert.Equal(2, commands.Where(n => n.Names.First() == "#cls").Count());
-            Assert.Equal(2, commands.Where(n => n.Names.Last() == "#clear").Count());
-            Assert.NotNull(commands.Where(n => n.Names.First() == "#help").SingleOrDefault());
-            Assert.NotNull(commands.Where(n => n.Names.First() == "#reset").SingleOrDefault());
+            Assert.Equal(2, commands.Where(n => n.Names.First() == "cls").Count());
+            Assert.Equal(2, commands.Where(n => n.Names.Last() == "clear").Count());
+            Assert.NotNull(commands.Where(n => n.Names.First() == "help").SingleOrDefault());
+            Assert.NotNull(commands.Where(n => n.Names.First() == "reset").SingleOrDefault());
         }
 
         [WorkItem(3970, "https://github.com/dotnet/roslyn/issues/3970")]


### PR DESCRIPTION
This is a fix for unit test broke by https://github.com/dotnet/roslyn/pull/6434