### PR TITLE
[AskMode] Fix issue with #load of files that can't be read as text...

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -58,6 +59,60 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // a.csx(3,21): error CS0103: The name 'asdf' does not exist in the current context
                 //                     asdf();
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "asdf").WithArguments("asdf").WithLocation(3, 21));
+        }
+
+        [Fact]
+        public void FileThatCannotBeDecoded()
+        {
+            var code = "#load \"b.csx\"";
+            var resolver = TestSourceReferenceResolver.Create(
+                KeyValuePair.Create<string, object>("a.csx", new byte[] { 0xd8, 0x00, 0x00 }),
+                KeyValuePair.Create<string, object>("b.csx", "#load \"a.csx\""));
+            var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
+            var compilation = CreateCompilationWithMscorlib45(code, sourceFileName: "external1.csx", options: options, parseOptions: TestOptions.Script);
+            var external1 = compilation.SyntaxTrees.Last();
+            var external2 = Parse(code, filename: "external2.csx", options: TestOptions.Script);
+            compilation = compilation.AddSyntaxTrees(external2);
+
+            Assert.Equal(3, compilation.SyntaxTrees.Length);
+            compilation.GetParseDiagnostics().Verify(
+                // (1,7): error CS2015: 'a.csx' is a binary file instead of a text file
+                // #load "a.csx"
+                Diagnostic(ErrorCode.ERR_BinaryFile, @"""a.csx""").WithArguments("a.csx").WithLocation(1, 7));
+
+            var external3 = Parse(@"
+                #load ""b.csx""
+                #load ""a.csx""", filename: "external3.csx", options: TestOptions.Script);
+            compilation = compilation.ReplaceSyntaxTree(external1, external3);
+
+            Assert.Equal(3, compilation.SyntaxTrees.Length);
+            compilation.GetParseDiagnostics().Verify(
+                // external3.csx(3,23): error CS2015: 'a.csx' is a binary file instead of a text file
+                //                 #load "a.csx"
+                Diagnostic(ErrorCode.ERR_BinaryFile, @"""a.csx""").WithArguments("a.csx").WithLocation(3, 23),
+                // b.csx(1,7): error CS2015: 'a.csx' is a binary file instead of a text file
+                // #load "a.csx"
+                Diagnostic(ErrorCode.ERR_BinaryFile, @"""a.csx""").WithArguments("a.csx").WithLocation(1, 7));
+
+            var external4 = Parse("#load \"a.csx\"", filename: "external4.csx", options: TestOptions.Script);
+            compilation = compilation.ReplaceSyntaxTree(external3, external4);
+
+            Assert.Equal(3, compilation.SyntaxTrees.Length);
+            compilation.GetParseDiagnostics().Verify(
+                // external4.csx(1,7): error CS2015: 'a.csx' is a binary file instead of a text file
+                // #load "a.csx"
+                Diagnostic(ErrorCode.ERR_BinaryFile, @"""a.csx""").WithArguments("a.csx").WithLocation(1, 7),
+                // b.csx(1,7): error CS2015: 'a.csx' is a binary file instead of a text file
+                // #load "a.csx"
+                Diagnostic(ErrorCode.ERR_BinaryFile, @"""a.csx""").WithArguments("a.csx").WithLocation(1, 7));
+
+            compilation = compilation.RemoveSyntaxTrees(external2);
+
+            Assert.Equal(external4, compilation.SyntaxTrees.Single());
+            compilation.GetParseDiagnostics().Verify(
+                // external4.csx(1,7): error CS2015: 'a.csx' is a binary file instead of a text file
+                // #load "a.csx"
+                Diagnostic(ErrorCode.ERR_BinaryFile, @"""a.csx""").WithArguments("a.csx").WithLocation(1, 7));
         }
 
         [Fact]

--- a/src/Test/Utilities/Shared/Mocks/TestSourceReferenceResolver.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestSourceReferenceResolver.cs
@@ -15,17 +15,22 @@ namespace Roslyn.Test.Utilities
 
         public static SourceReferenceResolver Create(params KeyValuePair<string, string>[] sources)
         {
-            return TestSourceReferenceResolver.Create(sources.ToDictionary(p => p.Key, p => p.Value));
+            return new TestSourceReferenceResolver(sources.ToDictionary(p => p.Key, p => (object)p.Value));
+        }
+
+        public static SourceReferenceResolver Create(params KeyValuePair<string, object>[] sources)
+        {
+            return new TestSourceReferenceResolver(sources.ToDictionary(p => p.Key, p => p.Value));
         }
 
         public static SourceReferenceResolver Create(Dictionary<string, string> sources = null)
         {
-            return (sources == null || sources.Count == 0) ? Default : new TestSourceReferenceResolver(sources);
+            return new TestSourceReferenceResolver(sources.ToDictionary(p => p.Key, p => (object)p.Value));
         }
 
-        private readonly Dictionary<string, string> _sources;
+        private readonly Dictionary<string, object> _sources;
 
-        private TestSourceReferenceResolver(Dictionary<string, string> sources)
+        private TestSourceReferenceResolver(Dictionary<string, object> sources)
         {
             _sources = sources;
         }
@@ -39,7 +44,8 @@ namespace Roslyn.Test.Utilities
         {
             if (_sources != null && resolvedPath != null)
             {
-                return new MemoryStream(Encoding.UTF8.GetBytes(_sources[resolvedPath]));
+                var data = _sources[resolvedPath];
+                return new MemoryStream((data is string) ? Encoding.UTF8.GetBytes((string)data) : (byte[])data);
             }
             else
             {


### PR DESCRIPTION
If a #load'ed file can be resolved, but cannot be read (or cannot be read as text), it doesn't get added to the map of resolved file paths -> SyntaxTrees (because there is no SyntaxTree to add).  This wasn't handled in the remove and replace helpers that rebuild the various syntax maps.  In addition, we were attempting to add #load'ed trees to the ordinal map twice in the case that their ordinal position needed to be shifted after a remove or replace.

(fixes #6589)