### PR TITLE
Adjust ErrorLogger to conform to current SARIF draft 

### DIFF
--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -1,0 +1,38 @@
+Introduction
+============
+The C# and Visual Basic compilers support a /errorlog:<file> switch on
+the command line to log all diagnostics in a structured, JSON format.
+
+The log format is SARIF (Static Analysis Results Interchange Format)
+and is defined by https://github.com/sarif-standard/sarif-spec
+
+Note that the format has not been finalized and the specification is
+still a draft. It will remain subject to breaking changes until the
+`version` property is emitted with a value of "1.0" or greater.
+
+This document does not repeat the details of the SARIF format, but
+rather adds information that is specific to the implementation provided
+by the C# and Visual Basic Compilers.
+
+
+Issue Properties
+================
+The SARIF standard allows the `properties` property of `issue` objects
+to contain arbitrary (string, string) key-value pairs.
+
+The keys and values used by the C# and VB compilers are serialized from
+the corresponding `Microsoft.CodeAnalysis.Diagnostic` and its
+`Microsoft.CodeAnalysis.DiagnosticDescriptor` as follows:
+
+Key                      | Value
+------------------------ | ------------
+"severity"               | `Diagnostic.Severity` ("Hidden", "Info", "Warning, or "Error")
+"warningLevel"           | `Diagnostic.WarningLevel` ("1", "2", "3", or "4" for "Warning" severity; omitted otherwise)
+"defaultSeverity"        | `Diagnostic.DefaultSeverity` ("Hidden", "Info", "Warning, "Error")
+"title"                  | `DiagnosticDesciptor.Title` (omitted if null or empty)
+"category"               | `Diagnostic.Category`
+"helpLink"               | `DiagnosticDescriptor.HelpLink` (omitted if null or empty)
+"isEnabledByDefault"     | `Diagnostic.IsEnabledByDefault` ("True" or "False")
+"isSuppressedInSource"   | `Diagnostic.IsSuppressedInSource` ("True" or "False")
+"customTags"             | `Diagnostic.CustomTags` (joined together in a `;`-delimted list)
+"customProperties.[key]" | `Diagnostic.Properties[key]` (for each key in the dictionary)

--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -46,7 +46,9 @@ class C
 
             var expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd);
             var expectedIssues = @"
-  ""issues"": [
+      ""issues"": [
+      ]
+    }
   ]
 }";
             var expectedText = expectedHeader + expectedIssues;
@@ -83,52 +85,54 @@ public class C
 
             var expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd);
             var expectedIssues = string.Format(@"
-  ""issues"": [
-    {{
-      ""ruleId"": ""CS0169"",
-      ""locations"": [
+      ""issues"": [
         {{
-          ""analysisTarget"": [
+          ""ruleId"": ""CS0169"",
+          ""locations"": [
             {{
-              ""uri"": ""{0}"",
-              ""region"": {{
-                ""startLine"": 3,
-                ""startColumn"": 16,
-                ""endLine"": 3,
-                ""endColumn"": 17
-              }}
+              ""analysisTarget"": [
+                {{
+                  ""uri"": ""{0}"",
+                  ""region"": {{
+                    ""startLine"": 4,
+                    ""startColumn"": 17,
+                    ""endLine"": 4,
+                    ""endColumn"": 18
+                  }}
+                }}
+              ]
             }}
-          ]
+          ],
+          ""fullMessage"": ""The field 'C.x' is never used"",
+          ""properties"": {{
+            ""severity"": ""Warning"",
+            ""warningLevel"": ""3"",
+            ""defaultSeverity"": ""Warning"",
+            ""title"": ""Field is never used"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": ""Compiler;Telemetry""
+          }}
+        }},
+        {{
+          ""ruleId"": ""CS5001"",
+          ""locations"": [
+          ],
+          ""fullMessage"": ""Program does not contain a static 'Main' method suitable for an entry point"",
+          ""properties"": {{
+            ""severity"": ""Error"",
+            ""defaultSeverity"": ""Error"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": ""Compiler;Telemetry;NotConfigurable""
+          }}
         }}
-      ],
-      ""fullMessage"": ""The field 'C.x' is never used"",
-      ""properties"": {{
-        ""severity"": ""Warning"",
-        ""warningLevel"": ""3"",
-        ""defaultSeverity"": ""Warning"",
-        ""title"": ""Field is never used"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": ""Compiler;Telemetry""
-      }}
-    }},
-    {{
-      ""ruleId"": ""CS5001"",
-      ""locations"": [
-      ],
-      ""fullMessage"": ""Program does not contain a static 'Main' method suitable for an entry point"",
-      ""properties"": {{
-        ""severity"": ""Error"",
-        ""defaultSeverity"": ""Error"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": ""Compiler;Telemetry;NotConfigurable""
-      }}
+      ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.EscapeDirectorySeparatorChar(sourceFile));
+}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFile));
 
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);
@@ -167,52 +171,54 @@ public class C
 
             var expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd);
             var expectedIssues = string.Format(@"
-  ""issues"": [
-    {{
-      ""ruleId"": ""CS0169"",
-      ""locations"": [
+      ""issues"": [
         {{
-          ""analysisTarget"": [
+          ""ruleId"": ""CS0169"",
+          ""locations"": [
             {{
-              ""uri"": ""{0}"",
-              ""region"": {{
-                ""startLine"": 4,
-                ""startColumn"": 16,
-                ""endLine"": 4,
-                ""endColumn"": 17
-              }}
+              ""analysisTarget"": [
+                {{
+                  ""uri"": ""{0}"",
+                  ""region"": {{
+                    ""startLine"": 5,
+                    ""startColumn"": 17,
+                    ""endLine"": 5,
+                    ""endColumn"": 18
+                  }}
+                }}
+              ]
             }}
-          ]
+          ],
+          ""fullMessage"": ""The field 'C.x' is never used"",
+          ""properties"": {{
+            ""severity"": ""Warning"",
+            ""warningLevel"": ""3"",
+            ""defaultSeverity"": ""Warning"",
+            ""title"": ""Field is never used"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""True"",
+            ""customTags"": ""Compiler;Telemetry""
+          }}
+        }},
+        {{
+          ""ruleId"": ""CS5001"",
+          ""locations"": [
+          ],
+          ""fullMessage"": ""Program does not contain a static 'Main' method suitable for an entry point"",
+          ""properties"": {{
+            ""severity"": ""Error"",
+            ""defaultSeverity"": ""Error"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": ""Compiler;Telemetry;NotConfigurable""
+          }}
         }}
-      ],
-      ""fullMessage"": ""The field 'C.x' is never used"",
-      ""properties"": {{
-        ""severity"": ""Warning"",
-        ""warningLevel"": ""3"",
-        ""defaultSeverity"": ""Warning"",
-        ""title"": ""Field is never used"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""True"",
-        ""customTags"": ""Compiler;Telemetry""
-      }}
-    }},
-    {{
-      ""ruleId"": ""CS5001"",
-      ""locations"": [
-      ],
-      ""fullMessage"": ""Program does not contain a static 'Main' method suitable for an entry point"",
-      ""properties"": {{
-        ""severity"": ""Error"",
-        ""defaultSeverity"": ""Error"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": ""Compiler;Telemetry;NotConfigurable""
-      }}
+      ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.EscapeDirectorySeparatorChar(sourceFile));
+}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFile));
 
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.WellKnownStrings.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.WellKnownStrings.cs
@@ -11,9 +11,10 @@ namespace Microsoft.CodeAnalysis
         {
             public const string OutputFormatVersion = "version";
             public const string ToolFileVersion = "fileVersion";
-            public const string ToolAssemblyVersion = "productVersion";
+            public const string ToolAssemblyVersion = "version";
             public const string ToolInfo = "toolInfo";
-            public const string ToolName = "toolName";
+            public const string ToolName = "name";
+            public const string RunLogs = "runLogs";
             public const string Issues = "issues";
             public const string DiagnosticId = "ruleId";
             public const string Locations = "locations";
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             public const string IsSuppressedInSource = "isSuppressedInSource";
             public const string Properties = "properties";
             public const string Location = "analysisTarget";
-            public const string LocationSyntaxTreePath = "uri";
+            public const string LocationSyntaxTreeUri = "uri";
             public const string LocationSpanInfo = "region";
             public const string LocationSpanStartLine = "startLine";
             public const string LocationSpanStartColumn = "startColumn";

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -46,7 +46,9 @@ End Class
 
             Dim expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd)
             Dim expectedIssues = "
-  ""issues"": [
+      ""issues"": [
+      ]
+    }
   ]
 }"
 
@@ -89,52 +91,54 @@ End Class
 
             Dim expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd)
             Dim expectedIssues = String.Format("
-  ""issues"": [
-    {{
-      ""ruleId"": ""BC42024"",
-      ""locations"": [
+      ""issues"": [
         {{
-          ""analysisTarget"": [
+          ""ruleId"": ""BC42024"",
+          ""locations"": [
             {{
-              ""uri"": ""{0}"",
-              ""region"": {{
-                ""startLine"": 3,
-                ""startColumn"": 12,
-                ""endLine"": 3,
-                ""endColumn"": 13
-              }}
+              ""analysisTarget"": [
+                {{
+                  ""uri"": ""{0}"",
+                  ""region"": {{
+                    ""startLine"": 4,
+                    ""startColumn"": 13,
+                    ""endLine"": 4,
+                    ""endColumn"": 14
+                  }}
+                }}
+              ]
             }}
-          ]
+          ],
+          ""fullMessage"": ""Unused local variable: 'x'."",
+          ""properties"": {{
+            ""severity"": ""Warning"",
+            ""warningLevel"": ""1"",
+            ""defaultSeverity"": ""Warning"",
+            ""title"": ""Unused local variable"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": ""Compiler;Telemetry""
+          }}
+        }},
+        {{
+          ""ruleId"": ""BC30420"",
+          ""locations"": [
+          ],
+          ""fullMessage"": ""'Sub Main' was not found in '{1}'."",
+          ""properties"": {{
+            ""severity"": ""Error"",
+            ""defaultSeverity"": ""Error"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": ""Compiler;Telemetry;NotConfigurable""
+          }}
         }}
-      ],
-      ""fullMessage"": ""Unused local variable: 'x'."",
-      ""properties"": {{
-        ""severity"": ""Warning"",
-        ""warningLevel"": ""1"",
-        ""defaultSeverity"": ""Warning"",
-        ""title"": ""Unused local variable"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": ""Compiler;Telemetry""
-      }}
-    }},
-    {{
-      ""ruleId"": ""BC30420"",
-      ""locations"": [
-      ],
-      ""fullMessage"": ""'Sub Main' was not found in '{1}'."",
-      ""properties"": {{
-        ""severity"": ""Error"",
-        ""defaultSeverity"": ""Error"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": ""Compiler;Telemetry;NotConfigurable""
-      }}
+      ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.EscapeDirectorySeparatorChar(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
+}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)
@@ -178,52 +182,54 @@ End Class
 
             Dim expectedHeader = GetExpectedErrorLogHeader(actualOutput, cmd)
             Dim expectedIssues = String.Format("
-  ""issues"": [
-    {{
-      ""ruleId"": ""BC42024"",
-      ""locations"": [
+      ""issues"": [
         {{
-          ""analysisTarget"": [
+          ""ruleId"": ""BC42024"",
+          ""locations"": [
             {{
-              ""uri"": ""{0}"",
-              ""region"": {{
-                ""startLine"": 4,
-                ""startColumn"": 12,
-                ""endLine"": 4,
-                ""endColumn"": 13
-              }}
+              ""analysisTarget"": [
+                {{
+                  ""uri"": ""{0}"",
+                  ""region"": {{
+                    ""startLine"": 5,
+                    ""startColumn"": 13,
+                    ""endLine"": 5,
+                    ""endColumn"": 14
+                  }}
+                }}
+              ]
             }}
-          ]
+          ],
+          ""fullMessage"": ""Unused local variable: 'x'."",
+          ""properties"": {{
+            ""severity"": ""Warning"",
+            ""warningLevel"": ""1"",
+            ""defaultSeverity"": ""Warning"",
+            ""title"": ""Unused local variable"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""True"",
+            ""customTags"": ""Compiler;Telemetry""
+          }}
+        }},
+        {{
+          ""ruleId"": ""BC30420"",
+          ""locations"": [
+          ],
+          ""fullMessage"": ""'Sub Main' was not found in '{1}'."",
+          ""properties"": {{
+            ""severity"": ""Error"",
+            ""defaultSeverity"": ""Error"",
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": ""True"",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": ""Compiler;Telemetry;NotConfigurable""
+          }}
         }}
-      ],
-      ""fullMessage"": ""Unused local variable: 'x'."",
-      ""properties"": {{
-        ""severity"": ""Warning"",
-        ""warningLevel"": ""1"",
-        ""defaultSeverity"": ""Warning"",
-        ""title"": ""Unused local variable"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""True"",
-        ""customTags"": ""Compiler;Telemetry""
-      }}
-    }},
-    {{
-      ""ruleId"": ""BC30420"",
-      ""locations"": [
-      ],
-      ""fullMessage"": ""'Sub Main' was not found in '{1}'."",
-      ""properties"": {{
-        ""severity"": ""Error"",
-        ""defaultSeverity"": ""Error"",
-        ""category"": ""Compiler"",
-        ""isEnabledByDefault"": ""True"",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": ""Compiler;Telemetry;NotConfigurable""
-      }}
+      ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.EscapeDirectorySeparatorChar(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
+}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -64,25 +64,15 @@ namespace Microsoft.CodeAnalysis
 
             private static string GetExpectedPropertiesMapText()
             {
-                var isFirst = true;
-                var expectedText = @",
-        ""customProperties"": {";
+                var expectedText = "";
 
                 foreach (var kvp in s_properties.OrderBy(kvp => kvp.Key))
                 {
-                    if (!isFirst)
-                    {
-                        expectedText += ",";
-                    }
-
+                    expectedText += ",";
                     expectedText += string.Format(@"
-          ""{0}"": ""{1}""", kvp.Key, kvp.Value);
-
-                    isFirst = false;
+            ""customProperties.{0}"": ""{1}""", kvp.Key, kvp.Value);
                 }
 
-                expectedText += @"
-        }";
                 return expectedText;
             }
 
@@ -91,67 +81,69 @@ namespace Microsoft.CodeAnalysis
                 var tree = compilation.SyntaxTrees.First();
                 var root = tree.GetRoot();
                 var expectedLineSpan = root.GetLocation().GetLineSpan();
-                var filePath = EscapeDirectorySeparatorChar(tree.FilePath);
+                var filePath = GetEscapedUriForPath(tree.FilePath);
 
                 return @"
-  ""issues"": [
-    {
-      ""ruleId"": """ + Descriptor1.Id + @""",
-      ""locations"": [
+      ""issues"": [
         {
-          ""analysisTarget"": [
+          ""ruleId"": """ + Descriptor1.Id + @""",
+          ""locations"": [
             {
-              ""uri"": """ + filePath + @""",
-              ""region"": {
-                ""startLine"": " + expectedLineSpan.StartLinePosition.Line + @",
-                ""startColumn"": " + expectedLineSpan.StartLinePosition.Character + @",
-                ""endLine"": " + expectedLineSpan.EndLinePosition.Line + @",
-                ""endColumn"": " + expectedLineSpan.EndLinePosition.Character + @"
-              }
+              ""analysisTarget"": [
+                {
+                  ""uri"": """ + filePath + @""",
+                  ""region"": {
+                    ""startLine"": " + (expectedLineSpan.StartLinePosition.Line + 1) + @",
+                    ""startColumn"": " + (expectedLineSpan.StartLinePosition.Character + 1) + @",
+                    ""endLine"": " + (expectedLineSpan.EndLinePosition.Line + 1) + @",
+                    ""endColumn"": " + (expectedLineSpan.EndLinePosition.Character + 1) + @"
+                  }
+                }
+              ]
             }
-          ]
+          ],
+          ""shortMessage"": """ + Descriptor1.MessageFormat + @""",
+          ""fullMessage"": """ + Descriptor1.Description + @""",
+          ""properties"": {
+            ""severity"": """ + Descriptor1.DefaultSeverity + @""",
+            ""warningLevel"": ""1"",
+            ""defaultSeverity"": """ + Descriptor1.DefaultSeverity + @""",
+            ""title"": """ + Descriptor1.Title + @""",
+            ""category"": """ + Descriptor1.Category + @""",
+            ""helpLink"": """ + Descriptor1.HelpLinkUri + @""",
+            ""isEnabledByDefault"": """ + Descriptor1.IsEnabledByDefault + @""",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": """ + Descriptor1.CustomTags.Join(";") + @"""" +
+            GetExpectedPropertiesMapText() + @"
+          }
+        },
+        {
+          ""ruleId"": """ + Descriptor2.Id + @""",
+          ""locations"": [
+          ],
+          ""shortMessage"": """ + Descriptor2.MessageFormat + @""",
+          ""fullMessage"": """ + Descriptor2.Description + @""",
+          ""properties"": {
+            ""severity"": """ + Descriptor2.DefaultSeverity + @""",
+            ""defaultSeverity"": """ + Descriptor2.DefaultSeverity + @""",
+            ""title"": """ + Descriptor2.Title + @""",
+            ""category"": """ + Descriptor2.Category + @""",
+            ""helpLink"": """ + Descriptor2.HelpLinkUri + @""",
+            ""isEnabledByDefault"": """ + Descriptor2.IsEnabledByDefault + @""",
+            ""isSuppressedInSource"": ""False"",
+            ""customTags"": """ + Descriptor2.CustomTags.Join(";") + @"""" +
+            GetExpectedPropertiesMapText() + @"
+          }
         }
-      ],
-      ""shortMessage"": """ + Descriptor1.MessageFormat + @""",
-      ""fullMessage"": """ + Descriptor1.Description + @""",
-      ""properties"": {
-        ""severity"": """ + Descriptor1.DefaultSeverity + @""",
-        ""warningLevel"": ""1"",
-        ""defaultSeverity"": """ + Descriptor1.DefaultSeverity + @""",
-        ""title"": """ + Descriptor1.Title + @""",
-        ""category"": """ + Descriptor1.Category + @""",
-        ""helpLink"": """ + Descriptor1.HelpLinkUri + @""",
-        ""isEnabledByDefault"": """ + Descriptor1.IsEnabledByDefault + @""",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": """ + Descriptor1.CustomTags.Join(";") + @"""" +
-        GetExpectedPropertiesMapText() + @"
-      }
-    },
-    {
-      ""ruleId"": """ + Descriptor2.Id + @""",
-      ""locations"": [
-      ],
-      ""shortMessage"": """ + Descriptor2.MessageFormat + @""",
-      ""fullMessage"": """ + Descriptor2.Description + @""",
-      ""properties"": {
-        ""severity"": """ + Descriptor2.DefaultSeverity + @""",
-        ""defaultSeverity"": """ + Descriptor2.DefaultSeverity + @""",
-        ""title"": """ + Descriptor2.Title + @""",
-        ""category"": """ + Descriptor2.Category + @""",
-        ""helpLink"": """ + Descriptor2.HelpLinkUri + @""",
-        ""isEnabledByDefault"": """ + Descriptor2.IsEnabledByDefault + @""",
-        ""isSuppressedInSource"": ""False"",
-        ""customTags"": """ + Descriptor2.CustomTags.Join(";") + @"""" +
-        GetExpectedPropertiesMapText() + @"
-      }
+      ]
     }
   ]
 }";
             }
 
-            public static string EscapeDirectorySeparatorChar(string input)
+            public static string GetEscapedUriForPath(string path)
             {
-                return input.Replace(Path.DirectorySeparatorChar.ToString(), @"\" + Path.DirectorySeparatorChar);
+                return new Uri(path, UriKind.RelativeOrAbsolute).ToString().Replace("/", "\\/");
             }
         }
 

--- a/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
@@ -292,16 +292,17 @@ namespace Microsoft.CodeAnalysis
         {
             var expectedToolName = compiler.GetToolName();
             var expectedProductVersion = compiler.GetAssemblyVersion().ToString(fieldCount: 3);
-            var fileVersion = compiler.GetAssemblyFileVersion();
-            var expectedFileVersion = fileVersion.Substring(0, fileVersion.LastIndexOf('.'));
+            var expectedFileVersion = compiler.GetAssemblyFileVersion();
 
             return string.Format(@"{{
   ""version"": ""{0}"",
-  ""toolInfo"": {{
-    ""toolName"": ""{1}"",
-    ""productVersion"": ""{2}"",
-    ""fileVersion"": ""{3}""
-  }},", ErrorLogger.OutputFormatVersion, expectedToolName, expectedProductVersion, expectedFileVersion);
+  ""runLogs"": [
+    {{
+      ""toolInfo"": {{
+        ""name"": ""{1}"",
+        ""version"": ""{2}"",
+        ""fileVersion"": ""{3}""
+      }},", ErrorLogger.OutputFormatVersion, expectedToolName, expectedProductVersion, expectedFileVersion);
         }
 
         public static string Stringize(this Diagnostic e)


### PR DESCRIPTION
* Add doc about log format

* Change structure from:
```
   {
      "version": <version>,
      "toolInfo": <toolInfo>,
      "issues": [ <issue>* ]
   }
```
to:
```
    {
      "version": <version>,
      "runLogs": [
        {
          "toolInfo": <toolInfo>,
           "issues": [ <issue>* ]
        }
      ]
    }
```

* Flatten custom properties to conform to requirement for all issue
property values to be strings:

```
   "customProperties": { "a": "b", "c": "d" }
-> "customProperties.a": "b", "customProperties.c": "d"
```
* Rename toolName -> name

* Rename productVersion -> version

* Let original fileVersion through without trimming off 4th part

* Use actual URI syntax for "uri" elements

* Make region start/end line/column 1-based

cc @mavasani @srivatsn @lgolding @michaelcfanning 

Fix #3670 
Fix #5752

(Side note: I've made the changes as minimally as possible. Separately, I think there could be significant benefit to the following refactoring, but didn't want to mix it with the functional change here:

1. Split out a separate, forward-only internal JsonWriter from ErrorLogger
2. Write everything out directly via (1) without intermediate Issue, Value, ImmutableArray objects

I could look at doing that as a follow-up if you'd like and agree it would be valuable.)
