### PR TITLE
Disable pumping in one more place in the project system

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -215,9 +215,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         internal void StartPushingToWorkspaceAndNotifyOfOpenDocuments(IEnumerable<AbstractProject> projects)
         {
-            foreach (var hostState in _workspaceHosts)
+            using (Dispatcher.CurrentDispatcher.DisableProcessing())
             {
-                hostState.StartPushingToWorkspaceAndNotifyOfOpenDocuments(projects);
+                foreach (var hostState in _workspaceHosts)
+                {
+                    hostState.StartPushingToWorkspaceAndNotifyOfOpenDocuments(projects);
+                }
             }
         }
 


### PR DESCRIPTION
Windows erorr reporting shows reports of crashes due to LockRecursionException
due to the following pattern:
* ASP.NET design view forces a lazy loaded tab to be populated during solution load
* That causes us to need to start pushing to workspace hosts in
  VisualStudioProjectTracker.StartPushingToWorkspaceAndNotifyOfOpenDocuments
* Ends up waiting in Workspace.OnDocumentOpened.
* Waiting pumps, and ASP.NET is finished parsing, so it tries to set the compilation options
* Workspace.OnCompilationOptionsChanged throws because the lock is the same one being waited
  on by Workspace.OnDocumentOpened.

Fixes one of the causes of internal bug 149765.