### PR TITLE
Offer 'generate constructor' when a derived type doesn't include a delegating constructor to it's base type

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -420,7 +420,7 @@ compareTokens: false);
 @"class C { private readonly int x ; public C ( int x ) { this . x = x ; } void Test ( ) { int x = 10 ; C c = new C ( x ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestNoGenerationIntoEntirelyHiddenType()
         {
             TestMissing(
@@ -441,7 +441,7 @@ class D
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestNestedConstructorCall()
         {
             Test(
@@ -569,7 +569,7 @@ class D
         }
 
         [WorkItem(889349)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestConstructorGenerationForDifferentNamedParameter()
         {
             Test(
@@ -611,7 +611,7 @@ class Program
         }
 
         [WorkItem(528257)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateInInaccessibleType()
         {
             Test(
@@ -628,7 +628,7 @@ class Program
             }
 
             [WorkItem(1241, @"https://github.com/dotnet/roslyn/issues/1241")]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
             public void TestGenerateConstructorInIncompleteLambda()
             {
                 Test(
@@ -638,7 +638,7 @@ class Program
         }
 
         [WorkItem(5274, "https://github.com/dotnet/roslyn/issues/5274")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateIntoDerivedClassWithAbstractBase()
         {
             Test(
@@ -690,6 +690,70 @@ class Class1
         {
             _val = val;
         }
+    }
+}");
+        }
+
+        [WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public void TestGenerateFromDerivedClass() 
+        {
+            Test(
+@"
+class Base
+{
+    public Base(string value)
+    {
+    }
+}
+
+class [||]Derived : Base
+{
+}",
+@"
+class Base
+{
+    public Base(string value)
+    {
+    }
+} 
+
+class Derived : Base
+{
+    public Derived(string value) : base(value)
+    {
+    }
+}");
+        }
+
+        [WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public void TestGenerateFromDerivedClass2()
+        {
+            Test(
+@"
+class Base
+{
+    public Base(int a, string value = null)
+    {
+    }
+}
+
+class [||]Derived : Base
+{
+}",
+@"
+class Base
+{
+    public Base(int a, string value = null)
+    {
+    }
+} 
+
+class Derived : Base
+{
+    public Derived(int a, string value = null) : base(a, value)
+    {
     }
 }");
         }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -501,5 +501,66 @@ NewLines("Imports System.Linq \n Class C \n Private v As Integer \n Sub New() \n
             End Sub
         End Class
 
+        <WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Sub TestGenerateInDerivedType1()
+            Test(
+"
+Public Class Base
+    Public Sub New(a As String)
+
+    End Sub
+End Class
+
+Public Class [||]Derived
+    Inherits Base
+
+End Class",
+"
+Public Class Base
+    Public Sub New(a As String)
+
+    End Sub
+End Class
+
+Public Class Derived
+    Inherits Base
+
+    Public Sub New(a As String)
+        MyBase.New(a)
+    End Sub
+End Class")
+        End Sub
+
+        <WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Sub TestGenerateInDerivedType2()
+            Test(
+"
+Public Class Base
+    Public Sub New(a As Integer, Optional b As String = Nothing)
+
+    End Sub
+End Class
+
+Public Class [||]Derived
+    Inherits Base
+
+End Class",
+"
+Public Class Base
+    Public Sub New(a As Integer, Optional b As String = Nothing)
+
+    End Sub
+End Class
+
+Public Class Derived
+    Inherits Base
+
+    Public Sub New(a As Integer, Optional b As String = Nothing)
+        MyBase.New(a, b)
+    End Sub
+End Class")
+        End Sub
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
@@ -36,9 +36,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateConstructor
             return service.GenerateConstructorAsync(document, node, cancellationToken);
         }
 
-        protected override bool IsCandidate(SyntaxNode node)
+        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
-            return node is SimpleNameSyntax || node is ObjectCreationExpressionSyntax || node is ConstructorInitializerSyntax || node is AttributeSyntax;
+            if (node is SimpleNameSyntax || 
+                node is ObjectCreationExpressionSyntax || 
+                node is ConstructorInitializerSyntax || 
+                node is AttributeSyntax)
+            {
+                return true;
+            }
+
+            return diagnostic.Id == CS7036 && node is ClassDeclarationSyntax;
         }
 
         protected override SyntaxNode GetTargetNode(SyntaxNode node)

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateEnumMember
             return service.GenerateEnumMemberAsync(document, node, cancellationToken);
         }
 
-        protected override bool IsCandidate(SyntaxNode node)
+        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
             return node is IdentifierNameSyntax;
         }

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateConversionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateConversionCodeFixProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod
             get { return ImmutableArray.Create(CS0029, CS0030); }
         }
 
-        protected override bool IsCandidate(SyntaxNode node)
+        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
             return node.IsKind(SyntaxKind.IdentifierName) ||
                    node.IsKind(SyntaxKind.MethodDeclaration) ||

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateMethodCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod
             get { return ImmutableArray.Create(CS0103, CS1061, CS0117, CS0122, CS0539, CS1501, CS1503, CS0305, CS0308, CS1660, CS1739, CS7036); }
         }
 
-        protected override bool IsCandidate(SyntaxNode node)
+        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
             return node.IsKind(SyntaxKind.IdentifierName) ||
                    node.IsKind(SyntaxKind.MethodDeclaration) ||

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateType
             get { return ImmutableArray.Create(CS0103, CS0117, CS0234, CS0246, CS0305, CS0308, CS0426, CS0616); }
         }
 
-        protected override bool IsCandidate(SyntaxNode node)
+        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
             var qualified = node as QualifiedNameSyntax;
             if (qualified != null)

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateVariable
             get { return ImmutableArray.Create(CS1061, CS0103, CS0117, CS0539, CS0246); }
         }
 
-        protected override bool IsCandidate(SyntaxNode node)
+        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
             return node is SimpleNameSyntax || node is PropertyDeclarationSyntax || node is MemberBindingExpressionSyntax;
         }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
@@ -29,6 +30,11 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateConstructor
             return node is ConstructorInitializerSyntax;
         }
 
+        protected override bool IsClassDeclarationGeneration(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken)
+        {
+            return node is ClassDeclarationSyntax;
+        }
+
         protected override bool TryInitializeConstructorInitializerGeneration(
             SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken,
             out SyntaxToken token, out IList<ArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn)
@@ -52,6 +58,35 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateConstructor
             arguments = null;
             typeToGenerateIn = null;
             return false;
+        }
+
+        protected override bool TryInitializeClassDeclarationGenerationState(
+            SemanticDocument document,
+            SyntaxNode node,
+            CancellationToken cancellationToken,
+            out SyntaxToken token,
+            out IMethodSymbol delegatedConstructor,
+            out INamedTypeSymbol typeToGenerateIn)
+        {
+            token = default(SyntaxToken);
+            typeToGenerateIn = null;
+            delegatedConstructor = null;
+
+            var semanticModel = document.SemanticModel;
+            var classDeclaration = (ClassDeclarationSyntax)node;
+            var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration, cancellationToken);
+
+            var baseType = classSymbol.BaseType;
+            var constructor = baseType.Constructors.FirstOrDefault(c => IsSymbolAccessible(c, document));
+            if (constructor == null)
+            {
+                return false;
+            }
+
+            typeToGenerateIn = classSymbol;
+            delegatedConstructor = constructor;
+            token = classDeclaration.Identifier;
+            return true;
         }
 
         protected override bool TryInitializeSimpleNameGenerationState(

--- a/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
@@ -22,8 +22,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes.GenerateMember
                 return;
             }
 
+            var diagnostic = context.Diagnostics.First();
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            var names = GetTargetNodes(root, context.Span);
+            var names = GetTargetNodes(root, context.Span, diagnostic);
             foreach (var name in names)
             {
                 var codeActions = await GetCodeActionsAsync(context.Document, name, context.CancellationToken).ConfigureAwait(false);
@@ -44,12 +45,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.GenerateMember
             return node;
         }
 
-        protected virtual bool IsCandidate(SyntaxNode node)
+        protected virtual bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
             return false;
         }
 
-        protected virtual IEnumerable<SyntaxNode> GetTargetNodes(SyntaxNode root, TextSpan span)
+        protected virtual IEnumerable<SyntaxNode> GetTargetNodes(SyntaxNode root, TextSpan span, Diagnostic diagnostic)
         {
             var token = root.FindToken(span.Start);
             if (!token.Span.IntersectsWith(span))
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.GenerateMember
                 yield break;
             }
 
-            var nodes = token.GetAncestors<SyntaxNode>().Where(IsCandidate);
+            var nodes = token.GetAncestors<SyntaxNode>().Where(n => IsCandidate(n, diagnostic));
             foreach (var node in nodes)
             {
                 var name = GetTargetNode(node);

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
@@ -22,10 +22,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateConstructor
         Friend Const BC30455 As String = "BC30455" ' error BC30455: Argument not specified for parameter 'x' of 'Public Sub New(x As Integer)'.
         Friend Const BC30512 As String = "BC30512" ' error BC30512: Option Strict On disallows implicit conversions from 'Object' to 'Integer'.
         Friend Const BC32006 As String = "BC32006" ' error BC32006: 'Char' values cannot be converted to 'Integer'. 
+        Friend Const BC30387 As String = "BC30387" ' error BC32006: Class 'Derived' must declare a 'Sub New' because its base class 'Base' does not have an accessible 'Sub New' that can be called with no arguments. 
 
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30057, BC30272, BC30274, BC30389, BC30455, BC32006, BC30512)
+                Return ImmutableArray.Create(BC30057, BC30272, BC30274, BC30389, BC30455, BC32006, BC30512, BC30387)
             End Get
         End Property
 
@@ -53,8 +54,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateConstructor
             Return node
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode) As Boolean
-            Return TypeOf node Is SimpleNameSyntax OrElse TypeOf node Is InvocationExpressionSyntax OrElse TypeOf node Is ObjectCreationExpressionSyntax OrElse TypeOf node Is AttributeSyntax
+        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
+            If TypeOf node Is SimpleNameSyntax OrElse TypeOf node Is InvocationExpressionSyntax OrElse TypeOf node Is ObjectCreationExpressionSyntax OrElse TypeOf node Is AttributeSyntax Then
+                Return True
+            End If
+
+            Return diagnostic.Id = BC30387 AndAlso TypeOf node Is ClassBlockSyntax
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEnumMember
             Return service.GenerateEnumMemberAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
             Return TypeOf node Is MemberAccessExpressionSyntax
         End Function
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateConversionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateConversionCodeFixProvider.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
             Return service.GenerateConversionAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
             Return TypeOf node Is QualifiedNameSyntax OrElse
                 TypeOf node Is SimpleNameSyntax OrElse
                 TypeOf node Is MemberAccessExpressionSyntax OrElse

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
             Return service.GenerateMethodAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
             Return TypeOf node Is QualifiedNameSyntax OrElse
                 TypeOf node Is SimpleNameSyntax OrElse
                 TypeOf node Is MemberAccessExpressionSyntax OrElse

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateType
             Return service.GenerateTypeAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
             Dim qualified = TryCast(node, QualifiedNameSyntax)
             If qualified IsNot Nothing Then
                 Return True

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateVariable
             Return service.GenerateVariableAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
             If TypeOf node Is QualifiedNameSyntax OrElse TypeOf node Is MemberAccessExpressionSyntax Then
                 Return True
             End If

--- a/src/Features/VisualBasic/Portable/GenerateMember/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateMember/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateConstructor
         End Function
 
         Protected Overrides Function GenerateParameterNames(semanticModel As SemanticModel, arguments As IEnumerable(Of ArgumentSyntax), Optional reservedNames As IList(Of String) = Nothing) As IList(Of String)
-            Return semanticModel.GenerateParameterNames(arguments.ToList(), reservedNames)
+            Return semanticModel.GenerateParameterNames(arguments?.ToList(), reservedNames)
         End Function
 
         Protected Overrides Function GetArgumentType(semanticModel As SemanticModel, argument As ArgumentSyntax, cancellationToken As CancellationToken) As Microsoft.CodeAnalysis.ITypeSymbol
@@ -144,6 +144,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateConstructor
 
         Protected Overrides Function IsConversionImplicit(compilation As Compilation, sourceType As ITypeSymbol, targetType As ITypeSymbol) As Boolean
             Return compilation.ClassifyConversion(sourceType, targetType).IsWidening
+        End Function
+
+        Protected Overrides Function IsClassDeclarationGeneration(document As SemanticDocument,
+                                                                  node As SyntaxNode,
+                                                                  cancellationToken As CancellationToken) As Boolean
+            Return TypeOf node Is ClassBlockSyntax
+        End Function
+
+        Protected Overrides Function TryInitializeClassDeclarationGenerationState(
+                document As SemanticDocument,
+                classDeclaration As SyntaxNode,
+                cancellationToken As CancellationToken,
+                ByRef token As SyntaxToken,
+                ByRef delegatedConstructor As IMethodSymbol,
+                ByRef typeToGenerateIn As INamedTypeSymbol) As Boolean
+            Dim semanticModel = document.SemanticModel
+            Dim classBlock = DirectCast(classDeclaration, ClassBlockSyntax)
+            Dim classSymbol = semanticModel.GetDeclaredSymbol(classBlock.BlockStatement, cancellationToken)
+
+            Dim baseType = classSymbol.BaseType
+            Dim constructor = baseType.Constructors.FirstOrDefault(Function(c) IsSymbolAccessible(c, document))
+            If constructor Is Nothing Then
+                Return False
+            End If
+
+            typeToGenerateIn = classSymbol
+            delegatedConstructor = constructor
+            token = classBlock.BlockStatement.Identifier
+            Return True
         End Function
 
         Private Shared ReadOnly s_annotation As SyntaxAnnotation = New SyntaxAnnotation


### PR DESCRIPTION
Fixes: https://github.com/dotnet/Roslyn/issues/6541