### PR TITLE
Disable AppDomain isolation in unit tests

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -107,8 +107,8 @@ Global
 		src\Test\Utilities\Shared\TestUtilities.projitems*{6ff42825-5464-4151-ac55-ed828168c192}*SharedItemsImports = 13
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
-		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
+		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{c1930979-c824-496b-a630-70f5369a636f}*SharedItemsImports = 13

--- a/src/Compilers/CSharp/Test/CommandLine/app.config
+++ b/src/Compilers/CSharp/Test/CommandLine/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/CSharp/Test/Emit/app.config
+++ b/src/Compilers/CSharp/Test/Emit/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/CSharp/Test/Semantic/app.config
+++ b/src/Compilers/CSharp/Test/Semantic/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/CSharp/Test/Symbol/app.config
+++ b/src/Compilers/CSharp/Test/Symbol/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/CSharp/Test/Syntax/app.config
+++ b/src/Compilers/CSharp/Test/Syntax/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/CSharp/Test/WinRT/app.config
+++ b/src/Compilers/CSharp/Test/WinRT/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/Core/CodeAnalysisTest/app.config
+++ b/src/Compilers/Core/CodeAnalysisTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/Core/MSBuildTaskTests/app.config
+++ b/src/Compilers/Core/MSBuildTaskTests/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/Core/VBCSCompilerTests/app.config
+++ b/src/Compilers/Core/VBCSCompilerTests/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/Test/Utilities/CSharp/app.config
+++ b/src/Compilers/Test/Utilities/CSharp/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/Test/Utilities/VisualBasic/app.config
+++ b/src/Compilers/Test/Utilities/VisualBasic/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/VisualBasic/Test/CommandLine/app.config
+++ b/src/Compilers/VisualBasic/Test/CommandLine/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/VisualBasic/Test/Emit/app.config
+++ b/src/Compilers/VisualBasic/Test/Emit/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/VisualBasic/Test/Semantic/app.config
+++ b/src/Compilers/VisualBasic/Test/Semantic/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/VisualBasic/Test/Symbol/app.config
+++ b/src/Compilers/VisualBasic/Test/Symbol/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Compilers/VisualBasic/Test/Syntax/app.config
+++ b/src/Compilers/VisualBasic/Test/Syntax/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb.Tests/app.config
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb.Tests/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/EditorFeatures/CSharpTest/app.config
+++ b/src/EditorFeatures/CSharpTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/EditorFeatures/CSharpTest2/app.config
+++ b/src/EditorFeatures/CSharpTest2/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="true"/>
   </appSettings>

--- a/src/EditorFeatures/Test/app.config
+++ b/src/EditorFeatures/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/EditorFeatures/Test2/app.config
+++ b/src/EditorFeatures/Test2/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/EditorFeatures/TestUtilities/app.config
+++ b/src/EditorFeatures/TestUtilities/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/EditorFeatures/VisualBasicTest/app.config
+++ b/src/EditorFeatures/VisualBasicTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/app.config
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/app.config
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/app.config
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/app.config
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/app.config
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/app.config
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Interactive/HostTest/app.config
+++ b/src/Interactive/HostTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/InteractiveWindow/EditorTest/app.config
+++ b/src/InteractiveWindow/EditorTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/app.config
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Samples/CSharp/MakeConst/Test/app.config
+++ b/src/Samples/CSharp/MakeConst/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Samples/Shared/UnitTestFramework/app.config
+++ b/src/Samples/Shared/UnitTestFramework/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Test/app.config
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/app.config
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Samples/VisualBasic/MakeConst/Test/app.config
+++ b/src/Samples/VisualBasic/MakeConst/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Scripting/CSharpTest/app.config
+++ b/src/Scripting/CSharpTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Scripting/CoreTest/app.config
+++ b/src/Scripting/CoreTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Scripting/VisualBasicTest/app.config
+++ b/src/Scripting/VisualBasicTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Test/Utilities/App.config
+++ b/src/Test/Utilities/App.config
@@ -3,7 +3,7 @@
 
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/VisualStudio/CSharp/Test/app.config
+++ b/src/VisualStudio/CSharp/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/VisualStudio/Core/Test/app.config
+++ b/src/VisualStudio/Core/Test/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Workspaces/CSharpTest/app.config
+++ b/src/Workspaces/CSharpTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Workspaces/CoreTest/app.config
+++ b/src/Workspaces/CoreTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="required"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>

--- a/src/Workspaces/VisualBasicTest/app.config
+++ b/src/Workspaces/VisualBasicTest/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
+    <add key="xunit.appDomain" value="denied"/>
     <add key="xunit.diagnosticMessages" value="false"/>
     <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>


### PR DESCRIPTION
This change disables AppDomain isolation in the unit tests that don't require it.  This is necessary for our goal of running many of the suites on CoreCLR and helps reduce our exposure to #6358.

The AppDomain creation code incorrectly used AppDomain.CurrentDomain.BaseDirectory as the new base directory.  There is no gurantee this points to the directory containing the unit test binaries and this is actually the case in xunit without AppDomains.  Instead it points to the directory containing xunit.oconsole.x86 and uses AppDomain.ResolveAssembly / LoadFrom to resolve unit test binaries.

Switching over to no AppDomains in xunit was causing the creation of RuntimeAssemblyManager across AppDomains to fail.  The error given was a failure to load Roslyn.Test.Utilities.Desktop in the original AppDomain.  This is odd given that the code is executing inside Roslyn.Test.Utilities.Desktop.  The error was fixed by hooking AppDomain.AssemblyResolve in the original AppDomain and essentially reloading the DLL.  I'm not completely sure why this worked but I suspect it has to do with the original AppDomain having an incorrect base directory.