### PR TITLE
Remove extraneous quotation marks

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -283,9 +283,9 @@
                      ('$(Language)' == 'C#' OR '$(Language)' == 'VB') AND
                      '$(BuildingProject)' == 'true'"
           Inputs="@(IntermediateAssembly)"
-          Outputs="@(IntermediateAssembly);&quot;$(PostCompileBinaryModificationSentinelFile)&quot;">
+          Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
 
-    <Exec Command="&quot;$(FakeSignToolPath)&quot; -f &quot;@(IntermediateAssembly)&quot;" />
+    <Exec Command="&quot;$(FakeSignToolPath)&quot; &quot;@(IntermediateAssembly)&quot;" />
 
   </Target>
 


### PR DESCRIPTION
They prevent the files listed in the `Outputs` attribute of the
`FakeSign` target from being found.

Roll back the earlier workaround of passing `-f`.

Fixes #6533