### PR TITLE
[WIP] use Concat instead of Format when simple

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -12,7 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(conversion.ConversionKind == ConversionKind.InterpolatedString);
             BoundExpression format;
             ArrayBuilder<BoundExpression> expressions;
-            MakeInterpolatedStringFormat((BoundInterpolatedString)conversion.Operand, out format, out expressions);
+            ArrayBuilder<BoundExpression> concatExpressions;
+            MakeInterpolatedStringFormat((BoundInterpolatedString)conversion.Operand, out format, out expressions, out concatExpressions);
             expressions.Insert(0, format);
             var stringFactory = _factory.WellKnownType(WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory);
 
@@ -32,13 +33,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private void MakeInterpolatedStringFormat(BoundInterpolatedString node, out BoundExpression format, out ArrayBuilder<BoundExpression> expressions)
+        private bool MakeInterpolatedStringFormat(BoundInterpolatedString node, out BoundExpression format, out ArrayBuilder<BoundExpression> expressions, out ArrayBuilder<BoundExpression> concatExpressions)
         {
             _factory.Syntax = node.Syntax;
             int n = node.Parts.Length - 1;
             var formatString = PooledStringBuilder.GetInstance();
             expressions = ArrayBuilder<BoundExpression>.GetInstance(n + 1);
+            concatExpressions = ArrayBuilder<BoundExpression>.GetInstance(n + 1);
             int nextFormatPosition = 0;
+            bool isSimpleConcatString = true;
             for (int i = 0; i <= n; i++)
             {
                 var part = node.Parts[i];
@@ -47,6 +50,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // this is one of the literal parts
                     formatString.Builder.Append(part.ConstantValue.StringValue);
+                    
+                    // no point in continuing to unescape when the result will be unused
+                    if (isSimpleConcatString) 
+                    {
+                        part = HandleEscapeSequences(part);
+                    }
                 }
                 else
                 {
@@ -55,69 +64,97 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (fillin.Alignment != null && !fillin.Alignment.HasErrors)
                     {
                         formatString.Builder.Append(",").Append(fillin.Alignment.ConstantValue.Int64Value);
+                        isSimpleConcatString = false;
                     }
                     if (fillin.Format != null && !fillin.Format.HasErrors)
                     {
                         formatString.Builder.Append(":").Append(fillin.Format.ConstantValue.StringValue);
+                        isSimpleConcatString = false;
                     }
                     formatString.Builder.Append("}");
-                    var value = fillin.Value;
-                    if (value.Type?.TypeKind == TypeKind.Dynamic)
+                    part = fillin.Value;
+                    if (part.Type?.TypeKind == TypeKind.Dynamic)
                     {
-                        value = MakeConversion(value, _compilation.ObjectType, @checked: false);
+                        part = MakeConversion(part, _compilation.ObjectType, @checked: false);
                     }
 
-                    expressions.Add(value); // NOTE: must still be lowered
+                    expressions.Add(part); // NOTE: must still be lowered
                 }
+                concatExpressions.Add(part); // NOTE: must still be lowered
             }
 
             format = _factory.StringLiteral(formatString.ToStringAndFree());
+            return isSimpleConcatString;
+        }
+
+        private BoundLiteral HandleEscapeSequences(BoundExpression input) 
+        {
+            // There are no fill-ins. Handle the escaping of {{ and }} and return the value.
+            Debug.Assert(!input.HasErrors && input.ConstantValue != null && input.ConstantValue.IsString);
+            var builder = PooledStringBuilder.GetInstance();
+            var formatText = input.ConstantValue.StringValue;
+            int formatLength = formatText.Length;
+            for (int i = 0; i < formatLength; i++)
+            {
+                char c = formatText[i];
+                builder.Builder.Append(c);
+                if ((c == '{' || c == '}') && (i + 1) < formatLength && formatText[i + 1] == c)
+                {
+                    i++;
+                }
+            }
+            return _factory.StringLiteral(builder.ToStringAndFree());
         }
 
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
             //
-            // We lower an interpolated string into an invocation of String.Format.  For example, we translate the expression
+            // We lower an interpolated string into an invocation of String.Format or string concatenation, depending on 
+            // the existence of string format instructions. Some examples:
             //
-            //     $"Jenny don\'t change your number { 8675309 }"
+            //     $"Braces {{ }}"
+            //     $"#{a}-{b}"
+            //     $"Jenny don\'t change your number { 8675309 :#-0000}"
             //
             // into
             //
-            //     String.Format("Jenny don\'t change your number {0}", new object[] { 8675309 })
+            //     "Braces { }"
+            //     "#" + a + "-" + b
+            //     String.Format("Jenny don\'t change your number {0:#-0000}", new object[] { 8675309 })
             //
 
             Debug.Assert(node.Type.SpecialType == SpecialType.System_String); // if target-converted, we should not get here.
             BoundExpression format;
             ArrayBuilder<BoundExpression> expressions;
-            MakeInterpolatedStringFormat(node, out format, out expressions);
-            if (expressions.Count == 0)
+            ArrayBuilder<BoundExpression> concatExpressions;
+            bool isSimpleConcatString = MakeInterpolatedStringFormat(node, out format, out expressions, out concatExpressions);
+            if (expressions.Count == 0) 
             {
-                // There are no fill-ins. Handle the escaping of {{ and }} and return the value.
-                Debug.Assert(!format.HasErrors && format.ConstantValue != null && format.ConstantValue.IsString);
-                var builder = PooledStringBuilder.GetInstance();
-                var formatText = format.ConstantValue.StringValue;
-                int formatLength = formatText.Length;
-                for (int i = 0; i < formatLength; i++)
-                {
-                    char c = formatText[i];
-                    builder.Builder.Append(c);
-                    if ((c == '{' || c == '}') && (i + 1) < formatLength && formatText[i + 1] == c)
-                    {
-                        i++;
-                    }
-                }
-                return _factory.StringLiteral(builder.ToStringAndFree());
+                return HandleEscapeSequences(format);
             }
 
+            var stringType = node.Type;
+            BoundExpression result;
             // The normal pattern for lowering is to lower subtrees before the enclosing tree. However we cannot lower
             // the arguments first in this situation because we do not know what conversions will be
             // produced for the arguments until after we've done overload resolution. So we produce the invocation
             // and then lower it along with its arguments.
-            expressions.Insert(0, format);
-            var stringType = node.Type;
-            var result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(),
-                allowUnexpandedForm: false // if an interpolation expression is the null literal, it should not match a params parameter.
-                );
+            if (isSimpleConcatString) 
+            {
+                result = _factory.StaticCall(stringType, "Concat", concatExpressions.ToImmutableAndFree(),
+                    allowUnexpandedForm: false
+                    );
+
+            } 
+            else 
+            {
+                expressions.Insert(0, format);
+                result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(),
+                    allowUnexpandedForm: false
+                    // if an interpolation expression is the null literal, it should not match a params parameter.
+                    );
+
+            }
             if (!result.HasAnyErrors)
             {
                 result = VisitExpression(result); // lower the arguments AND handle expanded form, argument conversions, etc.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -5526,14 +5526,23 @@ class C : TestBase
             Expression<Func<string>> f;
             f = () => $"""";
             Check<string>(f, ""Constant( Type:System.String)"");
+            f = () => $""{1,1}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object)](Constant({0,1} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            f = () => $""{1}{2,1}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object)](Constant({0}{1,1} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            f = () => $""{1}{2,1}{3}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object, System.Object)](Constant({0}{1,1}{2} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object), Convert(Constant(3 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            f = () => $""{1}{2}{3,1}{4}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object[])](Constant({0}{1}{2,1}{3} Type:System.String), NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
+
             f = () => $""{1}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object)](Constant({0} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            Check<string>(f, ""Call(null.[System.String Concat(System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object)) Type:System.String)"");
             f = () => $""{1}{2}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object)](Constant({0}{1} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            Check<string>(f, ""Call(null.[System.String Concat(System.Object, System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object)) Type:System.String)"");
             f = () => $""{1}{2}{3}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object, System.Object)](Constant({0}{1}{2} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object), Convert(Constant(3 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            Check<string>(f, ""Call(null.[System.String Concat(System.Object, System.Object, System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object), Convert(Constant(3 Type:System.Int32) Type:System.Object)) Type:System.String)"");
             f = () => $""{1}{2}{3}{4}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object[])](Constant({0}{1}{2}{3} Type:System.String), NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
+            Check<string>(f, ""Call(null.[System.String Concat(System.Object[])](NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
             Console.WriteLine(""DONE"");
     }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -5537,7 +5537,7 @@ class C : TestBase
             Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object[])](Constant({0}{1}{2,1}{3} Type:System.String), NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
 
             f = () => $""{1}"";
-            Check<string>(f, ""Call(null.[System.String Concat(System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            Check<string>(f, ""Call(Constant(1 Type:System.Int32).[System.String ToString()]() Type:System.String)"");
             f = () => $""{1}{2}"";
             Check<string>(f, ""Call(null.[System.String Concat(System.Object, System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object)) Type:System.String)"");
             f = () => $""{1}{2}{3}"";

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -5524,6 +5524,7 @@ class C : TestBase
         where T : struct
     {
             Expression<Func<string>> f;
+            Expression<Func<string>> g;
             f = () => $"""";
             Check<string>(f, ""Constant( Type:System.String)"");
             f = () => $""{1,1}"";
@@ -5543,6 +5544,17 @@ class C : TestBase
             Check<string>(f, ""Call(null.[System.String Concat(System.Object, System.Object, System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object), Convert(Constant(3 Type:System.Int32) Type:System.Object)) Type:System.String)"");
             f = () => $""{1}{2}{3}{4}"";
             Check<string>(f, ""Call(null.[System.String Concat(System.Object[])](NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
+
+            f = () => $""{null}{null}{null}"";
+            Check<string>(f, ""Constant( Type:System.String)"");
+            f = () => $""{""""}"";
+            Check<string>(f, ""Constant( Type:System.String)"");
+            f = () => $""{new object()}"";
+            Check<string>(f, ""Coalesce(Call(null.[System.String Concat(System.Object)](New([Void .ctor()]() Type:System.Object)) Type:System.String) Constant( Type:System.String) Type:System.String)"");
+            string x = """";
+            f = () => $""{x}"";
+            g = () => x ?? """";
+            Check<string>(f, ToString<string>(g));
             Console.WriteLine(""DONE"");
     }
 
@@ -5551,7 +5563,7 @@ class C : TestBase
         M<S>();
     }
 }";
-
+            
             const string expectedOutput = @"DONE";
             CompileAndVerify(
                 new[] { source, ExpressionTestLibrary },

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -921,7 +921,7 @@ class Program {
             .VerifyEmitDiagnostics(new CodeAnalysis.Emit.EmitOptions(runtimeMetadataVersion: "x.y"),
                 // (15,21): error CS0117: 'string' does not contain a definition for 'Format'
                 //             var s = $"X = { 1 } ";
-                Diagnostic(ErrorCode.ERR_NoSuchMember, @"$""X = { 1 } """).WithArguments("string", "Format").WithLocation(15, 21)
+                Diagnostic(ErrorCode.ERR_NoSuchMember, @"$""X = { 1 } """).WithArguments("string", "Concat").WithLocation(15, 21)
             );
         }
 
@@ -946,7 +946,7 @@ class Program {
     {
         public static void Main()
         {
-            var s = $""X = { 1 } "";
+            var s = $""X = { 1 , 1 } "";
         }
     }
 }";
@@ -954,7 +954,7 @@ class Program {
             .VerifyEmitDiagnostics(new CodeAnalysis.Emit.EmitOptions(runtimeMetadataVersion: "x.y"),
                 // (17,21): error CS0029: Cannot implicitly convert type 'bool' to 'string'
                 //             var s = $"X = { 1 } ";
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"$""X = { 1 } """).WithArguments("bool", "string").WithLocation(17, 21)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"$""X = { 1 , 1 } """).WithArguments("bool", "string").WithLocation(17, 21)
             );
         }
 
@@ -990,8 +990,8 @@ class Program {
     {
         public static void Main()
         {
-            var s1 = $""X = { 1 } "";
-            FormattableString s2 = $""X = { 1 } "";
+            var s1 = $""X = { 1 , 1 } "";
+            FormattableString s2 = $""X = { 1 , 1 } "";
         }
     }
 }";
@@ -1001,12 +1001,12 @@ class Program {
 @"{
   // Code size       35 (0x23)
   .maxstack  2
-  IL_0000:  ldstr      ""X = {0} ""
+  IL_0000:  ldstr      ""X = {0,1} ""
   IL_0005:  ldc.i4.1
   IL_0006:  call       ""System.Bozo string.Format(string, int)""
   IL_000b:  call       ""string System.Bozo.op_Implicit(System.Bozo)""
   IL_0010:  pop
-  IL_0011:  ldstr      ""X = {0} ""
+  IL_0011:  ldstr      ""X = {0,1} ""
   IL_0016:  ldc.i4.1
   IL_0017:  call       ""System.Bozo System.Runtime.CompilerServices.FormattableStringFactory.Create(string, int)""
   IL_001c:  call       ""System.FormattableString System.Bozo.op_Implicit(System.Bozo)""

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -38,56 +38,598 @@ Jenny don't change your number     867-5309.
         }
 
         [Fact]
-        public void TestFormatAndConcatOverloads()
+        public void TestFormatAndConcatOverloads01()
         {
-            string source =
+            var text =
 @"using System;
+
 class Program
 {
+    static string Test => $"""";
+
     static void Main(string[] args)
     {
-        Console.WriteLine($""{null}"" == """"); // """"
-
-        string s = null;
-        Console.WriteLine($""{s}"" == """"); // s ?? """"
-        Console.WriteLine($""{s}{s}"" == """"); // Concat(string, string) ?? """"
-        Console.WriteLine($""{s} {s}"" == "" ""); // Concat(string, string, string)
-        Console.WriteLine($""{s}{s}{s}"" == """"); // Concat(string, string, string) ?? """"
-        Console.WriteLine($""{s}{s}{s}{s}"" == """"); // Concat(string, string, string, string) ?? """"
-        Console.WriteLine($""{s}{s}{s}{s}{s}"" == """"); // Concat(string[]) ?? """"
-        
-        object o = null;
-        Console.WriteLine($""{o}"" == """"); // Concat(object) ?? """"
-        Console.WriteLine($""{o}{1}"" == ""1""); // Concat(object, object)
-        Console.WriteLine($""{o}{o}"" == """"); // Concat(object, object) ?? """"
-        Console.WriteLine($""{o}{o}{o}"" == """"); // Concat(object, object, object) ?? """"
-        Console.WriteLine($""{o}{o}{o}{o}"" == """"); // Concat(object[]) ?? """"
-        
-        Console.WriteLine($""{null,0}"" == """"); // Format(string, object)
-        Console.WriteLine($""{null,0}{null}"" == """"); // Format(string, object, object)
-        Console.WriteLine($""{null,0}{null}{null}"" == """"); // Format(string, object, object, object)
-        Console.WriteLine($""{null,0}{null}{null}{null}"" == """"); // Format(string, object[])
+        Console.WriteLine(Test == """");
     }
-}
-";
-            string expectedOutput =
-@"True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True";
-            CompileAndVerify(source, expectedOutput: expectedOutput);
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  ldstr      """"
+  IL_0005:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads02()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  ldstr      """"
+  IL_0005:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads03()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{""""}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  ldstr      """"
+  IL_0005:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads04()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_000e
+  IL_0008:  pop
+  IL_0009:  ldstr      """"
+  IL_000e:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads05()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       25 (0x19)
+  .maxstack  2
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldsfld     ""string Program.s""
+  IL_000a:  call       ""string string.Concat(string, string)""
+  IL_000f:  dup
+  IL_0010:  brtrue.s   IL_0018
+  IL_0012:  pop
+  IL_0013:  ldstr      """"
+  IL_0018:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads06()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s} "";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == "" "");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       16 (0x10)
+  .maxstack  2
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldstr      "" ""
+  IL_000a:  call       ""string string.Concat(string, string)""
+  IL_000f:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads07()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s} {s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == "" "");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       21 (0x15)
+  .maxstack  3
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldstr      "" ""
+  IL_000a:  ldsfld     ""string Program.s""
+  IL_000f:  call       ""string string.Concat(string, string, string)""
+  IL_0014:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads08()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}{s}{s}{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       35 (0x23)
+  .maxstack  4
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldsfld     ""string Program.s""
+  IL_000a:  ldsfld     ""string Program.s""
+  IL_000f:  ldsfld     ""string Program.s""
+  IL_0014:  call       ""string string.Concat(string, string, string, string)""
+  IL_0019:  dup
+  IL_001a:  brtrue.s   IL_0022
+  IL_001c:  pop
+  IL_001d:  ldstr      """"
+  IL_0022:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads09()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}{s}{s}{s}{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       61 (0x3d)
+  .maxstack  4
+  IL_0000:  ldc.i4.5
+  IL_0001:  newarr     ""string""
+  IL_0006:  dup
+  IL_0007:  ldc.i4.0
+  IL_0008:  ldsfld     ""string Program.s""
+  IL_000d:  stelem.ref
+  IL_000e:  dup
+  IL_000f:  ldc.i4.1
+  IL_0010:  ldsfld     ""string Program.s""
+  IL_0015:  stelem.ref
+  IL_0016:  dup
+  IL_0017:  ldc.i4.2
+  IL_0018:  ldsfld     ""string Program.s""
+  IL_001d:  stelem.ref
+  IL_001e:  dup
+  IL_001f:  ldc.i4.3
+  IL_0020:  ldsfld     ""string Program.s""
+  IL_0025:  stelem.ref
+  IL_0026:  dup
+  IL_0027:  ldc.i4.4
+  IL_0028:  ldsfld     ""string Program.s""
+  IL_002d:  stelem.ref
+  IL_002e:  call       ""string string.Concat(params string[])""
+  IL_0033:  dup
+  IL_0034:  brtrue.s   IL_003c
+  IL_0036:  pop
+  IL_0037:  ldstr      """"
+  IL_003c:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads10()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       20 (0x14)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  call       ""string string.Concat(object)""
+  IL_000a:  dup
+  IL_000b:  brtrue.s   IL_0013
+  IL_000d:  pop
+  IL_000e:  ldstr      """"
+  IL_0013:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads11()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{1}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == ""1"");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       17 (0x11)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  ldc.i4.1
+  IL_0006:  box        ""int""
+  IL_000b:  call       ""string string.Concat(object, object)""
+  IL_0010:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads12()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       25 (0x19)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  ldsfld     ""object Program.o""
+  IL_000a:  call       ""string string.Concat(object, object)""
+  IL_000f:  dup
+  IL_0010:  brtrue.s   IL_0018
+  IL_0012:  pop
+  IL_0013:  ldstr      """"
+  IL_0018:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads13()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{o}{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       30 (0x1e)
+  .maxstack  3
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  ldsfld     ""object Program.o""
+  IL_000a:  ldsfld     ""object Program.o""
+  IL_000f:  call       ""string string.Concat(object, object, object)""
+  IL_0014:  dup
+  IL_0015:  brtrue.s   IL_001d
+  IL_0017:  pop
+  IL_0018:  ldstr      """"
+  IL_001d:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads14()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{o}{o}{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       53 (0x35)
+  .maxstack  4
+  IL_0000:  ldc.i4.4
+  IL_0001:  newarr     ""object""
+  IL_0006:  dup
+  IL_0007:  ldc.i4.0
+  IL_0008:  ldsfld     ""object Program.o""
+  IL_000d:  stelem.ref
+  IL_000e:  dup
+  IL_000f:  ldc.i4.1
+  IL_0010:  ldsfld     ""object Program.o""
+  IL_0015:  stelem.ref
+  IL_0016:  dup
+  IL_0017:  ldc.i4.2
+  IL_0018:  ldsfld     ""object Program.o""
+  IL_001d:  stelem.ref
+  IL_001e:  dup
+  IL_001f:  ldc.i4.3
+  IL_0020:  ldsfld     ""object Program.o""
+  IL_0025:  stelem.ref
+  IL_0026:  call       ""string string.Concat(params object[])""
+  IL_002b:  dup
+  IL_002c:  brtrue.s   IL_0034
+  IL_002e:  pop
+  IL_002f:  ldstr      """"
+  IL_0034:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads15()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null,0}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldstr      ""{0,0}""
+  IL_0005:  ldnull
+  IL_0006:  call       ""string string.Format(string, object)""
+  IL_000b:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads16()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}{null,0}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       13 (0xd)
+  .maxstack  3
+  IL_0000:  ldstr      ""{0}{1,0}""
+  IL_0005:  ldnull
+  IL_0006:  ldnull
+  IL_0007:  call       ""string string.Format(string, object, object)""
+  IL_000c:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads17()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}{null,0}{null}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       14 (0xe)
+  .maxstack  4
+  IL_0000:  ldstr      ""{0}{1,0}{2}""
+  IL_0005:  ldnull
+  IL_0006:  ldnull
+  IL_0007:  ldnull
+  IL_0008:  call       ""string string.Format(string, object, object, object)""
+  IL_000d:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads18()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}{null,0}{null}{null}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       17 (0x11)
+  .maxstack  2
+  IL_0000:  ldstr      ""{0}{1,0}{2}{3}""
+  IL_0005:  ldc.i4.4
+  IL_0006:  newarr     ""object""
+  IL_000b:  call       ""string string.Format(string, params object[])""
+  IL_0010:  ret
+}");
+        }
+
+        [Fact]
+        public void DoNotBoxToStringCall()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{1}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == ""1"");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       16 (0x10)
+  .maxstack  1
+  .locals init (int V_0)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  constrained. ""int""
+  IL_000a:  callvirt   ""string object.ToString()""
+  IL_000f:  ret
+}");
         }
 
         [Fact]
@@ -1069,6 +1611,50 @@ class Program {
   IL_001c:  call       ""System.FormattableString System.Bozo.op_Implicit(System.Bozo)""
   IL_0021:  pop
   IL_0022:  ret
+}");
+        }
+
+        [Fact]
+        public void SillyToString()
+        {
+            var text =
+@"using System;
+
+struct S
+{
+    public override string ToString()
+    {
+        return null;
+    }
+}
+
+class Program
+{
+    static string Test => $""{new S()}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       33 (0x21)
+  .maxstack  2
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.0
+  IL_000a:  ldloca.s   V_0
+  IL_000c:  constrained. ""S""
+  IL_0012:  callvirt   ""string object.ToString()""
+  IL_0017:  dup
+  IL_0018:  brtrue.s   IL_0020
+  IL_001a:  pop
+  IL_001b:  ldstr      """"
+  IL_0020:  ret
 }");
         }
 


### PR DESCRIPTION
If there are no format string *alignment* or *formatString* parameters, it should be faster to do a `string.Concat` call instead of `string.Format`.

Fixes #6669 

Now against the correct fork.

Tests cases coming... I think this is the wrong way to fix this anyway. This only affects interpolated strings, but all string format calls could use this optimization.