### PR TITLE
Don't generate a binding redirect for Microsoft.Build.Tasks.CodeAnalysis

### DIFF
--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -3,8 +3,6 @@
 using Microsoft.VisualStudio.Shell;
 using Roslyn.VisualStudio.Setup;
 
-[assembly: ProvideRoslynBindingRedirection("Microsoft.Build.Tasks.CodeAnalysis")]
-
 [assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp")]
 [assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp.EditorFeatures")]
 [assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.CSharp.Features")]


### PR DESCRIPTION
Hopefully, this will fix internal bug 157535.