### PR TITLE
bypass Format on simple constant interpolated strings

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis.Collections;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -9,17 +10,34 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private BoundExpression RewriteInterpolatedStringConversion(BoundConversion conversion)
         {
+            //
+            // This method rewrites expressions where interpolated strings are used where an object
+            // implementing `System.IFormattable` or `System.FormattableString` is expected.
+            // For example:
+            //
+            //    IFormattable f = $"Log dump {item.Id}: {item.Title}\n--\n{item.Message}\n\n--\n{item.Timestamp}";
+            //
+            // That interpolated string would be converted into an instance of IFormattable with
+            // these properties:
+            //
+            // * `f.Format == "Log dump {0}: {1}\n--\n{2}\n\n--\n{3}"`
+            // * `f.GetArguments()` returns an `object[]` containing the values
+            //   `{ item.Id, item.Title, item.Message, item.Timestamp}`
+            //
+
             Debug.Assert(conversion.ConversionKind == ConversionKind.InterpolatedString);
+
             BoundExpression format;
             ArrayBuilder<BoundExpression> expressions;
             MakeInterpolatedStringFormat((BoundInterpolatedString)conversion.Operand, out format, out expressions);
             expressions.Insert(0, format);
             var stringFactory = _factory.WellKnownType(WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory);
 
-            // The normal pattern for lowering is to lower subtrees before the enclosing tree. However we cannot lower
-            // the arguments first in this situation because we do not know what conversions will be
-            // produced for the arguments until after we've done overload resolution. So we produce the invocation
-            // and then lower it along with its arguments.
+            // [abnormal pattern lowering procedure]:
+            // The normal pattern for lowering is to lower subtrees before the enclosing tree.
+            // However we cannot lower the arguments first in this situation because we do not know
+            // what conversions will be produced for the arguments until after we've done overload
+            // resolution. So we produce the invocation and then lower it along with its arguments.
             var result = _factory.StaticCall(stringFactory, "Create", expressions.ToImmutableAndFree(),
                 allowUnexpandedForm: false // if an interpolation expression is the null literal, it should not match a params parameter.
                 );
@@ -34,19 +52,73 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void MakeInterpolatedStringFormat(BoundInterpolatedString node, out BoundExpression format, out ArrayBuilder<BoundExpression> expressions)
         {
+            ArrayBuilder<BoundExpression> concatExpressions;
+            bool isSimpleConcatString;
+            bool potentiallyNull;
+            MakeInterpolatedStringFormat(node, out format, out expressions, out concatExpressions, out isSimpleConcatString, out potentiallyNull);
+        }
+
+        private void MakeInterpolatedStringFormat(
+            BoundInterpolatedString node,
+            out BoundExpression format,
+            out ArrayBuilder<BoundExpression> expressions,
+            out ArrayBuilder<BoundExpression> concatExpressions,
+            out bool isSimpleConcatString,
+            out bool potentiallyNull)
+        {
+
+            //
+            // The interpolated string is passed in parsed and bound to an array of parts
+            // representing each segment and hole.
+            //
+            // A segment is the string literal between:
+            //
+            // * the start of the string and first open brace marking a hole
+            // * close braces and open braces marking holes
+            // * the final close brace of a hole and end of string
+            // * the entire string if no holes exist
+            //
+            // Empty segments do not exist in the parts array unless the entire interpolated
+            // string is $"", in which case the only element in the parts array is the string 
+            // literal "". Segments may contain escaped open braces `{{` and escaped close braces 
+            // `}}`. These must be unescaped if the string is going to bypass `string.Format`.
+            //
+            // A hole is the part of the string marked by the syntax 
+            // `{ <interpolation-expression> <optional-comma-field-width> <optional-colon-format> }`.
+            //
+            // Thus multiple holes may be next to each other, but 2 segments never are and the parts
+            // array always has at least 1 element or node has errors.
+            //
+            // If no holes contain field widths or formats, `node` is eligible to be lowered into a
+            // `string.Concat` call instead of `string.Format`. Since `string.Concat` returns `null`
+            // if all arguments are null (possible if the interpolated string contains 0 segments and
+            // one or more holes that all are null), we must track this possibility and lower with
+            // `string.Concat(...) ?? ""` when no argument is known to be not null after that 
+            // argument has been converted to a string.
+            //
+            
             _factory.Syntax = node.Syntax;
             int n = node.Parts.Length - 1;
             var formatString = PooledStringBuilder.GetInstance();
             expressions = ArrayBuilder<BoundExpression>.GetInstance(n + 1);
+            concatExpressions = ArrayBuilder<BoundExpression>.GetInstance(n + 1);
             int nextFormatPosition = 0;
+            isSimpleConcatString = true;
+            potentiallyNull = true;
             for (int i = 0; i <= n; i++)
             {
                 var part = node.Parts[i];
                 var fillin = part as BoundStringInsert;
                 if (fillin == null)
                 {
-                    // this is one of the literal parts
+                    // this is a segment
                     formatString.Builder.Append(part.ConstantValue.StringValue);
+                    
+                    if (isSimpleConcatString)
+                    {
+                        // no point in continuing to unescape when the result will be unused
+                        part = HandleEscapeSequences(part);
+                    }
                 }
                 else
                 {
@@ -55,70 +127,165 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (fillin.Alignment != null && !fillin.Alignment.HasErrors)
                     {
                         formatString.Builder.Append(",").Append(fillin.Alignment.ConstantValue.Int64Value);
+                        isSimpleConcatString = false;
                     }
                     if (fillin.Format != null && !fillin.Format.HasErrors)
                     {
                         formatString.Builder.Append(":").Append(fillin.Format.ConstantValue.StringValue);
+                        isSimpleConcatString = false;
                     }
                     formatString.Builder.Append("}");
-                    var value = fillin.Value;
-                    if (value.Type?.TypeKind == TypeKind.Dynamic)
+                    part = fillin.Value;
+                    if (part.Type?.TypeKind == TypeKind.Dynamic) 
                     {
-                        value = MakeConversion(value, _compilation.ObjectType, @checked: false);
+                        part = MakeConversion(part, _compilation.ObjectType, @checked: false);
                     }
 
-                    expressions.Add(value); // NOTE: must still be lowered
+                    expressions.Add(part); // NOTE: must still be lowered
                 }
+                if (!isSimpleConcatString || part.ConstantValue == ConstantValue.Null)
+                {
+                    // It is safe to skip adding parts to the concatExpressions array in both these cases
+                    // because in the former the array will be unused and in the latter Concat will ignore
+                    // the argument.
+                    continue;
+                }
+                potentiallyNull = potentiallyNull && CallToStringCouldBeNull(part);
+                concatExpressions.Add(part); // NOTE: must still be lowered
             }
 
             format = _factory.StringLiteral(formatString.ToStringAndFree());
         }
 
+        private bool CallToStringCouldBeNull(BoundExpression input)
+        {
+            //checking if expr?.ToString() could possibly return null
+
+            Debug.Assert(input != null);
+
+            if (input.ConstantValue != null)
+            {
+                return false;
+            }
+            var type = input.Type;
+            if (type == null)
+            {
+                return true;
+            }
+            if (type.IsReferenceType || type.IsNullableType())
+            {
+                return true;
+            }
+            var specialType = type.SpecialType;
+            switch (specialType)
+            {
+                case SpecialType.System_Enum:
+                case SpecialType.System_Boolean:
+                case SpecialType.System_Char:
+                case SpecialType.System_SByte:
+                case SpecialType.System_Byte:
+                case SpecialType.System_Int16:
+                case SpecialType.System_UInt16:
+                case SpecialType.System_Int32:
+                case SpecialType.System_UInt32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_UInt64:
+                case SpecialType.System_Decimal:
+                case SpecialType.System_Single:
+                case SpecialType.System_Double:
+                case SpecialType.System_IntPtr:
+                case SpecialType.System_UIntPtr:
+                case SpecialType.System_DateTime:
+                    return false;
+            }
+            return true;
+        }
+
+        private BoundLiteral HandleEscapeSequences(BoundExpression input)
+        {
+            // Handle the escaping of {{ and }} and return the value for this string literal constant.
+            Debug.Assert(!input.HasErrors && input.ConstantValue != null && input.ConstantValue.IsString);
+
+            var builder = PooledStringBuilder.GetInstance();
+            var formatText = input.ConstantValue.StringValue;
+            int formatLength = formatText.Length;
+            for (int i = 0; i < formatLength; i++)
+            {
+                char c = formatText[i];
+                builder.Builder.Append(c);
+                if ((c == '{' || c == '}') && (i + 1) < formatLength && formatText[i + 1] == c)
+                {
+                    i++;
+                }
+            }
+            return _factory.StringLiteral(builder.ToStringAndFree());
+        }
+
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
             //
-            // We lower an interpolated string into an invocation of String.Format.  For example, we translate the expression
+            // We lower an interpolated string into an invocation of String.Format or string
+            // concatenation, depending on the existence of string format instructions.
+            // Some examples:
             //
-            //     $"Jenny don\'t change your number { 8675309 }"
+            //     $"Braces {{ }}"
+            //     $"#{a}-{b}"
+            //     $"Jenny don\'t change your number { 8675309 :#-0000}"
             //
             // into
             //
-            //     String.Format("Jenny don\'t change your number {0}", new object[] { 8675309 })
+            //     "Braces { }"
+            //     "#" + a + "-" + b
+            //     String.Format("Jenny don\'t change your number {0:#-0000}", new object[] { 8675309 })
             //
 
+            Debug.Assert(node != null);
             Debug.Assert(node.Type.SpecialType == SpecialType.System_String); // if target-converted, we should not get here.
+
             BoundExpression format;
             ArrayBuilder<BoundExpression> expressions;
-            MakeInterpolatedStringFormat(node, out format, out expressions);
+            ArrayBuilder<BoundExpression> concatExpressions;
+            bool isSimpleConcatString;
+            bool potentiallyNull;
+            MakeInterpolatedStringFormat(node, out format, out expressions, out concatExpressions, out isSimpleConcatString, out potentiallyNull);
             if (expressions.Count == 0)
             {
-                // There are no fill-ins. Handle the escaping of {{ and }} and return the value.
-                Debug.Assert(!format.HasErrors && format.ConstantValue != null && format.ConstantValue.IsString);
-                var builder = PooledStringBuilder.GetInstance();
-                var formatText = format.ConstantValue.StringValue;
-                int formatLength = formatText.Length;
-                for (int i = 0; i < formatLength; i++)
-                {
-                    char c = formatText[i];
-                    builder.Builder.Append(c);
-                    if ((c == '{' || c == '}') && (i + 1) < formatLength && formatText[i + 1] == c)
-                    {
-                        i++;
-                    }
-                }
-                return _factory.StringLiteral(builder.ToStringAndFree());
+                return HandleEscapeSequences(format);
             }
 
-            // The normal pattern for lowering is to lower subtrees before the enclosing tree. However we cannot lower
-            // the arguments first in this situation because we do not know what conversions will be
-            // produced for the arguments until after we've done overload resolution. So we produce the invocation
-            // and then lower it along with its arguments.
-            expressions.Insert(0, format);
             var stringType = node.Type;
-            var result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(),
-                allowUnexpandedForm: false // if an interpolation expression is the null literal, it should not match a params parameter.
-                );
-            if (!result.HasAnyErrors)
+            BoundExpression result = null;
+            // see [abnormal pattern lowering procedure]
+            if (isSimpleConcatString)
+            {
+                var args = concatExpressions.ToImmutableAndFree();
+                if (args.Length == 0)
+                {
+                    // input was $"{null}{null}{null}...
+                    return _factory.StringLiteral("");
+                }
+
+                result = args[0];
+                if (args.Length == 1 && result.Type?.IsValueType == true && result.Type?.IsNullableType() == false)
+                {
+                    result = _factory.Call(args[0], _factory.SpecialMethod(SpecialMember.System_Object__ToString));
+                }
+                else if(args.Length > 1 || result.Type != stringType)
+                {
+                    result = _factory.StaticCall(stringType, "Concat", args, false);
+                }
+
+                if (potentiallyNull)
+                {
+                    result = _factory.Coalesce(result, _factory.StringLiteral(""));
+                }
+            }
+            if (result == null)
+            {
+                expressions.Insert(0, format);
+                result = _factory.StaticCall(stringType, "Format", expressions.ToImmutableAndFree(), false);
+            }
+            if (!result.HasAnyErrors) 
             {
                 result = VisitExpression(result); // lower the arguments AND handle expanded form, argument conversions, etc.
                 result = MakeImplicitConversion(result, node.Type);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -5524,16 +5524,37 @@ class C : TestBase
         where T : struct
     {
             Expression<Func<string>> f;
+            Expression<Func<string>> g;
             f = () => $"""";
             Check<string>(f, ""Constant( Type:System.String)"");
+            f = () => $""{1,1}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object)](Constant({0,1} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            f = () => $""{1}{2,1}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object)](Constant({0}{1,1} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            f = () => $""{1}{2,1}{3}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object, System.Object)](Constant({0}{1,1}{2} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object), Convert(Constant(3 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            f = () => $""{1}{2}{3,1}{4}"";
+            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object[])](Constant({0}{1}{2,1}{3} Type:System.String), NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
+
             f = () => $""{1}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object)](Constant({0} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            Check<string>(f, ""Call(Constant(1 Type:System.Int32).[System.String ToString()]() Type:System.String)"");
             f = () => $""{1}{2}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object)](Constant({0}{1} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            Check<string>(f, ""Call(null.[System.String Concat(System.Object, System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object)) Type:System.String)"");
             f = () => $""{1}{2}{3}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object, System.Object, System.Object)](Constant({0}{1}{2} Type:System.String), Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object), Convert(Constant(3 Type:System.Int32) Type:System.Object)) Type:System.String)"");
+            Check<string>(f, ""Call(null.[System.String Concat(System.Object, System.Object, System.Object)](Convert(Constant(1 Type:System.Int32) Type:System.Object), Convert(Constant(2 Type:System.Int32) Type:System.Object), Convert(Constant(3 Type:System.Int32) Type:System.Object)) Type:System.String)"");
             f = () => $""{1}{2}{3}{4}"";
-            Check<string>(f, ""Call(null.[System.String Format(System.String, System.Object[])](Constant({0}{1}{2}{3} Type:System.String), NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
+            Check<string>(f, ""Call(null.[System.String Concat(System.Object[])](NewArrayInit([Convert(Constant(1 Type:System.Int32) Type:System.Object) Convert(Constant(2 Type:System.Int32) Type:System.Object) Convert(Constant(3 Type:System.Int32) Type:System.Object) Convert(Constant(4 Type:System.Int32) Type:System.Object)] Type:System.Object[])) Type:System.String)"");
+
+            f = () => $""{null}{null}{null}"";
+            Check<string>(f, ""Constant( Type:System.String)"");
+            f = () => $""{""""}"";
+            Check<string>(f, ""Constant( Type:System.String)"");
+            f = () => $""{new object()}"";
+            Check<string>(f, ""Coalesce(Call(null.[System.String Concat(System.Object)](New([Void .ctor()]() Type:System.Object)) Type:System.String) Constant( Type:System.String) Type:System.String)"");
+            string x = """";
+            f = () => $""{x}"";
+            g = () => x ?? """";
+            Check<string>(f, ToString<string>(g));
             Console.WriteLine(""DONE"");
     }
 
@@ -5542,7 +5563,7 @@ class C : TestBase
         M<S>();
     }
 }";
-
+            
             const string expectedOutput = @"DONE";
             CompileAndVerify(
                 new[] { source, ExpressionTestLibrary },

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -38,6 +38,601 @@ Jenny don't change your number     867-5309.
         }
 
         [Fact]
+        public void TestFormatAndConcatOverloads01()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $"""";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  ldstr      """"
+  IL_0005:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads02()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  ldstr      """"
+  IL_0005:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads03()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{""""}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  ldstr      """"
+  IL_0005:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads04()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_000e
+  IL_0008:  pop
+  IL_0009:  ldstr      """"
+  IL_000e:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads05()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       25 (0x19)
+  .maxstack  2
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldsfld     ""string Program.s""
+  IL_000a:  call       ""string string.Concat(string, string)""
+  IL_000f:  dup
+  IL_0010:  brtrue.s   IL_0018
+  IL_0012:  pop
+  IL_0013:  ldstr      """"
+  IL_0018:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads06()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s} "";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == "" "");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       16 (0x10)
+  .maxstack  2
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldstr      "" ""
+  IL_000a:  call       ""string string.Concat(string, string)""
+  IL_000f:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads07()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s} {s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == "" "");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       21 (0x15)
+  .maxstack  3
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldstr      "" ""
+  IL_000a:  ldsfld     ""string Program.s""
+  IL_000f:  call       ""string string.Concat(string, string, string)""
+  IL_0014:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads08()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}{s}{s}{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       35 (0x23)
+  .maxstack  4
+  IL_0000:  ldsfld     ""string Program.s""
+  IL_0005:  ldsfld     ""string Program.s""
+  IL_000a:  ldsfld     ""string Program.s""
+  IL_000f:  ldsfld     ""string Program.s""
+  IL_0014:  call       ""string string.Concat(string, string, string, string)""
+  IL_0019:  dup
+  IL_001a:  brtrue.s   IL_0022
+  IL_001c:  pop
+  IL_001d:  ldstr      """"
+  IL_0022:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads09()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string s = null;
+    static string Test => $""{s}{s}{s}{s}{s}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       61 (0x3d)
+  .maxstack  4
+  IL_0000:  ldc.i4.5
+  IL_0001:  newarr     ""string""
+  IL_0006:  dup
+  IL_0007:  ldc.i4.0
+  IL_0008:  ldsfld     ""string Program.s""
+  IL_000d:  stelem.ref
+  IL_000e:  dup
+  IL_000f:  ldc.i4.1
+  IL_0010:  ldsfld     ""string Program.s""
+  IL_0015:  stelem.ref
+  IL_0016:  dup
+  IL_0017:  ldc.i4.2
+  IL_0018:  ldsfld     ""string Program.s""
+  IL_001d:  stelem.ref
+  IL_001e:  dup
+  IL_001f:  ldc.i4.3
+  IL_0020:  ldsfld     ""string Program.s""
+  IL_0025:  stelem.ref
+  IL_0026:  dup
+  IL_0027:  ldc.i4.4
+  IL_0028:  ldsfld     ""string Program.s""
+  IL_002d:  stelem.ref
+  IL_002e:  call       ""string string.Concat(params string[])""
+  IL_0033:  dup
+  IL_0034:  brtrue.s   IL_003c
+  IL_0036:  pop
+  IL_0037:  ldstr      """"
+  IL_003c:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads10()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       20 (0x14)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  call       ""string string.Concat(object)""
+  IL_000a:  dup
+  IL_000b:  brtrue.s   IL_0013
+  IL_000d:  pop
+  IL_000e:  ldstr      """"
+  IL_0013:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads11()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{1}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == ""1"");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       17 (0x11)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  ldc.i4.1
+  IL_0006:  box        ""int""
+  IL_000b:  call       ""string string.Concat(object, object)""
+  IL_0010:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads12()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       25 (0x19)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  ldsfld     ""object Program.o""
+  IL_000a:  call       ""string string.Concat(object, object)""
+  IL_000f:  dup
+  IL_0010:  brtrue.s   IL_0018
+  IL_0012:  pop
+  IL_0013:  ldstr      """"
+  IL_0018:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads13()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{o}{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       30 (0x1e)
+  .maxstack  3
+  IL_0000:  ldsfld     ""object Program.o""
+  IL_0005:  ldsfld     ""object Program.o""
+  IL_000a:  ldsfld     ""object Program.o""
+  IL_000f:  call       ""string string.Concat(object, object, object)""
+  IL_0014:  dup
+  IL_0015:  brtrue.s   IL_001d
+  IL_0017:  pop
+  IL_0018:  ldstr      """"
+  IL_001d:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads14()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static object o = null;
+    static string Test => $""{o}{o}{o}{o}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       53 (0x35)
+  .maxstack  4
+  IL_0000:  ldc.i4.4
+  IL_0001:  newarr     ""object""
+  IL_0006:  dup
+  IL_0007:  ldc.i4.0
+  IL_0008:  ldsfld     ""object Program.o""
+  IL_000d:  stelem.ref
+  IL_000e:  dup
+  IL_000f:  ldc.i4.1
+  IL_0010:  ldsfld     ""object Program.o""
+  IL_0015:  stelem.ref
+  IL_0016:  dup
+  IL_0017:  ldc.i4.2
+  IL_0018:  ldsfld     ""object Program.o""
+  IL_001d:  stelem.ref
+  IL_001e:  dup
+  IL_001f:  ldc.i4.3
+  IL_0020:  ldsfld     ""object Program.o""
+  IL_0025:  stelem.ref
+  IL_0026:  call       ""string string.Concat(params object[])""
+  IL_002b:  dup
+  IL_002c:  brtrue.s   IL_0034
+  IL_002e:  pop
+  IL_002f:  ldstr      """"
+  IL_0034:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads15()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null,0}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldstr      ""{0,0}""
+  IL_0005:  ldnull
+  IL_0006:  call       ""string string.Format(string, object)""
+  IL_000b:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads16()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}{null,0}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       13 (0xd)
+  .maxstack  3
+  IL_0000:  ldstr      ""{0}{1,0}""
+  IL_0005:  ldnull
+  IL_0006:  ldnull
+  IL_0007:  call       ""string string.Format(string, object, object)""
+  IL_000c:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads17()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}{null,0}{null}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       14 (0xe)
+  .maxstack  4
+  IL_0000:  ldstr      ""{0}{1,0}{2}""
+  IL_0005:  ldnull
+  IL_0006:  ldnull
+  IL_0007:  ldnull
+  IL_0008:  call       ""string string.Format(string, object, object, object)""
+  IL_000d:  ret
+}");
+        }
+
+        [Fact]
+        public void TestFormatAndConcatOverloads18()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{null}{null,0}{null}{null}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       17 (0x11)
+  .maxstack  2
+  IL_0000:  ldstr      ""{0}{1,0}{2}{3}""
+  IL_0005:  ldc.i4.4
+  IL_0006:  newarr     ""object""
+  IL_000b:  call       ""string string.Format(string, params object[])""
+  IL_0010:  ret
+}");
+        }
+
+        [Fact]
+        public void DoNotBoxToStringCall()
+        {
+            var text =
+@"using System;
+
+class Program
+{
+    static string Test => $""{1}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == ""1"");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       16 (0x10)
+  .maxstack  1
+  .locals init (int V_0)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  constrained. ""int""
+  IL_000a:  callvirt   ""string object.ToString()""
+  IL_000f:  ret
+}");
+        }
+
+        [Fact]
         public void TestOnlyInterp()
         {
             string source =
@@ -914,14 +1509,18 @@ class Program {
         public static void Main()
         {
             var s = $""X = { 1 } "";
+            var t = $""X = { 1 , 1 } "";
         }
     }
 }";
             CreateCompilation(text, options: new CSharpCompilationOptions(OutputKind.ConsoleApplication))
             .VerifyEmitDiagnostics(new CodeAnalysis.Emit.EmitOptions(runtimeMetadataVersion: "x.y"),
-                // (15,21): error CS0117: 'string' does not contain a definition for 'Format'
+                // (15,21): error CS0117: 'string' does not contain a definition for 'Concat'
                 //             var s = $"X = { 1 } ";
-                Diagnostic(ErrorCode.ERR_NoSuchMember, @"$""X = { 1 } """).WithArguments("string", "Format").WithLocation(15, 21)
+                Diagnostic(ErrorCode.ERR_NoSuchMember, @"$""X = { 1 } """).WithArguments("string", "Concat").WithLocation(15, 21),
+                // (16,21): error CS0117: 'string' does not contain a definition for 'Format'
+                //             var s = $"X = { 1 , 1 } ";
+                Diagnostic(ErrorCode.ERR_NoSuchMember, @"$""X = { 1 , 1 } """).WithArguments("string", "Format").WithLocation(16, 21)
             );
         }
 
@@ -946,15 +1545,15 @@ class Program {
     {
         public static void Main()
         {
-            var s = $""X = { 1 } "";
+            var s = $""X = { 1 , 1 } "";
         }
     }
 }";
             CreateCompilation(text, options: new CSharpCompilationOptions(OutputKind.ConsoleApplication))
             .VerifyEmitDiagnostics(new CodeAnalysis.Emit.EmitOptions(runtimeMetadataVersion: "x.y"),
                 // (17,21): error CS0029: Cannot implicitly convert type 'bool' to 'string'
-                //             var s = $"X = { 1 } ";
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"$""X = { 1 } """).WithArguments("bool", "string").WithLocation(17, 21)
+                //             var s = $"X = { 1 , 1 } ";
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"$""X = { 1 , 1 } """).WithArguments("bool", "string").WithLocation(17, 21)
             );
         }
 
@@ -990,8 +1589,8 @@ class Program {
     {
         public static void Main()
         {
-            var s1 = $""X = { 1 } "";
-            FormattableString s2 = $""X = { 1 } "";
+            var s1 = $""X = { 1 , 1 } "";
+            FormattableString s2 = $""X = { 1 , 1 } "";
         }
     }
 }";
@@ -1001,17 +1600,61 @@ class Program {
 @"{
   // Code size       35 (0x23)
   .maxstack  2
-  IL_0000:  ldstr      ""X = {0} ""
+  IL_0000:  ldstr      ""X = {0,1} ""
   IL_0005:  ldc.i4.1
   IL_0006:  call       ""System.Bozo string.Format(string, int)""
   IL_000b:  call       ""string System.Bozo.op_Implicit(System.Bozo)""
   IL_0010:  pop
-  IL_0011:  ldstr      ""X = {0} ""
+  IL_0011:  ldstr      ""X = {0,1} ""
   IL_0016:  ldc.i4.1
   IL_0017:  call       ""System.Bozo System.Runtime.CompilerServices.FormattableStringFactory.Create(string, int)""
   IL_001c:  call       ""System.FormattableString System.Bozo.op_Implicit(System.Bozo)""
   IL_0021:  pop
   IL_0022:  ret
+}");
+        }
+
+        [Fact]
+        public void SillyToString()
+        {
+            var text =
+@"using System;
+
+struct S
+{
+    public override string ToString()
+    {
+        return null;
+    }
+}
+
+class Program
+{
+    static string Test => $""{new S()}"";
+
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Test == """");
+    }
+}";
+            var compilation = CompileAndVerify(text, expectedOutput: "True");
+            compilation.VerifyIL("Program.Test.get",
+@"{
+  // Code size       33 (0x21)
+  .maxstack  2
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.0
+  IL_000a:  ldloca.s   V_0
+  IL_000c:  constrained. ""S""
+  IL_0012:  callvirt   ""string object.ToString()""
+  IL_0017:  dup
+  IL_0018:  brtrue.s   IL_0020
+  IL_001a:  pop
+  IL_001b:  ldstr      """"
+  IL_0020:  ret
 }");
         }
 


### PR DESCRIPTION
When an interpolated string doesn't have alignment or formatString parameters it is faster to instead use Concat. Further optimizations can be done on calls to Concat with only one parameter.

Fixes #6669