### PR TITLE
Handle assembly qualified names in CodeModel2.DotNetNameFromLanguageS…

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -3021,6 +3021,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
 
         public override ITypeSymbol GetTypeSymbolFromFullName(string fullName, Compilation compilation)
         {
+            // Some clients pass us an assembly qualified name, which we don't handle.  Just lop off the
+            // assembly info if so.
+            var index = fullName.IndexOf(',');
+            if (index > 0)
+            {
+                fullName = fullName.Substring(0, index);
+            }
+
             ITypeSymbol typeSymbol = compilation.GetTypeByMetadataName(fullName);
 
             if (typeSymbol == null)

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
@@ -288,6 +288,28 @@ namespace N
 
 #End Region
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <WorkItem(163175, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems#_a=edit&id=163175")>
+        Public Sub DotNetNameFromLanguageSpecific_AssemblyQualifiedNestedType()
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> AssemblyName="MyAssembly" CommonReferences="true">
+                                    <Document FilePath="C.cs"><![CDATA[
+namespace N
+{
+    public class C
+    {
+        public class Nested { }
+    }
+}
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestRootCodeModel(workspace, Sub(rootCodeModel)
+                                             Assert.Equal("N.C+Nested", rootCodeModel.DotNetNameFromLanguageSpecific("N.C+Nested, MyAssembly"))
+                                         End Sub)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
@@ -250,6 +250,27 @@ End Namespace
                 End Sub)
         End Sub
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <WorkItem(163175, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems#_a=edit&id=163175")>
+        Public Sub DotNetNameFromLanguageSpecific_AssemblyQualifiedNestedType()
+            Dim workspace = <Workspace>
+                                <Project Language=<%= LanguageName %> AssemblyName="MyAssembly" CommonReferences="true">
+                                    <Document FilePath="C.vb"><![CDATA[
+Namespace N
+    Public Class C
+        Public Class Nested
+        End Class
+    End Class
+End Namespace
+]]></Document>
+                                </Project>
+                            </Workspace>
+
+            TestRootCodeModel(workspace, Sub(rootCodeModel)
+                                             Assert.Equal("N.C+Nested", rootCodeModel.DotNetNameFromLanguageSpecific("N.C+Nested, MyAssembly"))
+                                         End Sub)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.VisualBasic

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -3559,6 +3559,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
         End Function
 
         Public Overrides Function GetTypeSymbolFromFullName(fullName As String, compilation As Compilation) As ITypeSymbol
+            ' Some clients pass us an assembly qualified name, which we don't handle.  Just lop off the
+            ' assembly info if so.
+            Dim index = fullName.IndexOf(","c)
+            If index > 0 Then
+                fullName = fullName.Substring(0, index)
+            End If
+
             Dim typeSymbol As ITypeSymbol = compilation.GetTypeByMetadataName(fullName)
 
             If typeSymbol Is Nothing Then


### PR DESCRIPTION
…pecific

Some clients actually pass us assembly qualified names (including + for nested
types), which aren't exactly the "language specific" representation, but for
compat reasons, we'll handle them.

Fixes internal bug 163175.