### PR TITLE
Avoid file locking issue

### DIFF
--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -77,7 +77,7 @@
     <!-- If we're on Visual Studio 2015 RTM and  we still have Roslyn installed, our VSIX-producing packages are not going to install, so let's not even try.
          Update 1 supports this, so we'll use csi.exe's existence as a simple proxy for whether we have Update 1 installed or not.
          OpenSourceDebug overrides this by simple virtue that it's property setting is after the include of this file. -->
-    <DeployExtension Condition="Exists('$(DevEnvDir)\CommonExtensions\Microsoft\Roslyn\Language Services\extension.vsixmanifest') and !Exists('$(MSBuildBinPath)\csi.exe')">false</DeployExtension>
+    <DeployExtension Condition="'$(DeployExtension)' == '' AND Exists('$(DevEnvDir)\CommonExtensions\Microsoft\Roslyn\Language Services\extension.vsixmanifest') AND !Exists('$(MSBuildBinPath)\csi.exe')">false</DeployExtension>
   </PropertyGroup>
 
   <Choose>

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -11,7 +11,7 @@ set BuildRestore=false
 REM Because override the C#/VB toolset to build against our LKG package, it is important
 REM that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise, 
 REM we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
-set MSBuildAdditionalCommandLineArgs=/nologo /v:m /m /nodeReuse:false
+set MSBuildAdditionalCommandLineArgs=/nologo /v:m /m /nodeReuse:false /p:DeployExtension=false
 
 :ParseArguments
 if "%1" == "" goto :DoneParsing


### PR DESCRIPTION
Jenkins is failing intermitently with a file locking issue due to deployment of this binary.  Temporarily disabling while we investigate.