### PR TITLE
Fix issue with VB preprocesser keywords appearing in the completion list within incomplete preprocesser

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/ConstDirectiveKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/ConstDirectiveKeywordRecommenderTests.vb
@@ -1,22 +1,13 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Test.Utilities
-Imports Xunit
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.PreprocessorDirectives
     Public Class ConstDirectiveKeywordRecommenderTests
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashConstInFile()
             VerifyRecommendationsContain(<File>|</File>, "#Const")
         End Sub
 
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashConstInMethodBody()
             VerifyRecommendationsContain(<MethodBody>|</MethodBody>, "#Const")
         End Sub
@@ -31,25 +22,34 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Pr
                                          </File>, "#Const")
         End Sub
 
-        <WpfFact>
         <WorkItem(544629)>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashConstAfterSingleNonMatchingCharacter()
             VerifyRecommendationsContain(<File>a|</File>, "#Const")
         End Sub
 
-        <WpfFact>
         <WorkItem(544629)>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashConstAfterPartialConstWithoutHash()
             VerifyRecommendationsContain(<File>Con|</File>, "#Const")
         End Sub
 
-        <WpfFact>
         <WorkItem(722, "https://github.com/dotnet/roslyn/issues/722")>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub NotAfterHashConst()
             VerifyRecommendationsMissing(<File>#Const |</File>, "#Const")
+        End Sub
+
+        <WorkItem(6389, "https://github.com/dotnet/roslyn/issues/6389")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub NotAfterHashRegion()
+            VerifyRecommendationsMissing(<File>
+                                         Class C
+
+                                             #Region |
+
+                                         End Class
+                                         </File>, "#Const")
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/IfDirectiveKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/IfDirectiveKeywordRecommenderTests.vb
@@ -1,33 +1,35 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Test.Utilities
-Imports Xunit
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.PreprocessorDirectives
     Public Class IfDirectiveKeywordRecommenderTests
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashIfInFile()
             VerifyRecommendationsContain(<File>|</File>, "#If")
         End Sub
 
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashIfInMethodBody()
             VerifyRecommendationsContain(<MethodBody>|</MethodBody>, "#If")
         End Sub
 
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub NotInEnumBlockMemberDeclaration()
             VerifyRecommendationsMissing(<File>
                                              Enum foo
                                                 |
                                             End enum
+                                         </File>, "#If")
+        End Sub
+
+        <WorkItem(6389, "https://github.com/dotnet/roslyn/issues/6389")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub NotAfterHashRegion()
+            VerifyRecommendationsMissing(<File>
+                                         Class C
+
+                                             #Region |
+
+                                         End Class
                                          </File>, "#If")
         End Sub
     End Class

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/RegionDirectiveKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/RegionDirectiveKeywordRecommenderTests.vb
@@ -1,30 +1,20 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Test.Utilities
-Imports Xunit
-
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.PreprocessorDirectives
     Public Class RegionDirectiveKeywordRecommenderTests
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashRegionInFile()
             VerifyRecommendationsContain(<File>|</File>, "#Region")
         End Sub
 
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub HashRegionInLambda()
             VerifyRecommendationsContain(<ClassDeclaration>Dim x = Function()
 |
 End Function</ClassDeclaration>, "#Region")
         End Sub
 
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub NotInEnumBlockMemberDeclaration()
             VerifyRecommendationsMissing(<File>
                                              Enum foo
@@ -33,13 +23,24 @@ End Function</ClassDeclaration>, "#Region")
                                          </File>, "#Region")
         End Sub
 
-        <WpfFact>
-        <Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Sub NotAfterHashEnd()
             VerifyRecommendationsMissing(<File>
 #Region "foo"
 
 #End |</File>, "#Region")
+        End Sub
+
+        <WorkItem(6389, "https://github.com/dotnet/roslyn/issues/6389")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub NotAfterHashRegion()
+            VerifyRecommendationsMissing(<File>
+                                         Class C
+
+                                             #Region |
+
+                                         End Class
+                                         </File>, "#Region")
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/WarningDirectiveKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/PreprocessorDirectives/WarningDirectiveKeywordRecommenderTests.vb
@@ -140,5 +140,18 @@ Enum E
 End Enum
                                          </File>, "#Enable Warning", "#Disable Warning")
         End Sub
+
+        <WorkItem(6389, "https://github.com/dotnet/roslyn/issues/6389")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Sub NotAfterHashRegion()
+            VerifyRecommendationsMissing(<File>
+                                         Class C
+
+                                             #Region |
+
+                                         End Class
+                                         </File>, "#Enable Warning", "#Disable Warning")
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #6389.

To determine whether preprocesser keywords should appear in the completion list, we first check to see if we're in a processor start context. As part of this check we test for implicit line continuation, which can be a bit complex. Essentially, we check the trailing trivia of the starting token and each missing token following it. Then, when we encounter a non-missing token, we check its leading trivia. Unfortunately, the code didn't expect that the leading trivia of the next non-missing token could overlap with the starting token, which can happen if the starting token inside of structured trivia.

Consider the following code:

```VB
Class C

    #Region |
End Class
```

In this case, there is a missing string literal token at the marked position to check. Then, we encounter a non-missing token: "End". However, the leading trivia of "End" includes the incomplete #Region preprocessor plus the whitespace before it. However, the code never checks to see if the leading trivia overlaps the #Region, so it happily starts checking for implicit line contination before #Region, causing an incorrect result.

This fix adds that check.

Tagging @dotnet/roslyn-ide 