### PR TITLE
Implement DocComment property for external code model elements

### DIFF
--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeClassTests.vb
@@ -7,6 +7,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
     Public Class ExternalCodeClassTests
         Inherits AbstractCodeClassTests
 
+#Region "Doc Comment"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub DocComment1()
+            Dim code =
+<Code>
+/// &lt;summary&gt;This is my comment!&lt;/summary&gt;
+class C$$
+{
+}
+</Code>
+
+            TestDocComment(code, "<doc>" & vbCrLf & "  <summary>This is my comment!</summary>" & vbCrLf & "</doc>")
+        End Sub
+
+#End Region
+
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub ExpectedClassMembers()
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeClassTests.vb
@@ -22,6 +22,20 @@ class C$$
             TestDocComment(code, "<doc>" & vbCrLf & "  <summary>This is my comment!</summary>" & vbCrLf & "</doc>")
         End Sub
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub DocComment2()
+            Dim code =
+<Code>
+/// &lt;summary&gt;This is my comment!&lt;/summary&gt;
+/// &lt;remarks /&gt;
+class C$$
+{
+}
+</Code>
+
+            TestDocComment(code, "<doc>" & vbCrLf & "  <summary>This is my comment!</summary>" & vbCrLf & "  <remarks />" & vbCrLf & "</doc>")
+        End Sub
+
 #End Region
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
@@ -7,6 +7,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasi
     Public Class ExternalCodeClassTests
         Inherits AbstractCodeClassTests
 
+#Region "Doc Comment"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub DocComment1()
+            Dim code =
+<Code>
+''' &lt;summary&gt;This is my comment!&lt;/summary&gt;
+Class C$$
+End Class
+</Code>
+
+            TestDocComment(code, "<doc>" & vbCrLf & "  <summary>This is my comment!</summary>" & vbCrLf & "</doc>")
+        End Sub
+
+#End Region
+
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub ExpectedClassMembers()
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeClassTests.vb
@@ -21,6 +21,19 @@ End Class
             TestDocComment(code, "<doc>" & vbCrLf & "  <summary>This is my comment!</summary>" & vbCrLf & "</doc>")
         End Sub
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub DocComment2()
+            Dim code =
+<Code>
+''' &lt;summary&gt;This is my comment!&lt;/summary&gt;
+''' &lt;remarks /&gt;
+Class C$$
+End Class
+</Code>
+
+            TestDocComment(code, "<doc>" & vbCrLf & "  <summary>This is my comment!</summary>" & vbCrLf & "  <remarks />" & vbCrLf & "</doc>")
+        End Sub
+
 #End Region
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>


### PR DESCRIPTION
Fixes #6466.

**Customer scenario**: Visual Studio extensions that access the DocComment property of a Code Model element defined in metadata will not be returned the documentation comment as they did in Visual Studio 2013. Instead, the property throws an exception.

**Fix Description**: Implement the DocComment property for external code model elements.

**Testing Done**:
* Added unit test coverage

Tagging @dotnet/roslyn-ide 