### PR TITLE
added a flag to re-analysis that let caller to decide whether an item…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
                         _diagnosticAnalyzerService?.Reanalyze(
                             document.Project.Solution.Workspace,
-                            documentIds: SpecializedCollections.SingletonEnumerable(document.Id));
+                            documentIds: SpecializedCollections.SingletonEnumerable(document.Id), highPriority: true);
                     }
 
                     // Disallow the existing TrackingSession from triggering IdentifierFound.

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
                 // don't rely on background parser to have tree. explicitly do it here.
                 await TouchEverything(workspace.CurrentSolution).ConfigureAwait(true);
 
-                service.Reanalyze(workspace, worker, projectIds: null, documentIds: SpecializedCollections.SingletonEnumerable<DocumentId>(info.Id));
+                service.Reanalyze(workspace, worker, projectIds: null, documentIds: SpecializedCollections.SingletonEnumerable<DocumentId>(info.Id), highPriority: false);
 
                 await TouchEverything(workspace.CurrentSolution).ConfigureAwait(true);
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -119,14 +119,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _hostAnalyzerManager.IsAnalyzerSuppressed(analyzer, project);
         }
 
-        public void Reanalyze(Workspace workspace, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null)
+        public void Reanalyze(Workspace workspace, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null, bool highPriority = false)
         {
             BaseDiagnosticIncrementalAnalyzer analyzer;
 
             var service = workspace.Services.GetService<ISolutionCrawlerService>();
             if (service != null && _map.TryGetValue(workspace, out analyzer))
             {
-                service.Reanalyze(workspace, analyzer, projectIds, documentIds);
+                service.Reanalyze(workspace, analyzer, projectIds, documentIds, highPriority);
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private void OnDocumentActiveContextChanged(object sender, DocumentEventArgs e)
         {
-            Reanalyze(e.Document.Project.Solution.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(e.Document.Id));
+            Reanalyze(e.Document.Project.Solution.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(e.Document.Id), highPriority: true);
         }
 
         // internal for testing

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             if (PreferLiveErrorsOnOpenedFiles(workspace) && workspace.IsDocumentOpen(document.Id))
             {
                 // enqueue re-analysis of open documents.
-                this.Owner.Reanalyze(workspace, documentIds: SpecializedCollections.SingletonEnumerable(document.Id));
+                this.Owner.Reanalyze(workspace, documentIds: SpecializedCollections.SingletonEnumerable(document.Id), highPriority: true);
                 return;
             }
 

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// re-analyze given projects and documents
         /// </summary>
-        void Reanalyze(Workspace workspace, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null);
+        void Reanalyze(Workspace workspace, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null, bool highPriority = false);
 
         /// <summary>
         /// get specific diagnostics currently stored in the source. returned diagnostic might be out-of-date if solution has changed but analyzer hasn't run for the new solution.
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// get diagnostics currently stored in the source. returned diagnostic might be out-of-date if solution has changed but analyzer hasn't run for the new solution.
         /// </summary>
-        Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Workspace workspace, ProjectId projectId = null, DocumentId documentId = null, bool includeSuppressedDiagnostics = false,  CancellationToken cancellationToken = default(CancellationToken));
+        Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Workspace workspace, ProjectId projectId = null, DocumentId documentId = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// get specific diagnostics for the given solution. all diagnostics returned should be up-to-date with respect to the given solution.

--- a/src/Features/Core/Portable/SolutionCrawler/ISolutionCrawlerService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/ISolutionCrawlerService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         /// Ask solution crawler to re-analyze given <see cref="ProjectId"/>s or/and <see cref="DocumentId"/>s 
         /// in given <see cref="Workspace"/> with given <see cref="IIncrementalAnalyzer"/>.
         /// </summary>
-        void Reanalyze(Workspace workspace, IIncrementalAnalyzer analyzer, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null);
+        void Reanalyze(Workspace workspace, IIncrementalAnalyzer analyzer, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null, bool highPriority = false);
 
         /// <summary>
         /// Get <see cref="ISolutionCrawlerProgressReporter"/> for the given <see cref="Workspace"/>

--- a/src/Features/Core/Portable/SolutionCrawler/InvocationReasons.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/InvocationReasons.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal partial struct InvocationReasons : IEnumerable<string>
     {
-        public static readonly InvocationReasons Empty = new InvocationReasons(ImmutableHashSet.Create<string>());
+        public static readonly InvocationReasons Empty = new InvocationReasons(ImmutableHashSet<string>.Empty);
 
         private readonly ImmutableHashSet<string> _reasons;
 
@@ -30,7 +30,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public InvocationReasons With(InvocationReasons invocationReasons)
         {
-            return new InvocationReasons((_reasons ?? ImmutableHashSet.Create<string>()).Union(invocationReasons._reasons));
+            return new InvocationReasons((_reasons ?? ImmutableHashSet<string>.Empty).Union(invocationReasons._reasons));
+        }
+
+        public InvocationReasons With(string reason)
+        {
+            return new InvocationReasons((_reasons ?? ImmutableHashSet<string>.Empty).Add(reason));
         }
 
         public bool IsEmpty

--- a/src/Features/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
@@ -39,10 +39,16 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                     PredefinedInvocationReasons.DocumentRemoved));
 
         public static readonly InvocationReasons DocumentOpened =
-            new InvocationReasons(PredefinedInvocationReasons.DocumentOpened);
+            new InvocationReasons(
+                ImmutableHashSet.Create<string>(
+                                    PredefinedInvocationReasons.DocumentOpened,
+                                    PredefinedInvocationReasons.HighPriority));
 
         public static readonly InvocationReasons DocumentClosed =
-            new InvocationReasons(PredefinedInvocationReasons.DocumentClosed);
+            new InvocationReasons(
+                ImmutableHashSet.Create<string>(
+                                    PredefinedInvocationReasons.DocumentClosed,
+                                    PredefinedInvocationReasons.HighPriority));
 
         public static readonly InvocationReasons DocumentChanged =
             new InvocationReasons(
@@ -68,5 +74,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public static readonly InvocationReasons Reanalyze =
             new InvocationReasons(PredefinedInvocationReasons.Reanalyze);
+
+        public static readonly InvocationReasons ReanalyzeHighPriority =
+            Reanalyze.With(PredefinedInvocationReasons.HighPriority);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/PredefinedInvocationReasons.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/PredefinedInvocationReasons.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public const string DocumentRemoved = "DocumentRemoved";
         public const string DocumentOpened = "DocumentOpened";
         public const string DocumentClosed = "DocumentClosed";
+        public const string HighPriority = "HighPriority";
 
         public const string SyntaxChanged = "SyntaxChanged";
         public const string SemanticChanged = "SemanticChanged";

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         private const string Kind = "Kind";
         private const string Analyzer = "Analyzer";
         private const string DocumentCount = "DocumentCount";
+        private const string HighPriority = "HighPriority";
         private const string Enabled = "Enabled";
         private const string AnalyzerCount = "AnalyzerCount";
         private const string PersistentStorage = "PersistentStorage";
@@ -67,13 +68,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }));
         }
 
-        public static void LogReanalyze(int correlationId, IIncrementalAnalyzer analyzer, IEnumerable<DocumentId> documentIds)
+        public static void LogReanalyze(int correlationId, IIncrementalAnalyzer analyzer, IEnumerable<DocumentId> documentIds, bool highPriority)
         {
             Logger.Log(FunctionId.WorkCoordinatorRegistrationService_Reanalyze, KeyValueLogMessage.Create(m =>
             {
                 m[Id] = correlationId;
                 m[Analyzer] = analyzer.ToString();
                 m[DocumentCount] = documentIds == null ? 0 : documentIds.Count();
+                m[HighPriority] = highPriority;
             }));
         }
 

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             SolutionCrawlerLogger.LogUnregistration(coordinator.CorrelationId);
         }
 
-        public void Reanalyze(Workspace workspace, IIncrementalAnalyzer analyzer, IEnumerable<ProjectId> projectIds, IEnumerable<DocumentId> documentIds)
+        public void Reanalyze(Workspace workspace, IIncrementalAnalyzer analyzer, IEnumerable<ProjectId> projectIds, IEnumerable<DocumentId> documentIds, bool highPriority)
         {
             lock (_gate)
             {
@@ -92,14 +92,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 // no specific projects or documents provided
                 if (projectIds == null && documentIds == null)
                 {
-                    coordinator.Reanalyze(analyzer, workspace.CurrentSolution.Projects.SelectMany(p => p.DocumentIds).ToSet());
+                    coordinator.Reanalyze(analyzer, workspace.CurrentSolution.Projects.SelectMany(p => p.DocumentIds).ToSet(), highPriority);
                     return;
                 }
 
                 // specific documents provided
                 if (projectIds == null)
                 {
-                    coordinator.Reanalyze(analyzer, documentIds.ToSet());
+                    coordinator.Reanalyze(analyzer, documentIds.ToSet(), highPriority);
                     return;
                 }
 
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 var set = new HashSet<DocumentId>(documentIds ?? SpecializedCollections.EmptyEnumerable<DocumentId>());
                 set.UnionWith(projectIds.Select(id => solution.GetProject(id)).SelectMany(p => p.DocumentIds));
 
-                coordinator.Reanalyze(analyzer, set);
+                coordinator.Reanalyze(analyzer, set, highPriority);
             }
         }
 

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerService.cs
@@ -19,13 +19,13 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         [ExportWorkspaceService(typeof(ISolutionCrawlerService), ServiceLayer.Default), Shared]
         internal class SolutionCrawlerService : ISolutionCrawlerService
         {
-            public void Reanalyze(Workspace workspace, IIncrementalAnalyzer analyzer, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null)
+            public void Reanalyze(Workspace workspace, IIncrementalAnalyzer analyzer, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null, bool highPriority = false)
             {
                 // if solution crawler doesn't exist for the given workspace. don't do anything
                 var registration = workspace.Services.GetService<ISolutionCrawlerRegistrationService>() as SolutionCrawlerRegistrationService;
                 if (registration != null)
                 {
-                    registration.Reanalyze(workspace, analyzer, projectIds, documentIds);
+                    registration.Reanalyze(workspace, analyzer, projectIds, documentIds, highPriority);
                 }
             }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -161,13 +161,13 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
             }
 
-            public void Reanalyze(IIncrementalAnalyzer analyzer, IEnumerable<DocumentId> documentIds)
+            public void Reanalyze(IIncrementalAnalyzer analyzer, IEnumerable<DocumentId> documentIds, bool highPriority = false)
             {
                 var asyncToken = _listener.BeginAsyncOperation("Reanalyze");
                 _eventProcessingQueue.ScheduleTask(
-                    () => EnqueueWorkItemAsync(analyzer, documentIds), _shutdownToken).CompletesAsyncOperation(asyncToken);
+                    () => EnqueueWorkItemAsync(analyzer, documentIds, highPriority), _shutdownToken).CompletesAsyncOperation(asyncToken);
 
-                SolutionCrawlerLogger.LogReanalyze(CorrelationId, analyzer, documentIds);
+                SolutionCrawlerLogger.LogReanalyze(CorrelationId, analyzer, documentIds, highPriority);
             }
 
             private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
@@ -435,7 +435,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
             }
 
-            private async Task EnqueueWorkItemAsync(IIncrementalAnalyzer analyzer, IEnumerable<DocumentId> documentIds)
+            private async Task EnqueueWorkItemAsync(IIncrementalAnalyzer analyzer, IEnumerable<DocumentId> documentIds, bool highPriority)
             {
                 var solution = _registration.CurrentSolution;
                 foreach (var documentId in documentIds)
@@ -449,8 +449,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     var priorityService = document.GetLanguageService<IWorkCoordinatorPriorityService>();
                     var isLowPriority = priorityService != null && await priorityService.IsLowPriorityAsync(document, _shutdownToken).ConfigureAwait(false);
 
+                    var invocationReasons = highPriority ? InvocationReasons.ReanalyzeHighPriority : InvocationReasons.Reanalyze;
+
                     _documentAndProjectWorkerProcessor.Enqueue(
-                        new WorkItem(documentId, document.Project.Language, InvocationReasons.Reanalyze,
+                        new WorkItem(documentId, document.Project.Language, invocationReasons,
                         isLowPriority, analyzer, _listener.BeginAsyncOperation("WorkItem")));
                 }
             }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                 // If we are fixing selected diagnostics in error list, then get the diagnostics from error list entry snapshots.
                 // Otherwise, get all diagnostics from the diagnostic service.
                 var diagnosticsToFixTask = selectedEntriesOnly ?
-                    _suppressionStateService.GetSelectedItemsAsync(isAddSuppression, cancellationToken):
+                    _suppressionStateService.GetSelectedItemsAsync(isAddSuppression, cancellationToken) :
                     GetAllBuildDiagnosticsAsync(shouldFixInProject, cancellationToken);
 
                 diagnosticsToFix = diagnosticsToFixTask.WaitAndGetResult(cancellationToken).ToImmutableHashSet();
@@ -382,8 +382,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
             // Kick off diagnostic re-analysis for affected projects so that diagnostics gets refreshed.
             Task.Run(() =>
             {
-                var uniqueProjectIds = diagnosticsToFix.Where(d => d.ProjectId != null).Select(d => d.ProjectId).Distinct();
-                _diagnosticService.Reanalyze(_workspace, uniqueProjectIds);
+                var reanalyzeDocuments = diagnosticsToFix.Where(d => d.DocumentId != null).Select(d => d.DocumentId).Distinct();
+                _diagnosticService.Reanalyze(_workspace, documentIds: reanalyzeDocuments, highPriority: true);
             });
 
             return true;

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -156,7 +156,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Return If(includeSuppressedDiagnostics, _data, _data.WhereAsArray(Function(d) Not d.IsSuppressed))
             End Function
 
-            Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing) Implements IDiagnosticAnalyzerService.Reanalyze
+            Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing, Optional highPriority As Boolean = False) Implements IDiagnosticAnalyzerService.Reanalyze
             End Sub
 
             Public Function GetDiagnosticDescriptors(projectOpt As Project) As ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)) Implements IDiagnosticAnalyzerService.GetDiagnosticDescriptors

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
                 Return If(includeSuppressedDiagnostics, _data, _data.WhereAsArray(Function(d) Not d.IsSuppressed))
             End Function
 
-            Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing) Implements IDiagnosticAnalyzerService.Reanalyze
+            Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing, Optional highPriority As Boolean = False) Implements IDiagnosticAnalyzerService.Reanalyze
             End Sub
 
             Public Function GetDiagnosticDescriptors(projectOpt As Project) As ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticDescriptor)) Implements IDiagnosticAnalyzerService.GetDiagnosticDescriptors


### PR DESCRIPTION
… is high priority work or not.

since this logic is now exposed to outside of engine, engine needs to be guarded from abuser so, logic is added to drop cache if there is too many high priority work. before only engine can decide what is high priority or not.