### PR TITLE
Greatly improve performance of Object Browser first open

### DIFF
--- a/src/Compilers/CSharp/CscCore/CscCore.csproj
+++ b/src/Compilers/CSharp/CscCore/CscCore.csproj
@@ -75,8 +75,8 @@
     <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
       <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
     </Compile>
-    <Compile Include="..\..\Shared\AnalyzerAssemblyLoadUtils.cs">
-      <Link>AnalyzerAssemblyLoadUtils.cs</Link>
+    <Compile Include="..\..\Shared\AssemblyIdentityUtils.cs">
+      <Link>AssemblyIdentityUtils.cs</Link>
     </Compile>
     <Compile Include="Csc.cs" />
     <Compile Include="Program.cs" />

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -53,8 +53,8 @@
     <Compile Include="..\..\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
-    <Compile Include="..\..\Shared\AnalyzerAssemblyLoadUtils.cs">
-      <Link>AnalyzerAssemblyLoadUtils.cs</Link>
+    <Compile Include="..\..\Shared\AssemblyIdentityUtils.cs">
+      <Link>AssemblyIdentityUtils.cs</Link>
     </Compile>
     <Compile Include="..\..\Shared\ConsoleUtil.cs">
       <Link>ConsoleUtil.cs</Link>

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -51,8 +51,8 @@
     <Compile Include="..\..\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
-    <Compile Include="..\..\Shared\AnalyzerAssemblyLoadUtils.cs">
-      <Link>AnalyzerAssemblyLoadUtils.cs</Link>
+    <Compile Include="..\..\Shared\AssemblyIdentityUtils.cs">
+      <Link>AssemblyIdentityUtils.cs</Link>
     </Compile>
     <Compile Include="..\..\Shared\ShadowCopyAnalyzerAssemblyLoader.cs">
       <Link>ShadowCopyAnalyzerAssemblyLoader.cs</Link>

--- a/src/Compilers/Shared/AbstractAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/AbstractAnalyzerAssemblyLoader.cs
@@ -11,7 +11,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Roslyn.Utilities;
 
-using static Microsoft.CodeAnalysis.AnalyzerAssemblyLoadUtils;
+using static Microsoft.CodeAnalysis.AssemblyIdentityUtils;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Shared/AssemblyIdentityUtils.cs
+++ b/src/Compilers/Shared/AssemblyIdentityUtils.cs
@@ -9,7 +9,7 @@ using System.Reflection.PortableExecutable;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal static class AnalyzerAssemblyLoadUtils
+    internal static class AssemblyIdentityUtils
     {
         public static AssemblyIdentity TryGetAssemblyIdentity(string filePath)
         {
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis
                     ImmutableArray<byte> publicKeyOrToken = !publicKeyHandle.IsNil
                         ? metadataReader.GetBlobBytes(publicKeyHandle).AsImmutableOrNull()
                         : default(ImmutableArray<byte>);
+
                     return new AssemblyIdentity(name, version, cultureName, publicKeyOrToken, hasPublicKey);
                 }
             }

--- a/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 using System.Runtime.Loader;
 using Roslyn.Utilities;
 
-using static Microsoft.CodeAnalysis.AnalyzerAssemblyLoadUtils;
+using static Microsoft.CodeAnalysis.AssemblyIdentityUtils;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
+++ b/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
@@ -74,8 +74,8 @@
     <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
       <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
     </Compile>
-    <Compile Include="..\..\Shared\AnalyzerAssemblyLoadUtils.cs">
-      <Link>AnalyzerAssemblyLoadUtils.cs</Link>
+    <Compile Include="..\..\Shared\AssemblyIdentityUtils.cs">
+      <Link>AssemblyIdentityUtils.cs</Link>
     </Compile>
     <Compile Include="Vbc.cs" />
     <Compile Include="Program.cs" />

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -72,8 +72,8 @@
     <Compile Include="..\..\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
-    <Compile Include="..\..\Shared\AnalyzerAssemblyLoadUtils.cs">
-      <Link>AnalyzerAssemblyLoadUtils.cs</Link>
+    <Compile Include="..\..\Shared\AssemblyIdentityUtils.cs">
+      <Link>AssemblyIdentityUtils.cs</Link>
     </Compile>
     <Compile Include="..\..\Shared\ConsoleUtil.cs">
       <Link>ConsoleUtil.cs</Link>

--- a/src/Test/Utilities/Desktop/TestUtilities.Desktop.csproj
+++ b/src/Test/Utilities/Desktop/TestUtilities.Desktop.csproj
@@ -90,8 +90,8 @@
     <Compile Include="..\..\..\Compilers\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\Compilers\Shared\AnalyzerAssemblyLoadUtils.cs">
-      <Link>AnalyzerAssemblyLoadUtils.cs</Link>
+    <Compile Include="..\..\..\Compilers\Shared\AssemblyIdentityUtils.cs">
+      <Link>AssemblyIdentityUtils.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Compilers\Shared\SimpleAnalyzerAssemblyLoader.cs">
       <Link>SimpleAnalyzerAssemblyLoader.cs</Link>

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
@@ -626,28 +626,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                         assemblyIdentitySet = new HashSet<AssemblyIdentity>();
                     }
 
-                    var compilation = project.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-
-                    foreach (var reference in compilation.References)
+                    foreach (var reference in project.MetadataReferences)
                     {
-                        if (reference is CompilationReference)
+                        var portableExecutableReference = reference as PortableExecutableReference;
+                        if (portableExecutableReference != null)
                         {
-                            continue;
-                        }
+                            var assemblyIdentity = AssemblyIdentityUtils.TryGetAssemblyIdentity(portableExecutableReference.FilePath);
+                            if (assemblyIdentity != null && !assemblyIdentitySet.Contains(assemblyIdentity))
+                            {
+                                assemblyIdentitySet.Add(assemblyIdentity);
 
-                        var assemblySymbol = compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
-                        if (assemblySymbol == null)
-                        {
-                            continue;
+                                var referenceListItem = new ReferenceListItem(projectId, assemblyIdentity.Name, reference);
+                                referenceListItemBuilder.Add(referenceListItem);
+                            }
                         }
-
-                        if (assemblyIdentitySet.Contains(assemblySymbol.Identity))
-                        {
-                            continue;
-                        }
-
-                        assemblyIdentitySet.Add(assemblySymbol.Identity);
-                        referenceListItemBuilder.Add(new ReferenceListItem(projectId, assemblySymbol.Name, reference));
                     }
                 }
             }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/ObjectList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/ObjectList.cs
@@ -950,33 +950,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                     return false;
                 }
 
-                var metadataReference = referenceListItem.MetadataReference as PortableExecutableReference;
-                if (metadataReference == null)
+                var portableExecutableReference = referenceListItem.MetadataReference as PortableExecutableReference;
+                if (portableExecutableReference == null)
                 {
                     return false;
                 }
 
-                var compilation = referenceListItem.GetCompilation(this.LibraryManager.Workspace);
-                if (compilation == null)
+                var assemblyIdentity = AssemblyIdentityUtils.TryGetAssemblyIdentity(portableExecutableReference.FilePath);
+                if (assemblyIdentity == null)
                 {
                     return false;
                 }
 
-                var assemblySymbol = referenceListItem.GetAssembly(compilation);
-                if (assemblySymbol == null)
-                {
-                    return false;
-                }
-
-                data.bstrFile = metadataReference.FilePath;
+                data.bstrFile = portableExecutableReference.FilePath;
                 data.type = VSCOMPONENTTYPE.VSCOMPONENTTYPE_ComPlus;
 
-                var identity = assemblySymbol.Identity;
-
-                data.wFileMajorVersion = (ushort)identity.Version.Major;
-                data.wFileMinorVersion = (ushort)identity.Version.Minor;
-                data.wFileBuildNumber = (ushort)identity.Version.Build;
-                data.wFileRevisionNumber = (ushort)identity.Version.Revision;
+                data.wFileMajorVersion = (ushort)assemblyIdentity.Version.Major;
+                data.wFileMinorVersion = (ushort)assemblyIdentity.Version.Minor;
+                data.wFileBuildNumber = (ushort)assemblyIdentity.Version.Build;
+                data.wFileRevisionNumber = (ushort)assemblyIdentity.Version.Revision;
             }
 
             return true;

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -59,8 +59,8 @@
     <Compile Include="..\..\..\Compilers\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>InternalUtilities\AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\Compilers\Shared\AnalyzerAssemblyLoadUtils.cs">
-      <Link>AnalyzerAssemblyLoadUtils.cs</Link>
+    <Compile Include="..\..\..\Compilers\Shared\AssemblyIdentityUtils.cs">
+      <Link>AssemblyIdentityUtils.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Compilers\Shared\GlobalAssemblyCacheHelpers\GlobalAssemblyCacheLocation.cs">
       <Link>InternalUtilities\GlobalAssemblyCache.cs</Link>


### PR DESCRIPTION
Fixes #3851

Object Browser was forcing compilations to be realized just to compute the assembly identity for each of a compilation's metadata references. With this change, the Object Browser will use the metadata references from the project and call the same utility function that is used to read assembly identity for analyzer assemblies.

Tagging @dotnet/roslyn-ide for review and @amcasey as FYI