### PR TITLE
Documentation for csc and vbc command-line.

### DIFF
--- a/docs/compilers/CSharp/CommandLine.md
+++ b/docs/compilers/CSharp/CommandLine.md
@@ -1,0 +1,78 @@
+# Visual C# Compiler Options
+
+| FLAG | DESCRIPTION |
+| ---- | ---- |
+| **OUTPUT FILES** |
+| `/out:`*file* | Specify output file name (default: base name of file with main class or first file)
+| `/target:exe` |  Build a console executable (default) (Short form: `/t:exe`)
+| `/target:winexe` | Build a Windows executable (Short form: `/t:winexe` )
+| `/target:library` | Build a library (Short form: `/t:library`)
+| `/target:module` | Build a module that can be added to another assembly (Short form: `/t:module`)
+| `/target:appcontainerexe` | Build an Appcontainer executable (Short form: `/t:appcontainerexe`)
+| `/target:winmdobj` | Build a Windows Runtime intermediate file that is consumed by WinMDExp (Short form: `/t:winmdobj`)
+| `/doc:`*file* | XML Documentation file to generate
+| `/platform:`*string* | Limit which platforms this code can run on: `x86`, `Itanium`, `x64`, `arm`, `anycpu32bitpreferred`, or `anycpu`. The default is `anycpu`.
+| **INPUT FILES**
+| `/recurse:`*wildcard* | Include all files in the current directory and subdirectories according to the wildcard  specifications
+| `/reference:`*alias*=*file* | Reference metadata from the specified assembly file using the given alias (Short form: `/r`)
+| `/reference:`*file list* | Reference metadata from the specified assembly files (Short form: `/r`)
+| `/addmodule:`*file list* | Link the specified modules into this assembly
+| `/link:`*file list* | Embed metadata from the specified interop assembly files (Short form: `/l`)
+| `/analyzer:`*file list* | Run the analyzers from this assembly (Short form: `/a`)
+| `/additionalfile:`*file list* | Additional files that don't directly affect code generation but may be used by analyzers for producing errors or warnings.
+| **RESOURCES**
+| `/win32res:`*file* | Specify a Win32 resource file (.res)
+| `/win32icon:`*file* | Use this icon for the output
+| `/win32manifest`:*file* | Specify a Win32 manifest file (.xml)
+| `/nowin32manifest` | Do not include the default Win32 manifest
+| `/resource`:*resinfo* | Embed the specified resource (Short form: `/res`)
+| `/linkresource`:*resinfo* | Link the specified resource to this assembly (Short form: `/linkres`) Where the *resinfo* format  is *file*{`,`*string name*{`,``public``|``private`}}
+| **CODE GENERATION**
+| `/debug`{`+`&#124;`-`} | Emit (or do not Emit) debugging information
+| `/debug`:{`full`&#124;`pdbonly`&#124;`portable`} | Specify debugging type (`full` is default, and  enables attaching a debugger to a running program. `portable` is a cross-platform format)
+| `/optimize`{`+`&#124;`-`} | Enable optimizations (Short form: `/o`)
+| `/deterministic` | Produce a deterministic assembly (including module version GUID and timestamp)
+| **ERRORS AND WARNINGS**
+| `/warnaserror`{`+`&#124;`-`} | Report all warnings as errors
+| `/warnaserror`{`+`&#124;`-`}`:`*warn list* | Report specific warnings as errors
+| `/warn`:*n* | Set warning level (0-4) (Short form: `/w`)
+| `/nowarn`:*warn list* | Disable specific warning messages
+| `/ruleset`:*file* | Specify a ruleset file that disables specific diagnostics.
+| `/errorlog`:*file* | Specify a file to log all compiler and analyzer diagnostics.
+| `/reportanalyzer` | Report additional analyzer information, such as execution time.
+| **LANGUAGE**
+| `/checked`{`+`&#124;`-`} | Generate overflow checks
+| `/unsafe`{`+`&#124;`-`} | Allow 'unsafe' code
+| `/define:`*symbol list* | Define conditional compilation symbol(s) (Short form: `/d`)
+| `/langversion`:*string* | Specify language version mode: `ISO-1`, `ISO-2`, `3`, `4`, `5`, `6`, or `Default`
+| **SECURITY**
+| `/delaysign`{`+`&#124;`-`} | Delay-sign the assembly using only the public portion of the strong name key
+| `/keyfile:`*file* | Specify a strong name key file
+| `/keycontainer`:*string* | Specify a strong name key container
+| `/highentropyva`{`+`&#124;`-`} | Enable high-entropy ASLR
+| **MISCELLANEOUS**
+| `@`*file* | Read response file for more options
+| `/help` | Display a usage message (Short form: `/?`)
+| `/nologo` | Suppress compiler copyright message
+| `/noconfig` | Do not auto include `CSC.RSP` file
+| `/parallel`{`+`&#124;`-`} | Concurrent build.
+| **ADVANCED**
+| `/baseaddress:`*address* | Base address for the library to be built
+| `/bugreport:`*file* | Create a 'Bug Report' file
+| `/checksumalgorithm:`*alg* | Specify algorithm for calculating source file checksum stored in PDB. Supported values are: `SHA1` (default) or `SHA256`.
+| `/codepage:`*n* | Specify the codepage to use when opening source files
+| `/utf8output` | Output compiler messages in UTF-8 encoding
+| `/main`:*type* | Specify the type that contains the entry point (ignore all other possible entry points) (Short form: `/m`)
+| `/fullpaths` | Compiler generates fully qualified paths
+| `/filealign`:*n* | Specify the alignment used for output file sections
+| `/pathmap:`*k1*=*v1*,*k2*=*v2*,... | Specify a mapping for source path names output by the compiler.
+| `/pdb:`*file* | Specify debug information file name (default: output file name with `.pdb` extension)
+| `/errorendlocation` | Output line and column of the end location of each error
+| `/preferreduilang` | Specify the preferred output language name.
+| `/nostdlib`{`+`&#124;`-`} | Do not reference standard library `mscorlib.dll`
+| `/subsystemversion:`*string* | Specify subsystem version of this assembly
+| `/lib:`*file list* | Specify additional directories to search in for references
+| `/errorreport:`*string* | Specify how to handle internal compiler errors: `prompt`, `send`, `queue`, or `none`. The default is `queue`.
+| `/appconfig:`*file* | Specify an application configuration file containing assembly binding settings
+| `/moduleassemblyname:`*string* | Name of the assembly which this module will be a part of
+| `/modulename:`*string* | Specify the name of the source module

--- a/docs/compilers/Visual Basic/CommandLine.md
+++ b/docs/compilers/Visual Basic/CommandLine.md
@@ -1,0 +1,87 @@
+# Visual Basic Compiler Options
+
+| FLAG | DESCRIPTION |
+| ---- | ---- |
+| **OUTPUT FILE**
+| `/out:`*file* | Specifies the output file name.
+| `/target:exe` | Create a console application (default). (Short form: `/t`)
+| `/target:winexe` | Create a Windows application.
+| `/target:library` | Create a library assembly.
+| `/target:module` | Create a module that can be added to an assembly.
+| `/target:appcontainerexe` | Create a Windows application that runs in AppContainer.
+| `/target:winmdobj` | Create a Windows Metadata intermediate file
+| `/doc`{`+`&#124;`-`} | Generates XML documentation file.
+| `/doc:`*file* | Generates XML documentation file to *file*.
+| **INPUT FILES**
+| `/addmodule:`*file_list* | Reference metadata from the specified modules
+| `/link:`*file_list* | Embed metadata from the specified interop assembly. (Short form: `/l`)
+| `/recurse:`*wildcard* | Include all files in the current directory and subdirectories according to the wildcard specifications.
+| `/reference:`*file_list* | Reference metadata from the specified assembly. (Short form: `/r`)
+| `/analyzer:`*file_list* | Run the analyzers from this assembly (Short form: `/a`)
+| `/additionalfile:`*file list* | Additional files that don't directly affect code generation but may be used by analyzers for producing errors or warnings.
+| **RESOURCES**
+| `/linkresource`:*resinfo* | Link the specified resource to this assembly (Short form: `/linkres`) Where the *resinfo* format  is *file*{`,`*string name*{`,``public``|``private`}}
+| `/resource`:*resinfo* | Embed the specified resource (Short form: `/res`)
+| `/nowin32manifest` | The default manifest should not be embedded in the manifest section of the output PE.
+| `/win32icon:`*file* | Specifies a Win32 icon file (.ico) for the default Win32 resources.
+| `/win32manifest:`*file* | The provided file is embedded in the manifest section of the output PE.
+| `/win32resource:`*file* | Specifies a Win32 resource file (.res).
+| **CODE GENERATION**
+| `/optimize`{`+`&#124;`-`} | Enable optimizations.
+| `/removeintchecks`{`+`&#124;`-`} | Remove integer checks. Default off.
+| `/debug`{`+`&#124;`-`} | Emit debugging information.
+| `/debug:full` | Emit full debugging information (default).
+| `/debug:portable` | Emit debugging information in the portable format.
+| `/debug:pdbonly` | Emit PDB file only.
+| `/deterministic` | Produce a deterministic assembly (including module version GUID and timestamp)
+| **ERRORS AND WARNINGS**
+| `/nowarn` | Disable all warnings.
+| `/nowarn:`*number_list* | Disable a list of individual warnings.
+| `/warnaserror`{`+`&#124;`-`} | Treat all warnings as errors.
+| `/warnaserror`{`+`&#124;`-`}:*number_list* | Treat a list of warnings as errors.
+| `/ruleset:`*file* | Specify a ruleset file that disables specific diagnostics.
+| `/errorlog:`*file* | Specify a file to log all compiler and analyzer diagnostics.
+| `/reportanalyzer` | Report additional analyzer information, such as execution time.
+| **LANGUAGE**
+| `/define:`*symbol_list* | Declare global conditional compilation symbol(s). *symbol_list* is *name*`=`*value*`,`...  (Short form: `/d`)
+| `/imports:`*import_list* | Declare global Imports for namespaces in referenced metadata files. *import_list* is *namespace*`,`...
+| `/langversion:`*number* | Specify language version: `9`&#124;`9.0`&#124;`10`&#124;`10.0`&#124;`11`&#124;`11.0`&#124;`12`&#124;`12.0`&#124;`13`&#124;`13.0`&#124;`14`&#124;`14.0`. The default is `14`.
+| `/optionexplicit`{`+`&#124;`-`} | Require explicit declaration of variables.
+| `/optioninfer`{`+`&#124;`-`} | Allow type inference of variables.
+| `/rootnamespace`:*string* | Specifies the root Namespace for all top-level type declarations.
+| `/optionstrict`{`+`&#124;`-`} | Enforce strict language semantics.
+| `/optionstrict:custom` | Warn when strict language semantics are not respected.
+| `/optioncompare:binary` | Specifies binary-style string comparisons. This is the default.
+| `/optioncompare:text` | Specifies text-style string comparisons.
+| **MISCELLANEOUS**
+| `/help` | Display a usage message. (Short form: `/?`)
+| `/noconfig` | Do not auto-include VBC.RSP file.
+| `/nologo` | Do not display compiler copyright banner.
+| `/quiet` | Quiet output mode.
+| `/verbose` | Display verbose messages.
+| `/parallel`{`+`&#124;`-`} | Concurrent build. 
+| **ADVANCED**
+| `/baseaddress:`*number* | The base address for a library or module (hex).
+| `/bugreport:`*file* | Create bug report file.
+| `/checksumalgorithm:`*alg* | Specify algorithm for calculating source file checksum stored in PDB. Supported values are: `SHA1` (default) or `SHA256`.
+| `/codepage:`*number* | Specifies the codepage to use when opening source files.
+| `/delaysign`{`+`&#124;`-`} | Delay-sign the assembly using only the public portion of the strong name key.
+| `/errorreport:`*string* | Specifies how to handle internal compiler errors; must be `prompt`, `send`, `none`, or `queue` (default).
+| `/filealign:`*number* | Specify the alignment used for output file sections.
+| `/highentropyva`{`+`&#124;`-`} | Enable high-entropy ASLR.
+| `/keycontainer:`*string* | Specifies a strong name key container.
+| `/keyfile:`*file* | Specifies a strong name key file.
+| `/libpath:`*path_list* | List of directories to search for metadata references. (Semi-colon delimited.)
+| `/main:`*class* | Specifies the Class or Module that contains Sub Main. It can also be a Class that inherits from System.Windows.Forms.Form. (Short form: `/m`)
+| `/moduleassemblyname:`*string* | Name of the assembly which this module will be a part of.
+| `/netcf` | Target the .NET Compact Framework.
+| `/nostdlib` | Do not reference standard libraries (`system.dll` and `VBC.RSP` file).
+| `/pathmap:`*k1*=*v1*,*k2*=*v2*,... |  Specify a mapping for source path names output by the compiler.
+| `/platform:`*string* | Limit which platforms this code can run on; must be `x86`, `x64`, `Itanium`, `arm`, `AnyCPU32BitPreferred` or `anycpu` (default).
+| `/preferreduilang` | Specify the preferred output language name.
+| `/sdkpath:`*path* | Location of the .NET Framework SDK directory (`mscorlib.dll`).
+| `/subsystemversion:`*version* | Specify subsystem version of the output PE.  *version* is *number*{.*number*}
+| `/utf8output`{`+`&#124;`-`} | Emit compiler output in UTF8 character encoding.
+| `@`*file* | Insert command-line settings from a text file
+| `/vbruntime`{+&#124;-&#124;*} | Compile with/without the default Visual Basic runtime.
+| `/vbruntime:`*file* | Compile with the alternate Visual Basic runtime in *file*.


### PR DESCRIPTION
Currently these are almost the same as csc /help and vbc /help, but it is intended that over time these documents be expanded to include a more complete description of the syntax and semantics of each command-line flag.

Fixes #1074

@dotnet/roslyn-compiler Please review.