### PR TITLE
Instrument LocalsTests.Constants to diagnose overflow

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -460,7 +461,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void Constants()
         {
             var source =
-@"class C
+    @"class C
 {
     const int x = 2;
     static int F(int w)
@@ -481,18 +482,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.F",
-                atLineNumber: 888);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
+            ImmutableArray<MetadataReference> references;
+            byte[] exeBytes;
+            byte[] pdbBytes;
+
+            compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
+
+            try
+            {
+                var runtime = CreateRuntimeInstance(
+                    ExpressionCompilerUtilities.GenerateUniqueName(),
+                    references.AddIntrinsicAssembly(),
+                    exeBytes,
+                    SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+
+                var context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.F",
+                    atLineNumber: 888);
+
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
 {
 // Code size        2 (0x2)
 .maxstack  1
@@ -502,7 +517,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 IL_0000:  ldc.i4.3
 IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -512,22 +527,21 @@ IL_0001:  ret
   IL_0000:  ldnull
   IL_0001:  ret
 }");
-            locals.Free();
-
-            context = CreateMethodContext(
-                runtime,
-                methodName: "C.F",
-                atLineNumber: 999);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 5);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "u");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "z", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
-@"{
+                locals.Free();
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.F",
+                    atLineNumber: 999);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 5);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "u");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "z", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+    @"{
 // Code size        6 (0x6)
 .maxstack  1
 .locals init (bool V_0,
@@ -536,7 +550,21 @@ IL_0001:  ret
 IL_0000:  ldstr      ""str""
 IL_0005:  ret
 }");
-            locals.Free();
+                locals.Free();
+            }
+            catch (OverflowException e) when (LogConstantsOverflow(e, exeBytes, pdbBytes))
+            {
+            }
+        }
+
+        private static bool LogConstantsOverflow(Exception e, byte[] exeBytes, byte[] pdbBytes)
+        {
+            var id = Guid.NewGuid();
+            var tempDir = Path.GetTempPath();
+            File.WriteAllBytes(Path.Combine(tempDir, $"EEConstantsTest_{id}.exe"), exeBytes);
+            File.WriteAllBytes(Path.Combine(tempDir, $"EEConstantsTest_{id}.pdb"), pdbBytes);
+
+            return FatalError.Report(e);
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.IO
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.Test.Utilities
@@ -475,21 +476,33 @@ Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim runtime = CreateRuntimeInstance(comp)
-            Dim context = CreateMethodContext(
+
+            Dim exeBytes As Byte() = Nothing
+            Dim pdbBytes As Byte() = Nothing
+            Dim references As ImmutableArray(Of MetadataReference) = Nothing
+            comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
+
+            Try
+                Dim runtime = CreateRuntimeInstance(
+                ExpressionCompilerUtilities.GenerateUniqueName(),
+                references.AddIntrinsicAssembly(),
+                exeBytes,
+                SymReaderFactory.CreateReader(pdbBytes, exeBytes))
+
+                Dim context = CreateMethodContext(
                 runtime,
                 methodName:="C.F",
                 atLineNumber:=888)
-            Dim testData = New CompilationTestData()
-            Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
-            Dim typeName As String = Nothing
-            context.CompileGetLocals(locals, argumentsOnly:=False, typeName:=typeName, testData:=testData)
+                Dim testData = New CompilationTestData()
+                Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
+                Dim typeName As String = Nothing
+                context.CompileGetLocals(locals, argumentsOnly:=False, typeName:=typeName, testData:=testData)
 
-            Assert.Equal(4, locals.Count)
+                Assert.Equal(4, locals.Count)
 
-            VerifyLocal(testData, typeName, locals(0), "<>m0", "w")
-            VerifyLocal(testData, typeName, locals(1), "<>m1", "F")
-            VerifyLocal(testData, typeName, locals(2), "<>m2", "y", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
+                VerifyLocal(testData, typeName, locals(0), "<>m0", "w")
+                VerifyLocal(testData, typeName, locals(1), "<>m1", "F")
+                VerifyLocal(testData, typeName, locals(2), "<>m2", "y", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
 "{
   // Code size        2 (0x2)
   .maxstack  1
@@ -499,7 +512,7 @@ End Class
   IL_0000:  ldc.i4.3
   IL_0001:  ret
 }")
-            VerifyLocal(testData, typeName, locals(3), "<>m3", "v", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
+                VerifyLocal(testData, typeName, locals(3), "<>m3", "v", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
 "{
   // Code size        2 (0x2)
   .maxstack  1
@@ -511,23 +524,23 @@ End Class
 }
 ")
 
-            context = CreateMethodContext(
+                context = CreateMethodContext(
                 runtime,
                 methodName:="C.F",
                 atLineNumber:=999) ' Changed this (was Nothing)
-            testData = New CompilationTestData()
-            locals.Clear()
-            typeName = Nothing
-            context.CompileGetLocals(locals, argumentsOnly:=False, typeName:=typeName, testData:=testData)
+                testData = New CompilationTestData()
+                locals.Clear()
+                typeName = Nothing
+                context.CompileGetLocals(locals, argumentsOnly:=False, typeName:=typeName, testData:=testData)
 
-            Assert.Equal(6, locals.Count)
+                Assert.Equal(6, locals.Count)
 
-            VerifyLocal(testData, typeName, locals(0), "<>m0", "w")
-            VerifyLocal(testData, typeName, locals(1), "<>m1", "F")
-            VerifyLocal(testData, typeName, locals(2), "<>m2", "u")
-            VerifyLocal(testData, typeName, locals(3), "<>m3", "y", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult)
-            VerifyLocal(testData, typeName, locals(4), "<>m4", "v", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult)
-            VerifyLocal(testData, typeName, locals(5), "<>m5", "z", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
+                VerifyLocal(testData, typeName, locals(0), "<>m0", "w")
+                VerifyLocal(testData, typeName, locals(1), "<>m1", "F")
+                VerifyLocal(testData, typeName, locals(2), "<>m2", "u")
+                VerifyLocal(testData, typeName, locals(3), "<>m3", "y", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult)
+                VerifyLocal(testData, typeName, locals(4), "<>m4", "v", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult)
+                VerifyLocal(testData, typeName, locals(5), "<>m5", "z", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
 "{
   // Code size        6 (0x6)
   .maxstack  1
@@ -538,8 +551,20 @@ End Class
   IL_0005:  ret
 }")
 
-            locals.Free()
+                locals.Free()
+
+            Catch e As OverflowException When LogConstantsOverflow(e, exeBytes, pdbBytes)
+            End Try
         End Sub
+
+        Private Shared Function LogConstantsOverflow(e As Exception, exeBytes As Byte(), pdbBytes As Byte()) As Boolean
+            Dim id = Guid.NewGuid()
+            Dim tempDir = Path.GetTempPath()
+            File.WriteAllBytes(Path.Combine(tempDir, $"EEConstantsTest_{id}.exe"), exeBytes)
+            File.WriteAllBytes(Path.Combine(tempDir, $"EEConstantsTest_{id}.pdb"), pdbBytes)
+
+            Return FatalError.Report(e)
+        End Function
 
         <Fact>
         Public Sub ConstantEnum()


### PR DESCRIPTION
The test fails intermittently, see e.g. #6651