### PR TITLE
Fix the batch pragma suppression fixer to handle the case where multi…

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -185,6 +185,7 @@
     <Compile Include="CodeActions\Preview\PreviewTests.cs" />
     <Compile Include="CodeActions\ReplaceMethodWithProperty\ReplaceMethodWithPropertyTests.cs" />
     <Compile Include="Diagnostics\Suppression\RemoveSuppressionTests.cs" />
+    <Compile Include="Diagnostics\Suppression\SuppressionTest_FixMultipleTests.cs" />
     <Compile Include="Diagnostics\UseAutoProperty\UseAutoPropertyTests.cs" />
     <Compile Include="CommentSelection\CSharpCommentSelectionTests.cs" />
     <Compile Include="Completion\CompletionProviders\AbstractCSharpCompletionProviderTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixMultipleTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixMultipleTests.cs
@@ -113,8 +113,8 @@ using System;
 #pragma warning disable InfoDiagnostic // InfoDiagnostic Title
 #pragma warning disable InfoDiagnostic2 // InfoDiagnostic2 Title
 class Class1
-#pragma warning restore InfoDiagnostic // InfoDiagnostic Title
 #pragma warning restore InfoDiagnostic2 // InfoDiagnostic2 Title
+#pragma warning restore InfoDiagnostic // InfoDiagnostic Title
 {
     int Method()
     {
@@ -125,8 +125,8 @@ class Class1
 #pragma warning disable InfoDiagnostic // InfoDiagnostic Title
 #pragma warning disable InfoDiagnostic2 // InfoDiagnostic2 Title
 class Class2
-#pragma warning restore InfoDiagnostic // InfoDiagnostic Title
 #pragma warning restore InfoDiagnostic2 // InfoDiagnostic2 Title
+#pragma warning restore InfoDiagnostic // InfoDiagnostic Title
 {
 }
 class Class3 { }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixMultipleTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixMultipleTests.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeFixes.Suppression;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.Suppression;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Suppression
+{
+    public partial class CSharpSuppressionTests : AbstractSuppressionDiagnosticTest
+    {
+        #region "Fix selected occurrences tests"
+
+        public abstract class CSharpFixMultipleSuppressionTests : CSharpSuppressionTests
+        {
+            protected override int CodeActionIndex => 0;
+
+            internal override Tuple<DiagnosticAnalyzer, ISuppressionFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
+            {
+                return new Tuple<DiagnosticAnalyzer, ISuppressionFixProvider>(
+                    new UserDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
+            }
+
+            private class UserDiagnosticAnalyzer : DiagnosticAnalyzer
+            {
+                public static readonly DiagnosticDescriptor Decsciptor1 =
+                    new DiagnosticDescriptor("InfoDiagnostic", "InfoDiagnostic Title", "InfoDiagnostic", "InfoDiagnostic", DiagnosticSeverity.Info, isEnabledByDefault: true);
+                public static readonly DiagnosticDescriptor Decsciptor2 =
+                    new DiagnosticDescriptor("InfoDiagnostic2", "InfoDiagnostic2 Title", "InfoDiagnostic2", "InfoDiagnostic2", DiagnosticSeverity.Info, isEnabledByDefault: true);
+
+                public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Decsciptor1, Decsciptor2);
+
+                public override void Initialize(AnalysisContext context)
+                {
+                    context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ClassDeclaration);
+                }
+
+                public void AnalyzeNode(SyntaxNodeAnalysisContext context)
+                {
+                    var classDecl = (ClassDeclarationSyntax)context.Node;
+                    var location = classDecl.Identifier.GetLocation();
+                    context.ReportDiagnostic(Diagnostic.Create(Decsciptor1, location));
+                    context.ReportDiagnostic(Diagnostic.Create(Decsciptor2, location));
+                }
+            }
+
+            #region "Pragma disable tests"
+
+            public class CSharpFixMultiplePragmaWarningSuppressionTests : CSharpFixMultipleSuppressionTests
+            {
+                private string FixMultipleActionEquivalenceKey => FeaturesResources.SuppressWithPragma;
+
+                [Fact]
+                [Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+                [WorkItem(6455, "https://github.com/dotnet/roslyn/issues/6455")]
+                public void TestFixMultipleInDocument()
+                {
+                    var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+{|FixAllInSelection:class Class1
+{
+    int Method()
+    {
+        int x = 0;
+    }
+}
+
+class Class2
+{
+}|}
+class Class3 { }
+        </Document>
+        <Document>
+class Class3
+{
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+class Class1
+{
+    int Method()
+    {
+        int x = 0;
+    }
+}
+
+class Class2
+{
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+                    var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+#pragma warning disable InfoDiagnostic // InfoDiagnostic Title
+#pragma warning disable InfoDiagnostic2 // InfoDiagnostic2 Title
+class Class1
+#pragma warning restore InfoDiagnostic // InfoDiagnostic Title
+#pragma warning restore InfoDiagnostic2 // InfoDiagnostic2 Title
+{
+    int Method()
+    {
+        int x = 0;
+    }
+}
+
+#pragma warning disable InfoDiagnostic // InfoDiagnostic Title
+#pragma warning disable InfoDiagnostic2 // InfoDiagnostic2 Title
+class Class2
+#pragma warning restore InfoDiagnostic // InfoDiagnostic Title
+#pragma warning restore InfoDiagnostic2 // InfoDiagnostic2 Title
+{
+}
+class Class3 { }
+        </Document>
+        <Document>
+class Class3
+{
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+class Class1
+{
+    int Method()
+    {
+        int x = 0;
+    }
+}
+
+class Class2
+{
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+                    Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: FixMultipleActionEquivalenceKey);
+                }
+
+            }
+
+            #endregion
+        }
+
+        #endregion
+    }
+}

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaBatchFixHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaBatchFixHelpers.cs
@@ -94,19 +94,22 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                             newSuppressionFix.Action.GetCodeActions().OfType<IPragmaBasedCodeAction>().SingleOrDefault();
                         if (newPragmaAction != null)
                         {
-                            // Get the changed document with pragma suppression add/removals.
+                            // Get the text changes with pragma suppression add/removals.
                             // Note: We do it one token at a time to ensure we get single text change in the new document, otherwise UpdateDiagnosticSpans won't function as expected.
                             // Update the diagnostics spans based on the text changes.
-                            var startTokenChanges = await GetChangedDocumentAsync(newPragmaAction, currentDocument, diagnostics, currentDiagnosticSpans,
+                            var startTokenChanges = await GetTextChangesAsync(newPragmaAction, currentDocument, diagnostics, currentDiagnosticSpans,
                                 includeStartTokenChange: true, includeEndTokenChange: false, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                            var endTokenChanges = await GetChangedDocumentAsync(newPragmaAction, currentDocument, diagnostics, currentDiagnosticSpans,
+                            var endTokenChanges = await GetTextChangesAsync(newPragmaAction, currentDocument, diagnostics, currentDiagnosticSpans,
                                 includeStartTokenChange: false, includeEndTokenChange: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                             var currentText = await currentDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
                             var orderedChanges = startTokenChanges.Concat(endTokenChanges).OrderBy(change => change.Span).Distinct();
                             var newText = currentText.WithChanges(orderedChanges);
                             currentDocument = currentDocument.WithText(newText);
+
+                            // Update the diagnostics spans based on the text changes.
+                            UpdateDiagnosticSpans(diagnostics, currentDiagnosticSpans, orderedChanges);
                         }
                     }
                 }
@@ -114,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 return currentDocument;
             }
 
-            private static async Task<IEnumerable<TextChange>> GetChangedDocumentAsync(
+            private static async Task<IEnumerable<TextChange>> GetTextChangesAsync(
                 IPragmaBasedCodeAction pragmaAction,
                 Document currentDocument,
                 ImmutableArray<Diagnostic> diagnostics,
@@ -123,71 +126,59 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 bool includeEndTokenChange,
                 CancellationToken cancellationToken)
             {
-                var newDocument = await pragmaAction.GetChangedDocumentAsync(includeStartTokenChange, includeEndTokenChange, cancellationToken).ConfigureAwait(false);
-                
-                // Update the diagnostics spans based on the text changes.
-                var textChanges = await newDocument.GetTextChangesAsync(currentDocument, cancellationToken).ConfigureAwait(false);
-                foreach (var textChange in textChanges)
-                {
-                    UpdateDiagnosticSpans(diagnostics, currentDiagnosticSpans, textChange);
-                }
-
-                return textChanges;
+                var newDocument = await pragmaAction.GetChangedDocumentAsync(includeStartTokenChange, includeEndTokenChange, cancellationToken).ConfigureAwait(false);                
+                return await newDocument.GetTextChangesAsync(currentDocument, cancellationToken).ConfigureAwait(false);
             }
 
-            private static async Task UpdateDiagnosticSpansAsync(Document currentDocument, Document newDocument, ImmutableArray<Diagnostic> diagnostics, Dictionary<Diagnostic, TextSpan> currentDiagnosticSpans, CancellationToken cancellationToken)
+            private static void UpdateDiagnosticSpans(ImmutableArray<Diagnostic> diagnostics, Dictionary<Diagnostic, TextSpan> currentDiagnosticSpans, IEnumerable<TextChange> textChanges)
             {
-                // Update the diagnostics spans based on the text changes.
-                var textChanges = await newDocument.GetTextChangesAsync(currentDocument, cancellationToken).ConfigureAwait(false);
-                foreach (var textChange in textChanges)
-                {
-                    UpdateDiagnosticSpans(diagnostics, currentDiagnosticSpans, textChange);
-                }
-            }
-
-            private static void UpdateDiagnosticSpans(ImmutableArray<Diagnostic> diagnostics, Dictionary<Diagnostic, TextSpan> currentDiagnosticSpans, TextChange textChange)
-            {
-                var isAdd = textChange.Span.Length == 0;
-                Func<TextSpan, bool> isPriorSpan = span => span.End <= textChange.Span.Start;
-                Func<TextSpan, bool> isFollowingSpan = span => span.Start >= textChange.Span.End;
-                Func<TextSpan, bool> isEnclosingSpan = span => span.Contains(textChange.Span);
+                Func<TextSpan, TextChange, bool> isPriorSpan = (span, textChange) => span.End <= textChange.Span.Start;
+                Func<TextSpan, TextChange, bool> isFollowingSpan = (span, textChange) => span.Start >= textChange.Span.End;
+                Func<TextSpan, TextChange, bool> isEnclosingSpan = (span, textChange) => span.Contains(textChange.Span);
 
                 foreach (var diagnostic in diagnostics)
                 {
-                    TextSpan currentSpan;
-                    if (!currentDiagnosticSpans.TryGetValue(diagnostic, out currentSpan))
+                    // We use 'originalSpan' to identify if the diagnostic is prior/following/enclosing with respect to each text change.
+                    // We use 'currentSpan' to track updates made to the originalSpan by each text change.
+                    TextSpan originalSpan;
+                    if (!currentDiagnosticSpans.TryGetValue(diagnostic, out originalSpan))
                     {
                         continue;
                     }
 
-                    if (isPriorSpan(currentSpan))
+                    var currentSpan = originalSpan;
+                    foreach (var textChange in textChanges)
                     {
-                        // Prior span, needs no update.
-                        continue;
-                    }
+                        if (isPriorSpan(originalSpan, textChange))
+                        {
+                            // Prior span, needs no update.
+                            continue;
+                        }
 
-                    var delta = textChange.NewText.Length - textChange.Span.Length;
-                    if (delta != 0)
-                    {
-                        if (isFollowingSpan(currentSpan))
+                        var delta = textChange.NewText.Length - textChange.Span.Length;
+                        if (delta != 0)
                         {
-                            // Following span.
-                            var newStart = currentSpan.Start + delta;
-                            var newSpan = new TextSpan(newStart, currentSpan.Length);
-                            currentDiagnosticSpans[diagnostic] = newSpan;
-                        }
-                        else if (isEnclosingSpan(currentSpan))
-                        {
-                            // Enclosing span.
-                            var newLength = currentSpan.Length + delta;
-                            var newSpan = new TextSpan(currentSpan.Start, newLength);
-                            currentDiagnosticSpans[diagnostic] = newSpan;
-                        }
-                        else
-                        {
-                            // Overlapping span.
-                            // Drop conflicting diagnostics.
-                            currentDiagnosticSpans.Remove(diagnostic);
+                            if (isFollowingSpan(originalSpan, textChange))
+                            {
+                                // Following span.
+                                var newStart = currentSpan.Start + delta;
+                                currentSpan = new TextSpan(newStart, currentSpan.Length);
+                                currentDiagnosticSpans[diagnostic] = currentSpan;
+                            }
+                            else if (isEnclosingSpan(originalSpan, textChange))
+                            {
+                                // Enclosing span.
+                                var newLength = currentSpan.Length + delta;
+                                currentSpan = new TextSpan(currentSpan.Start, newLength);
+                                currentDiagnosticSpans[diagnostic] = currentSpan;
+                            }
+                            else
+                            {
+                                // Overlapping span.
+                                // Drop conflicting diagnostics.
+                                currentDiagnosticSpans.Remove(diagnostic);
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
…ple diagnostics with different IDs are being suppressed on the same token

Current logic in batch pragma fixer merges individual fixes in a document by applying each pragma fix sequentially and keeping track of new diagnostics spans for remaining diagnostics. The latter logic that computes new spans was using out of date spans, causing the subsequent fixes to be incorrectly applied. This change fixes that logic.

Fixes #6455