### PR TITLE
Use XUnit assert and CultureInfo value equality to verify test assumption.

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/InterpolatedStringTests.vb
@@ -582,8 +582,7 @@ End Module
     </file>
 </compilation>, expectedOutput:="1,51,51,51.5")
 
-            Debug.Assert(Threading.Thread.CurrentThread.CurrentCulture Is previousCulture)
-
+            Assert.Equal(previousCulture, Threading.Thread.CurrentThread.CurrentCulture)
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes #6257.

@dotnet/roslyn-compiler Please review.