### PR TITLE
Support removal namespace in interactive mode

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -623,10 +623,11 @@ class C
         }
 
         [WpfFact]
-        public void Delete_Entire_Namespace()
+        public void Delete_EntireNamespace()
         {
             string src1 = @"
-namespace N {
+namespace N
+{
     class C
     {
         static void Main(String[] args)

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -622,6 +622,28 @@ class C
             edits.VerifyRudeDiagnostics(active);
         }
 
+        [WpfFact]
+        public void Delete_Entire_Namespace()
+        {
+            string src1 = @"
+namespace N {
+    class C
+    {
+        static void Main(String[] args)
+        {
+            <AS:0>Console.WriteLine(1);</AS:0>
+        }
+    }
+}";
+            string src2 = @"<AS:0></AS:0>";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.Delete, null, "namespace"));
+        }
+
         #endregion
 
         #region Constructors

--- a/src/EditorFeatures/Test/EditAndContinue/ActiveStatementDescription.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/ActiveStatementDescription.cs
@@ -112,7 +112,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 var ids = GetIds(match.Groups["Id"].Value);
                 int absoluteOffset = offset + markedSyntax.Index;
 
-                yield return ValueTuple.Create(new TextSpan(absoluteOffset, markedSyntax.Length), ids);
+                var span = markedSyntax.Length != 0 ? new TextSpan(absoluteOffset, markedSyntax.Length) : new TextSpan();
+                yield return ValueTuple.Create(span, ids);
 
                 foreach (var nestedSpan in GetSpansRecursive(regex, contentGroupName, markedSyntax.Value, absoluteOffset))
                 {

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -615,7 +615,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         continue;
                     }
 
-                    // Finds a matching syntax node in the new source.
+                    // Find a matching syntax node in the new source.
                     // In case the node got deleted the newMember may be missing.
                     // For those the active span should remain empty.
                     SyntaxNode newMember;

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -554,17 +554,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             Debug.Assert(updatedMethods.Count == 0);
 
             var updatedTrackingSpans = new List<KeyValuePair<ActiveStatementId, TextSpan>>();
-            bool[] editedActiveStatements = new bool[newActiveStatements.Length];
+            BitVector editedActiveStatements = BitVector.Create(newActiveStatements.Length);
 
             for (int i = 0; i < script.Edits.Length; i++)
             {
                 var edit = script.Edits[i];
 
-                AnalyzeUpdatedActiveMethodBodies(script, i, editMap, oldText, newText, documentId, trackingService, oldActiveStatements, newActiveStatements, newExceptionRegions, updatedMethods, editedActiveStatements, updatedTrackingSpans, diagnostics);
+                AnalyzeUpdatedActiveMethodBodies(script, i, editMap, oldText, newText, documentId, trackingService, oldActiveStatements, ref editedActiveStatements, newActiveStatements, newExceptionRegions, updatedMethods, updatedTrackingSpans, diagnostics);
                 ReportSyntacticRudeEdits(diagnostics, script.Match, edit, editMap);
             }
 
-            UpdateUneditedSpans(diagnostics, script.Match, oldText, newText, documentId, trackingService, oldActiveStatements, newActiveStatements, newExceptionRegions, editedActiveStatements, updatedTrackingSpans);
+            UpdateUneditedSpans(diagnostics, script.Match, oldText, newText, documentId, trackingService, oldActiveStatements, editedActiveStatements, newActiveStatements, newExceptionRegions, updatedTrackingSpans);
 
             if (updatedTrackingSpans.Count > 0)
             {
@@ -580,9 +580,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             DocumentId documentId,
             IActiveStatementTrackingService trackingService,
             ImmutableArray<ActiveStatementSpan> oldActiveStatements,
+            BitVector editedActiveStatements,
             [In, Out]LinePositionSpan[] newActiveStatements,
             [In, Out]ImmutableArray<LinePositionSpan>[] newExceptionRegions,
-            [In, Out]bool[] editedActiveStatements,
             [In, Out]List<KeyValuePair<ActiveStatementId, TextSpan>> updatedTrackingSpans)
         {
             Debug.Assert(oldActiveStatements.Length == newActiveStatements.Length);
@@ -842,10 +842,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             DocumentId documentId,
             IActiveStatementTrackingService trackingService,
             ImmutableArray<ActiveStatementSpan> oldActiveStatements,
+            ref BitVector editedActiveStatements,
             [Out]LinePositionSpan[] newActiveStatements,
             [Out]ImmutableArray<LinePositionSpan>[] newExceptionRegions,
             [Out]List<UpdatedMemberInfo> updatedMembers,
-            [Out]bool[] editedActiveStatements,
             [Out]List<KeyValuePair<ActiveStatementId, TextSpan>> updatedTrackingSpans,
             [Out]List<RudeEditDiagnostic> diagnostics)
         {


### PR DESCRIPTION
Fixes issue #4230 where removal of top-level statements would crash VS
Makes syntax analysis handle this edge case when diagnostic spans are empty.