### PR TITLE
Enable determinism end-to-end tests and fix SourceFileResolver

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -37,6 +37,7 @@
     <Compile Include="PEWriter\BlobTests.cs" />
     <Compile Include="RealParserTests.cs" />
     <Compile Include="SimpleAnalyzerAssemblyLoaderTests.cs" />
+    <Compile Include="SourceFileResolverTest.cs" />
     <Compile Include="Text\LargeEncodedTextTests.cs" />
     <Compile Include="Text\SourceTextStreamTests.cs" />
     <Compile Include="XmlDocumentationCommentTextReaderTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
@@ -1,0 +1,39 @@
+﻿using Roslyn.Utilities;
+using System;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class SourceFileResolverTest
+    {
+        [Fact]
+        public void IncorrectPathmaps()
+        {
+            string isABaseDirectory = "";
+            if (PortableShim.Path.DirectorySeparatorChar == '/') {
+                isABaseDirectory = "/";
+            }
+            else
+            {
+                isABaseDirectory = "C://";
+            }
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new SourceFileResolver(
+                    ImmutableArray.Create(""), 
+                    isABaseDirectory, 
+                    ImmutableArray.Create(KeyValuePair.Create<string, string>("key", null))));
+        }
+
+        [Fact]
+        public void badBaseDirectory()
+        {
+            Assert.Throws<ArgumentException>(() => 
+                new SourceFileResolver(
+                    ImmutableArray.Create(""), 
+                    "not_a_root directory", 
+                    ImmutableArray.Create(KeyValuePair.Create<string, string>("key", "value"))));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -406,15 +406,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A value in the pathMap is empty..
-        /// </summary>
-        internal static string EmptyValueInPathMap {
-            get {
-                return ResourceManager.GetString("EmptyValueInPathMap", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;end&apos; must not be less than &apos;start&apos;.
         /// </summary>
         internal static string EndMustNotBeLessThanStart {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -865,6 +865,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A value in the pathMap is null..
+        /// </summary>
+        internal static string NullValueInPathMap {
+            get {
+                return ResourceManager.GetString("NullValueInPathMap", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Output kind not supported..
         /// </summary>
         internal static string OutputKindNotSupported {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -222,9 +222,6 @@
   <data name="EmptyKeyInPathMap" xml:space="preserve">
     <value>A key in the pathMap is empty.</value>
   </data>
-  <data name="EmptyValueInPathMap" xml:space="preserve">
-    <value>A value in the pathMap is empty.</value>
-  </data>
   <data name="KeyInPathMapEndsWithSeparator" xml:space="preserve">
     <value>A key in the pathMap ends with a path separator.</value>
   </data>

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -222,6 +222,9 @@
   <data name="EmptyKeyInPathMap" xml:space="preserve">
     <value>A key in the pathMap is empty.</value>
   </data>
+  <data name="NullValueInPathMap" xml:space="preserve">
+    <value>A value in the pathMap is null.</value>
+  </data>
   <data name="KeyInPathMapEndsWithSeparator" xml:space="preserve">
     <value>A key in the pathMap ends with a path separator.</value>
   </data>

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis
                     var value = kv.Value;
                     if (value == null)
                     {
-                        throw new ArgumentNullException(nameof(PathMap));
+                        throw new ArgumentNullException(nameof(pathMap));
                     }
 
                     if (IsPathSeparator(key[key.Length - 1]))

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis
                     var value = kv.Value;
                     if (value == null)
                     {
-                        throw new ArgumentNullException(nameof(pathMap));
+                        throw new ArgumentException(CodeAnalysisResources.NullValueInPathMap, nameof(pathMap));
                     }
 
                     if (IsPathSeparator(key[key.Length - 1]))

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -62,9 +62,9 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     var value = kv.Value;
-                    if (value == null || value.Length == 0)
+                    if (value == null)
                     {
-                        throw new ArgumentException(CodeAnalysisResources.EmptyValueInPathMap, nameof(pathMap));
+                        throw new ArgumentNullException(nameof(PathMap));
                     }
 
                     if (IsPathSeparator(key[key.Length - 1]))

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Roslyn.Utilities;

--- a/src/Compilers/Server/VBCSCompilerTests/EndToEndDeterminismTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/EndToEndDeterminismTest.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
-    class EndToEndDeterminismTest: TestBase
+    public class EndToEndDeterminismTest: TestBase
     {
         private string _flags = "/shared /deterministic+ /nologo /t:library /pdb:none";
 


### PR DESCRIPTION
Due to a mistake on my part, apparently end-to-end tests haven't been running on the CI server.  This change fixes that, and also fixes a bug that would have been caught if they had been running.

@jaredpar 
@dotnet/roslyn-compiler 