### PR TITLE
[Update1] Make code more resilient to potential bad situations.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/EditorFeatures/Core/Implementation/ReferenceHighlighting/AbstractDocumentHighlightsService.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
                 return additionalReferenceProvider.GetAdditionalReferencesAsync(document, symbol, cancellationToken);
             }
 
-            return Task.FromResult<IEnumerable<Location>>(SpecializedCollections.EmptyEnumerable<Location>());
+            return Task.FromResult(SpecializedCollections.EmptyEnumerable<Location>());
         }
 
         private async Task<IEnumerable<DocumentHighlights>> CreateSpansAsync(
@@ -248,18 +248,26 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ReferenceHighlighting
 
         private async Task<ValueTuple<Document, TextSpan>?> GetLocationSpanAsync(Solution solution, Location location, CancellationToken cancellationToken)
         {
-            var tree = location.SourceTree;
+            if (location != null && location.IsInSource)
+            {
+                var tree = location.SourceTree;
 
-            var document = solution.GetDocument(tree);
-            var syntaxFacts = document.Project.LanguageServices.GetService<ISyntaxFactsService>();
+                var document = solution.GetDocument(tree);
+                var syntaxFacts = document?.Project?.LanguageServices?.GetService<ISyntaxFactsService>();
 
-            // Specify findInsideTrivia: true to ensure that we search within XML doc comments.
-            var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-            var token = root.FindToken(location.SourceSpan.Start, findInsideTrivia: true);
+                if (syntaxFacts != null)
+                {
+                    // Specify findInsideTrivia: true to ensure that we search within XML doc comments.
+                    var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+                    var token = root.FindToken(location.SourceSpan.Start, findInsideTrivia: true);
 
-            return syntaxFacts.IsGenericName(token.Parent) || syntaxFacts.IsIndexerMemberCRef(token.Parent)
-                ? ValueTuple.Create(document, token.Span)
-                : ValueTuple.Create(document, location.SourceSpan);
+                    return syntaxFacts.IsGenericName(token.Parent) || syntaxFacts.IsIndexerMemberCRef(token.Parent)
+                        ? ValueTuple.Create(document, token.Span)
+                        : ValueTuple.Create(document, location.SourceSpan);
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
We're seeing a crash in highlight references in the below code.  Unfortunately, the dump is merely at the point where we're reporting the NullRefException, not the point when the NullRefException actually happens.

From a visual examination i've hazarded guesses as to what might be going wrong, and i've added some resiliency to the code for those cases.  