### PR TITLE
Corrects the ConvertToAutoPropertyCS sample

### DIFF
--- a/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
+++ b/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
@@ -60,7 +60,7 @@ namespace ConvertToAutoPropertyCS
             // Retrieve the symbol for the field's variable
             if (field.Declaration.Variables.Count == 1)
             {
-                if (object.Equals(semanticModel.GetDeclaredSymbol(field.Declaration.Variables.FirstOrDefault()), backingField))
+                if (object.Equals(semanticModel.GetDeclaredSymbol(field.Declaration.Variables.Single()), backingField))
                 {
                     return null;
                 }

--- a/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
+++ b/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
@@ -60,7 +60,7 @@ namespace ConvertToAutoPropertyCS
             // Retrieve the symbol for the field's variable
             if (field.Declaration.Variables.Count == 1)
             {
-                if (object.Equals(semanticModel.GetDeclaredSymbol(field.Declaration.Variables.Single()), backingField))
+                if (object.Equals(semanticModel.GetDeclaredSymbol(field.Declaration.Variables.First()), backingField))
                 {
                     return null;
                 }

--- a/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
+++ b/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
@@ -60,7 +60,7 @@ namespace ConvertToAutoPropertyCS
             // Retrieve the symbol for the field
             if (field.Declaration.Variables.Count == 1)
             {
-                if (object.Equals(semanticModel.GetDeclaredSymbol(field), backingField))
+                if (object.Equals(semanticModel.GetDeclaredSymbol(field.Declaration.Variables.FirstOrDefault()), backingField))
                 {
                     return null;
                 }

--- a/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
+++ b/src/Samples/CSharp/ConvertToAutoProperty/Impl/PropertyRewriter.cs
@@ -57,7 +57,7 @@ namespace ConvertToAutoPropertyCS
 
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax field)
         {
-            // Retrieve the symbol for the field
+            // Retrieve the symbol for the field's variable
             if (field.Declaration.Variables.Count == 1)
             {
                 if (object.Equals(semanticModel.GetDeclaredSymbol(field.Declaration.Variables.FirstOrDefault()), backingField))


### PR DESCRIPTION
Correctly checks for the field variable's symbol in the **ConvertToAutoPropertyCS** sample

This fixes #2127 

---

This fix could be improved by also cleaning up fields with multiple variables declared. Currently a field with multiple variables is left intact. Do we want to demonstrate such scenario in a code fix provider?

![img](https://i.gyazo.com/2eb49f2f68ee0902546a594359e8571d.png)

This can be accomplished with the following code:
```csharp
            else if (field.Declaration.Variables.Count > 1)
            {
                return field.WithDeclaration(
                    field.Declaration.WithVariables(
                        SyntaxFactory.SeparatedList(
                            field.Declaration.Variables.Where(
                                v => !object.Equals(semanticModel.GetDeclaredSymbol(v), backingField)
                            )
                        )
                    )
                );
            }
```

However, this would require Linq which is against [the contribution guidelines](https://github.com/dotnet/roslyn/wiki/Contributing-Code) regarding the compiler hot path. This is an analyzer, is Linq ok here? 