### PR TITLE
Prevent MEF DefaultHost loading in the syntactic classifier

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.Editor.Implementation.Workspaces;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
 {
@@ -44,10 +45,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
                         associatedViewService: null,
                         allLanguageServices: ImmutableArray<Lazy<ILanguageService, LanguageServiceMetadata>>.Empty,
                         contentTypes: ImmutableArray<Lazy<ILanguageService, ContentTypeLanguageMetadata>>.Empty,
-                        asyncListeners: ImmutableArray<Lazy<IAsynchronousOperationListener, FeatureMetadata>>.Empty),
+                        asyncListeners: ImmutableArray<Lazy<IAsynchronousOperationListener, FeatureMetadata>>.Empty,
+                        mefHostServicesFactoryService: workspace.GetService<MefHostServicesFactoryService>()),
                     viewSupportsClassificationServiceOpt: null,
                     associatedViewService: null,
                     editorClassificationService: null,
+                    hostServices: null,
                     languageName: null);
 
                 SnapshotSpan span = default(SnapshotSpan);

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -654,6 +654,7 @@
     <Compile Include="Implementation\TodoComment\TodoCommentTokens.cs" />
     <Compile Include="Implementation\Workspaces\EditorErrorReportingService.cs" />
     <Compile Include="Implementation\Workspaces\EditorErrorReportingServiceFactory.cs" />
+    <Compile Include="Implementation\Workspaces\MefHostServicesFactoryService.cs" />
     <Compile Include="Implementation\Workspaces\ProjectCacheServiceFactory.cs" />
     <Compile Include="Implementation\Workspaces\EditorTextFactoryService.cs" />
     <Compile Include="Implementation\Workspaces\ProjectCacheService.cs" />

--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             private readonly IEditorClassificationService _editorClassificationService;
             private readonly IViewSupportsClassificationService _viewSupportsClassificationServiceOpt;
             private readonly ITextBufferAssociatedViewService _associatedViewService;
+            private readonly HostServices _hostServices;
 
             private readonly string _languageName;
 
@@ -88,6 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 IViewSupportsClassificationService viewSupportsClassificationServiceOpt,
                 ITextBufferAssociatedViewService associatedViewService,
                 IEditorClassificationService editorClassificationService,
+                HostServices hostServices,
                 string languageName)
             {
                 _subjectBuffer = subjectBuffer;
@@ -98,6 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 _viewSupportsClassificationServiceOpt = viewSupportsClassificationServiceOpt;
                 _associatedViewService = associatedViewService;
                 _editorClassificationService = editorClassificationService;
+                _hostServices = hostServices;
                 _languageName = languageName;
 
                 _workQueue = new AsynchronousSerialWorkQueue(asyncListener);
@@ -184,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                     _isClassificationOnlyWorkspace = true;
                     if (_languageName != null)
                     {
-                        _workspace = new AdhocWorkspace();
+                        _workspace = new AdhocWorkspace(_hostServices);
                         var solution = _workspace.CreateSolution(SolutionId.CreateNewId());
                         var project = solution.AddProject(name: string.Empty, assemblyName: string.Empty, language: _languageName);
 

--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.CodeAnalysis.Editor.Implementation.Workspaces;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
@@ -28,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         private readonly IForegroundNotificationService _notificationService;
         private readonly IViewSupportsClassificationService _viewSupportsClassificationServiceOpt;
         private readonly ITextBufferAssociatedViewService _associatedViewService;
+        private readonly HostServices _hostServices;
         private readonly IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> _editorClassificationLanguageServices;
         private readonly IEnumerable<Lazy<ILanguageService, ContentTypeLanguageMetadata>> _contentTypesToLanguageNames;
         private readonly IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> _asyncListeners;
@@ -41,6 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             ClassificationTypeMap typeMap,
             [Import(AllowDefault = true)] IViewSupportsClassificationService viewSupportsClassificationServiceOpt,
             ITextBufferAssociatedViewService associatedViewService,
+            [Import] MefHostServicesFactoryService mefHostServicesFactoryService,
             [ImportMany] IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> allLanguageServices,
             [ImportMany] IEnumerable<Lazy<ILanguageService, ContentTypeLanguageMetadata>> contentTypes,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
@@ -52,6 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             _editorClassificationLanguageServices = allLanguageServices.Where(s => s.Metadata.ServiceType == typeof(IEditorClassificationService).AssemblyQualifiedName);
             _contentTypesToLanguageNames = contentTypes.Where(x => x.Metadata.DefaultContentType != null);
             _asyncListeners = asyncListeners;
+            _hostServices = mefHostServicesFactoryService.CreateHostServices();
         }
 
         public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
@@ -83,6 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                     _viewSupportsClassificationServiceOpt,
                     _associatedViewService, 
                     editorClassificationService,
+                    _hostServices,
                     languageName);
 
                 _tagComputers.Add(buffer, tagComputer);

--- a/src/EditorFeatures/Core/Implementation/Workspaces/MefHostServicesFactoryService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/MefHostServicesFactoryService.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
+{
+    [Export]
+    internal sealed class MefHostServicesFactoryService : IMefHostExportProvider
+    {
+        private readonly IEnumerable<Lazy<IWorkspaceServiceFactory, WorkspaceServiceMetadata>> _workspaceServiceFactories;
+        private readonly IEnumerable<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> _workspaceServices;
+        private readonly IEnumerable<Lazy<ILanguageServiceFactory, LanguageServiceMetadata>> _languageServiceFactories;
+        private readonly IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> _languageServices;
+        private readonly IEnumerable<Lazy<ILanguageService, ContentTypeLanguageMetadata>> _contentTypeLanguageMetadata;
+
+        [ImportingConstructor]
+        public MefHostServicesFactoryService(
+            [ImportMany] IEnumerable<Lazy<IWorkspaceServiceFactory, WorkspaceServiceMetadata>> workspaceServiceFactories,
+            [ImportMany] IEnumerable<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> workspaceServices,
+            [ImportMany] IEnumerable<Lazy<ILanguageServiceFactory, LanguageServiceMetadata>> languageServiceFactories,
+            [ImportMany] IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> languageServices,
+            [ImportMany] IEnumerable<Lazy<ILanguageService, ContentTypeLanguageMetadata>> contentTypeLanguageMetadata)
+        {
+            _workspaceServiceFactories = workspaceServiceFactories;
+            _workspaceServices = workspaceServices;
+            _languageServiceFactories = languageServiceFactories;
+            _languageServices = languageServices;
+            _contentTypeLanguageMetadata = contentTypeLanguageMetadata;
+        }
+
+        public IEnumerable<Lazy<TExtension, TMetadata>> GetExports<TExtension, TMetadata>()
+        {
+            if (typeof(TExtension) == typeof(IWorkspaceServiceFactory) && typeof(TMetadata) == typeof(WorkspaceServiceMetadata))
+            {
+                return (IEnumerable<Lazy<TExtension, TMetadata>>)_workspaceServiceFactories;
+            }
+            else if (typeof(TExtension) == typeof(IWorkspaceService) && typeof(TMetadata) == typeof(WorkspaceServiceMetadata))
+            {
+                return (IEnumerable<Lazy<TExtension, TMetadata>>)_workspaceServices;
+            }
+            else if (typeof(TExtension) == typeof(ILanguageServiceFactory) && typeof(TMetadata) == typeof(LanguageServiceMetadata))
+            {
+                return (IEnumerable<Lazy<TExtension, TMetadata>>)_languageServiceFactories;
+            }
+            else if (typeof(TExtension) == typeof(ILanguageService) && typeof(TMetadata) == typeof(LanguageServiceMetadata))
+            {
+                return (IEnumerable<Lazy<TExtension, TMetadata>>)_languageServices;
+            }
+            else if (typeof(TExtension) == typeof(ILanguageService) && typeof(TMetadata) == typeof(ContentTypeLanguageMetadata))
+            {
+                return (IEnumerable<Lazy<TExtension, TMetadata>>)_contentTypeLanguageMetadata;
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public HostServices CreateHostServices()
+        {
+            return new MefHostServices(this);
+        }
+
+        private class MefHostServices : HostServices
+        {
+            private readonly IMefHostExportProvider _mefHostExportProvider;
+
+            public MefHostServices(IMefHostExportProvider mefHostExportProvider)
+            {
+                _mefHostExportProvider = mefHostExportProvider;
+            }
+
+            protected internal override HostWorkspaceServices CreateWorkspaceServices(Workspace workspace)
+            {
+                return new MefWorkspaceServices(_mefHostExportProvider, workspace);
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Test/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/Test/MinimalTestExportProvider.cs
@@ -54,7 +54,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 typeof(SymbolMapping.SymbolMappingServiceFactory),
                 typeof(TestWaitIndicator),
                 typeof(TestExtensionErrorHandler),
-                typeof(TestExportProvider)
+                typeof(TestExportProvider),
+                typeof(Implementation.Workspaces.MefHostServicesFactoryService)
             };
 
             return types.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(InternalSolutionCrawlerOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/IMefHostExportProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/IMefHostExportProvider.cs
@@ -11,6 +11,5 @@ namespace Microsoft.CodeAnalysis.Host.Mef
     internal interface IMefHostExportProvider
     {
         IEnumerable<Lazy<TExtension, TMetadata>> GetExports<TExtension, TMetadata>();
-        IEnumerable<Lazy<TExtension>> GetExports<TExtension>();
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefHostServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefHostServices.cs
@@ -50,11 +50,6 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             return new MefWorkspaceServices(this, workspace);
         }
 
-        IEnumerable<Lazy<TExtension>> IMefHostExportProvider.GetExports<TExtension>()
-        {
-            return _compositionContext.GetExports<TExtension>().Select(e => new Lazy<TExtension>(() => e));
-        }
-
         IEnumerable<Lazy<TExtension, TMetadata>> IMefHostExportProvider.GetExports<TExtension, TMetadata>()
         {
             var importer = new WithMetadataImporter<TExtension, TMetadata>();


### PR DESCRIPTION
The syntactic classification tagger was creating a AdhocWorkspace when the buffer being tagged was otherwise attached to a real workspace. It was creating one with the default constructor, which in Visual Studio does not use the Visual Studio MEF composition but rather creates its own. This causes more assemblies to be loaded than we would like since it does not have any caching. The fix is to create a HostServices that does get its exports from the Visual Studio MEF composition.

This fixes internal bug 160968.

This was regressed as a part of #6392. This was the bug fix where we would once again classify text buffers for things like TFS annotate and diff. To simplify the change we avoided writing code I'm writing as a part of this PR, and then did a bunch of validation to ensure it wouldn't run in scenarios other than the TFS scenario. We missed testing the ASP.NET scenario.

This was pair programmed with @jmarolf. @dotnet/roslyn-ide, please code review this carefully as we are currently considering it for the stabilization branch.