### PR TITLE
Set DeployExtension=false in BuildAndTest.proj...

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -20,7 +20,7 @@
   <Target Name="Build">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
              Targets="Build"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"
@@ -32,7 +32,7 @@
   <Target Name="Clean">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false"
+             Properties="RestorePackages=false;DeployExtension=false"
              Targets="Clean"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"
@@ -44,7 +44,7 @@
   <Target Name="Rebuild">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="RestorePackages=false;TreatWarningsAsErrors=true;DeployExtension=false"
              Targets="Rebuild"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -11,7 +11,7 @@ set BuildRestore=false
 REM Because override the C#/VB toolset to build against our LKG package, it is important
 REM that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise, 
 REM we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
-set MSBuildAdditionalCommandLineArgs=/nologo /v:m /m /nodeReuse:false /p:DeployExtension=false
+set MSBuildAdditionalCommandLineArgs=/nologo /v:m /m /nodeReuse:false
 
 :ParseArguments
 if "%1" == "" goto :DoneParsing


### PR DESCRIPTION
BuildAndTest.cmd already sets this property.  We should have the same
behavior if you're performing the analogous operation in the "Open"
submodule.  Since we never run IDE tests as a part of BuildAndTest, it
shouldn't matter that we don't deploy the extensions.  Without this,
"msbuild BuildAndTest.proj" doesn't work on clean VS install.