### PR TITLE
Save the IVsInteractiveWindow when it is created

### DIFF
--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
@@ -73,9 +73,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
         {
             if (rguidPersistenceSlot == ToolWindowId)
             {
-                var result = _interactiveWindowProvider.Create((int)id);
-
-                return (result != null) ? VSConstants.S_OK : VSConstants.E_FAIL;
+                _interactiveWindowProvider.Create((int)id);
+                return VSConstants.S_OK;
             }
 
             return VSConstants.E_FAIL;


### PR DESCRIPTION
...not just when it is opened.  Otherwise, we won't know about it if VS
creates it for us (to persist it across sessions).

Fixes #6413