### PR TITLE
Introduce placeholders for deprecated GeneratedNameKinds

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal enum GeneratedNameKind
@@ -35,6 +37,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         AsyncBuilderField = 't',
         DynamicCallSiteContainerType = 'o',
         DynamicCallSiteField = 'p',
+
+        // Deprecated - emitted by Dev12, but not by Roslyn.
+        // Don't reuse the values because the debugger might encounter them when consuming old binaries.
+        [Obsolete] Deprecated_OuterscopeLocals = '6',
+        [Obsolete] Deprecated_IteratorInstance = 'a',
+        [Obsolete] Deprecated_InitializerLocal = 'g',
+        [Obsolete] Deprecated_AnonymousTypeTypeParameter = 'j',
+        [Obsolete] Deprecated_DynamicDelegate = 'q',
+        [Obsolete] Deprecated_ComrefCallLocal = 'r',
     }
 
     internal static class GeneratedNameKindExtensions


### PR DESCRIPTION
...to ensure we don't reuse values that could have been emitted by dev12.

Fixes internal bug 163613.