### PR TITLE
Fakesign

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -285,7 +285,7 @@
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);&quot;$(PostCompileBinaryModificationSentinelFile)&quot;">
 
-    <Exec Command="&quot;$(FakeSignToolPath)&quot; &quot;@(IntermediateAssembly)&quot;" />
+    <Exec Command="&quot;$(FakeSignToolPath)&quot; -f &quot;@(IntermediateAssembly)&quot;" />
 
   </Target>
 


### PR DESCRIPTION
FakeSign should use the -f (force) option.  If the assembly is already signed then the build should proceed, not exit