### PR TITLE
Improve stack strings in telemetry reports

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -47,7 +47,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 MethodBase method = frame.GetMethod();
                 if (method == null) continue;
 
-                builder.Append(method);
+                // method.ToString() does not include the declaring type, so we'll prepend it manually.
+                // It will appear before the return type, but that won't disrupt our telemetry.
+                builder.Append(method.ReflectedType.ToString().Replace(',', '\''));
+                builder.Append("::");
+                builder.Append(method.ToString().Replace(',', '\''));
                 builder.Append(';'); // Method signatures should not contain semicolons.
             }
 


### PR DESCRIPTION
 1. Replace the commas to avoid disrupting csv files.
 2. Prepend the type names, since they don't seem to be included by
 default.