### PR TITLE
Overridden member for a member of constructed generic type should be calculated based on overridden member for its definition.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -117,7 +117,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (this.IsOverride)
                 {
-                    return (EventSymbol)OverriddenOrHiddenMembers.GetOverriddenMember();
+                    if (IsDefinition)
+                    {
+                        return (EventSymbol)OverriddenOrHiddenMembers.GetOverriddenMember();
+                    }
+
+                    return (EventSymbol)OverriddenOrHiddenMembersResult.GetOverriddenMember(this, OriginalDefinition.OverriddenEvent);
                 }
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -364,7 +364,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (this.IsOverride && ReferenceEquals(this.ConstructedFrom, this))
                 {
-                    return (MethodSymbol)OverriddenOrHiddenMembers.GetOverriddenMember();
+                    if (IsDefinition)
+                    {
+                        return (MethodSymbol)OverriddenOrHiddenMembers.GetOverriddenMember();
+                    }
+
+                    return (MethodSymbol)OverriddenOrHiddenMembersResult.GetOverriddenMember(this, OriginalDefinition.OverriddenMethod);
                 }
 
                 return null;

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -177,7 +177,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (this.IsOverride)
                 {
-                    return (PropertySymbol)OverriddenOrHiddenMembers.GetOverriddenMember();
+                    if (IsDefinition)
+                    {
+                        return (PropertySymbol)OverriddenOrHiddenMembers.GetOverriddenMember();
+                    }
+
+                    return (PropertySymbol)OverriddenOrHiddenMembersResult.GetOverriddenMember(this, OriginalDefinition.OverriddenProperty);
                 }
                 return null;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
@@ -94,9 +94,9 @@ class EntryPoint
 }
 ";
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                // (22,9): error CS0121: The call is ambiguous between the following methods or properties: 'Base<TLong, TInt>.Method(TLong, int)' and 'Base<TLong, TInt>.Method(long, TInt)'
+                // (22,9): error CS0121: The call is ambiguous between the following methods or properties: 'Base<TLong, TInt>.Method(long, TInt)' and 'Base<TLong, TInt>.Method(TLong, int)'
                 //         new Derived2().Method(1L, 2); //CS0121
-                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Base<TLong, TInt>.Method(TLong, int)", "Base<TLong, TInt>.Method(long, TInt)"));
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Base<TLong, TInt>.Method(long, TInt)", "Base<TLong, TInt>.Method(TLong, int)"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
@@ -3611,6 +3611,334 @@ class Derived : Base
             CreateCompilationWithMscorlib(source).VerifyDiagnostics();
         }
 
+        [Fact]
+        [WorkItem(6148, "https://github.com/dotnet/roslyn/issues/6148")]
+        public void AbstractGenericBase_01()
+        {
+            var text = @"
+class C
+{
+    public static void Main()
+    {
+        var t = new Required();
+        t.Test1(null);
+        t.Test2(null);
+    }
+}
+
+public abstract class Validator
+{
+    public abstract void DoValidate(object objectToValidate);
+
+    public void Test1(object objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class Validator<T> : Validator
+{
+    public override void DoValidate(object objectToValidate)
+    {
+        System.Console.WriteLine(""void Validator<T>.DoValidate(object objectToValidate)"");
+    }
+
+    protected abstract void DoValidate(T objectToValidate);
+
+    public void Test2(T objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class ValidatorBase<T> : Validator<T>
+{
+    protected override void DoValidate(T objectToValidate)
+    {
+        System.Console.WriteLine(""void ValidatorBase<T>.DoValidate(T objectToValidate)"");
+    }
+}
+
+public class Required : ValidatorBase<object>
+{
+}
+";
+            var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe);
+
+            var validatorBaseT = compilation.GetTypeByMetadataName("ValidatorBase`1");
+            var doVaidateT = validatorBaseT.GetMember<MethodSymbol>("DoValidate");
+
+            Assert.Equal(1, doVaidateT.OverriddenOrHiddenMembers.OverriddenMembers.Length);
+            Assert.Equal("void Validator<T>.DoValidate(T objectToValidate)", doVaidateT.OverriddenMethod.ToTestDisplayString());
+            Assert.False(validatorBaseT.AbstractMembers.Any());
+
+            var validatorBaseObject = validatorBaseT.Construct(compilation.ObjectType);
+            var doVaidateObject = validatorBaseObject.GetMember<MethodSymbol>("DoValidate");
+
+            Assert.Equal(2, doVaidateObject.OverriddenOrHiddenMembers.OverriddenMembers.Length);
+            Assert.Equal("void Validator<T>.DoValidate(T objectToValidate)", doVaidateObject.OverriddenMethod.OriginalDefinition.ToTestDisplayString());
+            Assert.False(validatorBaseObject.AbstractMembers.Any());
+
+            CompileAndVerify(compilation, expectedOutput: @"void Validator<T>.DoValidate(object objectToValidate)
+void ValidatorBase<T>.DoValidate(T objectToValidate)");
+        }
+
+        [Fact]
+        [WorkItem(6148, "https://github.com/dotnet/roslyn/issues/6148")]
+        public void AbstractGenericBase_02()
+        {
+            var text = @"
+class C
+{
+    public static void Main()
+    {
+        var t = new Required();
+        t.Test1(null);
+        t.Test2(null);
+    }
+}
+
+public abstract class Validator
+{
+    public abstract void DoValidate(object objectToValidate);
+
+    public void Test1(object objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class Validator<T> : Validator
+{
+    public abstract override void DoValidate(object objectToValidate);
+
+    public virtual void DoValidate(T objectToValidate)
+    {
+        System.Console.WriteLine(""void Validator<T>.DoValidate(T objectToValidate)"");
+    }
+
+    public void Test2(T objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+
+public abstract class ValidatorBase<T> : Validator<T>
+{
+    public override void DoValidate(T objectToValidate)
+    {
+        System.Console.WriteLine(""void ValidatorBase<T>.DoValidate(T objectToValidate)"");
+    }
+}
+
+public class Required : ValidatorBase<object>
+{
+}";
+            var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe);
+
+            compilation.VerifyDiagnostics(
+        // (46,14): error CS0534: 'Required' does not implement inherited abstract member 'Validator<object>.DoValidate(object)'
+        // public class Required : ValidatorBase<object>
+        Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Required").WithArguments("Required", "Validator<object>.DoValidate(object)").WithLocation(46, 14)
+                );
+        }
+
+        [Fact]
+        [WorkItem(6148, "https://github.com/dotnet/roslyn/issues/6148")]
+        public void AbstractGenericBase_03()
+        {
+            var text = @"
+class C
+{
+    public static void Main()
+    {
+        var t = new Required();
+        t.Test1(null);
+        t.Test2(null);
+    }
+}
+
+public abstract class Validator0<T>
+{
+    public abstract void DoValidate(T objectToValidate);
+
+    public void Test2(T objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class Validator<T> : Validator0<T>
+{
+    public virtual void DoValidate(object objectToValidate)
+    {
+        System.Console.WriteLine(""void Validator<T>.DoValidate(object objectToValidate)"");
+    }
+
+    public void Test1(object objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+
+public abstract class ValidatorBase<T> : Validator<T>
+{
+    public override void DoValidate(T objectToValidate)
+    {
+        System.Console.WriteLine(""void ValidatorBase<T>.DoValidate(T objectToValidate)"");
+    }
+}
+
+public class Required : ValidatorBase<object>
+{
+}
+";
+            var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe);
+
+            CompileAndVerify(compilation, expectedOutput: @"void Validator<T>.DoValidate(object objectToValidate)
+void ValidatorBase<T>.DoValidate(T objectToValidate)");
+        }
+
+        [Fact]
+        [WorkItem(6148, "https://github.com/dotnet/roslyn/issues/6148")]
+        public void AbstractGenericBase_04()
+        {
+            var text = @"
+class C
+{
+    public static void Main()
+    {
+        var t = new Required();
+        Test1(t);
+        Test2(t, null);
+    }
+
+    static void Test1(Validator v)
+    {
+        v.Test1(null);
+    }
+
+    static void Test2<T>(Validator<T> v, T o)
+    {
+        v.Test2(o);
+    }
+}
+
+public abstract class Validator
+{
+    public abstract void DoValidate(object objectToValidate);
+
+    public void Test1(object objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class Validator<T> : Validator
+{
+    public virtual void DoValidate(T objectToValidate)
+    {
+        System.Console.WriteLine(""void Validator<T>.DoValidate(T objectToValidate)"");
+    }
+
+    public void Test2(T objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class ValidatorBase<T> : Validator<T>
+{
+    public override void DoValidate(object objectToValidate)
+    {
+        System.Console.WriteLine(""void ValidatorBase<T>.DoValidate(object objectToValidate)"");
+    }
+}
+
+public class Required : ValidatorBase<object>
+{
+}
+";
+            var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe);
+
+            CompileAndVerify(compilation, expectedOutput: @"void ValidatorBase<T>.DoValidate(object objectToValidate)
+void Validator<T>.DoValidate(T objectToValidate)");
+        }
+
+        [Fact]
+        [WorkItem(6148, "https://github.com/dotnet/roslyn/issues/6148")]
+        public void AbstractGenericBase_05()
+        {
+            var text = @"
+class C
+{
+    public static void Main()
+    {
+        var t = new Required();
+        t.Test1(null);
+        t.Test2(null);
+    }
+}
+
+public abstract class Validator0<T>
+{
+    public abstract void DoValidate(object objectToValidate);
+
+    public void Test1(object objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class Validator<T> : Validator0<int>
+{
+    public override void DoValidate(object objectToValidate)
+    {
+        System.Console.WriteLine(""void Validator<T>.DoValidate(object objectToValidate)"");
+    }
+
+    protected abstract void DoValidate(T objectToValidate);
+
+    public void Test2(T objectToValidate)
+    {
+         DoValidate(objectToValidate);
+    }
+}
+
+public abstract class ValidatorBase<T> : Validator<T>
+{
+    protected override void DoValidate(T objectToValidate)
+    {
+        System.Console.WriteLine(""void ValidatorBase<T>.DoValidate(T objectToValidate)"");
+    }
+}
+
+public class Required : ValidatorBase<object>
+{
+}
+";
+            var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe);
+
+            var validatorBaseT = compilation.GetTypeByMetadataName("ValidatorBase`1");
+            var doVaidateT = validatorBaseT.GetMember<MethodSymbol>("DoValidate");
+
+            Assert.Equal(1, doVaidateT.OverriddenOrHiddenMembers.OverriddenMembers.Length);
+            Assert.Equal("void Validator<T>.DoValidate(T objectToValidate)", doVaidateT.OverriddenMethod.ToTestDisplayString());
+            Assert.False(validatorBaseT.AbstractMembers.Any());
+
+            var validatorBaseObject = validatorBaseT.Construct(compilation.ObjectType);
+            var doVaidateObject = validatorBaseObject.GetMember<MethodSymbol>("DoValidate");
+
+            Assert.Equal(2, doVaidateObject.OverriddenOrHiddenMembers.OverriddenMembers.Length);
+            Assert.Equal("void Validator<T>.DoValidate(T objectToValidate)", doVaidateObject.OverriddenMethod.OriginalDefinition.ToTestDisplayString());
+            Assert.False(validatorBaseObject.AbstractMembers.Any());
+
+            CompileAndVerify(compilation, expectedOutput: @"void Validator<T>.DoValidate(object objectToValidate)
+void ValidatorBase<T>.DoValidate(T objectToValidate)");
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -89,11 +89,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public ReadOnly Property OverriddenEvent As EventSymbol
             Get
                 If Me.IsOverrides Then
-                    For Each OverriddenEvent In OverriddenOrHiddenMembers.OverriddenMembers
-                        If OverriddenEvent.IsMustOverride OrElse OverriddenEvent.IsOverridable OrElse OverriddenEvent.IsOverrides Then
-                            Return DirectCast(OverriddenEvent, EventSymbol)
-                        End If
-                    Next
+                    If IsDefinition Then
+                        Return OverriddenOrHiddenMembers.OverriddenMember
+                    End If
+
+                    Return OverriddenMembersResult(Of EventSymbol).GetOverriddenMember(Me, Me.OriginalDefinition.OverriddenEvent)
                 End If
 
                 Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -266,7 +266,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return DirectCast(Me.AssociatedSymbol, PropertySymbol).GetAccessorOverride(getter:=(MethodKind = MethodKind.PropertyGet))
                 Else
                     If Me.IsOverrides AndAlso Me.ConstructedFrom Is Me Then
-                        Return OverriddenMembers.OverriddenMember
+                        If IsDefinition Then
+                            Return OverriddenMembers.OverriddenMember
+                        End If
+
+                        Return OverriddenMembersResult(Of MethodSymbol).GetOverriddenMember(Me, Me.OriginalDefinition.OverriddenMethod)
                     End If
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -233,7 +233,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public ReadOnly Property OverriddenProperty As PropertySymbol
             Get
                 If Me.IsOverrides Then
-                    Return OverriddenMembers.OverriddenMember
+                    If IsDefinition Then
+                        Return OverriddenMembers.OverriddenMember
+                    End If
+
+                    Return OverriddenMembersResult(Of PropertySymbol).GetOverriddenMember(Me, Me.OriginalDefinition.OverriddenProperty)
                 End If
 
                 Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -2086,6 +2086,7 @@ lReportErrorOnTwoTokens:
                                                                             isOverrides:=True))
                 End If
 
+                Debug.Assert(IsDefinition)
                 Dim overridden = overriddenMembers.OverriddenMember
 
                 If overridden IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -734,6 +734,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                                             isOverrides:=True, isWithEvents:=Me.IsWithEvents))
                 End If
 
+                Debug.Assert(IsDefinition)
                 Dim overridden = overriddenMembers.OverriddenMember
 
                 If overridden IsNot Nothing Then


### PR DESCRIPTION
Fixes #6148.

@dotnet/roslyn-compiler Please review.