### PR TITLE
Disable VS Hosting Process by default

### DIFF
--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -136,6 +136,11 @@
     <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Host processes are only really useful for a few of our programs; most need command line arguments -->
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+
   <!--
     If TargetNetFX20 is true the project targets Framework 2.0 reference assemblies provided by Microsoft.NetFX20 nuget package.
     Use the latest Framework toolset to build, but set msbuild properties below


### PR DESCRIPTION
Roslyn really doesn't build all that many executables that you'd want to
start without arguments, and typically the vshost processes just sit there
cluttering up the tree in Process Explorer.