### PR TITLE
Revert "Remove SymReader mock, use the real reader since we always have ISymUnmanagedReader3 now"

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var source =
 @"class C
-{   
+{
     static void M()
     {
         const dynamic d = null;
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             ImmutableArray<MetadataReference> references;
             comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
 
             var context = CreateMethodContext(runtime, "C.M");
             var testData = new CompilationTestData();
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             ImmutableArray<MetadataReference> references;
             comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
 
             var context = CreateMethodContext(runtime, "C.M");
             var testData = new CompilationTestData();
@@ -250,7 +250,7 @@ class Generic<T>
             ImmutableArray<MetadataReference> references;
             comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
 
             var context = CreateMethodContext(runtime, "C.M");
             var testData = new CompilationTestData();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 references.AddIntrinsicAssembly(),
                 exeBytes,
-                includeSymbols ? SymReaderFactory.CreateReader(pdbBytes, exeBytes) : null);
+                includeSymbols ? new SymReader(pdbBytes, exeBytes) : null);
         }
 
         internal RuntimeInstance CreateRuntimeInstance(

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             CSharpMetadataContext previous = default(CSharpMetadataContext);
             int startOffset;
             int endOffset;
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes));
             ImmutableArray<MetadataBlock> typeBlocks;
             ImmutableArray<MetadataBlock> methodBlocks;
             Guid moduleVersionId;
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // With different references.
             var fewerReferences = references.Remove(referenceA);
             Assert.Equal(fewerReferences.Length, references.Length - 1);
-            runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), fewerReferences, exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), fewerReferences, exeBytes, new SymReader(pdbBytes));
             GetContextState(runtime, "C.F", out methodBlocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
             // Different references. No reuse.
@@ -1090,7 +1090,7 @@ class B : A
                 assemblyName: moduleId.ToString("D"),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: exeBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(pdbBytes));
+                symReader: new SymReader(pdbBytes.ToArray()));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -1142,7 +1142,7 @@ class B : A
                 assemblyName: moduleId.ToString("D"),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: exeBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(pdbBytes));
+                symReader: new SymReader(pdbBytes.ToArray()));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -1193,7 +1193,7 @@ class B : A
                 assemblyName: moduleId.ToString("D"),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: exeBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(pdbBytes));
+                symReader: new SymReader(pdbBytes.ToArray()));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -3830,7 +3830,7 @@ class C
                     referenceN0, // From D1
                     referenceN1, // From D2
                     referenceN2); // From D2
-            var runtime = CreateRuntimeInstance(assemblyName, references, exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var runtime = CreateRuntimeInstance(assemblyName, references, exeBytes, new SymReader(pdbBytes));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -4551,7 +4551,7 @@ class C
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: exeBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(pdbBytes));
+                symReader: new SymReader(pdbBytes.ToArray()));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -4728,7 +4728,7 @@ struct S
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: exeBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(pdbBytes));
+                symReader: new SymReader(pdbBytes.ToArray()));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.<>c__DisplayClass2.<Test>b__1");
@@ -5181,7 +5181,7 @@ class C
                 assemblyName: GetUniqueName(),
                 references: ImmutableArray.Create(WinRtRefs),
                 exeBytes: ilBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(ilPdbBytes.ToArray()));
+                symReader: new SymReader(ilPdbBytes.ToArray()));
 
             var context = CreateMethodContext(runtime, "C.M");
 
@@ -5527,7 +5527,7 @@ class C
                 includeLocalSignatures: false);
 
             modulesBuilder.Add(corruptMetadata);
-            modulesBuilder.Add(exeReference.ToModuleInstance(exeBytes, SymReaderFactory.CreateReader(pdbBytes)));
+            modulesBuilder.Add(exeReference.ToModuleInstance(exeBytes, new SymReader(pdbBytes)));
             modulesBuilder.AddRange(references.Select(r => r.ToModuleInstance(fullImage: null, symReader: null)));
             var modules = modulesBuilder.ToImmutableAndFree();
 
@@ -5580,7 +5580,7 @@ public class C
             var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
             Assert.True(result);
 
-            var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef), exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef), exeBytes, new SymReader(pdbBytes));
             var context = CreateMethodContext(runtime, "C.M");
 
             var expectedError = "error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.";
@@ -5666,7 +5666,7 @@ public class Source
             var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
             Assert.True(result);
 
-            var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef, libAv1Ref, libBv2Ref), exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef, libAv1Ref, libBv2Ref), exeBytes, new SymReader(pdbBytes));
             var context = CreateMethodContext(runtime, "Source.Test");
 
             string error;
@@ -5972,8 +5972,10 @@ public class C
                 pdbStream2.Position = 0;
                 peStream2.Position = 0;
 
-                var symReader = SymReaderFactory.CreateReader(pdbStream1);
-                symReader.UpdateSymbolStore(pdbStream2);
+                // Note: This SymReader will behave differently from the ISymUnmanagedReader
+                // we receive during real debugging.  We're just using it as a rough
+                // approximation of ISymUnmanagedReader3, which is unavailable here.
+                var symReader = new SymReader(new[] { pdbStream1, pdbStream2 }, peStream2, null);
 
                 var runtime = CreateRuntimeInstance(
                     GetUniqueName(),

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
@@ -636,7 +636,7 @@ class C : I<int>
                 assemblyName: GetUniqueName(),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: ilBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(ilPdbBytes));
+                symReader: new SymReader(ilPdbBytes.ToArray(), ilBytes.ToArray()));
 
             var context = CreateMethodContext(runtime, "C.<I<System.Int32>.F>d__0.MoveNext");
             VerifyHasThis(context, "C", @"
@@ -791,7 +791,7 @@ static class C
                 assemblyName: GetUniqueName(),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: ilBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(ilPdbBytes.ToArray()));
+                symReader: new SymReader(ilPdbBytes.ToArray()));
 
             var context = CreateMethodContext(runtime, "C.<M>b__0");
             VerifyNoThis(context);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 references,
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes),
+                new SymReader(pdbBytes),
                 includeLocalSignatures: false);
             var context = CreateMethodContext(
                 runtime,
@@ -589,7 +589,7 @@ class C
             ImmutableArray<MetadataReference> references;
             compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -650,7 +650,7 @@ class P
             ImmutableArray<MetadataReference> references;
             compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -1691,7 +1691,7 @@ public struct B
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 ImmutableArray.Create(MscorlibRef), // no reference to compilation0
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+                new SymReader(pdbBytes));
 
             var context = CreateMethodContext(
                 runtime,
@@ -1743,7 +1743,7 @@ public struct B
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 ImmutableArray.Create(MscorlibRef), // no reference to compilation0
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+                new SymReader(pdbBytes));
 
             var context = CreateMethodContext(
                 runtime,
@@ -1841,7 +1841,7 @@ class C
             ImmutableArray<MetadataReference> references;
             comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -1880,7 +1880,7 @@ class C
             ImmutableArray<MetadataReference> references;
             comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -1922,7 +1922,7 @@ class C
             ImmutableArray<MetadataReference> references;
             comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, new SymReader(pdbBytes, exeBytes));
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -2703,7 +2703,7 @@ class C
             var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
             Assert.True(result);
 
-            var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef), exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef), exeBytes, new SymReader(pdbBytes));
 
             string typeName;
             var locals = ArrayBuilder<LocalAndMethod>.GetInstance();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -750,7 +750,7 @@ class UseLinq
             var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
             Assert.True(result);
 
-            var runtime = CreateRuntimeInstance(GetUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var runtime = CreateRuntimeInstance(GetUniqueName(), references, exeBytes, new SymReader(pdbBytes));
             return CreateMethodContext(runtime, methodName);
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
@@ -98,7 +98,7 @@ public interface I
                 Guid.NewGuid().ToString("D"),
                 references,
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+                new SymReader(pdbBytes));
             var context = CreateMethodContext(runtime, "C.M");
             string error;
             var testData = new CompilationTestData();
@@ -184,9 +184,9 @@ public interface I
             // Create runtime from modules { mscorlib, PIA, A, B }.
             var modulesBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
             modulesBuilder.Add(MscorlibRef.ToModuleInstance(fullImage: null, symReader: null));
-            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage: exeA, symReader: SymReaderFactory.CreateReader(pdbA)));
+            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage: exeA, symReader: new SymReader(pdbA)));
             modulesBuilder.Add(referencePIA.ToModuleInstance(fullImage: null, symReader: null));
-            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage: exeB, symReader: SymReaderFactory.CreateReader(pdbB)));
+            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage: exeB, symReader: new SymReader(pdbB)));
 
             using (var runtime = new RuntimeInstance(modulesBuilder.ToImmutableAndFree()))
             {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
@@ -949,7 +949,7 @@ class C
                 assemblyNameB,
                 ImmutableArray.Create(MscorlibRef, referenceA2).AddIntrinsicAssembly(),
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+                new SymReader(pdbBytes));
 
             //// typeof(Exception), typeof(A<B<object>>), typeof(B<A<object>[]>)
             var context = CreateMethodContext(
@@ -1047,8 +1047,8 @@ class B
 
             var modulesBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
             modulesBuilder.Add(MscorlibRef.ToModuleInstance(fullImage: null, symReader: null));
-            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage: exeA, symReader: SymReaderFactory.CreateReader(pdbA)));
-            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage: exeB, symReader: SymReaderFactory.CreateReader(pdbB)));
+            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage: exeA, symReader: new SymReader(pdbA)));
+            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage: exeB, symReader: new SymReader(pdbB)));
             modulesBuilder.Add(ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance(fullImage: null, symReader: null));
 
             using (var runtime = new RuntimeInstance(modulesBuilder.ToImmutableAndFree()))

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 assemblyNameC,
                 ImmutableArray.Create(MscorlibRef, referenceAS1, referenceAS2, referenceBS2, referenceBS1, referenceBS2),
                 exeBytesC1,
-                SymReaderFactory.CreateReader(pdbBytesC1)))
+                new SymReader(pdbBytesC1)))
             {
                 ImmutableArray<MetadataBlock> typeBlocks;
                 ImmutableArray<MetadataBlock> methodBlocks;
@@ -357,7 +357,7 @@ public class B
             compilationA.EmitAndGetReferences(out exeBytesA, out pdbBytesA, out referencesA);
             var referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display: assemblyNameA);
             var identityA = referenceA.GetAssemblyIdentity();
-            var moduleA = referenceA.ToModuleInstance(exeBytesA, SymReaderFactory.CreateReader(pdbBytesA));
+            var moduleA = referenceA.ToModuleInstance(exeBytesA, new SymReader(pdbBytesA));
 
             var assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName();
             var compilationB = CreateCompilationWithMscorlibAndSystemCore(sourceB, options: TestOptions.DebugDll, assemblyName: assemblyNameB, references: new[] { referenceA });
@@ -366,7 +366,7 @@ public class B
             ImmutableArray<MetadataReference> referencesB;
             compilationB.EmitAndGetReferences(out exeBytesB, out pdbBytesB, out referencesB);
             var referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display: assemblyNameB);
-            var moduleB = referenceB.ToModuleInstance(exeBytesB, SymReaderFactory.CreateReader(pdbBytesB));
+            var moduleB = referenceB.ToModuleInstance(exeBytesB, new SymReader(pdbBytesB));
 
             var moduleBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
             moduleBuilder.AddRange(referencesA.Select(r => r.ToModuleInstance(null, null)));
@@ -493,7 +493,7 @@ class C
             compilationA.EmitAndGetReferences(out exeBytesA, out pdbBytesA, out referencesA);
             var referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display: assemblyNameA);
             var identityA = referenceA.GetAssemblyIdentity();
-            var moduleA = referenceA.ToModuleInstance(exeBytesA, SymReaderFactory.CreateReader(pdbBytesA));
+            var moduleA = referenceA.ToModuleInstance(exeBytesA, new SymReader(pdbBytesA));
 
             var assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName();
             var compilationB = CreateCompilation(
@@ -506,7 +506,7 @@ class C
             ImmutableArray<MetadataReference> referencesB;
             compilationB.EmitAndGetReferences(out exeBytesB, out pdbBytesB, out referencesB);
             var referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display: assemblyNameB);
-            var moduleB = referenceB.ToModuleInstance(exeBytesB, SymReaderFactory.CreateReader(pdbBytesB));
+            var moduleB = referenceB.ToModuleInstance(exeBytesB, new SymReader(pdbBytesB));
 
             // Include an empty assembly to verify that not all assemblies
             // with no references are treated as mscorlib.
@@ -681,7 +681,7 @@ public class B
             compilationA.EmitAndGetReferences(out exeBytesA, out pdbBytesA, out referencesA);
             var referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display: assemblyNameA);
             var identityA = referenceA.GetAssemblyIdentity();
-            var moduleA = referenceA.ToModuleInstance(exeBytesA, SymReaderFactory.CreateReader(pdbBytesA));
+            var moduleA = referenceA.ToModuleInstance(exeBytesA, new SymReader(pdbBytesA));
 
             var assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName();
             var compilationB = CreateCompilationWithMscorlibAndSystemCore(sourceB, options: TestOptions.DebugDll, assemblyName: assemblyNameB, references: new[] { referenceA });
@@ -690,7 +690,7 @@ public class B
             ImmutableArray<MetadataReference> referencesB;
             compilationB.EmitAndGetReferences(out exeBytesB, out pdbBytesB, out referencesB);
             var referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display: assemblyNameB);
-            var moduleB = referenceB.ToModuleInstance(exeBytesB, SymReaderFactory.CreateReader(pdbBytesB));
+            var moduleB = referenceB.ToModuleInstance(exeBytesB, new SymReader(pdbBytesB));
 
             var moduleBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
             moduleBuilder.AddRange(referencesA.Select(r => r.ToModuleInstance(null, null)));

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
@@ -118,7 +118,7 @@ class C
                 assemblyName: GetUniqueName(),
                 references: ImmutableArray.Create(MscorlibRef),
                 exeBytes: exeBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(pdbBytes));
+                symReader: new SymReader(pdbBytes.ToArray()));
             var context = CreateMethodContext(runtime, methodName: "C.Test");
 
             Assert.Equal(DkmEvaluationResultAccessType.Private, GetResultProperties(context, "Private").AccessType);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -259,8 +259,10 @@ namespace D
                         // SymReader implements ISymUnmanagedReader3 and the COM object
                         // might not.
                         pdbbits.Position = 0;
-                        var reader = SymReaderFactory.CreateReader(pdbbits);
-                        return reader.GetCSharpGroupedImportStrings(methodToken, methodVersion: 1, externAliasStrings: out externAliasStrings);
+                        using (var reader = new SymReader(pdbbits.ToArray()))
+                        {
+                            return reader.GetCSharpGroupedImportStrings(methodToken, methodVersion: 1, externAliasStrings: out externAliasStrings);
+                        }
                     }
                 }
             }
@@ -1088,8 +1090,8 @@ public class C2 : C1
             var ref2 = AssemblyMetadata.CreateFromImage(dllBytes2).GetReference(display: "B");
 
             var modulesBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
-            modulesBuilder.Add(ref1.ToModuleInstance(dllBytes1, SymReaderFactory.CreateReader(pdbBytes1)));
-            modulesBuilder.Add(ref2.ToModuleInstance(dllBytes2, SymReaderFactory.CreateReader(pdbBytes2)));
+            modulesBuilder.Add(ref1.ToModuleInstance(dllBytes1, new SymReader(pdbBytes1, dllBytes1)));
+            modulesBuilder.Add(ref2.ToModuleInstance(dllBytes2, new SymReader(pdbBytes2, dllBytes2)));
             modulesBuilder.Add(MscorlibRef_v4_0_30316_17626.ToModuleInstance(fullImage: null, symReader: null));
             modulesBuilder.Add(ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance(fullImage: null, symReader: null));
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies), // no reference to Windows.winmd
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+                new SymReader(pdbBytes));
             var context = CreateMethodContext(runtime, "C.M");
             string error;
             var testData = new CompilationTestData();
@@ -97,7 +97,7 @@ class C
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies), // no reference to Windows.winmd
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+                new SymReader(pdbBytes));
             var context = CreateMethodContext(runtime, "C.M");
             string error;
             var testData = new CompilationTestData();
@@ -389,7 +389,7 @@ class C
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 runtimeReferences.AddIntrinsicAssembly(),
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+                new SymReader(pdbBytes));
         }
 
         private static byte[] ToVersion1_3(byte[] bytes)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
@@ -485,7 +485,7 @@ End Namespace
             End Using
             Assert.Equal(makePdb, pdbBytes IsNot Nothing)
             Dim compRef = AssemblyMetadata.CreateFromImage(peBytes).GetReference()
-            Return compRef.ToModuleInstance(peBytes, If(makePdb, SymReaderFactory.CreateReader(pdbBytes), Nothing))
+            Return compRef.ToModuleInstance(peBytes, If(makePdb, New SymReader(pdbBytes), Nothing))
         End Function
 
         Private Shared Function GetModuleInstanceForIL(ilSource As String) As ModuleInstance
@@ -493,7 +493,7 @@ End Namespace
             Dim pdbBytes As ImmutableArray(Of Byte) = Nothing
             EmitILToArray(ilSource, appendDefaultHeader:=False, includePdb:=True, assemblyBytes:=peBytes, pdbBytes:=pdbBytes)
             Dim compRef = AssemblyMetadata.CreateFromImage(peBytes).GetReference()
-            Return compRef.ToModuleInstance(peBytes.ToArray(), SymReaderFactory.CreateReader(pdbBytes))
+            Return compRef.ToModuleInstance(peBytes.ToArray(), New SymReader(pdbBytes.ToArray()))
         End Function
 
         Private Shared Sub CheckDteeMethodDebugInfo(methodDebugInfo As MethodDebugInfo, ParamArray namespaceNames As String())

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 references.AddIntrinsicAssembly(),
                 exeBytes,
-                If(includeSymbols, SymReaderFactory.CreateReader(pdbBytes, exeBytes), Nothing))
+                If(includeSymbols, New SymReader(pdbBytes, exeBytes), Nothing))
         End Function
 
         Friend Function CreateRuntimeInstance(

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
@@ -489,7 +489,7 @@ End Module
                 assemblyName:=GetUniqueName(),
                 references:=ImmutableArray.Create(MscorlibRef),
                 exeBytes:=ilBytes.ToArray(),
-                symReader:=SymReaderFactory.CreateReader(ilPdbBytes.ToArray()))
+                symReader:=New SymReader(ilPdbBytes.ToArray()))
 
             Dim context = CreateMethodContext(runtime, "C._Lambda$__1")
             VerifyNoMe(context)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
@@ -130,8 +130,9 @@ End Namespace
                         Dim methodToken = metadataReader.GetToken(methodHandle)
 
                         pdbbits.Position = 0
-                        Dim reader = SymReaderFactory.CreateReader(pdbbits)
-                        Return reader.GetVisualBasicImportStrings(methodToken, methodVersion:=1)
+                        Using reader As New SymReader(pdbbits)
+                            Return reader.GetVisualBasicImportStrings(methodToken, methodVersion:=1)
+                        End Using
                     End Using
                 End Using
             End Using
@@ -499,8 +500,8 @@ End Class
             Dim ref2 = AssemblyMetadata.CreateFromImage(dllBytes2).GetReference(display:="B")
 
             Dim modulesBuilder = ArrayBuilder(Of ModuleInstance).GetInstance()
-            modulesBuilder.Add(ref1.ToModuleInstance(dllBytes1, SymReaderFactory.CreateReader(pdbBytes1)))
-            modulesBuilder.Add(ref2.ToModuleInstance(dllBytes2, SymReaderFactory.CreateReader(pdbBytes2)))
+            modulesBuilder.Add(ref1.ToModuleInstance(dllBytes1, New SymReader(pdbBytes1, dllBytes1)))
+            modulesBuilder.Add(ref2.ToModuleInstance(dllBytes2, New SymReader(pdbBytes2, dllBytes2)))
             modulesBuilder.Add(MscorlibRef_v4_0_30316_17626.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing))
             modulesBuilder.Add(ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing))
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -248,7 +248,7 @@ End Class"
             Dim pdbBytes As Byte() = Nothing
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
             comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes), includeLocalSignatures:=False)
+            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, New SymReader(pdbBytes), includeLocalSignatures:=False)
             Dim context = CreateMethodContext(
                 runtime,
                 methodName:="C.M",
@@ -586,7 +586,7 @@ End Class"
             Dim pdbBytes As Byte() = Nothing
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
             comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
+            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, New SymReader(pdbBytes, exeBytes))
             Dim context = CreateMethodContext(
                 runtime,
                 methodName:="C.M")
@@ -642,7 +642,7 @@ End Class"
             Dim pdbBytes As Byte() = Nothing
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
             comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
+            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, New SymReader(pdbBytes, exeBytes))
             Dim context = CreateMethodContext(
                 runtime,
                 methodName:="C.M")
@@ -1727,7 +1727,7 @@ End Class"
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 ImmutableArray.Create(MscorlibRef), ' no reference to compilation0
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
+                New SymReader(pdbBytes))
 
             Dim context = CreateMethodContext(
                 runtime,
@@ -1801,7 +1801,7 @@ End Class
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
             comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
 
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
+            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, New SymReader(pdbBytes, exeBytes))
             Dim context = CreateMethodContext(
                 runtime,
                 methodName:="C.M")
@@ -1850,7 +1850,7 @@ End Class
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
             comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
 
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
+            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, New SymReader(pdbBytes, exeBytes))
             Dim context = CreateMethodContext(
                 runtime,
                 methodName:="C.M")
@@ -2678,7 +2678,7 @@ End Class
             ' Referencing SystemCoreRef and SystemXmlLinqRef will cause Microsoft.VisualBasic.Embedded to be compiled
             ' and it depends on EditorBrowsableAttribute.
             Dim runtimeReferences = ImmutableArray.Create(MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef)
-            Dim runtime = CreateRuntimeInstance(GetUniqueName(), runtimeReferences, exeBytes, SymReaderFactory.CreateReader(pdbBytes))
+            Dim runtime = CreateRuntimeInstance(GetUniqueName(), runtimeReferences, exeBytes, New SymReader(pdbBytes))
 
             Dim typeName As String = Nothing
             Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -343,7 +343,7 @@ End Class
                 GetUniqueName(),
                 ImmutableArray.Create(CSharpRef, ExpressionCompilerTestHelpers.IntrinsicAssemblyReference),
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
+                New SymReader(pdbBytes))
             Dim context = CreateMethodContext(
                 runtime,
                 "C.M")
@@ -580,7 +580,7 @@ End Class"
             Dim result = comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
             Assert.True(result)
 
-            Dim runtime = CreateRuntimeInstance(GetUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes))
+            Dim runtime = CreateRuntimeInstance(GetUniqueName(), references, exeBytes, New SymReader(pdbBytes))
             Return CreateMethodContext(runtime, methodName)
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
@@ -836,7 +836,7 @@ End Class"
                 assemblyNameB,
                 ImmutableArray.Create(MscorlibRef, referenceA2).AddIntrinsicAssembly(),
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
+                New SymReader(pdbBytes))
 
             ' GetType(Exception), GetType(A(Of B(Of Object))), GetType(B(Of A(Of Object)()))
             Dim context = CreateMethodContext(
@@ -925,8 +925,8 @@ End Class"
 
             Dim modulesBuilder = ArrayBuilder(Of ModuleInstance).GetInstance()
             modulesBuilder.Add(MscorlibRef.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing))
-            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage:=exeA, symReader:=SymReaderFactory.CreateReader(pdbA)))
-            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage:=exeB, symReader:=SymReaderFactory.CreateReader(pdbB)))
+            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage:=exeA, symReader:=New SymReader(pdbA)))
+            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage:=exeB, symReader:=New SymReader(pdbB)))
             modulesBuilder.Add(ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing))
 
             Using runtime = New RuntimeInstance(modulesBuilder.ToImmutableAndFree())

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -96,7 +96,7 @@ End Class"
                 assemblyNameC,
                 ImmutableArray.Create(MscorlibRef, referenceAS1, referenceAS2, referenceBS2, referenceBS1, referenceBS2),
                 exeBytesC1,
-                SymReaderFactory.CreateReader(pdbBytesC1))
+                New SymReader(pdbBytesC1))
 
                 Dim typeBlocks As ImmutableArray(Of MetadataBlock) = Nothing
                 Dim methodBlocks As ImmutableArray(Of MetadataBlock) = Nothing
@@ -197,7 +197,7 @@ End Class"
             compilationA.EmitAndGetReferences(exeBytesA, pdbBytesA, referencesA)
             Dim referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display:=assemblyNameA)
             Dim identityA = referenceA.GetAssemblyIdentity()
-            Dim moduleA = referenceA.ToModuleInstance(exeBytesA, SymReaderFactory.CreateReader(pdbBytesA))
+            Dim moduleA = referenceA.ToModuleInstance(exeBytesA, New SymReader(pdbBytesA))
 
             Dim assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName()
             Dim compilationB = CreateCompilationWithMscorlibAndVBRuntime(
@@ -209,7 +209,7 @@ End Class"
             Dim referencesB As ImmutableArray(Of MetadataReference) = Nothing
             compilationB.EmitAndGetReferences(exeBytesB, pdbBytesB, referencesB)
             Dim referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display:=assemblyNameB)
-            Dim moduleB = referenceB.ToModuleInstance(exeBytesB, SymReaderFactory.CreateReader(pdbBytesB))
+            Dim moduleB = referenceB.ToModuleInstance(exeBytesB, New SymReader(pdbBytesB))
 
             Dim moduleBuilder = ArrayBuilder(Of ModuleInstance).GetInstance()
             moduleBuilder.AddRange(referencesA.Select(Function(r) r.ToModuleInstance(Nothing, Nothing)))
@@ -348,7 +348,7 @@ End Class"
                 assemblyNameB,
                 ImmutableArray.Create(MscorlibRef, SystemRef, MsvbRef, referenceA1, referenceA2),
                 exeBytesB,
-                SymReaderFactory.CreateReader(pdbBytesB))
+                New SymReader(pdbBytesB))
 
                 Dim blocks As ImmutableArray(Of MetadataBlock) = Nothing
                 Dim moduleVersionId As Guid = Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
@@ -111,7 +111,7 @@ End Class
                 assemblyName:=GetUniqueName(),
                 references:=ImmutableArray.Create(MscorlibRef),
                 exeBytes:=exeBytes.ToArray(),
-                symReader:=SymReaderFactory.CreateReader(pdbBytes))
+                symReader:=New SymReader(pdbBytes.ToArray()))
             Dim context = CreateMethodContext(runtime, methodName:="C.Test")
 
             Assert.Equal(DkmEvaluationResultAccessType.Private, GetResultProperties(context, "[Private]").AccessType)
@@ -266,7 +266,7 @@ End Class
                 assemblyName:=GetUniqueName(),
                 references:=ImmutableArray.Create(MscorlibRef),
                 exeBytes:=exeBytes.ToArray(),
-                symReader:=SymReaderFactory.CreateReader(pdbBytes))
+                symReader:=New SymReader(pdbBytes.ToArray()))
             Dim context = CreateMethodContext(runtime, methodName:="C.Test")
 
             Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "F").ModifierFlags)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/WinMdTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/WinMdTests.vb
@@ -41,7 +41,7 @@ End Class"
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies), ' no reference to Windows.winmd
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
+                New SymReader(pdbBytes))
             Dim context = CreateMethodContext(runtime, "C.M")
             Dim errorMessage As String = Nothing
             Dim testData = New CompilationTestData()
@@ -248,7 +248,7 @@ End Class"
                 ExpressionCompilerUtilities.GenerateUniqueName(),
                 runtimeReferences.AddIntrinsicAssembly(),
                 exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
+                New SymReader(pdbBytes))
         End Function
 
         Private Shared Function ToVersion1_3(bytes As Byte()) As Byte()

--- a/src/Test/PdbUtilities/Pdb/SymReader.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReader.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using Microsoft.DiaSymReader;
+using Roslyn.Utilities;
+
+namespace Roslyn.Test.PdbUtilities
+{
+    // TODO: remove, use SymReaderFactory instead
+    public sealed class SymReader : ISymUnmanagedReader, ISymUnmanagedReader2, ISymUnmanagedReader3, IDisposable
+    {
+        /// <summary>
+        /// Mock implementation: instead of a single reader with multiple versions, we'll use an array
+        /// of readers - each with a single version.  We do this so that we can implement 
+        /// <see cref="ISymUnmanagedReader3.GetSymAttributeByVersion"/> on top of 
+        /// <see cref="ISymUnmanagedReader.GetSymAttribute"/>.
+        /// </summary>
+        private readonly ISymUnmanagedReader[] _readerVersions;
+
+        private readonly DummyMetadataImport _metadataImport;
+        private readonly PEReader _peReaderOpt;
+
+        private bool _isDisposed;
+
+        public SymReader(Stream pdbStream)
+            : this(new[] { pdbStream }, null, null)
+        {
+        }
+
+        public SymReader(byte[] pdbImage)
+           : this(new[] { new MemoryStream(pdbImage) }, null, null)
+        {
+        }
+
+        public SymReader(byte[] pdbImage, byte[] peImage)
+            : this(new[] { new MemoryStream(pdbImage) }, new MemoryStream(peImage), null)
+        {
+        }
+
+        public SymReader(Stream pdbStream, Stream peStream)
+            : this(new[] { pdbStream }, peStream, null)
+        {
+        }
+
+        public SymReader(Stream pdbStream, MetadataReader metadataReader)
+            : this(new[] { pdbStream }, null, metadataReader)
+        {
+        }
+
+        public SymReader(Stream[] pdbStreamsByVersion, Stream peStreamOpt, MetadataReader metadataReaderOpt)
+        {
+            if (peStreamOpt != null)
+            {
+                _peReaderOpt = new PEReader(peStreamOpt);
+                _metadataImport = new DummyMetadataImport(_peReaderOpt.GetMetadataReader());
+            }
+            else
+            {
+                _metadataImport = new DummyMetadataImport(metadataReaderOpt);
+            }
+
+            _readerVersions = pdbStreamsByVersion.Select(
+                pdbStream => CreateReader(pdbStream, _metadataImport)).ToArray();
+
+            // If ISymUnmanagedReader3 is available, then we shouldn't be passing in multiple byte streams - one should suffice.
+            Debug.Assert(!(UnversionedReader is ISymUnmanagedReader3) || _readerVersions.Length == 1);
+        }
+
+        private static ISymUnmanagedReader CreateReader(Stream pdbStream, object metadataImporter)
+        {
+            // NOTE: The product uses a different GUID (Microsoft.CodeAnalysis.ExpressionEvaluator.DkmUtilities.s_symUnmanagedReaderClassId).
+            Guid corSymReaderSxS = new Guid("0A3976C5-4529-4ef8-B0B0-42EED37082CD");
+            var reader = (ISymUnmanagedReader)Activator.CreateInstance(Marshal.GetTypeFromCLSID(corSymReaderSxS));
+            int hr = reader.Initialize(metadataImporter, null, null, new ComStreamWrapper(pdbStream));
+            SymUnmanagedReaderExtensions.ThrowExceptionForHR(hr);
+            return reader;
+        }
+
+        private ISymUnmanagedReader UnversionedReader => _readerVersions[0];
+
+        public int GetDocuments(int cDocs, out int pcDocs, ISymUnmanagedDocument[] pDocs)
+        {
+            return UnversionedReader.GetDocuments(cDocs, out pcDocs, pDocs);
+        }
+
+        public int GetMethod(int methodToken, out ISymUnmanagedMethod retVal)
+        {
+            // The EE should never be calling ISymUnmanagedReader.GetMethod.  In order to account
+            // for EnC updates, it should always be calling GetMethodByVersion instead.
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public int GetMethodByVersion(int methodToken, int version, out ISymUnmanagedMethod retVal)
+        {
+            // Versions are 1-based.
+            Debug.Assert(version >= 1);
+            var reader = _readerVersions[version - 1];
+            version = _readerVersions.Length > 1 ? 1 : version;
+            return reader.GetMethodByVersion(methodToken, version, out retVal);
+        }
+
+        public int GetSymAttribute(int token, string name, int sizeBuffer, out int lengthBuffer, byte[] buffer)
+        {
+            // The EE should never be calling ISymUnmanagedReader.GetSymAttribute.  
+            // In order to account for EnC updates, it should always be calling 
+            // ISymUnmanagedReader3.GetSymAttributeByVersion instead.
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public int GetSymAttributeByVersion(int methodToken, int version, string name, int bufferLength, out int count, byte[] customDebugInformation)
+        {
+            // Versions are 1-based.
+            Debug.Assert(version >= 1);
+            return _readerVersions[version - 1].GetSymAttribute(methodToken, name, bufferLength, out count, customDebugInformation);
+        }
+
+        public int GetUserEntryPoint(out int entryPoint)
+        {
+            return UnversionedReader.GetUserEntryPoint(out entryPoint);
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (!_isDisposed)
+            {
+                for (int i = 0; i < _readerVersions.Length; i++)
+                {
+                    int hr = (_readerVersions[i] as ISymUnmanagedDispose).Destroy();
+                    SymUnmanagedReaderExtensions.ThrowExceptionForHR(hr);
+                    _readerVersions[i] = null;
+                }
+
+                _peReaderOpt?.Dispose();
+                _metadataImport.Dispose();
+
+                _isDisposed = true;
+            }
+        }
+
+        public int GetDocument(string url, Guid language, Guid languageVendor, Guid documentType, out ISymUnmanagedDocument document)
+        {
+            return UnversionedReader.GetDocument(url, language, languageVendor, documentType, out document);
+        }
+
+        public int GetVariables(int methodToken, int bufferLength, out int count, ISymUnmanagedVariable[] variables)
+        {
+            return UnversionedReader.GetVariables(methodToken, bufferLength, out count, variables);
+        }
+
+        public int GetGlobalVariables(int bufferLength, out int count, ISymUnmanagedVariable[] variables)
+        {
+            return UnversionedReader.GetGlobalVariables(bufferLength, out count, variables);
+        }
+
+        public int GetMethodFromDocumentPosition(ISymUnmanagedDocument document, int line, int column, out ISymUnmanagedMethod method)
+        {
+            return UnversionedReader.GetMethodFromDocumentPosition(document, line, column, out method);
+        }
+
+        public int GetNamespaces(int bufferLength, out int count, ISymUnmanagedNamespace[] namespaces)
+        {
+            return UnversionedReader.GetNamespaces(bufferLength, out count, namespaces);
+        }
+
+        public int Initialize(object metadataImporter, string fileName, string searchPath, IStream stream)
+        {
+            return UnversionedReader.Initialize(metadataImporter, fileName, searchPath, stream);
+        }
+
+        public int UpdateSymbolStore(string fileName, IStream stream)
+        {
+            return UnversionedReader.UpdateSymbolStore(fileName, stream);
+        }
+
+        public int ReplaceSymbolStore(string fileName, IStream stream)
+        {
+            return UnversionedReader.ReplaceSymbolStore(fileName, stream);
+        }
+
+        public int GetSymbolStoreFileName(int bufferLength, out int count, char[] name)
+        {
+            return UnversionedReader.GetSymbolStoreFileName(bufferLength, out count, name);
+        }
+
+        public int GetMethodsFromDocumentPosition(ISymUnmanagedDocument document, int line, int column, int bufferLength, out int count, ISymUnmanagedMethod[] methods)
+        {
+            return UnversionedReader.GetMethodsFromDocumentPosition(document, line, column, bufferLength, out count, methods);
+        }
+
+        public int GetDocumentVersion(ISymUnmanagedDocument document, out int version, out bool isCurrent)
+        {
+            return UnversionedReader.GetDocumentVersion(document, out version, out isCurrent);
+        }
+
+        public int GetMethodVersion(ISymUnmanagedMethod method, out int version)
+        {
+            return UnversionedReader.GetMethodVersion(method, out version);
+        }
+
+        public int GetMethodByVersionPreRemap(int methodToken, int version, out ISymUnmanagedMethod method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int GetSymAttributePreRemap(int methodToken, string name, int bufferLength, out int count, byte[] customDebugInformation)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int GetMethodsInDocument(ISymUnmanagedDocument document, int bufferLength, out int count, ISymUnmanagedMethod[] methods)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int GetSymAttributeByVersionPreRemap(int methodToken, int version, string name, int bufferLength, out int count, byte[] customDebugInformation)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using Microsoft.DiaSymReader;
 using Roslyn.Utilities;
@@ -41,21 +38,6 @@ namespace Roslyn.Test.PdbUtilities
             int hr = reader.Initialize(metadataImporter, null, null, new ComStreamWrapper(pdbStream));
             SymUnmanagedReaderExtensions.ThrowExceptionForHR(hr);
             return reader;
-        }
-
-        public static ISymUnmanagedReader CreateReader(byte[] pdbImage, byte[] peImageOpt = null)
-        {
-            return CreateReader(new MemoryStream(pdbImage), (peImageOpt != null) ? new MemoryStream(peImageOpt) : null);
-        }
-
-        public static ISymUnmanagedReader CreateReader(ImmutableArray<byte> pdbImage, ImmutableArray<byte> peImageOpt = default(ImmutableArray<byte>))
-        {
-            return CreateReader(new MemoryStream(pdbImage.ToArray()), peImageOpt.IsDefault ? null : new MemoryStream(peImageOpt.ToArray()));
-        }
-
-        public static ISymUnmanagedReader CreateReader(Stream pdbStream, Stream peStreamOpt = null)
-        {
-            return CreateReader(pdbStream, (peStreamOpt != null) ? new PEReader(peStreamOpt, PEStreamOptions.PrefetchMetadata).GetMetadataReader() : null);
         }
 
         public static ISymUnmanagedReader CreateReader(Stream pdbStream, MetadataReader metadataReaderOpt)

--- a/src/Test/PdbUtilities/PdbUtilities.csproj
+++ b/src/Test/PdbUtilities/PdbUtilities.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Pdb\CustomDebugInfoUtilities.cs" />
     <Compile Include="Pdb\PdbToXml.cs" />
     <Compile Include="Pdb\PdbToXmlOptions.cs" />
+    <Compile Include="Pdb\SymReader.cs" />
     <Compile Include="Pdb\SymReaderFactory.cs" />
     <Compile Include="Pdb\Token2SourceLineExporter.cs" />
     <Compile Include="Shared\CustomDebugInfoReader.cs" />

--- a/src/Test/PdbUtilities/Shared/SymUnmanagedReaderExtensions.cs
+++ b/src/Test/PdbUtilities/Shared/SymUnmanagedReaderExtensions.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 using Roslyn.Utilities;
 
@@ -606,12 +605,6 @@ namespace Microsoft.DiaSymReader
             {
                 yield return new AsyncStepInfo(yieldOffsets[i], breakpointOffsets[i], breakpointMethods[i]);
             }
-        }
-
-        public static void UpdateSymbolStore(this ISymUnmanagedReader reader, Stream pdbStream)
-        {
-            int hr = reader.UpdateSymbolStore(null, new ComStreamWrapper(pdbStream));
-            ThrowExceptionForHR(hr);
         }
     }
 }


### PR DESCRIPTION
This reverts commit bb5091340addd8ffaa0c2586b7a0961040c73ada. We need to investigate intermittent failures in DiaSymReader first, such as #6651.