### PR TITLE
Checking whether the node we are given is null

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAsyncTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAsyncTests.cs
@@ -417,7 +417,6 @@ class Program
 @"using System ; using System . Threading . Tasks ; class Program { private async void method ( ) { string content = await Task < String > . Run ( async delegate ( ) { await Task . Delay ( 1000 ) ; return ""Test"" ; } ) ; } } ");
         }
 
-
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AddAsyncInDelegate2()
         {
@@ -432,6 +431,29 @@ class Program
             Test(
 @"using System ; using System . Threading . Tasks ; class Program { private void method ( ) { string content = await Task < String > . Run ( delegate ( ) { [|await Task . Delay ( 1000 )|] ; return ""Test"" ; } ) ; } } ",
 @"using System ; using System . Threading . Tasks ; class Program { private void method ( ) { string content = await Task < String > . Run ( async delegate ( ) { await Task . Delay ( 1000 ) ; return ""Test"" ; } ) ; } } ");
+        }
+
+        [WorkItem(6477, @"https://github.com/dotnet/roslyn/issues/6477")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        public void NullNodeCrash()
+        {
+            TestMissing(
+@"using System.Threading.Tasks;
+
+class C
+{
+    static async void Main()
+    {
+        try
+        {
+            [|await|]
+            await Task.Delay(100);
+        }
+        finally
+        {
+        }
+    }
+}");
         }
 
         internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAsyncTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAsyncTests.vb
@@ -271,6 +271,24 @@ End Class
             Test(initial, expected)
         End Sub
 
+        <WorkItem(6477, "https://github.com/dotnet/roslyn/issues/6477")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        Public Sub NullNodeCrash()
+            Dim initial =
+<File>
+Imports System
+Imports System.Threading.Tasks
+
+Module Program
+    Async Sub Main(args As String())
+        [|Await|]
+        Await Task.Delay(7)
+    End Sub
+End Module
+</File>
+            TestMissing(initial)
+        End Sub
+
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, CodeFixProvider)
             Return Tuple.Create(Of DiagnosticAnalyzer, CodeFixProvider)(
                 Nothing,

--- a/src/Features/CSharp/Portable/CodeFixes/Async/CSharpConvertToAsyncMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Async/CSharpConvertToAsyncMethodCodeFixProvider.cs
@@ -63,6 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             {
                 return null;
             }
+
             var methodSymbol = semanticModel.GetSymbolInfo(invocationExpression, cancellationToken).Symbol as IMethodSymbol;
             if (methodSymbol == null)
             {

--- a/src/Features/CSharp/Portable/CodeFixes/Async/CSharpConvertToAsyncMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Async/CSharpConvertToAsyncMethodCodeFixProvider.cs
@@ -59,6 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             CancellationToken cancellationToken)
         {
             var invocationExpression = node.ChildNodes().FirstOrDefault(n => n.IsKind(SyntaxKind.InvocationExpression));
+            if (invocationExpression == null)
+            {
+                return null;
+            }
             var methodSymbol = semanticModel.GetSymbolInfo(invocationExpression, cancellationToken).Symbol as IMethodSymbol;
             if (methodSymbol == null)
             {

--- a/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
@@ -47,6 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Async
             If oldNode Is Nothing Then
                 Return Nothing
             End If
+
             Dim methodSymbol = TryCast(semanticModel.GetSymbolInfo(oldNode).Symbol, IMethodSymbol)
             If methodSymbol Is Nothing Then
                 Return Nothing

--- a/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Async/VisualBasicConvertToAsyncFunctionCodeFixProvider.vb
@@ -44,6 +44,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Async
         End Function
 
         Private Async Function GetMethodFromExpression(oldNode As SyntaxNode, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Task(Of Tuple(Of SyntaxNode, MethodBlockSyntax))
+            If oldNode Is Nothing Then
+                Return Nothing
+            End If
             Dim methodSymbol = TryCast(semanticModel.GetSymbolInfo(oldNode).Symbol, IMethodSymbol)
             If methodSymbol Is Nothing Then
                 Return Nothing


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/6477

**Fix Description:**

Check whether the expression node we are given is null.

**Customer Impact:**

If the user has code like the following:

```C#
using System.Threading.Tasks;

class C
{
    static async void Main()
    {
        try
        {
            await 
            await Task.Delay(100);
        }
        finally
        {
        }
    }
}
```
When the user places their cursor on the first `await` statement, they will be notified that the `CSharpConvertToAsyncMethodCodeFixProvider` has crashed
