### PR TITLE
Removing WpfFact from Analyzer and Codefix tests

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Encaps
             return new EncapsulateFieldRefactoringProvider();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void PrivateFieldToPropertyIgnoringReferences()
         {
             var text = @"
@@ -56,7 +56,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void PrivateFieldToPropertyUpdatingReferences()
         {
             var text = @"
@@ -98,7 +98,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void PublicFieldIntoPublicPropertyIgnoringReferences()
         {
             var text = @"
@@ -140,7 +140,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void PublicFieldIntoPublicPropertyUpdatingReferences()
         {
             var text = @"
@@ -182,7 +182,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void StaticPreserved()
         {
             var text = @"class Program
@@ -210,7 +210,7 @@ class foo
             Test(text, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void UniqueNameGenerated()
         {
             var text = @"
@@ -242,7 +242,7 @@ class Program
             Test(text, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void GenericField()
         {
             var text = @"
@@ -272,7 +272,7 @@ class C<T>
             Test(text, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void NewFieldNameIsUnique()
         {
             var text = @"
@@ -304,7 +304,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void RespectReadonly()
         {
             var text = @"
@@ -329,7 +329,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void PreserveNewAndConsiderBaseMemberNames()
         {
             var text = @"
@@ -373,7 +373,7 @@ class d : c
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateMultiplePrivateFields()
         {
             var text = @"
@@ -428,7 +428,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateMultiplePrivateFields2()
         {
             var text = @"
@@ -485,7 +485,7 @@ class foo
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateSinglePublicFieldInMultipleVariableDeclarationAndUpdateReferences()
         {
             var text = @"
@@ -529,7 +529,7 @@ class foo
         }
 
         [WorkItem(694057)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void ConstFieldNoGetter()
         {
             var text = @"
@@ -557,7 +557,7 @@ class Program
         }
 
         [WorkItem(694276)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateFieldNamedValue()
         {
             var text = @"
@@ -585,7 +585,7 @@ class Program
         }
 
         [WorkItem(694276)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void PublicFieldNamed__()
         {
             var text = @"
@@ -618,7 +618,7 @@ class Program
         }
 
         [WorkItem(695046)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void AvailableNotJustOnVariableName()
         {
             var text = @"
@@ -632,7 +632,7 @@ class Program
         }
 
         [WorkItem(705898)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void CopyFieldAccessibility()
         {
             var text = @"
@@ -659,7 +659,7 @@ class Program
             Test(text, expected, compareTokens: false, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void UpdateReferencesCrossProject()
         {
             var text = @"
@@ -728,7 +728,7 @@ public class D
         }
 
         [WorkItem(713269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void PreserveUnsafe()
         {
             var text = @"
@@ -761,7 +761,7 @@ class C
         }
 
         [WorkItem(713240)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void ConsiderReturnTypeAccessibility()
         {
             var text = @"
@@ -804,7 +804,7 @@ internal enum State
         }
 
         [WorkItem(713191)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void DoNotReferToReadOnlyPropertyInConstructor()
         {
             var text = @"
@@ -840,7 +840,7 @@ class Program
         }
 
         [WorkItem(713191)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void DoNotReferToStaticReadOnlyPropertyInConstructor()
         {
             var text = @"
@@ -876,7 +876,7 @@ class Program
         }
 
         [WorkItem(765959)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void GenerateInTheCorrectPart()
         {
             var text = @"
@@ -909,7 +909,7 @@ partial class Program {
         }
 
         [WorkItem(829178)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void ErrorTolerance()
         {
             var text = @"class Program 
@@ -925,7 +925,7 @@ partial class Program {
         }
 
         [WorkItem(834072)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void DuplicateFieldErrorTolerance()
         {
             var text = @"
@@ -944,7 +944,7 @@ class Program
         }
 
         [WorkItem(862517)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void Trivia()
         {
             var text = @"
@@ -985,7 +985,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1096007, "https://github.com/dotnet/roslyn/issues/282")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void DoNotEncapsulateOutsideTypeDeclaration()
         {
             TestMissing(@"
@@ -1005,7 +1005,7 @@ enum E
         }
 
         [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishDottedI()
         {
             using (new CultureContext("tr-TR"))
@@ -1037,7 +1037,7 @@ class C
         }
 
         [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishUndottedI()
         {
             using (new CultureContext("tr-TR"))
@@ -1069,7 +1069,7 @@ class C
         }
 
         [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_Arabic()
         {
             using (new CultureContext("ar-EG"))
@@ -1101,7 +1101,7 @@ class C
         }
 
         [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_Spanish()
         {
             using (new CultureContext("es-ES"))
@@ -1133,7 +1133,7 @@ class C
         }
 
         [WorkItem(5524, "https://github.com/dotnet/roslyn/issues/5524")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void AlwaysUseEnglishUSCultureWhenFixingVariableNames_Greek()
         {
             using (new CultureContext("el-GR"))

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Extrac
         }
 
         [WorkItem(540799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestPartialSelection()
         {
             Test(
@@ -24,7 +24,7 @@ index: 0);
         }
 
         [WorkItem(540796)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestReadOfDataThatDoesNotFlowIn()
         {
             Test(
@@ -34,14 +34,14 @@ index: 0);
         }
 
         [WorkItem(540819)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestMissingOnGoto()
         {
             TestMissing(@"delegate int del ( int i ) ; class C { static void Main ( string [ ] args ) { del q = x => { [|goto label2 ; return x * x ;|] } ; label2 : return ; } } ");
         }
 
         [WorkItem(540819)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestOnStatementAfterUnconditionalGoto()
         {
             Test(
@@ -50,7 +50,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestMissingOnNamespace()
         {
             Test(
@@ -58,7 +58,7 @@ index: 0);
 @"class Program { void Main ( ) { {|Rename:NewMethod|} ( ) ; } private static void NewMethod ( ) { System . Console . WriteLine ( 4 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestMissingOnType()
         {
             Test(
@@ -66,7 +66,7 @@ index: 0);
 @"class Program { void Main ( ) { {|Rename:NewMethod|} ( ) ; } private static void NewMethod ( ) { System . Console . WriteLine ( 4 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestMissingOnBase()
         {
             Test(
@@ -75,7 +75,7 @@ index: 0);
         }
 
         [WorkItem(545623)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void TestOnActionInvocation()
         {
             Test(
@@ -84,7 +84,7 @@ index: 0);
         }
 
         [WorkItem(529841), WorkItem(714632)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void DisambiguateCallSiteIfNecessary1()
         {
             Test(
@@ -125,7 +125,7 @@ compareTokens: false);
         }
 
         [WorkItem(529841), WorkItem(714632)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void DisambiguateCallSiteIfNecessary2()
         {
             Test(
@@ -167,7 +167,7 @@ compareTokens: false);
 
         [WorkItem(530709)]
         [WorkItem(632182)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void DontOverparenthesize()
         {
             Test(
@@ -228,7 +228,7 @@ parseOptions: Options.Regular);
         }
 
         [WorkItem(632182)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void DontOverparenthesizeGenerics()
         {
             Test(
@@ -289,7 +289,7 @@ parseOptions: Options.Regular);
         }
 
         [WorkItem(984831)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void PreserveCommentsBeforeDeclaration_1()
         {
             Test(
@@ -333,7 +333,7 @@ compareTokens: false);
         }
 
         [WorkItem(984831)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void PreserveCommentsBeforeDeclaration_2()
         {
             Test(
@@ -385,7 +385,7 @@ compareTokens: false);
         }
 
         [WorkItem(984831)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public void PreserveCommentsBeforeDeclaration_3()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
             return new GenerateDefaultConstructorsCodeRefactoringProvider();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestProtectedBase()
         {
             Test(
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestPublicBase()
         {
             Test(
@@ -34,7 +34,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestInternalBase()
         {
             Test(
@@ -43,14 +43,14 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestPrivateBase()
         {
             TestMissing(
 @"class C : [||]B { } class B { private B(int x) { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestRefOutParams()
         {
             Test(
@@ -59,7 +59,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestFix1()
         {
             Test(
@@ -68,7 +68,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestFix2()
         {
             Test(
@@ -77,7 +77,7 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestRefactoring1()
         {
             Test(
@@ -86,7 +86,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestFixAll1()
         {
             Test(
@@ -95,7 +95,7 @@ index: 2);
 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestFixAll2()
         {
             Test(
@@ -104,7 +104,7 @@ index: 3);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestMissing1()
         {
             TestMissing(
@@ -112,7 +112,7 @@ index: 2);
         }
 
         [WorkItem(889349)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestDefaultConstructorGeneration_1()
         {
             Test(
@@ -121,7 +121,7 @@ index: 2);
         }
 
         [WorkItem(889349)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestDefaultConstructorGeneration_2()
         {
             Test(
@@ -129,7 +129,7 @@ index: 2);
 @"class C : B { internal C(int x) : base(x) { } private C(int y) { } } class B { internal B(int x) { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestFixCount1()
         {
             TestActionCount(
@@ -137,7 +137,7 @@ index: 2);
 count: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         [WorkItem(544070)]
         public void TestException1()
         {
@@ -171,7 +171,7 @@ index: 3,
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestException2()
         {
             Test(
@@ -180,7 +180,7 @@ compareTokens: false);
 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestException3()
         {
             Test(
@@ -189,7 +189,7 @@ index: 3);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public void TestException4()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
             return new AddConstructorParametersCodeRefactoringProvider();
         }
 
-        [WpfFact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        [Fact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
         public void TestAdd1()
         {
             Test(
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
 index: 0);
         }
 
-        [WpfFact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        [Fact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
         public void TestAddOptional1()
         {
             Test(
@@ -31,7 +31,7 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        [Fact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
         public void TestAddToConstructorWithMostMatchingParameters1()
         {
             Test(
@@ -40,7 +40,7 @@ index: 1);
 index: 0);
         }
 
-        [WpfFact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        [Fact, WorkItem(308077), Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
         public void TestAddOptionalToConstructorWithMostMatchingParameters1()
         {
             Test(
@@ -49,7 +49,7 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
         public void TestSmartTagDisplayText1()
         {
             TestSmartTagText(
@@ -58,7 +58,7 @@ string.Format(FeaturesResources.AddParametersTo, "Program", "bool"),
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
         public void TestSmartTagDisplayText2()
         {
             TestSmartTagText(

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
             return new GenerateConstructorCodeRefactoringProvider();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestSingleField()
         {
             Test(
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestMultipleFields()
         {
             Test(
@@ -34,7 +34,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestSecondField()
         {
             Test(
@@ -43,7 +43,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestFieldAssigningConstructor()
         {
             Test(
@@ -52,7 +52,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestFieldAssigningConstructor2()
         {
             Test(
@@ -61,7 +61,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestDelegatingConstructor()
         {
             Test(
@@ -70,14 +70,14 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestMissingWithExistingConstructor()
         {
             TestMissing(
 @"using System . Collections . Generic ; class Z { [|int a ; string b ;|] public Z ( int a ) { this . a = a ; } public Z ( int a , string b ) { this . a = a ; this . b = b ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestMultipleProperties()
         {
             Test(
@@ -86,7 +86,7 @@ index: 1);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestMultiplePropertiesWithQualification()
         {
             Test(
@@ -95,7 +95,7 @@ index: 0);
 index: 0, options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestStruct()
         {
             Test(
@@ -104,7 +104,7 @@ index: 0, options: new Dictionary<OptionKey, object> { { new OptionKey(Simplific
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestStruct1()
         {
             Test(
@@ -113,7 +113,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestStruct2()
         {
             Test(
@@ -122,7 +122,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestStruct3()
         {
             Test(
@@ -131,7 +131,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenericType()
         {
             Test(
@@ -140,7 +140,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestSmartTagText1()
         {
             TestSmartTagText(
@@ -148,7 +148,7 @@ index: 0);
 string.Format(FeaturesResources.GenerateConstructor, "Program", "bool, HashSet<string>"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestSmartTagText2()
         {
             TestSmartTagText(
@@ -156,7 +156,7 @@ string.Format(FeaturesResources.GenerateConstructor, "Program", "bool, HashSet<s
 string.Format(FeaturesResources.GenerateFieldAssigningConstructor, "Program", "bool, HashSet<string>"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestSmartTagText3()
         {
             TestSmartTagText(
@@ -165,7 +165,7 @@ string.Format(FeaturesResources.GenerateDelegatingConstructor, "Program", "bool,
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestContextualKeywordName()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
             return new GenerateEqualsAndGetHashCodeCodeRefactoringProvider();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsSingleField()
         {
             Test(
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Genera
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsLongName()
         {
             Test(
@@ -31,7 +31,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsKeywordName()
         {
             Test(
@@ -40,7 +40,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsProperty()
         {
             Test(
@@ -49,7 +49,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsBaseTypeWithNoEquals()
         {
             Test(
@@ -58,7 +58,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsBaseWithOverriddenEquals()
         {
             Test(
@@ -67,7 +67,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsOverriddenDeepBase()
         {
             Test(
@@ -76,7 +76,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsStruct()
         {
             Test(
@@ -85,7 +85,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestEqualsGenericType()
         {
             var code = @"
@@ -113,7 +113,7 @@ class Program<T>
             Test(code, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestGetHashCodeSingleField()
         {
             Test(
@@ -122,7 +122,7 @@ class Program<T>
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestGetHashCodeTypeParameter()
         {
             Test(
@@ -131,7 +131,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestGetHashCodeGenericType()
         {
             Test(
@@ -140,7 +140,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestGetHashCodeMultipleMembers()
         {
             Test(
@@ -149,7 +149,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestSmartTagText1()
         {
             TestSmartTagText(
@@ -157,7 +157,7 @@ index: 1);
 FeaturesResources.GenerateEqualsObject);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestSmartTagText2()
         {
             TestSmartTagText(
@@ -166,7 +166,7 @@ FeaturesResources.GenerateGetHashCode,
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public void TestSmartTagText3()
         {
             TestSmartTagText(

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -37,83 +37,83 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
             return fixedRoot.Members[0].Members[0].BodyOpt;
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void NotWithNoInitializer1()
         {
             TestMissing(GetTreeText(@"{ int [||]x; System.Console.WriteLine(x); }"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void NotWithNoInitializer2()
         {
             TestMissing(GetTreeText(@"{ int [||]x = ; System.Console.WriteLine(x); }"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void NotOnSecondWithNoInitializer()
         {
             TestMissing(GetTreeText(@"{ int x = 42, [||]y; System.Console.WriteLine(y); }"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void NotOnField()
         {
             TestMissing(@"class C { int [||]x = 42; void M() { System.Console.WriteLine(x); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void SingleStatement()
         {
             TestMissing(GetTreeText(@"{ int [||]x = 27; }"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void MultipleDeclarators_First()
         {
             TestMissing(GetTreeText(@"{ int [||]x = 0, y = 1, z = 2; }"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void MultipleDeclarators_Second()
         {
             TestMissing(GetTreeText(@"{ int x = 0, [||]y = 1, z = 2; }"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void MultipleDeclarators_Last()
         {
             TestMissing(GetTreeText(@"{ int x = 0, y = 1, [||]z = 2; }"));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Escaping1()
         {
             TestFixOne(@"{ int [||]x = 0; Console.WriteLine(x); }",
                        @"{ Console.WriteLine(0); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Escaping2()
         {
             TestFixOne(@"{ int [||]@x = 0; Console.WriteLine(x); }",
                        @"{ Console.WriteLine(0); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Escaping3()
         {
             TestFixOne(@"{ int [||]@x = 0; Console.WriteLine(@x); }",
                        @"{ Console.WriteLine(0); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Escaping4()
         {
             TestFixOne(@"{ int [||]x = 0; Console.WriteLine(@x); }",
                        @"{ Console.WriteLine(0); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Escaping5()
         {
             var code = @"
@@ -140,7 +140,7 @@ class C
             Test(code, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Call()
         {
             var code = @"
@@ -167,7 +167,7 @@ class C
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Conversion_NoChange()
         {
             var code = @"
@@ -194,14 +194,14 @@ class C
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Conversion_NoConversion()
         {
             TestFixOne(@"{ int [||]x = 3; x.ToString(); }",
                        @"{ 3.ToString(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Conversion_DifferentOverload()
         {
             Test(
@@ -229,7 +229,7 @@ index: 0,
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Conversion_DifferentMethod()
         {
             Test(
@@ -273,7 +273,7 @@ class C
     compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Conversion_SameMethod()
         {
             Test(
@@ -317,14 +317,14 @@ class C
     compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void NoCastOnVar()
         {
             TestFixOne(@"{ var [||]x = 0; Console.WriteLine(x); }",
                        @"{ Console.WriteLine(0); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DoubleAssignment()
         {
             var code = @"
@@ -349,21 +349,21 @@ class C
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestAnonymousType1()
         {
             TestFixOne(@"{ int [||]x = 42; var a = new { x }; }",
                        @"{ var a = new { x = 42 }; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestParenthesizedAtReference_Case3()
         {
             TestFixOne(@"{ int [||]x = 1 + 1; int y = x * 2; }",
                        @"{ int y = (1 + 1) * 2; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontBreakOverloadResolution_Case5()
         {
             var code = @"
@@ -394,7 +394,7 @@ class C
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontTouchUnrelatedBlocks()
         {
             var code = @"
@@ -421,7 +421,7 @@ class C
             Test(code, expected, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestLambdaParenthesizeAndCast_Case7()
         {
             var code = @"
@@ -447,7 +447,7 @@ class C
         }
 
         [WorkItem(538094)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParseAmbiguity1()
         {
             Test(
@@ -475,7 +475,7 @@ class C
         }
 
         [WorkItem(538094), WorkItem(541462)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParseAmbiguity2()
         {
             Test(
@@ -503,7 +503,7 @@ class C
         }
 
         [WorkItem(538094)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParseAmbiguity3()
         {
             Test(
@@ -532,7 +532,7 @@ class C
         }
 
         [WorkItem(544924)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParseAmbiguity4()
         {
             Test(
@@ -566,7 +566,7 @@ class Program
         }
 
         [WorkItem(544613)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParseAmbiguity5()
         {
             Test(
@@ -592,7 +592,7 @@ class Program
         }
 
         [WorkItem(538131)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestArrayInitializer()
         {
             TestFixOne(@"{ int[] [||]x = { 3, 4, 5 }; int a = Array.IndexOf(x, 3); }",
@@ -600,7 +600,7 @@ class Program
         }
 
         [WorkItem(545657)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestArrayInitializer2()
         {
             var initial = @"
@@ -626,7 +626,7 @@ class Program
         }
 
         [WorkItem(545657)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestArrayInitializer3()
         {
             var initial = @"
@@ -659,7 +659,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_RefParameter1()
         {
             var initial =
@@ -705,7 +705,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_RefParameter2()
         {
             var initial =
@@ -741,7 +741,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_AssignExpression()
         {
             var initial =
@@ -771,7 +771,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_AddAssignExpression1()
         {
             var initial =
@@ -801,7 +801,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_AddAssignExpression2()
         {
             var initial =
@@ -833,7 +833,7 @@ class C
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_SubtractAssignExpression()
         {
             var initial =
@@ -863,7 +863,7 @@ class Program
             Test(initial, expected, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_MultiplyAssignExpression()
         {
             var initial =
@@ -893,7 +893,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_DivideAssignExpression()
         {
             var initial =
@@ -923,7 +923,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_ModuloAssignExpression()
         {
             var initial =
@@ -953,7 +953,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_AndAssignExpression()
         {
             var initial =
@@ -983,7 +983,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_OrAssignExpression()
         {
             var initial =
@@ -1013,7 +1013,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_ExclusiveOrAssignExpression()
         {
             var initial =
@@ -1043,7 +1043,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_LeftShiftAssignExpression()
         {
             var initial =
@@ -1073,7 +1073,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_RightShiftAssignExpression()
         {
             var initial =
@@ -1103,7 +1103,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_PostIncrementExpression()
         {
             var initial =
@@ -1133,7 +1133,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_PreIncrementExpression()
         {
             var initial =
@@ -1163,7 +1163,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_PostDecrementExpression()
         {
             var initial =
@@ -1193,7 +1193,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_PreDecrementExpression()
         {
             var initial =
@@ -1223,7 +1223,7 @@ class Program
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_AddressOfExpression()
         {
             var initial = @"
@@ -1252,7 +1252,7 @@ class C
         }
 
         [WorkItem(545342)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConflict_UsedBeforeDeclaration()
         {
             var initial =
@@ -1278,7 +1278,7 @@ class C
             Test(initial, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Preprocessor1()
         {
             TestFixOne(@"
@@ -1303,7 +1303,7 @@ class C
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Preprocessor2()
         {
             TestFixOne(@"
@@ -1328,7 +1328,7 @@ compareTokens: false);
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Preprocessor3()
         {
             TestFixOne(@"
@@ -1354,7 +1354,7 @@ compareTokens: false);
         }
 
         [WorkItem(540164)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TriviaOnArrayInitializer()
         {
             var initial =
@@ -1380,7 +1380,7 @@ compareTokens: false);
         }
 
         [WorkItem(540156)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ProperlyFormatWhenRemovingDeclarator1()
         {
             var initial =
@@ -1407,7 +1407,7 @@ compareTokens: false);
         }
 
         [WorkItem(540156)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ProperlyFormatWhenRemovingDeclarator2()
         {
             var initial =
@@ -1434,7 +1434,7 @@ compareTokens: false);
         }
 
         [WorkItem(540156)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ProperlyFormatWhenRemovingDeclarator3()
         {
             var initial =
@@ -1461,7 +1461,7 @@ compareTokens: false);
         }
 
         [WorkItem(540186)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ProperlyFormatAnonymousTypeMember()
         {
             var initial =
@@ -1487,7 +1487,7 @@ compareTokens: false);
         }
 
         [WorkItem(6356, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineToAnonymousTypeProperty()
         {
             var initial =
@@ -1513,7 +1513,7 @@ compareTokens: false);
         }
 
         [WorkItem(528075)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineIntoDelegateInvocation()
         {
             var initial =
@@ -1541,7 +1541,7 @@ class Program
         }
 
         [WorkItem(541341)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineAnonymousMethodIntoNullCoalescingExpression()
         {
             var initial =
@@ -1571,7 +1571,7 @@ class Program
         }
 
         [WorkItem(541341)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineLambdaIntoNullCoalescingExpression()
         {
             var initial =
@@ -1601,7 +1601,7 @@ class Program
         }
 
         [WorkItem(538079)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForBoxingOperation1()
         {
             var initial =
@@ -1631,7 +1631,7 @@ class A
         }
 
         [WorkItem(538079)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForBoxingOperation2()
         {
             var initial =
@@ -1663,7 +1663,7 @@ class A
         }
 
         [WorkItem(538079)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForBoxingOperation3()
         {
             var initial =
@@ -1693,7 +1693,7 @@ class A
         }
 
         [WorkItem(538079)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForBoxingOperation4()
         {
             var initial =
@@ -1723,7 +1723,7 @@ class A
         }
 
         [WorkItem(538079)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForBoxingOperation5()
         {
             var initial =
@@ -1753,7 +1753,7 @@ class A
         }
 
         [WorkItem(540278)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestLeadingTrivia()
         {
             Test(
@@ -1781,7 +1781,7 @@ compareTokens: false);
         }
 
         [WorkItem(540278)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestLeadingAndTrailingTrivia()
         {
             Test(
@@ -1810,7 +1810,7 @@ compareTokens: false);
         }
 
         [WorkItem(540278)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestTrailingTrivia()
         {
             Test(
@@ -1837,7 +1837,7 @@ compareTokens: false);
         }
 
         [WorkItem(540278)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestPreprocessor()
         {
             Test(
@@ -1867,7 +1867,7 @@ compareTokens: false);
         }
 
         [WorkItem(540277)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestFormatting()
         {
             Test(
@@ -1892,7 +1892,7 @@ compareTokens: false);
         }
 
         [WorkItem(541694)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestSwitchSection()
         {
             Test(
@@ -1928,7 +1928,7 @@ compareTokens: false);
         }
 
         [WorkItem(542647)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void UnparenthesizeExpressionIfNeeded1()
         {
             Test(
@@ -1961,7 +1961,7 @@ class C
         }
 
         [WorkItem(545619)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void UnparenthesizeExpressionIfNeeded2()
         {
             Test(
@@ -1994,7 +1994,7 @@ class Program
         }
 
         [WorkItem(542656)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParenthesizeIfNecessary1()
         {
             Test(
@@ -2030,7 +2030,7 @@ class A
         }
 
         [WorkItem(544626)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParenthesizeIfNecessary2()
         {
             Test(
@@ -2064,7 +2064,7 @@ class C
         }
 
         [WorkItem(544415)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParenthesizeAddressOf1()
         {
             Test(
@@ -2094,7 +2094,7 @@ unsafe class C
         }
 
         [WorkItem(544922)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParenthesizeAddressOf2()
         {
             Test(
@@ -2124,7 +2124,7 @@ unsafe class C
         }
 
         [WorkItem(544921)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParenthesizePointerIndirection1()
         {
             Test(
@@ -2154,7 +2154,7 @@ unsafe class C
         }
 
         [WorkItem(544614)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParenthesizePointerIndirection2()
         {
             Test(
@@ -2184,7 +2184,7 @@ unsafe class C
         }
 
         [WorkItem(544563)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontInlineStackAlloc()
         {
             TestMissing(
@@ -2203,7 +2203,7 @@ unsafe class C
         }
 
         [WorkItem(543744)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineTempLambdaExpressionCastingError()
         {
             Test(
@@ -2229,7 +2229,7 @@ class Program
             compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForNull()
         {
             Test(
@@ -2257,7 +2257,7 @@ class C
             compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastIfNeeded1()
         {
             Test(
@@ -2283,7 +2283,7 @@ class C
         }
 
         [WorkItem(545161)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastIfNeeded2()
         {
             Test(
@@ -2318,7 +2318,7 @@ class C
         }
 
         [WorkItem(544612)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineIntoBracketedList()
         {
             Test(
@@ -2351,7 +2351,7 @@ class C
         }
 
         [WorkItem(542648)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void ParenthesizeAfterCastIfNeeded()
         {
             Test(
@@ -2387,7 +2387,7 @@ class Program
         }
 
         [WorkItem(544635)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForEnumZeroIfBoxed()
         {
             Test(
@@ -2420,7 +2420,7 @@ class Program
 
         [WorkItem(544636)]
         [WorkItem(554010)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForMethodGroupIfNeeded1()
         {
             Test(
@@ -2451,7 +2451,7 @@ class Program
 
         [WorkItem(544978)]
         [WorkItem(554010)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForMethodGroupIfNeeded2()
         {
             Test(
@@ -2481,7 +2481,7 @@ class Program
         }
 
         [WorkItem(545103)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontInsertCastForTypeThatNoLongerBindsToTheSameType()
         {
             Test(
@@ -2517,7 +2517,7 @@ class A<T>
         }
 
         [WorkItem(545170)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCorrectCastForDelegateCreationExpression()
         {
             Test(
@@ -2550,7 +2550,7 @@ class Program
         }
 
         [WorkItem(545523)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontInsertCastForObjectCreationIfUnneeded()
         {
             Test(
@@ -2580,7 +2580,7 @@ class Program
             compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontInsertCastInForeachIfUnneeded01()
         {
             Test(
@@ -2616,7 +2616,7 @@ class Program
             compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastInForeachIfNeeded01()
         {
             Test(
@@ -2652,7 +2652,7 @@ class Program
             compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastInForeachIfNeeded02()
         {
             Test(
@@ -2689,7 +2689,7 @@ class Program
         }
 
         [WorkItem(545601)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastToKeepGenericMethodInference()
         {
             Test(
@@ -2724,7 +2724,7 @@ class C
         }
 
         [WorkItem(545601)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastForKeepImplicitArrayInference()
         {
             Test(
@@ -2759,7 +2759,7 @@ class C
         }
 
         [WorkItem(545601)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertASingleCastToNotBreakOverloadResolution()
         {
             Test(
@@ -2792,7 +2792,7 @@ class C
         }
 
         [WorkItem(545601)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertASingleCastToNotBreakOverloadResolutionInLambdas()
         {
             Test(
@@ -2827,7 +2827,7 @@ class C
         }
 
         [WorkItem(545601)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertASingleCastToNotBreakResolutionOfOperatorOverloads()
         {
             Test(
@@ -2894,7 +2894,7 @@ class C
         }
 
         [WorkItem(545561)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastToNotBreakOverloadResolutionInUncheckedContext()
         {
             Test(
@@ -2939,7 +2939,7 @@ class X
         }
 
         [WorkItem(545564)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastToNotBreakOverloadResolutionInUnsafeContext()
         {
             Test(
@@ -2988,7 +2988,7 @@ static class C
         }
 
         [WorkItem(545783)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InsertCastToNotBreakOverloadResolutionInNestedLambdas()
         {
             Test(
@@ -3031,7 +3031,7 @@ class C
         }
 
         [WorkItem(546069)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestBrokenVariableDeclarator()
         {
             TestMissing(
@@ -3045,7 +3045,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestHiddenRegion1()
         {
             TestMissing(
@@ -3062,7 +3062,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestHiddenRegion2()
         {
             TestMissing(
@@ -3080,7 +3080,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestHiddenRegion3()
         {
             Test(
@@ -3112,7 +3112,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestHiddenRegion4()
         {
             Test(
@@ -3146,7 +3146,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestHiddenRegion5()
         {
             TestMissing(
@@ -3166,7 +3166,7 @@ compareTokens: false);
         }
 
         [WorkItem(530743)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineFromLabeledStatement()
         {
             Test(
@@ -3201,7 +3201,7 @@ class Program
         }
 
         [WorkItem(529698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineCompoundAssignmentIntoInitializer()
         {
             Test(
@@ -3234,7 +3234,7 @@ class Program
         }
 
         [WorkItem(609497)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Bugfix_609497()
         {
             Test(
@@ -3265,7 +3265,7 @@ class Program
         }
 
         [WorkItem(636319)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Bugfix_636319()
         {
             Test(
@@ -3298,7 +3298,7 @@ class Program
         }
 
         [WorkItem(609492)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Bugfix_609492()
         {
             Test(
@@ -3331,7 +3331,7 @@ class Program
         }
 
         [WorkItem(529950)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineTempDoesNotInsertUnnecessaryExplicitTypeInLambdaParameter()
         {
             Test(
@@ -3377,7 +3377,7 @@ static class C
         }
 
         [WorkItem(619425)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Bugfix_619425_RestrictedSimpleNameExpansion()
         {
             Test(
@@ -3418,7 +3418,7 @@ class A<B>
         }
 
         [WorkItem(529840)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void Bugfix_529840_DetectSemanticChangesAtInlineSite()
         {
             Test(
@@ -3482,7 +3482,7 @@ class A
         }
 
         [WorkItem(1091946)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConditionalAccessWithConversion()
         {
             Test(
@@ -3505,7 +3505,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestSimpleConditionalAccess()
         {
             Test(
@@ -3528,7 +3528,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConditionalAccessWithConditionalExpression()
         {
             Test(
@@ -3551,7 +3551,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         [WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")]
         public void TestConditionalAccessWithExtensionMethodInvocation()
         {
@@ -3608,7 +3608,7 @@ class C
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         [WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")]
         public void TestConditionalAccessWithExtensionMethodInvocation_2()
         {
@@ -3675,7 +3675,7 @@ class C
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestAliasQualifiedNameIntoInterpolation()
         {
             Test(
@@ -3698,7 +3698,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConditionalExpressionIntoInterpolation()
         {
             Test(
@@ -3721,7 +3721,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestConditionalExpressionIntoInterpolationWithFormatClause()
         {
             Test(
@@ -3744,7 +3744,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void TestInvocationExpressionIntoInterpolation()
         {
             Test(
@@ -3768,7 +3768,7 @@ class A
         }
 
         [WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontParenthesizeInterpolatedStringWithNoInterpolation()
         {
             Test(
@@ -3792,7 +3792,7 @@ class C
         }
 
         [WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void DontParenthesizeInterpolatedStringWithInterpolation()
         {
             Test(
@@ -3816,7 +3816,7 @@ class C
         }
 
         [WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineFormattableStringIntoCallSiteRequiringFormattableString()
         {
             const string initial = @"
@@ -3854,7 +3854,7 @@ class C
         }
 
         [WorkItem(4624, "https://github.com/dotnet/roslyn/issues/4624")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public void InlineFormattableStringIntoCallSiteWithFormattableStringOverload()
         {
             const string initial = @"

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             return new IntroduceVariableCodeRefactoringProvider();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMethodFix1()
         {
             Test(
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMethodFix2()
         {
             Test(
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMethodFix3()
         {
             var code =
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             Test(code, expected, index: 2, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMethodFix4()
         {
             var code =
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             Test(code, expected, index: 3, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestFieldFix1()
         {
             var code =
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestFieldFix2()
         {
             var code =
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             Test(code, expected, index: 1, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestConstFieldFix1()
         {
             var code =
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             Test(code, expected, index: 0, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestConstFieldFix2()
         {
             var code =
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             Test(code, expected, index: 1, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestConstructorFix1()
         {
             Test(
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestConstructorFix2()
         {
             Test(
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestParameterFix1()
         {
             Test(
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestParameterFix2()
         {
             Test(
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 1);
         }
 
-        [WpfFact]
+        [Fact]
         public void TestAttributeFix1()
         {
             Test(
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestAttributeFix2()
         {
             Test(
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMethodFixExistingName1()
         {
             Test(
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestFieldExistingName1()
         {
             var code =
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMethodFixComplexName1()
         {
             Test(
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMethodFixComplexName1NotVar()
         {
             Test(
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals), false } });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNameConflict1()
         {
             Test(
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
                 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNameConflict2()
         {
             Test(
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNameConflict2NotVar()
         {
             Test(
@@ -301,7 +301,7 @@ index: 0,
 options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals), false } });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNameVerbatimIdentifier1()
         {
             Test(
@@ -310,7 +310,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNameVerbatimIdentifier1NoVar()
         {
             Test(
@@ -320,7 +320,7 @@ index: 0,
 options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals), false } });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNameVerbatimIdentifier2()
         {
             Test(
@@ -328,7 +328,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
 @"static class G<T> { public class @class { } public static void Add(object t) { } static void Main() { var {|Rename:class1|} = new G<int>.@class(); G<int>.Add(class1); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNameVerbatimIdentifier2NoVar()
         {
             Test(
@@ -338,7 +338,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         }
 
         [WorkItem(540078)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestConstantField1()
         {
             Test(
@@ -346,7 +346,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
 @"class C { private const int {|Rename:V|} = 10 ; int [ ] array = new int [ V ] ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         [WorkItem(540079)]
         public void TestFormattingOfReplacedExpression1()
         {
@@ -371,7 +371,7 @@ compareTokens: false);
         }
 
         [WorkItem(540468)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestCantExtractMethodTypeParameterToField()
         {
             Test(
@@ -380,7 +380,7 @@ compareTokens: false);
         }
 
         [WorkItem(540468)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestCantExtractMethodTypeParameterToFieldCount()
         {
             TestActionCount(
@@ -390,7 +390,7 @@ count: 2);
 
         [WorkItem(552389)]
         [WorkItem(540482)]
-        [WpfFact(Skip = "552389"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact(Skip = "552389"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestConstantForFixedBufferInitializer()
         {
             Test(
@@ -400,7 +400,7 @@ index: 0);
         }
 
         [WorkItem(540486)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestFormattingOfIntroduceLocal()
         {
             Test(
@@ -423,7 +423,7 @@ index: 2,
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLocalConstant()
         {
             Test(
@@ -433,7 +433,7 @@ index: 2);
         }
 
         [WorkItem(542699)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestFieldConstant()
         {
             Test(
@@ -443,7 +443,7 @@ index: 1);
         }
 
         [WorkItem(542781)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnExpressionStatement()
         {
             TestMissing(
@@ -458,7 +458,7 @@ index: 1);
         }
 
         [WorkItem(542780)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestSingleQueryClause()
         {
             Test(
@@ -468,7 +468,7 @@ index: 0);
         }
 
         [WorkItem(542780)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestSingleQuerySelectOrGroupByClause()
         {
             Test(
@@ -477,7 +477,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLinqQuery()
         {
             Test(
@@ -486,7 +486,7 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestSingleQueryReplaceAll()
         {
             Test(
@@ -495,7 +495,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNestedQueryReplaceOne1()
         {
             Test(
@@ -504,7 +504,7 @@ index: 1);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNestedQueryReplaceAll1()
         {
             Test(
@@ -513,7 +513,7 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNestedQueryReplaceOne2()
         {
             Test(
@@ -522,7 +522,7 @@ index: 1);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNestedQueryReplaceAll2()
         {
             Test(
@@ -531,7 +531,7 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         [WorkItem(10742, "DevDiv_Projects/Roslyn")]
         public void TestAnonymousTypeMemberAssignment()
         {
@@ -539,7 +539,7 @@ index: 1);
 @"class C { void M ( ) { var a = new { [|A = 0|] } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         [WorkItem(10743, "DevDiv_Projects/Roslyn")]
         public void TestAnonymousTypeBody()
         {
@@ -548,7 +548,7 @@ index: 1);
         }
 
         [WorkItem(543477)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestImplicitlyTypedArraysUsedInCheckedExpression()
         {
             Test(
@@ -557,7 +557,7 @@ index: 1);
         }
 
         [WorkItem(543832)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnGenericTypeParameter()
         {
             TestMissing(
@@ -565,7 +565,7 @@ index: 1);
         }
 
         [WorkItem(543941)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestAnonymousType1()
         {
             Test(
@@ -574,7 +574,7 @@ index: 1);
         }
 
         [WorkItem(544099)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnAttributeNameEquals()
         {
             TestMissing(
@@ -589,7 +589,7 @@ class M
         }
 
         [WorkItem(544162)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnRightOfDot()
         {
             TestMissing(
@@ -597,7 +597,7 @@ class M
         }
 
         [WorkItem(544209)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnAttributeNamedParameter()
         {
             TestMissing(
@@ -605,7 +605,7 @@ class M
         }
 
         [WorkItem(544264)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnVariableWrite()
         {
             TestMissing(
@@ -614,7 +614,7 @@ class M
 
         [WorkItem(544577)]
         [WorkItem(909152)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestExpressionTLambda()
         {
             TestMissing(
@@ -622,7 +622,7 @@ class M
         }
 
         [WorkItem(544915)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnTypeSyntax()
         {
             TestMissing(
@@ -630,7 +630,7 @@ class M
         }
 
         [WorkItem(544610)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void ParenthesizeIfParseChanges()
         {
             var code = @"
@@ -657,7 +657,7 @@ class C
             Test(code, expected, index: 2, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingInPartiallyHiddenMethod()
         {
             TestMissing(
@@ -672,7 +672,7 @@ class C
 }", parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInVisibleMethod()
         {
             Test(
@@ -702,7 +702,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingInFieldInPartiallyHiddenType()
         {
             TestMissing(
@@ -715,7 +715,7 @@ compareTokens: false);
 #line default", parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingInAttributeInPartiallyHiddenType()
         {
             TestMissing(
@@ -727,7 +727,7 @@ class Program
 #line default", parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingInConstructorInitializerInPartiallyHiddenType()
         {
             TestMissing(
@@ -742,7 +742,7 @@ class Program
 #line default", parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingInParameterInPartiallyHiddenType()
         {
             TestMissing(
@@ -757,7 +757,7 @@ class Program
 #line default", parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingInQueryInPartiallyHiddenType()
         {
             TestMissing(
@@ -777,7 +777,7 @@ class Program
 }", parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInVisibleQueryInHiddenType()
         {
             Test(
@@ -818,28 +818,28 @@ compareTokens: false,
 parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnNamespace()
         {
             TestMissing(
 @"class Program { void Main ( ) { [|System|] . Console . WriteLine ( 4 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnType()
         {
             TestMissing(
 @"class Program { void Main ( ) { [|System . Console|] . WriteLine ( 4 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnBase()
         {
             TestMissing(
 @"class Program { void Main ( ) { [|base|] . ToString ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestVenusGeneration1()
         {
             TestMissing(
@@ -856,7 +856,7 @@ class Program
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestVenusGeneration2()
         {
             var code =
@@ -895,7 +895,7 @@ class Program
 }", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestVenusGeneration3()
         {
             var code =
@@ -919,7 +919,7 @@ class Program
         }
 
         [WorkItem(529795)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnNegatedLiteral()
         {
             TestMissing(
@@ -927,7 +927,7 @@ class Program
         }
 
         [WorkItem(546091)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNotOnInterfaceAttribute()
         {
             TestMissing(
@@ -935,7 +935,7 @@ class Program
         }
 
         [WorkItem(546095)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNotOnTypeOfInAttribute()
         {
             TestMissing(
@@ -943,7 +943,7 @@ class Program
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestPreferGenerateConstantField1()
         {
             Test(
@@ -952,7 +952,7 @@ class Program
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestPreferGenerateConstantField2()
         {
             Test(
@@ -962,7 +962,7 @@ index: 1);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestPreferGenerateConstantField3()
         {
             Test(
@@ -972,7 +972,7 @@ index: 2);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestPreferGenerateConstantField4()
         {
             Test(
@@ -982,7 +982,7 @@ index: 3);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoGenerateConstantFieldIfAccessingLocal1()
         {
             Test(
@@ -992,7 +992,7 @@ index: 0);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoGenerateConstantFieldIfAccessingLocal2()
         {
             Test(
@@ -1002,7 +1002,7 @@ index: 1);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoGenerateConstantFieldIfNotAccessingLocal1()
         {
             Test(
@@ -1011,7 +1011,7 @@ index: 1);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoGenerateConstantFieldIfNotAccessingLocal2()
         {
             Test(
@@ -1021,7 +1021,7 @@ index: 1);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoGenerateConstantFieldIfNotAccessingLocal3()
         {
             Test(
@@ -1031,7 +1031,7 @@ index: 2);
         }
 
         [WorkItem(530109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoGenerateConstantFieldIfNotAccessingLocal4()
         {
             Test(
@@ -1041,7 +1041,7 @@ index: 3);
         }
 
         [WorkItem(606347)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void InsertNeededCast1()
         {
             Test(
@@ -1087,7 +1087,7 @@ compareTokens: false);
         }
 
         [WorkItem(606347)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void InsertNeededCast1NotVar()
         {
             Test(
@@ -1133,7 +1133,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         }
 
         [WorkItem(606347), WorkItem(714632)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void InsertNeededCast2()
         {
             Test(
@@ -1170,7 +1170,7 @@ compareTokens: false);
         }
 
         [WorkItem(546512)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInSwitchSection()
         {
             Test(
@@ -1180,7 +1180,7 @@ index: 2);
         }
 
         [WorkItem(530480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLambdaParameter1()
         {
             Test(
@@ -1189,7 +1189,7 @@ index: 2);
         }
 
         [WorkItem(530480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLambdaParameter2()
         {
             Test(
@@ -1198,7 +1198,7 @@ index: 2);
         }
 
         [WorkItem(530480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLambdaParameter3()
         {
             Test(
@@ -1207,7 +1207,7 @@ index: 2);
         }
 
         [WorkItem(530480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLambdaParameter4()
         {
             Test(
@@ -1216,7 +1216,7 @@ index: 2);
         }
 
         [WorkItem(530480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLambdaParameter5()
         {
             Test(
@@ -1225,7 +1225,7 @@ index: 2);
         }
 
         [WorkItem(530721)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroVarInAction1()
         {
             Test(
@@ -1234,7 +1234,7 @@ index: 2);
         }
 
         [WorkItem(530919)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNullableOfPointerType()
         {
             Test(
@@ -1243,7 +1243,7 @@ index: 2);
         }
 
         [WorkItem(530919)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNullableOfPointerTypeNotVar()
         {
             Test(
@@ -1253,7 +1253,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         }
 
         [WorkItem(830885)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalRemovesUnnecessaryCast()
         {
             Test(
@@ -1262,7 +1262,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         }
 
         [WorkItem(655498)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void HandleParenthesizedExpression()
         {
             Test(
@@ -1295,7 +1295,7 @@ compareTokens: false);
         }
 
         [WorkItem(682683)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void DontRemoveParenthesesIfOperatorPrecedenceWouldBeBroken()
         {
             Test(
@@ -1324,7 +1324,7 @@ compareTokens: false);
         }
 
         [WorkItem(828108)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void UseNewSemanticModelForSimplification()
         {
             Test(
@@ -1360,7 +1360,7 @@ compareTokens: false);
         }
 
         [WorkItem(884961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInCollectionInitializer()
         {
             Test(
@@ -1387,7 +1387,7 @@ compareTokens: false);
         }
 
         [WorkItem(884961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInCollectionInitializerNoVar()
         {
             Test(
@@ -1415,7 +1415,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         }
 
         [WorkItem(854662)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInNestedCollectionInitializers()
         {
             Test(
@@ -1446,7 +1446,7 @@ compareTokens: false);
         }
 
         [WorkItem(884961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInArrayInitializer()
         {
             Test(
@@ -1473,7 +1473,7 @@ compareTokens: false);
         }
 
         [WorkItem(884961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestInArrayInitializerWithoutVar()
         {
             Test(
@@ -1501,7 +1501,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         }
 
         [WorkItem(1022447)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestFormattingOfIntroduceLocal2()
         {
             Test(
@@ -1537,7 +1537,7 @@ compareTokens: false);
         }
 
         [WorkItem(939259)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalWithTriviaInMultiLineStatements()
         {
             var code =
@@ -1567,7 +1567,7 @@ compareTokens: false);
         }
 
         [WorkItem(939259)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalWithTriviaInMultiLineStatements2()
         {
             var code =
@@ -1597,7 +1597,7 @@ compareTokens: false);
         }
 
         [WorkItem(1064803)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInStringInterpolation()
         {
             var code =
@@ -1623,7 +1623,7 @@ compareTokens: false);
         }
 
         [WorkItem(1037057)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalWithBlankLine()
         {
             Test(@"
@@ -1653,7 +1653,7 @@ class C
         }
 
         [WorkItem(1065661)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceVariableTextDoesntSpanLines()
         {
             TestSmartTagText(@"
@@ -1672,7 +1672,7 @@ index: 2);
         }
 
         [WorkItem(1097147)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestSmartNameForNullablesInConditionalAccessExpressionContext()
         {
             var code =
@@ -1700,7 +1700,7 @@ class C
         }
 
         [WorkItem(1097147)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestSmartNameForNullablesInConditionalAccessExpressionContext2()
         {
             var code =
@@ -1728,7 +1728,7 @@ class C
         }
 
         [WorkItem(1097147)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestSmartNameForNullablesInConditionalAccessExpressionContext3()
         {
             var code =
@@ -1774,7 +1774,7 @@ class B
         }
 
         [WorkItem(1097147)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestSmartNameForNullablesInConditionalAccessExpressionContext4()
         {
             var code =
@@ -1822,7 +1822,7 @@ class B
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethod()
         {
             var code =
@@ -1849,7 +1849,7 @@ class T
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedMethod()
         {
             var code =
@@ -1873,7 +1873,7 @@ class T
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedOperator()
         {
             var code =
@@ -1910,7 +1910,7 @@ class Complex
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedOperator()
         {
             var code =
@@ -1944,7 +1944,7 @@ class Complex
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedConversionOperator()
         {
             var code =
@@ -1982,7 +1982,7 @@ public struct DBBool
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedProperty()
         {
             var code =
@@ -2005,7 +2005,7 @@ class T
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedProperty()
         {
             var code =
@@ -2033,7 +2033,7 @@ class T
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceFieldInExpressionBodiedIndexer()
         {
             var code =
@@ -2057,7 +2057,7 @@ class SampleCollection<T>
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedIndexer()
         {
             var code =
@@ -2087,7 +2087,7 @@ class SampleCollection<T>
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestTrailingTriviaOnExpressionBodiedMethodRewrites()
         {
             var code =
@@ -2118,7 +2118,7 @@ class T
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestLeadingTriviaOnExpressionBodiedMethodRewrites()
         {
             var code =
@@ -2145,7 +2145,7 @@ class T
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestTriviaAroundArrowTokenInExpressionBodiedMemberSyntax()
         {
             var code =
@@ -2173,7 +2173,7 @@ class T
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [WorkItem(971, "http://github.com/dotnet/roslyn/issues/971")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedAnonymousMethodExpression()
         {
             var code =
@@ -2202,7 +2202,7 @@ class TestClass
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [WorkItem(971, "http://github.com/dotnet/roslyn/issues/971")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethodWithSingleLineBlockBodiedAnonymousMethodExpression()
         {
             var code =
@@ -2224,7 +2224,7 @@ class TestClass
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [WorkItem(971, "http://github.com/dotnet/roslyn/issues/971")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedSimpleLambdaExpression()
         {
             var code =
@@ -2252,7 +2252,7 @@ class TestClass
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethodWithExpressionBodiedSimpleLambdaExpression()
         {
             var code =
@@ -2278,7 +2278,7 @@ class TestClass
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [WorkItem(971, "http://github.com/dotnet/roslyn/issues/971")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedParenthesizedLambdaExpression()
         {
             var code =
@@ -2306,7 +2306,7 @@ class TestClass
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethodWithExpressionBodiedParenthesizedLambdaExpression()
         {
             var code =
@@ -2332,7 +2332,7 @@ class TestClass
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
         [WorkItem(971, "http://github.com/dotnet/roslyn/issues/971")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestIntroduceLocalInExpressionBodiedMethodWithBlockBodiedAnonymousMethodExpressionInMethodArgs()
         {
             var code =
@@ -2360,7 +2360,7 @@ class TestClass
         }
 
         [WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoConstantForInterpolatedStrings1()
         {
             var code =
@@ -2388,7 +2388,7 @@ class TestClass
         }
 
         [WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestNoConstantForInterpolatedStrings2()
         {
             var code =
@@ -2418,7 +2418,7 @@ class TestClass
         }
 
         [WorkItem(909152)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void TestMissingOnNullLiteral()
         {
             TestMissing(
@@ -2436,7 +2436,7 @@ class Test
         }
 
         [WorkItem(1130990)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void InParentConditionalAccessExpressions()
         {
             var code =
@@ -2466,7 +2466,7 @@ class C
         }
 
         [WorkItem(1130990)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void InParentConditionalAccessExpression2()
         {
             var code =
@@ -2497,7 +2497,7 @@ class C
 
         [WorkItem(1130990)]
         [WorkItem(3110, "https://github.com/dotnet/roslyn/issues/3110")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void MissingAcrossMultipleParentConditionalAccessExpressions()
         {
             TestMissing(
@@ -2513,7 +2513,7 @@ class C
         }
 
         [WorkItem(1130990)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void MissingOnInvocationExpressionInParentConditionalAccessExpressions()
         {
             TestMissing(
@@ -2529,7 +2529,7 @@ class C
         }
 
         [WorkItem(1130990)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void MissingOnMemberBindingExpressionInParentConditionalAccessExpressions()
         {
             TestMissing(
@@ -2544,7 +2544,7 @@ class C
         }
 
         [WorkItem(3147, "https://github.com/dotnet/roslyn/issues/3147")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void HandleFormattableStringTargetTyping1()
         {
             const string code = CodeSnippets.FormattableStringType + @"
@@ -2580,7 +2580,7 @@ namespace N
         }
 
         [WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void InAutoPropertyInitializer()
         {
             var code =
@@ -2601,7 +2601,7 @@ class C
         }
 
         [WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void InAutoPropertyInitializer2()
         {
             var code =
@@ -2622,7 +2622,7 @@ class C
         }
 
         [WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public void BlockContextPreferredOverAutoPropertyInitializerContext()
         {
             var code =

--- a/src/EditorFeatures/CSharpTest/CodeActions/InvertIf/InvertIfTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InvertIf/InvertIfTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 }";
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestIdentifier()
         {
             TestFixOne(
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestNotIdentifier()
         {
             TestFixOne(
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestEqualsEquals()
         {
             TestFixOne(
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a != b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestNotEquals()
         {
             TestFixOne(
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a == b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestGreaterThan()
         {
             TestFixOne(
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a <= b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestGreaterThanEquals()
         {
             TestFixOne(
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a < b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestLessThan()
         {
             TestFixOne(
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a >= b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestLessThanEquals()
         {
             TestFixOne(
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a > b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestParens()
         {
             TestFixOne(
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestIs()
         {
             TestFixOne(
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!(a is Foo)) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestCall()
         {
             TestFixOne(
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a.Foo()) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOr()
         {
             TestFixOne(
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a && !b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOr2()
         {
             TestFixOne(
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a && b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestAnd()
         {
             TestFixOne(
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a || !b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestAnd2()
         {
             TestFixOne(
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (a || b) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestParenthesizeAndForPrecedence()
         {
             TestFixOne(
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if ((!a || !b) && !c) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestPlus()
         {
             TestFixOne(
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!(a + b)) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestTrue()
         {
             TestFixOne(
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (false) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestFalse()
         {
             TestFixOne(
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (true) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestTrueAndFalse()
         {
             TestFixOne(
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (false || true) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestCurlies1()
         {
             TestFixOne(
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a) b(); else a();");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestCurlies2()
         {
             TestFixOne(
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a) b(); else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestCurlies3()
         {
             TestFixOne(
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a) { b(); } else a();");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestIfElseIf()
         {
             TestFixOne(
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a) { if (b) { b(); } } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestIfElseIf2()
         {
             TestFixOne(
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if (!a) { if (b) { b(); } else { c(); } } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestNested()
         {
             TestFixOne(
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
 @"if ((a != b || c == d) && (e >= f || g)) { b(); } else { a(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestKeepTriviaWithinExpression()
         {
             TestFixOne(
@@ -271,14 +271,14 @@ else
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestMissingOnNonEmptySpan()
         {
             TestMissing(
 @"class C { void F() { [|if (a) { a(); } else { b(); }|] } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOverlapsHiddenPosition1()
         {
             TestMissing(
@@ -294,7 +294,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOverlapsHiddenPosition2()
         {
             TestMissing(
@@ -317,7 +317,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOverlapsHiddenPosition3()
         {
             TestMissing(
@@ -340,7 +340,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOverlapsHiddenPosition4()
         {
             TestMissing(
@@ -363,7 +363,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOverlapsHiddenPosition5()
         {
             TestMissing(
@@ -386,7 +386,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOverlapsHiddenPosition6()
         {
             Test(
@@ -427,7 +427,7 @@ class C
 }", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestOverlapsHiddenPosition7()
         {
             Test(
@@ -472,7 +472,7 @@ class C
 #line default", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero()
         {
             TestFixOne(
@@ -480,7 +480,7 @@ class C
 @"string x; if (x.Length == 0) { EqualsZero(); } else { GreaterThanZero(); } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero2()
         {
             TestFixOne(
@@ -488,7 +488,7 @@ class C
 @"string[] x; if (x.Length == 0) { EqualsZero(); } else { GreaterThanZero(); } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero3()
         {
             TestFixOne(
@@ -496,7 +496,7 @@ class C
 @"string x; if (x.Length == 0x0) { b(); } else { a(); } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero4()
         {
             TestFixOne(
@@ -505,7 +505,7 @@ class C
         }
 
         [WorkItem(545986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero5()
         {
             TestFixOne(
@@ -514,7 +514,7 @@ class C
         }
 
         [WorkItem(545986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero6()
         {
             TestFixOne(
@@ -523,7 +523,7 @@ class C
         }
 
         [WorkItem(545986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero7()
         {
             TestFixOne(
@@ -532,7 +532,7 @@ class C
         }
 
         [WorkItem(545986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero8()
         {
             TestFixOne(
@@ -541,7 +541,7 @@ class C
         }
 
         [WorkItem(545986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero9()
         {
             TestFixOne(
@@ -550,7 +550,7 @@ class C
         }
 
         [WorkItem(545986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero10()
         {
             TestFixOne(
@@ -559,7 +559,7 @@ class C
         }
 
         [WorkItem(530505)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestSimplifyToLengthEqualsZero11()
         {
             TestFixOne(
@@ -567,7 +567,7 @@ class C
 @"string[] x; if (x.LongLength == 0) { EqualsZero(); } else { GreaterThanZero(); } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestDoesNotSimplifyToLengthEqualsZero()
         {
             TestFixOne(
@@ -575,7 +575,7 @@ class C
 @"string x; if (x.Length < 0) { b(); } else { a(); } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
         public void TestDoesNotSimplifyToLengthEqualsZero2()
         {
             TestFixOne(

--- a/src/EditorFeatures/CSharpTest/CodeActions/LambdaSimplifier/LambdaSimplifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/LambdaSimplifier/LambdaSimplifierTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
             return new LambdaSimplifierCodeRefactoringProvider();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixAll1()
         {
             Test(
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixCoContravariance1()
         {
             Test(
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixCoContravariance2()
         {
             Test(
@@ -40,28 +40,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixCoContravariance3()
         {
             TestMissing(
 @"using System; class C { void Foo() { Bar(s [||]=> Quux(s)); } void Bar(Func<string, string> f); object Quux(object o); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixCoContravariance4()
         {
             TestMissing(
 @"using System; class C { void Foo() { Bar(s [||]=> Quux(s)); } void Bar(Func<object, object> f); string Quux(string o); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixCoContravariance5()
         {
             TestMissing(
 @"using System; class C { void Foo() { Bar(s [||]=> Quux(s)); } void Bar(Func<object, string> f); object Quux(string o); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixAll2()
         {
             Test(
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixAll3()
         {
             Test(
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixAll4()
         {
             Test(
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
                 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestFixOneOrAll()
         {
             Test(
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Lambda
         }
 
         [WorkItem(542562)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestMissingOnAmbiguity1()
         {
             TestMissing(
@@ -123,7 +123,7 @@ class A
         }
 
         [WorkItem(627092)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestMissingOnLambdaWithDynamic_1()
         {
             TestMissing(
@@ -158,7 +158,7 @@ class C<T>
         }
 
         [WorkItem(627092)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestMissingOnLambdaWithDynamic_2()
         {
             TestMissing(
@@ -198,7 +198,7 @@ class Casd<T>
         }
 
         [WorkItem(544625)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void ParenthesizeIfParseChanges()
         {
             var code = @"
@@ -237,7 +237,7 @@ class C
         }
 
         [WorkItem(545856)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestWarningOnSideEffects()
         {
             Test(
@@ -246,7 +246,7 @@ class C
         }
 
         [WorkItem(545994)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public void TestNonReturnBlockSyntax()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.MoveDe
             return new MoveDeclarationNearReferenceCodeRefactoringProvider();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMove1()
         {
             Test(
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.MoveDe
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMove2()
         {
             Test(
@@ -32,7 +32,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMove3()
         {
             Test(
@@ -41,7 +41,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMove4()
         {
             Test(
@@ -50,7 +50,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestAssign1()
         {
             Test(
@@ -59,7 +59,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestAssign2()
         {
             Test(
@@ -68,7 +68,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestAssign3()
         {
             Test(
@@ -77,7 +77,7 @@ index: 0);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMissing1()
         {
             TestMissing(
@@ -85,21 +85,21 @@ index: 0);
         }
 
         [WorkItem(538424)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMissingWhenReferencedInDeclaration()
         {
             TestMissing(
 @"class Program { static void Main ( ) { object [ ] [||]x = { x = null } ; x . ToString ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMissingWhenInDeclarationGroup()
         {
             TestMissing(
 @"class Program { static void Main ( ) { int [||]i = 5; int j = 10; Console.WriteLine(i); } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         [WorkItem(541475)]
         public void Regression8190()
         {
@@ -107,7 +107,7 @@ index: 0);
 @"class Program { void M() { { object x; [|object|] } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestFormatting()
         {
             Test(
@@ -131,7 +131,7 @@ index: 0,
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMissingInHiddenBlock1()
         {
             TestMissing(
@@ -148,7 +148,7 @@ compareTokens: false);
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestMissingInHiddenBlock2()
         {
             TestMissing(
@@ -166,7 +166,7 @@ compareTokens: false);
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestAvailableInNonHiddenBlock1()
         {
             Test(
@@ -197,7 +197,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestAvailableInNonHiddenBlock2()
         {
             Test(
@@ -231,7 +231,7 @@ compareTokens: false);
         }
 
         [WorkItem(545435)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestWarnOnChangingScopes1()
         {
             Test(
@@ -240,7 +240,7 @@ compareTokens: false);
         }
 
         [WorkItem(545435)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void TestWarnOnChangingScopes2()
         {
             Test(
@@ -249,7 +249,7 @@ compareTokens: false);
         }
 
         [WorkItem(545840)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void InsertCastIfNecessary1()
         {
             Test(
@@ -296,7 +296,7 @@ compareTokens: false);
         }
 
         [WorkItem(545835)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void InsertCastIfNecessary2()
         {
             Test(
@@ -339,7 +339,7 @@ compareTokens: false);
         }
 
         [WorkItem(546267)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
         public void MissingIfNotInDeclarationSpan()
         {
             TestMissing(

--- a/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewExceptionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewExceptionTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             }
         }
 
-        [WpfFact]
+        [Fact]
         public void TestExceptionInDisplayText()
         {
             using (var workspace = CreateWorkspaceFromFile("class D {}", null, null))

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
             });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestTypeFromMultipleNamespaces1()
         {
             Test(
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 @"using System.Collections; class Class { IDictionary Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestTypeFromMultipleNamespaces2()
         {
             Test(
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenericWithNoArgs()
         {
             Test(
@@ -64,7 +64,7 @@ index: 1);
 @"using System.Collections.Generic; class Class { List Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenericWithCorrectArgs()
         {
             Test(
@@ -72,14 +72,14 @@ index: 1);
 @"using System.Collections.Generic; class Class { List<int> Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenericWithWrongArgs()
         {
             TestMissing(
 @"class Class { [|List<int,string>|] Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenericInLocalDeclaration()
         {
             Test(
@@ -87,7 +87,7 @@ index: 1);
 @"using System.Collections.Generic; class Class { void Foo() { List<int> a = new List<int>(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenericItemType()
         {
             Test(
@@ -95,7 +95,7 @@ index: 1);
 @"using System; using System.Collections.Generic; class Class { List<Int32> l; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenerateWithExistingUsings()
         {
             Test(
@@ -103,7 +103,7 @@ index: 1);
 @"using System; using System.Collections.Generic; class Class { List<int> Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenerateInNamespace()
         {
             Test(
@@ -111,7 +111,7 @@ index: 1);
 @"using System.Collections.Generic; namespace N { class Class { List<int> Method() { Foo(); } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenerateInNamespaceWithUsings()
         {
             Test(
@@ -119,7 +119,7 @@ index: 1);
 @"namespace N { using System; using System.Collections.Generic; class Class { List<int> Method() { Foo(); } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestExistingUsing()
         {
             TestActionCount(
@@ -132,7 +132,7 @@ count: 1);
         }
 
         [WorkItem(541730)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForGenericExtensionMethod()
         {
             Test(
@@ -141,7 +141,7 @@ count: 1);
         }
 
         [WorkItem(541730)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForNormalExtensionMethod()
         {
             Test(
@@ -150,7 +150,7 @@ count: 1);
 parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestOnEnum()
         {
             Test(
@@ -158,7 +158,7 @@ parseOptions: Options.Regular);
 @"using A; class Class { void Foo() { var a = Colors.Red; } } namespace A { enum Colors {Red, Green, Blue} }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestOnClassInheritance()
         {
             Test(
@@ -166,7 +166,7 @@ parseOptions: Options.Regular);
 @"using A; class Class : Class2 { } namespace A { class Class2 { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestOnImplementedInterface()
         {
             Test(
@@ -174,7 +174,7 @@ parseOptions: Options.Regular);
 @"using A; class Class : IFoo { } namespace A { interface IFoo { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAllInBaseList()
         {
             Test(
@@ -186,7 +186,7 @@ parseOptions: Options.Regular);
 @"using A; using B; class Class : IFoo, Class2 { } namespace A { class Class2 { } } namespace B { interface IFoo { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAttributeUnexpanded()
         {
             Test(
@@ -194,7 +194,7 @@ parseOptions: Options.Regular);
 @"using System; [Obsolete]class Class { }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAttributeExpanded()
         {
             Test(
@@ -203,7 +203,7 @@ parseOptions: Options.Regular);
         }
 
         [WorkItem(538018)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAfterNew()
         {
             Test(
@@ -211,7 +211,7 @@ parseOptions: Options.Regular);
 @"using System.Collections.Generic; class Class { void Foo() { List<int> l; l = new List<int>(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestArgumentsInMethodCall()
         {
             Test(
@@ -219,7 +219,7 @@ parseOptions: Options.Regular);
 @"using System; class Class { void Test() { Console.WriteLine(DateTime.Today); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestCallSiteArgs()
         {
             Test(
@@ -227,7 +227,7 @@ parseOptions: Options.Regular);
 @"using System; class Class { void Test(DateTime dt) { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestUsePartialClass()
         {
             Test(
@@ -235,7 +235,7 @@ parseOptions: Options.Regular);
 @"using B; namespace A { public class Class { PClass c; } } namespace B{ public partial class PClass { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGenericClassInNestedNamespace()
         {
             Test(
@@ -244,7 +244,7 @@ parseOptions: Options.Regular);
         }
 
         [WorkItem(541730)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestExtensionMethods()
         {
             Test(
@@ -253,7 +253,7 @@ parseOptions: Options.Regular);
         }
 
         [WorkItem(541730)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestQueryPatterns()
         {
             Test(
@@ -262,7 +262,7 @@ parseOptions: Options.Regular);
         }
 
         // Tests for Insertion Order
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimplePresortedUsings1()
         {
             Test(
@@ -270,7 +270,7 @@ parseOptions: Options.Regular);
 @"using B; using C; using D; class Class { void Method() { Foo.Bar(); } } namespace D { class Foo { public static void Bar() { } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimplePresortedUsings2()
         {
             Test(
@@ -278,7 +278,7 @@ parseOptions: Options.Regular);
 @"using A; using B; using C; class Class { void Method() { Foo.Bar(); } } namespace A { class Foo { public static void Bar() { } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleUnsortedUsings1()
         {
             Test(
@@ -286,7 +286,7 @@ parseOptions: Options.Regular);
 @"using C; using B; using A; class Class { void Method() { Foo.Bar(); } } namespace A { class Foo { public static void Bar() { } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleUnsortedUsings2()
         {
             Test(
@@ -294,7 +294,7 @@ parseOptions: Options.Regular);
 @"using D; using B; using C; class Class { void Method() { Foo.Bar(); } } namespace C { class Foo { public static void Bar() { } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestMultiplePresortedUsings1()
         {
             Test(
@@ -302,7 +302,7 @@ parseOptions: Options.Regular);
 @"using B; using B.X; using B.Y; class Class { void Method() { Foo.Bar(); } } namespace B { class Foo { public static void Bar() { } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestMultiplePresortedUsings2()
         {
             Test(
@@ -310,7 +310,7 @@ parseOptions: Options.Regular);
 @"using B.A; using B.X; using B.Y; class Class { void Method() { Foo.Bar(); } } namespace B.A { class Foo { public static void Bar() { } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestMultiplePresortedUsings3()
         {
             Test(
@@ -318,7 +318,7 @@ parseOptions: Options.Regular);
 @"using B.A; using B.X; using B.Y; class Class { void Method() { Foo.Bar(); } } namespace B { namespace A { class Foo { public static void Bar() { } } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestMultipleUnsortedUsings1()
         {
             Test(
@@ -326,7 +326,7 @@ parseOptions: Options.Regular);
 @"using B.Y; using B.X; using B.A; class Class { void Method() { Foo.Bar(); } } namespace B { namespace A { class Foo { public static void Bar() { } } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestMultipleUnsortedUsings2()
         {
             Test(
@@ -335,7 +335,7 @@ parseOptions: Options.Regular);
         }
 
         // System on top cases
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemSortedUsings1()
         {
             Test(
@@ -344,7 +344,7 @@ parseOptions: Options.Regular);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemSortedUsings2()
         {
             Test(
@@ -353,7 +353,7 @@ systemSpecialCase: true);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemSortedUsings3()
         {
             Test(
@@ -362,7 +362,7 @@ systemSpecialCase: true);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemUnsortedUsings1()
         {
             Test(
@@ -371,7 +371,7 @@ systemSpecialCase: true);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemUnsortedUsings2()
         {
             Test(
@@ -380,7 +380,7 @@ systemSpecialCase: true);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemUnsortedUsings3()
         {
             Test(
@@ -389,7 +389,7 @@ systemSpecialCase: true);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleBogusSystemUsings1()
         {
             Test(
@@ -398,7 +398,7 @@ systemSpecialCase: true);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleBogusSystemUsings2()
         {
             Test(
@@ -407,7 +407,7 @@ systemSpecialCase: true);
 systemSpecialCase: true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestUsingsWithComments()
         {
             Test(
@@ -417,7 +417,7 @@ systemSpecialCase: true);
         }
 
         // System Not on top cases
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemUnsortedUsings4()
         {
             Test(
@@ -426,7 +426,7 @@ systemSpecialCase: true);
 systemSpecialCase: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemSortedUsings5()
         {
             Test(
@@ -435,7 +435,7 @@ systemSpecialCase: false);
 systemSpecialCase: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleSystemSortedUsings4()
         {
             Test(
@@ -446,7 +446,7 @@ systemSpecialCase: false);
 
         [WorkItem(538136)]
         [WorkItem(538763)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForNamespace()
         {
             TestMissing(
@@ -454,7 +454,7 @@ systemSpecialCase: false);
         }
 
         [WorkItem(538220)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForFieldWithFormatting()
         {
             Test(
@@ -466,7 +466,7 @@ compareTokens: false);
         }
 
         [WorkItem(539657)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void BugFix5688()
         {
             Test(
@@ -475,7 +475,7 @@ compareTokens: false);
         }
 
         [WorkItem(539853)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void BugFix5950()
         {
             Test(
@@ -485,7 +485,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(540339)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddAfterDefineDirective1()
         {
             Test(
@@ -518,7 +518,7 @@ compareTokens: false);
         }
 
         [WorkItem(540339)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddAfterDefineDirective2()
         {
             Test(
@@ -545,7 +545,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddAfterDefineDirective3()
         {
             Test(
@@ -573,7 +573,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddAfterDefineDirective4()
         {
             Test(
@@ -602,7 +602,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddAfterExistingBanner()
         {
             Test(
@@ -631,7 +631,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddAfterExternAlias1()
         {
             Test(
@@ -662,7 +662,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddAfterExternAlias2()
         {
             Test(
@@ -696,7 +696,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestWithReferenceDirective()
         {
             var resolver = new TestMetadataReferenceResolver(assemblyNames: new Dictionary<string, PortableExecutableReference>()
@@ -717,7 +717,7 @@ compareTokens: false);
         }
 
         [WorkItem(542643)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAssemblyAttribute()
         {
             Test(
@@ -725,7 +725,7 @@ compareTokens: false);
 @"using System . Runtime . CompilerServices ; [ assembly : InternalsVisibleTo ( ""Project"" ) ] ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestDoNotAddIntoHiddenRegion()
         {
             TestMissing(
@@ -742,7 +742,7 @@ class Program
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddToVisibleRegion()
         {
             Test(
@@ -779,7 +779,7 @@ compareTokens: false);
         }
 
         [WorkItem(545248)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestVenusGeneration1()
         {
             TestMissing(
@@ -797,7 +797,7 @@ class C
         }
 
         [WorkItem(545774)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAttribute()
         {
             var input = @"[ assembly : [|Guid|] ( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ";
@@ -809,7 +809,7 @@ input,
         }
 
         [WorkItem(546833)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestNotOnOverloadResolutionError()
         {
             TestMissing(
@@ -817,7 +817,7 @@ input,
         }
 
         [WorkItem(17020, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForGenericArgument()
         {
             Test(
@@ -826,7 +826,7 @@ input,
         }
 
         [WorkItem(775448)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void ShouldTriggerOnCS0308()
         {
             // CS0308: The non-generic type 'A' cannot be used with type arguments
@@ -853,7 +853,7 @@ class Test
         }
 
         [WorkItem(838253)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestConflictedInaccessibleType()
         {
             Test(
@@ -863,7 +863,7 @@ systemSpecialCase: true);
         }
 
         [WorkItem(858085)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestConflictedAttributeName()
         {
             Test(
@@ -872,7 +872,7 @@ systemSpecialCase: true);
         }
 
         [WorkItem(872908)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestConflictedGenericName()
         {
             Test(
@@ -882,7 +882,7 @@ systemSpecialCase: true);
 
         [WorkItem(860648)]
         [WorkItem(902014)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestIncompleteSimpleLambdaExpression()
         {
             Test(
@@ -911,7 +911,7 @@ class Program
 
         [WorkItem(860648)]
         [WorkItem(902014)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestIncompleteParenthesizedLambdaExpression()
         {
             Test(
@@ -939,7 +939,7 @@ class Test
         }
 
         [WorkItem(913300)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestNoDuplicateReport()
         {
             TestActionCountInAllFixes(
@@ -961,7 +961,7 @@ class Test
         }
 
         [WorkItem(938296)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestNullParentInNode()
         {
             TestMissing(
@@ -977,14 +977,14 @@ class MultiDictionary<K, V> : Dictionary<K, HashSet<V>>
         }
 
         [WorkItem(968303)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestMalformedUsingSection()
         {
             TestMissing("[ class Class { [|List<|] }");
         }
 
         [WorkItem(875899)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingsWithExternAlias()
         {
             const string InitialWorkspace = @"
@@ -1034,7 +1034,7 @@ namespace ExternAliases
         }
 
         [WorkItem(875899)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingsWithPreExistingExternAlias()
         {
             const string InitialWorkspace = @"
@@ -1096,7 +1096,7 @@ namespace ExternAliases
         }
 
         [WorkItem(875899)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingsNoExtern()
         {
             const string InitialWorkspace = @"
@@ -1146,7 +1146,7 @@ namespace ExternAliases
         }
 
         [WorkItem(875899)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingsNoExternFilterGlobalAlias()
         {
             Test(
@@ -1169,7 +1169,7 @@ class Program
         }
 
         [WorkItem(916368)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForCref()
         {
             var initialText =
@@ -1191,7 +1191,7 @@ interface MyNotifyPropertyChanged { }";
         }
 
         [WorkItem(916368)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForCref2()
         {
             var initialText =
@@ -1213,7 +1213,7 @@ interface MyNotifyPropertyChanged { }";
         }
 
         [WorkItem(916368)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForCref3()
         {
             var initialText =
@@ -1262,7 +1262,7 @@ public class MyClass2
         }
 
         [WorkItem(916368)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForCref4()
         {
             var initialText =
@@ -1301,7 +1301,7 @@ public class MyClass
         }
 
         [WorkItem(773614)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddStaticType()
         {
             var initialText =
@@ -1341,7 +1341,7 @@ class Test
         }
 
         [WorkItem(773614)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddStaticType2()
         {
             var initialText =
@@ -1385,7 +1385,7 @@ class Test
         }
 
         [WorkItem(773614)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddStaticType3()
         {
             var initialText =
@@ -1409,7 +1409,7 @@ class Test
         }
 
         [WorkItem(773614)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddStaticType4()
         {
             var initialText =
@@ -1455,7 +1455,7 @@ class Test
         }
 
         [WorkItem(991463)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideUsingDirective1()
         {
             Test(
@@ -1464,7 +1464,7 @@ class Test
         }
 
         [WorkItem(991463)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideUsingDirective2()
         {
             Test(
@@ -1473,7 +1473,7 @@ class Test
         }
 
         [WorkItem(991463)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideUsingDirective3()
         {
             Test(
@@ -1482,7 +1482,7 @@ class Test
         }
 
         [WorkItem(991463)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideUsingDirective4()
         {
             Test(
@@ -1491,7 +1491,7 @@ class Test
         }
 
         [WorkItem(991463)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideUsingDirective5()
         {
             Test(
@@ -1500,7 +1500,7 @@ class Test
         }
 
         [WorkItem(991463)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideUsingDirective6()
         {
             TestMissing(
@@ -1508,7 +1508,7 @@ class Test
         }
 
         [WorkItem(1033612)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideLambda()
         {
             var initialText =
@@ -1531,7 +1531,7 @@ static void Main(string[] args)
         }
 
         [WorkItem(1033612)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideLambda2()
         {
             var initialText =
@@ -1554,7 +1554,7 @@ static void Main(string[] args)
         }
 
         [WorkItem(1033612)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideLambda3()
         {
             var initialText =
@@ -1585,7 +1585,7 @@ static void Main(string[] args)
         }
 
         [WorkItem(1033612)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddInsideLambda4()
         {
             var initialText =
@@ -1616,7 +1616,7 @@ static void Main(string[] args)
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddConditionalAccessExpression()
         {
             var initialText =
@@ -1656,7 +1656,7 @@ public class C
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddConditionalAccessExpression2()
         {
             var initialText =
@@ -1708,7 +1708,7 @@ public class C
         }
 
         [WorkItem(1089138)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAmbiguousUsingName()
         {
             Test(
@@ -1716,7 +1716,7 @@ public class C
 @"namespace ClassLibrary1 { using System ; using global::SubNamespaceName ; public class SomeTypeUser { SomeType field ; } } namespace SubNamespaceName { using System ; class SomeType { } } namespace ClassLibrary1 . SubNamespaceName { using System ; class SomeOtherFile { } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingInDirective()
         {
             Test(
@@ -1741,7 +1741,7 @@ using System.IO;
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingInDirective2()
         {
             Test(
@@ -1766,7 +1766,7 @@ using System.Text;
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingInDirective3()
         {
             Test(
@@ -1792,7 +1792,7 @@ using System.IO;
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingInDirective4()
         {
             Test(
@@ -1818,7 +1818,7 @@ using System.IO;
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestInaccessibleExtensionMethod()
         {
             const string initial = @"
@@ -1847,7 +1847,7 @@ namespace N2
         }
 
         [WorkItem(1116011)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForProperty()
         {
             Test(
@@ -1856,7 +1856,7 @@ namespace N2
         }
 
         [WorkItem(1116011)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForField()
         {
             Test(
@@ -1865,7 +1865,7 @@ namespace N2
         }
 
         [WorkItem(1893, "https://github.com/dotnet/roslyn/issues/1893")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestNameSimplification()
         {
             // Generated using directive must be simplified from "using A.B;" to "using B;" below.
@@ -1908,7 +1908,7 @@ namespace A.C
         }
 
         [WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingWithOtherExtensionsInScope()
         {
             Test(
@@ -1917,7 +1917,7 @@ namespace A.C
         }
 
         [WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingWithOtherExtensionsInScope2()
         {
             Test(
@@ -1926,7 +1926,7 @@ namespace A.C
         }
 
         [WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingWithOtherExtensionsInScope3()
         {
             Test(
@@ -1935,7 +1935,7 @@ namespace A.C
         }
 
         [WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingWithOtherExtensionsInScope4()
         {
             Test(
@@ -2094,7 +2094,7 @@ namespace A.C
             }
 
             [WorkItem(752640)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestUnknownIdentifierWithSyntaxError()
             {
                 Test(
@@ -2103,7 +2103,7 @@ namespace A.C
             }
 
             [WorkItem(829970)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
             {
                 Test(
@@ -2112,7 +2112,7 @@ namespace A.C
             }
 
             [WorkItem(829970)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestUnknownIdentifierGenericName()
             {
                 Test(
@@ -2121,7 +2121,7 @@ namespace A.C
             }
 
             [WorkItem(855748)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestGenericNameWithBrackets()
             {
                 Test(
@@ -2138,7 +2138,7 @@ namespace A.C
             }
 
             [WorkItem(867496)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestMalformedGenericParameters()
             {
                 Test(
@@ -2150,7 +2150,7 @@ namespace A.C
     @"using System.Collections.Generic; class Class { List<Y x; }");
             }
 
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestOutsideOfMethodWithMalformedGenericParameters()
             {
                 Test(
@@ -2159,7 +2159,7 @@ namespace A.C
             }
 
             [WorkItem(1744, @"https://github.com/dotnet/roslyn/issues/1744")]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestIncompleteCatchBlockInLambda()
             {
                 Test(
@@ -2168,7 +2168,7 @@ namespace A.C
             }
 
             [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestIncompleteLambda1()
             {
                 Test(
@@ -2177,7 +2177,7 @@ namespace A.C
             }
 
             [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
             public void TestIncompleteLambda2()
             {
                 Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_ExtensionMethods.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_ExtensionMethods.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 {
     public partial class AddUsingTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestWhereExtension()
         {
             Test(
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 @"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main ( string [ ] args ) { var q = args . Where } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSelectExtension()
         {
             Test(
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 @"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main ( string [ ] args ) { var q = args . Select } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestGroupByExtension()
         {
             Test(
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 @"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main ( string [ ] args ) { var q = args . GroupBy } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestJoinExtension()
         {
             Test(
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 @"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main ( string [ ] args ) { var q = args . Join } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void RegressionFor8455()
         {
             TestMissing(
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
         }
 
         [WorkItem(772321)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestExtensionWithThePresenceOfTheSameNameNonExtensionMethod()
         {
             Test(
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 
         [WorkItem(772321)]
         [WorkItem(920398)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestExtensionWithThePresenceOfTheSameNameNonExtensionPrivateMethod()
         {
             Test(
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 
         [WorkItem(772321)]
         [WorkItem(920398)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestExtensionWithThePresenceOfTheSameNameExtensionPrivateMethod()
         {
             Test(
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod()
         {
             Test(
@@ -88,7 +88,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod2()
         {
             Test(
@@ -98,7 +98,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod3()
         {
             Test(
@@ -108,7 +108,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod4()
         {
             Test(
@@ -118,7 +118,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod5()
         {
             Test(
@@ -128,7 +128,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod6()
         {
             Test(
@@ -138,7 +138,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod7()
         {
             Test(
@@ -148,7 +148,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod8()
         {
             Test(
@@ -158,7 +158,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod9()
         {
             Test(
@@ -168,7 +168,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod10()
         {
             Test(
@@ -178,7 +178,7 @@ parseOptions: null);
         }
 
         [WorkItem(269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestAddUsingForAddExtentionMethod11()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_Queries.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_Queries.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 {
     public partial class AddUsingTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleQuery()
         {
             Test(
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 @"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main ( string [ ] args ) { var q = from x in args select x} } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public void TestSimpleWhere()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAsyncTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAsyncTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Async
 {
     public partial class AddAsyncTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AwaitInVoidMethodWithModifiers()
         {
             var initial =
@@ -40,7 +40,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AwaitInTaskMethodNoModifiers()
         {
             var initial =
@@ -69,7 +69,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AwaitInTaskMethodWithModifiers()
         {
             var initial =
@@ -98,7 +98,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AwaitInLambdaFunction()
         {
             var initial =
@@ -129,7 +129,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AwaitInLambdaAction()
         {
             var initial =
@@ -158,7 +158,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod()
         {
             var initial =
@@ -183,7 +183,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod2()
         {
             var initial =
@@ -208,7 +208,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod3()
         {
             var initial =
@@ -233,7 +233,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod4()
         {
             var initial =
@@ -258,7 +258,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod5()
         {
             var initial =
@@ -281,7 +281,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod6()
         {
             var initial =
@@ -304,7 +304,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod7()
         {
             var initial =
@@ -327,7 +327,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod8()
         {
             var initial =
@@ -350,7 +350,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod9()
         {
             var initial =
@@ -373,7 +373,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void BadAwaitInNonAsyncMethod10()
         {
             var initial =
@@ -396,7 +396,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AwaitInMember()
         {
             var code =
@@ -409,7 +409,7 @@ class Program
             TestMissing(code);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AddAsyncInDelegate()
         {
             Test(
@@ -417,7 +417,7 @@ class Program
 @"using System ; using System . Threading . Tasks ; class Program { private async void method ( ) { string content = await Task < String > . Run ( async delegate ( ) { await Task . Delay ( 1000 ) ; return ""Test"" ; } ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AddAsyncInDelegate2()
         {
             Test(
@@ -425,7 +425,7 @@ class Program
 @"using System ; using System . Threading . Tasks ; class Program { private void method ( ) { string content = await Task < String > . Run ( async delegate ( ) { await Task . Delay ( 1000 ) ; return ""Test"" ; } ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void AddAsyncInDelegate3()
         {
             Test(
@@ -434,7 +434,7 @@ class Program
         }
 
         [WorkItem(6477, @"https://github.com/dotnet/roslyn/issues/6477")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)]
         public void NullNodeCrash()
         {
             TestMissing(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Async
 {
     public partial class AddAwaitTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand1()
         {
             var initial =
@@ -50,7 +50,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand_WithLeadingTrivia1()
         {
             var initial =
@@ -93,7 +93,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand_ConditionalExpressionWithTrailingTrivia_SingleLine()
         {
             var initial =
@@ -126,7 +126,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand_ConditionalExpressionWithTrailingTrivia_Multiline()
         {
             var initial =
@@ -163,7 +163,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand_NullCoalescingExpressionWithTrailingTrivia_SingleLine()
         {
             var initial =
@@ -196,7 +196,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand_NullCoalescingExpressionWithTrailingTrivia_Multiline()
         {
             var initial =
@@ -233,7 +233,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand_AsExpressionWithTrailingTrivia_SingleLine()
         {
             var initial =
@@ -262,7 +262,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void BadAsyncReturnOperand_AsExpressionWithTrailingTrivia_Multiline()
         {
             var initial =
@@ -299,7 +299,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TaskNotAwaited()
         {
             var initial =
@@ -326,7 +326,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TaskNotAwaited_WithLeadingTrivia()
         {
             var initial =
@@ -357,7 +357,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void FunctionNotAwaited()
         {
             var initial =
@@ -394,7 +394,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void FunctionNotAwaited_WithLeadingTrivia()
         {
             var initial =
@@ -435,7 +435,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void FunctionNotAwaited_WithLeadingTrivia1()
         {
             var initial =
@@ -476,7 +476,7 @@ class Program
             Test(initial, expected, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression()
         {
             Test(
@@ -484,7 +484,7 @@ class Program
 @"using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { int myInt = await MyIntMethodAsync ( ) ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpressionWithConversion()
         {
             Test(
@@ -492,14 +492,14 @@ class Program
 @"using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { long myInt = await MyIntMethodAsync ( ) ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpressionWithConversionInNonAsyncFunction()
         {
             TestMissing(
 @"using System . Threading . Tasks ; class TestClass { private Task MyTestMethod1Async ( ) { long myInt = [|MyIntMethodAsync ( )|] ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpressionWithConversionInAsyncFunction()
         {
             Test(
@@ -507,7 +507,7 @@ class Program
 @"using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { long myInt = await MyIntMethodAsync ( ) ; } private Task < object > MyIntMethodAsync ( ) { return Task . FromResult ( new object ( ) ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression1()
         {
             Test(
@@ -515,7 +515,7 @@ class Program
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Action lambda = async ( ) => { int myInt = await MyIntMethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression2()
         {
             Test(
@@ -523,21 +523,21 @@ class Program
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Func < Task > lambda = async ( ) => { int myInt = await MyIntMethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression3()
         {
             TestMissing(
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Func < Task > lambda = ( ) => { int myInt = MyInt [||] MethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression4()
         {
             TestMissing(
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Action lambda = ( ) => { int myInt = MyIntM [||] ethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression5()
         {
             Test(
@@ -545,7 +545,7 @@ class Program
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Action @delegate = async delegate { int myInt = await MyIntMethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression6()
         {
             Test(
@@ -553,21 +553,21 @@ class Program
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Func < Task > @delegate = async delegate { int myInt = await MyIntMethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression7()
         {
             TestMissing(
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Action @delegate = delegate { int myInt = MyInt [||] MethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAssignmentExpression8()
         {
             TestMissing(
 @"using System ; using System . Threading . Tasks ; class TestClass { private async Task MyTestMethod1Async ( ) { Func < Task > @delegate = delegate { int myInt = MyIntM [||] ethodAsync ( ) ; } ; } private Task < int > MyIntMethodAsync ( ) { return Task . FromResult ( result : 1 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestTernaryOperator()
         {
             Test(
@@ -575,7 +575,7 @@ class Program
 @"using System ; using System . Threading . Tasks ; class Program { async Task < int > A ( ) { return await ( true ? Task . FromResult ( 0 ) : Task . FromResult ( 1 ) ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestNullCoalescingOperator()
         {
             Test(
@@ -583,7 +583,7 @@ class Program
 @"using System ; using System . Threading . Tasks ; class Program { async Task < int > A ( ) { return await ( null ?? Task . FromResult ( 1 ) ) } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)]
         public void TestAsExpression()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/ChangeToAsyncTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/ChangeToAsyncTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Async
 {
     public partial class ChangeToAsyncTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToAsync)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToAsync)]
         public void CantAwaitAsyncVoid()
         {
             var initial =

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UserDiagnos
 {
     public class DiagnosticAnalyzerDriverTests
     {
-        [WpfFact]
+        [Fact]
         public void DiagnosticAnalyzerDriverAllInOne()
         {
             var source = TestResource.AllInOneCSharpCode;
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UserDiagnos
             }
         }
 
-        [WpfFact, WorkItem(908658)]
+        [Fact, WorkItem(908658)]
         public void DiagnosticAnalyzerDriverVsAnalyzerDriverOnCodeBlock()
         {
             var methodNames = new string[] { "Initialize", "AnalyzeCodeBlock" };
@@ -84,7 +84,7 @@ class C
             }
         }
 
-        [WpfFact]
+        [Fact]
         [WorkItem(759)]
         public void DiagnosticAnalyzerDriverIsSafeAgainstAnalyzerExceptions()
         {
@@ -98,7 +98,7 @@ class C
         }
 
         [WorkItem(908621)]
-        [WpfFact]
+        [Fact]
         public void DiagnosticServiceIsSafeAgainstAnalyzerExceptions_1()
         {
             var analyzer = new ThrowingDiagnosticAnalyzer<SyntaxKind>();
@@ -107,7 +107,7 @@ class C
         }
 
         [WorkItem(908621)]
-        [WpfFact]
+        [Fact]
         public void DiagnosticServiceIsSafeAgainstAnalyzerExceptions_2()
         {
             var analyzer = new ThrowingDoNotCatchDiagnosticAnalyzer<SyntaxKind>();
@@ -125,7 +125,7 @@ class C
             Assert.True(exceptions.Count == 0);
         }
 
-        [WpfFact]
+        [Fact]
         public void AnalyzerOptionsArePassedToAllAnalyzers()
         {
             using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(TestResource.AllInOneCSharpCode, TestOptions.Regular))
@@ -160,7 +160,7 @@ class C
             }
         }
 
-        [WpfFact]
+        [Fact]
         public void AnalyzerCreatedAtCompilationLevelNeedNotBeCompilationAnalyzer()
         {
             var source = @"x";
@@ -211,7 +211,7 @@ class C
             }
         }
 
-        [WpfFact]
+        [Fact]
         public void CodeBlockAnalyzersOnlyAnalyzeExecutableCode()
         {
             var source = @"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FixAllProvider/BatchFixerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FixAllProvider/BatchFixerTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.SimplifyTyp
 
         #region "Fix all occurrences tests"
 
-        [WpfFact, WorkItem(320)]
+        [Fact, WorkItem(320)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInDocument_QualifyWithThis()
         {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FullyQualif
             return Tuple.Create<DiagnosticAnalyzer, CodeFixProvider>(null, new CSharpFullyQualifyCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestTypeFromMultipleNamespaces1()
         {
             Test(
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FullyQualif
 @"class Class { System.Collections.IDictionary Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestTypeFromMultipleNamespaces2()
         {
             Test(
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FullyQualif
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericWithNoArgs()
         {
             Test(
@@ -41,7 +41,7 @@ index: 1);
 @"class Class { System.Collections.Generic.List Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericWithCorrectArgs()
         {
             Test(
@@ -49,7 +49,7 @@ index: 1);
 @"class Class { System.Collections.Generic.List<int> Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestSmartTagDisplayText()
         {
             TestSmartTagText(
@@ -57,14 +57,14 @@ index: 1);
 "System.Collections.Generic.List");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericWithWrongArgs()
         {
             TestMissing(
 @"class Class { [|List<int,string>|] Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericInLocalDeclaration()
         {
             Test(
@@ -72,7 +72,7 @@ index: 1);
 @"class Class { void Foo() { System.Collections.Generic.List<int> a = new List<int>(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericItemType()
         {
             Test(
@@ -80,7 +80,7 @@ index: 1);
 @"using System.Collections.Generic; class Class { List<System.Int32> l; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenerateWithExistingUsings()
         {
             Test(
@@ -88,7 +88,7 @@ index: 1);
 @"using System; class Class { System.Collections.Generic.List<int> Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenerateInNamespace()
         {
             Test(
@@ -96,7 +96,7 @@ index: 1);
 @"namespace N { class Class { System.Collections.Generic.List<int> Method() { Foo(); } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenerateInNamespaceWithUsings()
         {
             Test(
@@ -104,7 +104,7 @@ index: 1);
 @"namespace N { using System; class Class { System.Collections.Generic.List<int> Method() { Foo(); } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestExistingUsing()
         {
             TestActionCount(
@@ -116,21 +116,21 @@ count: 2);
 @"using System.Collections.Generic; class Class { System.Collections.IDictionary Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestMissingIfUniquelyBound()
         {
             TestMissing(
 @"using System; class Class { [|String|] Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestMissingIfUniquelyBoundGeneric()
         {
             TestMissing(
 @"using System.Collections.Generic; class Class { [|List<int>|] Method() { Foo(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestOnEnum()
         {
             Test(
@@ -138,7 +138,7 @@ count: 2);
 @"class Class { void Foo() { var a = A.Colors.Red; } } namespace A { enum Colors {Red, Green, Blue} }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestOnClassInheritance()
         {
             Test(
@@ -146,7 +146,7 @@ count: 2);
 @"class Class : A.Class2 { } namespace A { class Class2 { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestOnImplementedInterface()
         {
             Test(
@@ -154,7 +154,7 @@ count: 2);
 @"class Class : A.IFoo { } namespace A { interface IFoo { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestAllInBaseList()
         {
             Test(
@@ -166,7 +166,7 @@ count: 2);
 @"class Class : B.IFoo, A.Class2 { } namespace A { class Class2 { } } namespace B { interface IFoo { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestAttributeUnexpanded()
         {
             Test(
@@ -174,7 +174,7 @@ count: 2);
 @"[System.Obsolete]class Class { }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestAttributeExpanded()
         {
             Test(
@@ -183,7 +183,7 @@ count: 2);
         }
 
         [WorkItem(527360)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestExtensionMethods()
         {
             TestMissing(
@@ -191,7 +191,7 @@ count: 2);
         }
 
         [WorkItem(538018)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestAfterNew()
         {
             Test(
@@ -199,7 +199,7 @@ count: 2);
 @"class Class { void Foo() { List<int> l; l = new System.Collections.Generic.List<int>(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestArgumentsInMethodCall()
         {
             Test(
@@ -207,7 +207,7 @@ count: 2);
 @"class Class { void Test() { Console.WriteLine(System.DateTime.Today); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestCallSiteArgs()
         {
             Test(
@@ -215,7 +215,7 @@ count: 2);
 @"class Class { void Test(System.DateTime dt) { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestUsePartialClass()
         {
             Test(
@@ -223,7 +223,7 @@ count: 2);
 @"namespace A { public class Class { B.PClass c; } } namespace B{ public partial class PClass { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericClassInNestedNamespace()
         {
             Test(
@@ -231,7 +231,7 @@ count: 2);
 @"namespace A { namespace B { class GenericClass<T> { } } } namespace C { class Class { A.B.GenericClass<int> c; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestBeforeStaticMethod()
         {
             Test(
@@ -240,7 +240,7 @@ count: 2);
         }
 
         [WorkItem(538136)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestBeforeNamespace()
         {
             Test(
@@ -249,7 +249,7 @@ count: 2);
         }
 
         [WorkItem(527395)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestSimpleNameWithLeadingTrivia()
         {
             Test(
@@ -259,7 +259,7 @@ compareTokens: false);
         }
 
         [WorkItem(527395)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGenericNameWithLeadingTrivia()
         {
             Test(
@@ -269,7 +269,7 @@ compareTokens: false);
         }
 
         [WorkItem(538740)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestFullyQualifyTypeName()
         {
             Test(
@@ -278,7 +278,7 @@ compareTokens: false);
         }
 
         [WorkItem(538740)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestFullyQualifyTypeName_NotForGenericType()
         {
             TestMissing(
@@ -286,7 +286,7 @@ compareTokens: false);
         }
 
         [WorkItem(538764)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestFullyQualifyThroughAlias()
         {
             Test(
@@ -295,7 +295,7 @@ compareTokens: false);
         }
 
         [WorkItem(538763)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestFullyQualifyPrioritizeTypesOverNamespaces1()
         {
             Test(
@@ -304,7 +304,7 @@ compareTokens: false);
         }
 
         [WorkItem(538763)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestFullyQualifyPrioritizeTypesOverNamespaces2()
         {
             Test(
@@ -314,7 +314,7 @@ index: 1);
         }
 
         [WorkItem(539853)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void BugFix5950()
         {
             Test(
@@ -324,7 +324,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(540318)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestAfterAlias()
         {
             TestMissing(
@@ -332,7 +332,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(540942)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestMissingOnIncompleteStatement()
         {
             TestMissing(
@@ -340,7 +340,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(542643)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestAssemblyAttribute()
         {
             Test(
@@ -349,14 +349,14 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(543388)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestMissingOnAliasName()
         {
             TestMissing(
 @"using [|GIBBERISH|] = Foo . GIBBERISH ; class Program { static void Main ( string [ ] args ) { GIBBERISH x ; } } namespace Foo { public class GIBBERISH { } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestMissingOnAttributeOverloadResolutionError()
         {
             TestMissing(
@@ -364,7 +364,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(544950)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestNotOnAbstractConstructor()
         {
             TestMissing(
@@ -372,7 +372,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(545774)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestAttribute()
         {
             var input = @"[ assembly : [|Guid|] ( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ";
@@ -384,7 +384,7 @@ input,
         }
 
         [WorkItem(546027)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void TestGeneratePropertyFromAttribute()
         {
             TestMissing(
@@ -392,7 +392,7 @@ input,
         }
 
         [WorkItem(775448)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void ShouldTriggerOnCS0308()
         {
             // CS0308: The non-generic type 'A' cannot be used with type arguments
@@ -418,7 +418,7 @@ class Test
         }
 
         [WorkItem(947579)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void AmbiguousTypeFix()
         {
             Test(
@@ -439,7 +439,7 @@ namespace n2 { class A { }}");
         }
 
         [WorkItem(995857)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
         public void NonPublicNamespaces()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
                 null, new GenerateConstructorCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithSimpleArgument()
         {
             Test(
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { private int v; public C(int v) { this.v = v; } void M() { new C(1); } }");
         }
 
-        [WpfFact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithNoArgs()
         {
             Test(
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { public C() { } public C(int v) { } void M() { new C(); } }");
         }
 
-        [WpfFact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithNamedArg()
         {
             Test(
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { private int foo; public C(int foo) { this.foo = foo; } void M() { new C(foo: 1); } }");
         }
 
-        [WpfFact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField1()
         {
             Test(
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { void M() { new D(foo: 1); } } class D { private int foo; public D(int foo) { this.foo = foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField2()
         {
             Test(
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { void M() { new D(1); } } class D { private string v; private int v1; public D(int v1) { this.v1 = v1; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField3()
         {
             Test(
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { void M() { new D(1); } } class B { protected int v; } class D : B { public D(int v) { this.v = v; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField4()
         {
             Test(
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField5()
         {
             Test(
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField5WithQualification()
         {
             Test(
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField6()
         {
             Test(
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField7()
         {
             Test(
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField7WithQualification()
         {
             Test(
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField8()
         {
             Test(
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingField9()
         {
             Test(
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty1()
         {
             Test(
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty1WithQualification()
         {
             Test(
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty2()
         {
             Test(
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty3()
         {
             Test(
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty3WithQualification()
         {
             Test(
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty4()
         {
             Test(
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty4WithQualification()
         {
             Test(
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539444)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithExistingProperty5()
         {
             Test(
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { void M(int X) { new D(X); } } class B { protected int X { get; } } class D : B { private int x; public D(int x) { this.x = x; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithOutParam()
         {
             Test(
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { void M(int i) { new D(out i); } } class D { public D(out int i) { i = 0; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithBaseDelegatingConstructor1()
         {
             Test(
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { void M() { new D(1); } } class B { protected B(int x) { } } class D : B { public D(int x) : base(x) { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestWithBaseDelegatingConstructor2()
         {
             Test(
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class C { void M() { new D(1); } } class B { private B(int x) { } } class D : B { private int v; public D(int v) { this.v = v; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestStructInLocalInitializerWithSystemType()
         {
             Test(
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestEscapedName()
         {
             Test(
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestEscapedKeyword()
         {
             Test(
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
 @"class @int { private int v; public @int(int v) { this.v = v; } void M() { new @int(1); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestIsSymbolAccessibleWithInternalField()
         {
             Test(
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
         }
 
         [WorkItem(539548)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestFormatting()
         {
             Test(
@@ -305,7 +305,7 @@ compareTokens: false);
         }
 
         [WorkItem(5864, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestNotOnStructConstructor()
         {
             TestMissing(
@@ -313,7 +313,7 @@ compareTokens: false);
         }
 
         [WorkItem(539787)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateIntoCorrectPart()
         {
             Test(
@@ -321,7 +321,7 @@ compareTokens: false);
 @"partial class C { } partial class C { private string v ; public C ( string v ) { this . v = v ; } void Method ( ) { C c = new C ( ""a"" ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestDelegateToSmallerConstructor1()
         {
             Test(
@@ -329,7 +329,7 @@ compareTokens: false);
 @"class A { void M ( ) { Delta d1 = new Delta ( ""ss"" , 3 ) ; Delta d2 = new Delta ( ""ss"" , 5 , true ) ; } } class Delta { private bool v ; private string v1 ; private int v2 ; public Delta ( string v1 , int v2 ) { this . v1 = v1 ; this . v2 = v2 ; } public Delta ( string v1 , int v2 , bool v ) : this ( v1 , v2 ) { this . v = v ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestDelegateToSmallerConstructor2()
         {
             Test(
@@ -337,7 +337,7 @@ compareTokens: false);
 @"class A { void M ( ) { Delta d1 = new Delta ( ""ss"" , 3 ) ; Delta d2 = new Delta ( ""ss"" , 5 , true ) ; } } class Delta { private string a ; private int b ; private bool v ; public Delta ( string a , int b ) { this . a = a ; this . b = b ; } public Delta ( string a , int b , bool v) : this ( a , b ) { this . v = v ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestDelegateToSmallerConstructor3()
         {
             Test(
@@ -345,7 +345,7 @@ compareTokens: false);
 @"class A { void M ( ) { var d1 = new Base ( ""ss"" , 3 ) ; var d2 = new Delta ( ""ss"" , 5 , true ) ; } } class Base { private string v1 ; private int v2 ; public Base ( string v1 , int v2 ) { this . v1 = v1 ; this . v2 = v2 ; } } class Delta : Base { private bool v ; public Delta ( string v1 , int v2 , bool v ) : base ( v1 , v2 ) { this . v = v ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestDelegateToSmallerConstructor4()
         {
             Test(
@@ -353,7 +353,7 @@ compareTokens: false);
 @"class A { void M ( ) { Delta d1 = new Delta ( ""ss"" , 3 ) ; Delta d2 = new Delta ( ""ss"" , 5 , true ) ; } } class Delta { private bool v ; private string v1 ; private int v2 ;  public Delta ( string v1 , int v2 ) { this . v1 = v1 ; this . v2 = v2 ; } public Delta ( string v1 , int v2 , bool v ) : this ( v1 , v2 ) { this . v = v ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateFromThisInitializer1()
         {
             Test(
@@ -361,7 +361,7 @@ compareTokens: false);
 @"class C { private int v ; public C ( ) : this ( 4 ) { } public C ( int v ) { this . v = v ; } } ");
         }
 
-        [WpfFact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, WorkItem(910589), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateFromThisInitializer2()
         {
             Test(
@@ -369,7 +369,7 @@ compareTokens: false);
 @"class C { public C ( ) { } public C ( int i ) : this ( ) { } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateFromBaseInitializer1()
         {
             Test(
@@ -377,7 +377,7 @@ compareTokens: false);
 @"class C : B { public C ( int i ) : base ( i ) { } } class B { private int i ; public B ( int i ) { this . i = i ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateFromBaseInitializer2()
         {
             Test(
@@ -386,7 +386,7 @@ compareTokens: false);
         }
 
         [WorkItem(539969)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestNotOnExistingConstructor()
         {
             TestMissing(
@@ -394,7 +394,7 @@ compareTokens: false);
         }
 
         [WorkItem(539972)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestUnavailableTypeParameters()
         {
             Test(
@@ -403,7 +403,7 @@ compareTokens: false);
         }
 
         [WorkItem(541020)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateCallToDefaultConstructorInStruct()
         {
             Test(
@@ -412,7 +412,7 @@ compareTokens: false);
         }
 
         [WorkItem(541121)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestReadonlyFieldDelegation()
         {
             Test(
@@ -420,7 +420,7 @@ compareTokens: false);
 @"class C { private readonly int x ; public C ( int x ) { this . x = x ; } void Test ( ) { int x = 10 ; C c = new C ( x ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestNoGenerationIntoEntirelyHiddenType()
         {
             TestMissing(
@@ -441,7 +441,7 @@ class D
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestNestedConstructorCall()
         {
             Test(
@@ -490,7 +490,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithArgument()
         {
             Test(
@@ -499,7 +499,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithMultipleArguments()
         {
             Test(
@@ -508,7 +508,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithNamedArguments()
         {
             Test(
@@ -517,7 +517,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithAdditionalConstructors()
         {
             Test(
@@ -526,7 +526,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithOverloading()
         {
             Test(
@@ -535,7 +535,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithOverloadingMultipleParameters()
         {
             Test(
@@ -544,7 +544,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithAllValidParameters()
         {
             Test(
@@ -553,7 +553,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithDelegation()
         {
             TestMissing(
@@ -561,7 +561,7 @@ class D
         }
 
         [WorkItem(530003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestAttributesWithLambda()
         {
             TestMissing(
@@ -569,7 +569,7 @@ class D
         }
 
         [WorkItem(889349)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestConstructorGenerationForDifferentNamedParameter()
         {
             Test(
@@ -611,7 +611,7 @@ class Program
         }
 
         [WorkItem(528257)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public void TestGenerateInInaccessibleType()
         {
             Test(
@@ -628,7 +628,7 @@ class Program
             }
 
             [WorkItem(1241, @"https://github.com/dotnet/roslyn/issues/1241")]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
             public void TestGenerateConstructorInIncompleteLambda()
             {
                 Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
             return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(null, new GenerateEnumMemberCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestEmptyEnum()
         {
             Test(
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Red ; } } enum Color { Red } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithSingleMember()
         {
             Test(
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red , Blue } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithExistingComma()
         {
             Test(
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red , Blue , } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithMultipleMembers()
         {
             Test(
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Green ; } } enum Color { Red , Blue , Green } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithZero()
         {
             Test(
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 0 , Blue = 1 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithIntegralValue()
         {
             Test(
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 1 , Blue = 2 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithSingleBitIntegral()
         {
             Test(
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 2 , Blue = 4 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateIntoGeometricSequence()
         {
             Test(
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 1 , Yellow = 2 , Green = 4 , Blue = 8}");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithSimpleSequence1()
         {
             Test(
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 1 , Green = 2 , Blue = 3 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithSimpleSequence2()
         {
             Test(
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Green = 5 , Blue = 6 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithLeftShift0()
         {
             Test(
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Green = 1 << 0 , Blue = 1 << 1 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithLeftShift5()
         {
             Test(
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Green = 1 << 5 , Blue = 1 << 6 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestWithDifferentStyles()
         {
             Test(
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 2 , Green = 1 << 5 , Blue = 33 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestHex1()
         {
             Test(
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 0x1 , Blue = 0x2 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestHex9()
         {
             Test(
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 0x9 , Blue = 0xA } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestHexF()
         {
             Test(
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 0xF , Blue = 0x10 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterEnumWithIntegerMaxValue()
         {
             Test(
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = int.MaxValue , Blue = int.MinValue } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestUnsigned16BitEnums()
         {
             Test(
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color : ushort { Red = 65535 , Blue = 0 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateEnumMemberOfTypeLong()
         {
             Test(
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color : long { Red = long.MaxValue , Blue = long.MinValue } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterEnumWithLongMaxValueInHex()
         {
             Test(
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
         }
 
         [WorkItem(528312)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterEnumWithLongMinValueInHex()
         {
             Test(
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
         }
 
         [WorkItem(528312)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterPositiveLongInHex()
         {
             Test(
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color : long { Red = 0xFFFFFFFFFFFFFFFF , Green = 0x0 , Blue = 0x1 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterPositiveLongExprInHex()
         {
             Test(
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color : long { Red = 0x414 / 2 , Blue = 523 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterEnumWithULongMaxValue()
         {
             Test(
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color : ulong { Red = ulong.MaxValue , Blue = 0 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestNegativeRangeIn64BitSignedEnums()
         {
             Test(
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color : long { Red = -10 , Blue = -9 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateWithImplicitValues()
         {
             Test(
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red , Green , Yellow = -1 , Blue = 2 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateWithImplicitValues2()
         {
             Test(
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateEnu
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red , Green = 10 , Yellow , Blue }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestNoExtraneousStatementTerminatorBeforeCommentedMember()
         {
             Test(
@@ -276,7 +276,7 @@ enum Color
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestNoExtraneousStatementTerminatorBeforeCommentedMember2()
         {
             Test(
@@ -310,7 +310,7 @@ enum Color
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterEnumWithMinValue()
         {
             Test(
@@ -318,7 +318,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = int.MinValue , Blue = -2147483647 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterEnumWithMinValuePlusConstant()
         {
             Test(
@@ -326,7 +326,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = int.MinValue + 100 , Blue = -2147483547 } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateAfterEnumWithByteMaxValue()
         {
             Test(
@@ -334,7 +334,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color : byte { Red = 255 , Blue = 0 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateIntoBitshiftEnum1()
         {
             Test(
@@ -342,7 +342,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 1 << 1 , Green = 1 << 2 , Blue = 1 << 3 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateIntoBitshiftEnum2()
         {
             Test(
@@ -350,7 +350,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = 2 >> 1 , Blue = 2 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestStandaloneReference()
         {
             Test(
@@ -358,7 +358,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red = int.MinValue , Green = 1 , Blue = 2 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestCircularEnumsForErrorTolerance()
         {
             Test(
@@ -366,7 +366,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Circular . C ; } } enum Circular { A = B , B , C }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestEnumWithIncorrectValueForErrorTolerance()
         {
             Test(
@@ -374,7 +374,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Circular . B ; } } enum Circular : byte { A = -2 , B }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateIntoNewEnum()
         {
             Test(
@@ -382,7 +382,7 @@ compareTokens: false);
 @"class B : A { void Main ( ) { BaseColor . Blue ; } public new enum BaseColor { Yellow = 3 , Blue = 4 } } class A { public enum BaseColor { Red = 1, Green = 2 } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateIntoDerivedEnumMissingNewKeyword()
         {
             Test(
@@ -390,7 +390,7 @@ compareTokens: false);
 @"class B : A { void Main ( ) { BaseColor . Blue ; } public enum BaseColor { Yellow = 3 , Blue = 4 } } class A { public enum BaseColor { Red = 1, Green = 2 } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerateIntoBaseEnum()
         {
             Test(
@@ -398,7 +398,7 @@ compareTokens: false);
 @"class B : A { void Main ( ) { BaseColor . Blue ; } } class A { public enum BaseColor { Red = 1, Green = 2 , Blue = 3 } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestGenerationWhenMembersShareValues()
         {
             Test(
@@ -406,7 +406,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { Color . Blue ; } } enum Color { Red , Green , Yellow = Green , Blue = 2 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestInvokeFromAddAssignmentStatement()
         {
             Test(
@@ -414,7 +414,7 @@ compareTokens: false);
 @"class Program { void Main ( ) { int a = 1 ; a += Color . Blue ; } } enum Color { Red , Green = 10 , Yellow , Blue }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestFormatting()
         {
             Test(
@@ -445,7 +445,7 @@ compareTokens: false);
         }
 
         [WorkItem(540919)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestKeyword()
         {
             Test(
@@ -454,14 +454,14 @@ compareTokens: false);
         }
 
         [WorkItem(544333)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestNotAfterPointer()
         {
             TestMissing(
 @"struct MyStruct { public int MyField ; } class Program { static unsafe void Main ( string [ ] args ) { MyStruct s = new MyStruct ( ) ; MyStruct * ptr = & s ; var i1 = ( ( ) => & s ) -> [|M|] ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestMissingOnHiddenEnum()
         {
             TestMissing(
@@ -482,7 +482,7 @@ class Program
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestMissingOnPartiallyHiddenEnum()
         {
             TestMissing(
@@ -507,7 +507,7 @@ class Program
         }
 
         [WorkItem(545903)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestNoOctal()
         {
             Test(
@@ -516,7 +516,7 @@ class Program
         }
 
         [WorkItem(546654)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)]
         public void TestLastValueDoesNotHaveInitializer()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
             return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(null, new GenerateMethodCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleInvocationIntoSameType()
         {
             Test(
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo(); } private void Foo() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleInvocationOffOfThis()
         {
             Test(
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { this.Foo(); } private void Foo() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleInvocationOffOfType()
         {
             Test(
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Class.Foo(); } private static void Foo() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleInvocationValueExpressionArg()
         {
             Test(
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo(0); } private void Foo(int v) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleInvocationMultipleValueExpressionArg()
         {
             Test(
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo(0, 0); } private void Foo(int v1, int v2) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleInvocationValueArg()
         {
             Test(
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(int i) { Foo(i); } private void Foo(int i) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleInvocationNamedValueArg()
         {
             Test(
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(int i) { Foo(bar: i); } private void Foo(int bar) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateAfterMethod()
         {
             Test(
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo(); } private void Foo() { throw new NotImplementedException(); } void NextMethod() { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInterfaceNaming()
         {
             Test(
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(int i) { Foo(NextMethod()); } private void Foo(IFoo foo) { throw new NotImplementedException(); } IFoo NextMethod() { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestFuncArg0()
         {
             Test(
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(int i) { Foo(NextMethod); } private void Foo(Func<string> nextMethod) { throw new NotImplementedException(); } string NextMethod() { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestFuncArg1()
         {
             Test(
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(int i) { Foo(NextMethod); } private void Foo(Func<int,string> nextMethod) { throw new NotImplementedException(); } string NextMethod(int i) { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestActionArg()
         {
             Test(
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(int i) { Foo(NextMethod); } private void Foo(Action nextMethod) { throw new NotImplementedException(); } void NextMethod() { } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestActionArg1()
         {
             Test(
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         // Note: we only test type inference once.  This is just to verify that it's being used
         // properly by Generate Method.  The full wealth of type inference tests can be found
         // elsewhere and don't need to be repeated here.
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestTypeInference()
         {
             Test(
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         }
 
         [WorkItem(784793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestOutRefArguments()
         {
             Test(
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo(out a, ref b); } private void Foo(out object a, ref object b) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMemberAccessArgumentName()
         {
             Test(
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         }
 
         [WorkItem(784793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestParenthesizedArgumentName()
         {
             Test(
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         }
 
         [WorkItem(784793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestCastedArgumentName()
         {
             Test(
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo((Bar)this.Baz); } private void Foo(Bar baz) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestNullableArgument()
         {
             Test(
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { Foo((int?)1); } private void Foo(int? v) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestNullArgument()
         {
             Test(
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { Foo(null); } private void Foo(object p) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestTypeofArgument()
         {
             Test(
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { Foo(typeof(int)); } private void Foo(Type type) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDefaultArgument()
         {
             Test(
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { Foo(default(int)); } private void Foo(int v) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestAsArgument()
         {
             Test(
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { Foo(1 as int?); } private void Foo(int? v) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestPointArgument()
         {
             Test(
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { int* p; Foo(p); } private unsafe void Foo(int* p) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestArgumentWithPointerName()
         {
             Test(
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { int* p; Foo(p); } private unsafe void Foo(int* p) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestArgumentWithPointTo()
         {
             Test(
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { void Method() { int* p; Foo(*p); } private void Foo(int p) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact(Skip = "530177"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestArgumentWithAddress()
         {
             Test(
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class C { unsafe void Method() { int a = 10; Foo(&a); } private unsafe void Foo(int* p) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateWithPointerReturn()
         {
             Test(
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         }
 
         [WorkItem(784793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDuplicateNames()
         {
             Test(
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         }
 
         [WorkItem(784793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDuplicateNamesWithNamedArgument()
         {
             Test(
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         // Note: we do not test the range of places where a delegate type can be inferred.  This is
         // just to verify that it's being used properly by Generate Method.  The full wealth of
         // delegate inference tests can be found elsewhere and don't need to be repeated here.
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimpleDelegate()
         {
             Test(
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Func<int,string,bool> f = Foo; } private bool Foo(int arg1, string arg2) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDelegateWithRefParameter()
         {
             Test(
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
         //
         // add negative tests to verify that Generate Method doesn't show up in unexpected places.
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenericArgs1()
         {
             Test(
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo<int>(); } private void Foo<T>() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenericArgs2()
         {
             Test(
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method() { Foo<int,string>(); } private void Foo<T1,T2>() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenericArgsFromMethod()
         {
             Test(
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method<X,Y>(X x, Y y) { Foo(x); } private void Foo<X>(X x) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMultipleGenericArgsFromMethod()
         {
             Test(
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method<X,Y>(X x, Y y) { Foo(x, y); } private void Foo<X, Y>(X x, Y y) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMultipleGenericArgsFromMethod2()
         {
             Test(
@@ -328,7 +328,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method<X,Y>(Func<X> x, Y[] y) { Foo(y, x); } private void Foo<Y, X>(Y[] y, Func<X> x) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenericArgThatIsTypeParameter()
         {
             Test(
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Program { void Main < T > ( T t ) { Foo < T > ( t ) ; } private void Foo < T > ( T t ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMultipleGenericArgsThatAreTypeParameters()
         {
             Test(
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Program { void Main < T , U > ( T t , U u ) { Foo < T , U > ( t , u ) ; } private void Foo < T , U > ( T t , U u ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoOuterThroughInstance()
         {
             Test(
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Outer { class Class { void Method(Outer o) { o.Foo(); } } private void Foo() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoOuterThroughClass()
         {
             Test(
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Outer { class Class { void Method(Outer o) { Outer.Foo(); } } private static void Foo() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoSiblingThroughInstance()
         {
             Test(
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(Sibling s) { s.Foo(); } } class Sibling { internal void Foo() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoSiblingThroughClass()
         {
             Test(
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(Sibling s) { Sibling.Foo(); } } class Sibling { internal static void Foo() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoInterfaceThroughInstance()
         {
             Test(
@@ -384,7 +384,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"class Class { void Method(ISibling s) { s.Foo(); } } interface ISibling { void Foo(); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoInterfaceThroughInstanceWithDelegate()
         {
             Test(
@@ -392,7 +392,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMet
 @"using System; class Class { void Method(ISibling s) { Func<int,string> f = s.Foo; } } interface ISibling { string Foo(int arg); }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateAbstractIntoSameType()
         {
             Test(
@@ -402,7 +402,7 @@ index: 1);
         }
 
         [WorkItem(537906)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMethodReturningDynamic()
         {
             Test(
@@ -411,7 +411,7 @@ index: 1);
         }
 
         [WorkItem(537906)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMethodTakingDynamicArg()
         {
             Test(
@@ -420,7 +420,7 @@ index: 1);
         }
 
         [WorkItem(3203, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestNegativeWithNamedOptionalArg1()
         {
             TestMissing(
@@ -428,7 +428,7 @@ index: 1);
         }
 
         [WorkItem(537972)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestWithNamedOptionalArg2()
         {
             Test(
@@ -438,7 +438,7 @@ index: 1);
 namespace SyntaxError { class C1 { void Method(int num, string str) { } internal void Method(int num, string v) { throw new NotImplementedException(); } } class C2 { static void Method2() { (new C1()).Method(num: 5, ""hi""); } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestArgOrderInNamedArgs()
         {
             Test(
@@ -446,14 +446,14 @@ namespace SyntaxError { class C1 { void Method(int num, string str) { } internal
 @"using System; class Foo { static void Test() { (new Foo()). Method(3, 4, n1 : 5, n3 : 6, n2 : 7, n0 : 8); } private void Method(int v1, int v2, int n1, int n3, int n2, int n0) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestForMissingOptionalArg()
         {
             TestMissing(
 @"class Foo { static void Test ( ) { ( new Foo ( ) ) . [|Method|] ( s : ""hello"" , b : true ) ; } private void Method ( double n = 3.14 , string s , bool b ) { } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestNamingOfArgWithClashes()
         {
             Test(
@@ -461,7 +461,7 @@ namespace SyntaxError { class C1 { void Method(int num, string str) { } internal
 @"using System; class Foo { static int i = 32; static void Test() { (new Foo()).Method(s: ""hello"", i: 52); } private void Method(string s, int i) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestFixCountGeneratingIntoInterface()
         {
             TestActionCount(
@@ -470,7 +470,7 @@ count: 1);
         }
 
         [WorkItem(527278)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationOffOfBase()
         {
             Test(
@@ -478,7 +478,7 @@ count: 1);
 @"using System; class C3A { internal void M() { throw new NotImplementedException(); } } class C3 : C3A { public void C4() { base.M(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationWithinCtor()
         {
             Test(
@@ -486,7 +486,7 @@ count: 1);
 @"using System; class C1 { C1() { M(); } private void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationWithinBaseCtor()
         {
             Test(
@@ -495,14 +495,14 @@ count: 1);
         }
 
         [WorkItem(3095, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestForMultipleSmartTagsInvokingWithinCtor()
         {
             TestMissing(
 @"using System; class C1 { C1() { [|M|](); } private void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationWithinDestructor()
         {
             Test(
@@ -510,7 +510,7 @@ count: 1);
 @"using System; class C1 { ~C1() { M(); } private void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationWithinConditional()
         {
             Test(
@@ -518,7 +518,7 @@ count: 1);
 @"using System; class C4 { void A() { string s; if ((s = M()) == null) { } }  private string M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoStaticClass()
         {
             Test(
@@ -526,7 +526,7 @@ count: 1);
 @"using System; class Bar { void Test() { Foo.M(); } } static class Foo { internal static void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoAbstractClass()
         {
             Test(
@@ -534,7 +534,7 @@ count: 1);
 @"using System; class Bar { void Test() { Foo.M(); } } abstract class Foo { internal static void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoAbstractClassThoughInstance1()
         {
             Test(
@@ -542,7 +542,7 @@ count: 1);
 @"using System; class C { void Test(Foo f) { f.M(); } } abstract class Foo { internal void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoAbstractClassThoughInstance2()
         {
             Test(
@@ -551,7 +551,7 @@ count: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoPartialClass1()
         {
             Test(
@@ -559,7 +559,7 @@ index: 1);
 @"using System; class Bar { void Test() { Foo.M(); } } partial class Foo { internal static void M() { throw new NotImplementedException(); } } partial class Foo { }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoPartialClass2()
         {
             Test(
@@ -567,7 +567,7 @@ index: 1);
 @"using System; partial class Foo { void Test() { Foo.M(); } private static void M() { throw new NotImplementedException(); } } partial class Foo { } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoStruct()
         {
             Test(
@@ -576,7 +576,7 @@ index: 1);
         }
 
         [WorkItem(527291)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationOffOfIndexer()
         {
             Test(
@@ -586,7 +586,7 @@ class Foo { internal void M() { throw new NotImplementedException(); } }");
         }
 
         [WorkItem(527292)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationWithinForEach()
         {
             Test(
@@ -599,7 +599,7 @@ void Test() { foreach (C8A c8a in this.GetItems()) { c8a.M(); } } }
 class C8A { internal void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationOffOfAnotherMethodCall()
         {
             Test(
@@ -607,7 +607,7 @@ class C8A { internal void M() { throw new NotImplementedException(); } }");
 @"using System; class C9 { C9A m_item = new C9A(); C9A GetItem() { return m_item; } void Test() { GetItem().M(); } } struct C9A {  internal void M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationIntoNestedNamespaces()
         {
             Test(
@@ -616,7 +616,7 @@ namespace NS11A { namespace NS11B { class C11A { } } }",
 @"using System; namespace NS11X { namespace NS11Y { class C11 { void Test() { NS11A.NS11B.C11A.M(); } } } } namespace NS11A { namespace NS11B { class C11A { internal static void M() { throw new NotImplementedException(); } } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationIntoAliasedNamespaces()
         {
             Test(
@@ -636,7 +636,7 @@ namespace NS11A { namespace NS11B { class C11A { } } }",
 namespace NS11A {  namespace NS11B { class C11A { internal static void M() { throw new NotImplementedException(); } } } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInvocationOnGlobalNamespace()
         {
             Test(
@@ -647,7 +647,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
         }
 
         [WorkItem(538353)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoAppropriatePart()
         {
             Test(
@@ -656,7 +656,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
         }
 
         [WorkItem(538541)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateWithVoidArgument()
         {
             Test(
@@ -665,7 +665,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
         }
 
         [WorkItem(538993)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateInLambda()
         {
             Test(
@@ -673,7 +673,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
 @"using System; class Program { static void Main(string[] args) { Func<int, int> f = x => Foo(x); } private static int Foo(int x) { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateInAnonymousMethod()
         {
             Test(
@@ -682,7 +682,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface1()
         {
             Test(
@@ -691,7 +691,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface2()
         {
             Test(
@@ -700,7 +700,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface3()
         {
             Test(
@@ -709,7 +709,7 @@ namespace NS13A { namespace NS13B { struct S13A { internal static void M() { thr
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface4()
         {
             Test(
@@ -719,7 +719,7 @@ index: 0);
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface5()
         {
             Test(
@@ -729,7 +729,7 @@ index: 0);
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface6()
         {
             TestMissing(
@@ -737,7 +737,7 @@ index: 0);
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface7()
         {
             TestMissing(
@@ -745,7 +745,7 @@ index: 0);
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface8()
         {
             Test(
@@ -754,7 +754,7 @@ index: 0);
         }
 
         [WorkItem(539024)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOffOfExplicitInterface9()
         {
             // TODO(cyrusn): It might be nice if we generated "Foo(T i)" here in the future.
@@ -764,7 +764,7 @@ index: 0);
         }
 
         [WorkItem(5016, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodWithArgumentFromBaseConstructorsArgument()
         {
             Test(
@@ -773,7 +773,7 @@ index: 0);
         }
 
         [WorkItem(5016, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodWithArgumentFromGenericConstructorsArgument()
         {
             Test(
@@ -781,7 +781,7 @@ index: 0);
 @"using System; class A<T> { public A(T t) { } } class B : A<int> { B() : base(M()) { } private static int M() { throw new NotImplementedException(); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodWithVar()
         {
             Test(
@@ -790,7 +790,7 @@ index: 0);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestEscapedName()
         {
             Test(
@@ -799,7 +799,7 @@ index: 0);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestEscapedKeyword()
         {
             Test(
@@ -808,7 +808,7 @@ index: 0);
         }
 
         [WorkItem(539527)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter1()
         {
             Test(
@@ -817,7 +817,7 @@ index: 0);
         }
 
         [WorkItem(539527)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter2()
         {
             Test(
@@ -826,7 +826,7 @@ index: 0);
         }
 
         [WorkItem(539527)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter3()
         {
             Test(
@@ -835,7 +835,7 @@ index: 0);
         }
 
         [WorkItem(539527)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter4()
         {
             Test(
@@ -844,7 +844,7 @@ index: 0);
         }
 
         [WorkItem(539527)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter5()
         {
             Test(
@@ -853,7 +853,7 @@ index: 0);
         }
 
         [WorkItem(539596)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter6()
         {
             Test(
@@ -862,7 +862,7 @@ index: 0);
         }
 
         [WorkItem(539593)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter7()
         {
             Test(
@@ -871,7 +871,7 @@ index: 0);
         }
 
         [WorkItem(539593)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestUnmentionableTypeParameter8()
         {
             Test(
@@ -880,7 +880,7 @@ index: 0);
         }
 
         [WorkItem(539597)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestOddErrorType()
         {
             Test(
@@ -889,7 +889,7 @@ index: 0);
         }
 
         [WorkItem(539594)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenericOverloads()
         {
             Test(
@@ -898,7 +898,7 @@ index: 0);
         }
 
         [WorkItem(537929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInScript1()
         {
             Test(
@@ -907,7 +907,7 @@ index: 0);
 parseOptions: GetScriptOptions());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInTopLevelImplicitClass1()
         {
             Test(
@@ -915,7 +915,7 @@ parseOptions: GetScriptOptions());
 @"using System ; static void Main ( string [ ] args ) { Foo ( ) ; } void Foo ( ) { throw new NotImplementedException ( ) ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInNamespaceImplicitClass1()
         {
             Test(
@@ -923,7 +923,7 @@ parseOptions: GetScriptOptions());
 @"namespace N { using System ; static void Main ( string [ ] args ) { Foo ( ) ; } void Foo ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInNamespaceImplicitClass_FieldInitializer()
         {
@@ -933,7 +933,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539571)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimplification1()
         {
             Test(
@@ -942,7 +942,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539571)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestSimplification2()
         {
             Test(
@@ -951,7 +951,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539618)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestClashesWithMethod1()
         {
             TestMissing(
@@ -959,7 +959,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539618)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestClashesWithMethod2()
         {
             TestMissing(
@@ -967,7 +967,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539637)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestReservedParametername1()
         {
             Test(
@@ -976,7 +976,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539751)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestShadows1()
         {
             TestMissing(
@@ -984,7 +984,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539769)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestShadows2()
         {
             TestMissing(
@@ -992,7 +992,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539781)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInTopLevelMethod()
         {
             Test(
@@ -1001,7 +1001,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539823)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestLambdaReturnType()
         {
             Test(
@@ -1009,7 +1009,7 @@ parseOptions: GetScriptOptions());
 @"using System ; class C < T , R > { private static Func < T , R > g = null ; private static Func < T , R > f = ( T ) => { return Foo < T , R > ( g ) ; } ; private static R Foo < T1 , T2 > ( Func < T , R > g ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateWithThrow()
         {
             Test(
@@ -1017,7 +1017,7 @@ parseOptions: GetScriptOptions());
 @"using System ; using System . Collections . Generic ; using System . Linq ; class C { void M ( ) { throw F ( ) ; } private Exception F ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInDelegateConstructor()
         {
             Test(
@@ -1026,7 +1026,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539871)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDelegateScenario()
         {
             TestMissing(
@@ -1034,7 +1034,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539928)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInheritedTypeParameters1()
         {
             Test(
@@ -1043,7 +1043,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539928)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInheritedTypeParameters2()
         {
             Test(
@@ -1052,7 +1052,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539928)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInheritedTypeParameters3()
         {
             Test(
@@ -1061,7 +1061,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(538995)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestBug4777()
         {
             Test(
@@ -1070,7 +1070,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539856)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateOnInvalidInvocation()
         {
             TestMissing(
@@ -1078,7 +1078,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(539752)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMissingOnMultipleLambdaInferences()
         {
             TestMissing(
@@ -1086,7 +1086,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(540505)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestParameterTypeAmbiguity()
         {
             Test(
@@ -1095,7 +1095,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(541176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestTernaryWithBodySidesBroken1()
         {
             Test(
@@ -1104,7 +1104,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(541176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestTernaryWithBodySidesBroken2()
         {
             Test(
@@ -1112,7 +1112,7 @@ parseOptions: GetScriptOptions());
 @"using System; public class C { void Method ( ) { int a = 5 , b = 10 ; int x = a > b ? M ( a ) : M ( b ) ; } private int M ( int b ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestNotOnLeftOfAssign()
         {
             TestMissing(
@@ -1120,7 +1120,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(541405)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMissingOnImplementedInterfaceMethod()
         {
             TestMissing(
@@ -1128,7 +1128,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(541660)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDelegateNamedVar()
         {
             Test(
@@ -1137,7 +1137,7 @@ parseOptions: GetScriptOptions());
         }
 
         [WorkItem(540991)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestErrorVersusNamedTypeInSignature()
         {
             TestMissing(
@@ -1146,7 +1146,7 @@ Options.Regular);
         }
 
         [WorkItem(542529)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestTypeParameterConstraints1()
         {
             Test(
@@ -1155,7 +1155,7 @@ Options.Regular);
         }
 
         [WorkItem(542622)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestLambdaTypeParameters()
         {
             Test(
@@ -1164,7 +1164,7 @@ Options.Regular);
         }
 
         [WorkItem(542626)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMethodConstraints1()
         {
             Test(
@@ -1173,7 +1173,7 @@ Options.Regular);
         }
 
         [WorkItem(542627)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestCaptureMethodTypeParametersReferencedInOuterType1()
         {
             Test(
@@ -1182,7 +1182,7 @@ Options.Regular);
         }
 
         [WorkItem(542658)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestCaptureTypeParametersInConstraints()
         {
             Test(
@@ -1191,7 +1191,7 @@ Options.Regular);
         }
 
         [WorkItem(542659)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestConstraintOrder1()
         {
             Test(
@@ -1200,7 +1200,7 @@ Options.Regular);
         }
 
         [WorkItem(542678)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestConstraintOrder2()
         {
             Test(
@@ -1209,7 +1209,7 @@ Options.Regular);
         }
 
         [WorkItem(542674)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateStaticMethodInField()
         {
             Test(
@@ -1218,7 +1218,7 @@ Options.Regular);
         }
 
         [WorkItem(542680)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateIntoConstrainedTypeParameter()
         {
             Test(
@@ -1227,7 +1227,7 @@ Options.Regular);
         }
 
         [WorkItem(542750)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestCaptureOuterTypeParameter()
         {
             Test(
@@ -1236,7 +1236,7 @@ Options.Regular);
         }
 
         [WorkItem(542744)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestMostDerivedTypeParameter()
         {
             Test(
@@ -1245,7 +1245,7 @@ Options.Regular);
         }
 
         [WorkItem(543152)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestAnonymousTypeArgument()
         {
             Test(
@@ -1253,7 +1253,7 @@ Options.Regular);
 @"using System ; class C { void M ( ) { M ( new { x = 1 } ) ; } private void M ( object p ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestListOfAnonymousTypesArgument()
         {
             Test(
@@ -1262,7 +1262,7 @@ Options.Regular);
         }
 
         [WorkItem(543336)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateImplicitlyTypedArrays()
         {
             Test(
@@ -1271,7 +1271,7 @@ Options.Regular);
         }
 
         [WorkItem(543510)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenericArgWithMissingTypeParameter()
         {
             TestMissing(
@@ -1279,14 +1279,14 @@ Options.Regular);
         }
 
         [WorkItem(544334)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDuplicateWithErrorType()
         {
             TestMissing(
 @"using System ; class class1 { public void Test ( ) { [|Foo|] ( x ) ; } private void Foo ( object x ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestNoGenerationIntoEntirelyHiddenType()
         {
             TestMissing(
@@ -1307,7 +1307,7 @@ class D
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDoNotGenerateIntoHiddenRegion1()
         {
             Test(
@@ -1338,7 +1338,7 @@ class C
 }", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDoNotGenerateIntoHiddenRegion2()
         {
             Test(
@@ -1377,7 +1377,7 @@ class C
 }", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDoNotGenerateIntoHiddenRegion3()
         {
             Test(
@@ -1424,7 +1424,7 @@ class C
 }", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDoNotAddImportsIntoHiddenRegion()
         {
             Test(
@@ -1461,7 +1461,7 @@ class C
 
         [WorkItem(545397)]
         [WorkItem(784793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestVarParameterTypeName()
         {
             Test(
@@ -1470,7 +1470,7 @@ class C
         }
 
         [WorkItem(545269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateInVenus1()
         {
             TestMissing(
@@ -1489,7 +1489,7 @@ class C
         }
 
         [WorkItem(538521)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInIterator1()
         {
             Test(
@@ -1498,7 +1498,7 @@ class C
         }
 
         [WorkItem(784793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodMissingForAnyArgumentInInvocationHavingErrorTypeAndNotBelongingToEnclosingNamedType()
         {
             Test(
@@ -1530,7 +1530,7 @@ class Program
         }
 
         [WorkItem(907612)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodWithLambda()
         {
             Test(
@@ -1562,7 +1562,7 @@ class Program
         }
 
         [WorkItem(889349)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodForDifferentParameterName()
         {
             Test(
@@ -1596,7 +1596,7 @@ class C
         }
 
         [WorkItem(889349)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodForDifferentParameterNameCaseSensitive()
         {
             Test(
@@ -1630,7 +1630,7 @@ class C
         }
 
         [WorkItem(769760)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodForSameNamedButGenericUsage()
         {
             Test(
@@ -1672,7 +1672,7 @@ class Program
         }
 
         [WorkItem(910589)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodForNewErrorCodeCS7036()
         {
             Test(
@@ -1700,7 +1700,7 @@ class C
         }
 
         [WorkItem(934729)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodUnknownReturnTypeInLambda()
         {
             Test(
@@ -1729,7 +1729,7 @@ class C
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInUnsafeMethod()
         {
             Test(
@@ -1753,7 +1753,7 @@ class C {
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInUnsafeMethodWithPointerArray()
         {
             Test(
@@ -1781,7 +1781,7 @@ class C
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInUnsafeBlock()
         {
             Test(
@@ -1821,7 +1821,7 @@ class Program
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInUnsafeMethodNoPointersInParameterList()
         {
             Test(
@@ -1845,7 +1845,7 @@ class C {
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInUnsafeBlockNoPointers()
         {
             Test(
@@ -1885,7 +1885,7 @@ class Program
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodUnsafeReturnType()
         {
             Test(
@@ -1913,7 +1913,7 @@ class Program
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodUnsafeClass()
         {
             Test(
@@ -1941,7 +1941,7 @@ unsafe class Program
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodUnsafeNestedClass()
         {
             Test(
@@ -1975,7 +1975,7 @@ unsafe class Program
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodUnsafeNestedClass2()
         {
             Test(
@@ -2008,7 +2008,7 @@ class Program
 }", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestDoNotOfferMethodWithoutParenthesis()
         {
             TestMissing(
@@ -2016,7 +2016,7 @@ class Program
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf()
         {
             Test(
@@ -2044,7 +2044,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf2()
         {
             Test(
@@ -2072,7 +2072,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf3()
         {
             Test(
@@ -2100,7 +2100,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf4()
         {
             Test(
@@ -2146,7 +2146,7 @@ namespace Z
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf5()
         {
             TestMissing(
@@ -2160,7 +2160,7 @@ namespace Z
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf6()
         {
             TestMissing(
@@ -2175,7 +2175,7 @@ namespace Z
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf7()
         {
             Test(
@@ -2207,7 +2207,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf8()
         {
             Test(
@@ -2237,7 +2237,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf9()
         {
             Test(
@@ -2265,7 +2265,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf10()
         {
             Test(
@@ -2293,7 +2293,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf11()
         {
             Test(
@@ -2321,7 +2321,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf12()
         {
             TestMissing(
@@ -2342,7 +2342,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf13()
         {
             Test(
@@ -2382,7 +2382,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf14()
         {
             Test(
@@ -2422,7 +2422,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf15()
         {
             Test(
@@ -2462,7 +2462,7 @@ class C
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInsideNameOf16()
         {
             Test(
@@ -2502,7 +2502,7 @@ class C
         }
 
         [WorkItem(1075289)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodForInaccessibleMethod()
         {
             Test(
@@ -2550,7 +2550,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccessMissing()
         {
             TestMissing(
@@ -2558,7 +2558,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccess()
         {
             Test(
@@ -2567,7 +2567,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccess2()
         {
             Test(
@@ -2576,7 +2576,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccess3()
         {
             Test(
@@ -2585,7 +2585,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccess4()
         {
             Test(
@@ -2594,7 +2594,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestTestGenerateMethodInConditionalAccess5()
         {
             Test(
@@ -2603,7 +2603,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccess6()
         {
             Test(
@@ -2612,7 +2612,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccess7()
         {
             Test(
@@ -2621,7 +2621,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInConditionalAccess8()
         {
             Test(
@@ -2629,7 +2629,7 @@ namespace ConsoleApplication1
 @"using System ; class C { public E B { get ; private set ; } void Main ( C a ) { var x = a ? . B . C ( ) ; } public class E { internal object C ( ) { throw new NotImplementedException ( ) ; } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInPropertyInitializer()
         {
             Test(
@@ -2637,7 +2637,7 @@ namespace ConsoleApplication1
 @"using System ; class Program { public int MyProperty { get ; } = y ( ) ; private static int y ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInExpressionBodiedMember()
         {
             Test(
@@ -2645,7 +2645,7 @@ namespace ConsoleApplication1
 @"using System ; class Program { public int Y => y ( ) ; private int y ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInExpressionBodiedMember2()
         {
             Test(
@@ -2653,7 +2653,7 @@ namespace ConsoleApplication1
 @"using System ; class C { public static C GetValue ( C p ) => x ( ) ; private static C x ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInExpressionBodiedMember3()
         {
             Test(
@@ -2661,7 +2661,7 @@ namespace ConsoleApplication1
 @"using System ; class C { public static C operator -- ( C p ) => x ( ) ; private static C x ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInDictionaryInitializer()
         {
             Test(
@@ -2669,7 +2669,7 @@ namespace ConsoleApplication1
 @"using System ; using System . Collections . Generic ; class Program { static void Main ( string [ ] args ) { var x = new Dictionary < string , int > { [ key ( ) ] = 0 } ; } private static string key ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInDictionaryInitializer2()
         {
             Test(
@@ -2677,7 +2677,7 @@ namespace ConsoleApplication1
 @"using System ; using System . Collections . Generic ; class Program { static void Main ( string [ ] args ) { var x = new Dictionary < string , int > { [ ""Zero"" ] = 0 , [ One ( ) ] = 1 , [ ""Two"" ] = 2 } ; } private static string One ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodInDictionaryInitializer3()
         {
             Test(
@@ -2686,7 +2686,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(643, "https://github.com/dotnet/roslyn/issues/643")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodWithConfigureAwaitFalse()
         {
             Test(
@@ -2695,7 +2695,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(643, "https://github.com/dotnet/roslyn/issues/643")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodWithMethodChaining()
         {
             Test(
@@ -2704,7 +2704,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(643, "https://github.com/dotnet/roslyn/issues/643")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodWithMethodChaining2()
         {
             Test(
@@ -2713,7 +2713,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(529480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInCollectionInitializers1()
         {
             Test(
@@ -2722,7 +2722,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(529480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestInCollectionInitializers2()
         {
             Test(
@@ -2731,7 +2731,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(774321)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodEquivalenceKey()
         {
             TestEquivalenceKey(
@@ -2740,7 +2740,7 @@ string.Format(FeaturesResources.GenerateMethodIn, "M1", "C"));
         }
 
         [WorkItem(5338, "https://github.com/dotnet/roslyn/issues/5338")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestGenerateMethodLambdaOverload1()
         {
             Test(
@@ -2789,7 +2789,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateImplicitConversionGenericClass()
             {
                 Test(
@@ -2798,7 +2798,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateImplicitConversionClass()
             {
                 Test(
@@ -2807,7 +2807,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateImplicitConversionAwaitExpression()
             {
                 Test(
@@ -2816,7 +2816,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateImplicitConversionTargetTypeNotInSource()
             {
                 Test(
@@ -2825,7 +2825,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateExplicitConversionGenericClass()
             {
                 Test(
@@ -2834,7 +2834,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateExplicitConversionClass()
             {
                 Test(
@@ -2843,7 +2843,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateExplicitConversionAwaitExpression()
             {
                 Test(
@@ -2852,7 +2852,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestGenerateExplicitConversionTargetTypeNotInSource()
             {
                 Test(
@@ -2861,7 +2861,7 @@ class Class1
             }
 
             [WorkItem(774321)]
-            [WpfFact(Skip = "xunit2"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+            [Fact(Skip = "xunit2"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
             public void TestEquivalenceKey()
             {
                 TestEquivalenceKey(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateTyp
 
         #region Generics
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateTypeParameterFromArgumentInferT()
         {
             Test(
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateTyp
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromTypeParameter()
         {
             Test(
@@ -50,7 +50,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromASingleConstraintClause()
         {
             Test(
@@ -59,14 +59,14 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NegativeTestGenerateClassFromConstructorConstraint()
         {
             TestMissing(
 @"class EmployeeList<T> where T : Employee, [|new()|] { }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromMultipleTypeConstraintClauses()
         {
             Test(
@@ -75,14 +75,14 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NegativeTestGenerateClassFromClassOrStructConstraint()
         {
             TestMissing(
 @"class Derived<T, U> where U : [|struct|] where T : Base, new() { }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAbsenceOfGenerateIntoInvokingTypeForConstraintList()
         {
             TestActionCount(
@@ -95,7 +95,7 @@ parseOptions: Options.Regular);
 
         #region Lambdas
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromParenthesizedLambdaExpressionsParameter()
         {
             Test(
@@ -104,7 +104,7 @@ parseOptions: Options.Regular);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromParenthesizedLambdaExpressionsBody()
         {
             Test(
@@ -115,7 +115,7 @@ index: 2);
 
         #endregion
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromFieldDeclarationIntoSameType()
         {
             Test(
@@ -144,7 +144,7 @@ expectedContainers: new List<string> { "TestNamespace" },
 expectedDocumentName: "Foo.cs").ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromFieldDeclarationIntoSameNamespace()
         {
             Test(
@@ -153,7 +153,7 @@ expectedDocumentName: "Foo.cs").ConfigureAwait(true);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassWithCtorFromObjectCreation()
         {
             Test(
@@ -162,7 +162,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromBaseList()
         {
             Test(
@@ -171,7 +171,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromMethodParameters()
         {
             Test(
@@ -180,7 +180,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromMethodReturnType()
         {
             Test(
@@ -189,7 +189,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromAttribute()
         {
             Test(
@@ -198,7 +198,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromExpandedAttribute()
         {
             Test(
@@ -207,7 +207,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromCatchClause()
         {
             Test(
@@ -225,7 +225,7 @@ protected ExType(SerializationInfo info, StreamingContext context) : base(info, 
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromThrowStatement()
         {
             Test(
@@ -242,7 +242,7 @@ protected ExType(SerializationInfo info, StreamingContext context) : base(info, 
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromThrowStatementWithDifferentArg()
         {
             Test(
@@ -261,7 +261,7 @@ protected ExType(SerializationInfo info, StreamingContext context) : base(info, 
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromThrowStatementWithMatchingArg()
         {
             Test(
@@ -278,7 +278,7 @@ protected ExType(SerializationInfo info, StreamingContext context) : base(info, 
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAbsenceOfGenerateIntoInvokingTypeForBaseList()
         {
             TestActionCount(
@@ -287,7 +287,7 @@ count: 3,
 parseOptions: Options.Regular);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromUsingStatement()
         {
             Test(
@@ -296,7 +296,7 @@ parseOptions: Options.Regular);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassFromForeachStatement()
         {
             Test(
@@ -306,7 +306,7 @@ index: 2);
         }
 
         [WorkItem(538346)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateClassWhereKeywordBecomesTypeName()
         {
             Test(
@@ -315,7 +315,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NegativeTestGenerateClassOnContextualKeyword()
         {
             Test(
@@ -324,7 +324,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NegativeTestGenerateClassOnFrameworkTypes()
         {
             TestMissing(
@@ -338,7 +338,7 @@ index: 2);
         }
 
         [WorkItem(538409)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateIntoRightPart()
         {
             Test(
@@ -348,7 +348,7 @@ index: 2);
         }
 
         [WorkItem(538408)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeIntoCompilationUnit()
         {
             Test(
@@ -358,7 +358,7 @@ index: 1);
         }
 
         [WorkItem(538408)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeIntoNamespace()
         {
             Test(
@@ -368,7 +368,7 @@ index: 1);
         }
 
         [WorkItem(538115)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeWithPreprocessor()
         {
             Test(
@@ -395,7 +395,7 @@ compareTokens: false);
         }
 
         [WorkItem(538495)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeIntoContainingNamespace()
         {
             Test(
@@ -416,7 +416,7 @@ expectedDocumentName: "C.cs").ConfigureAwait(true);
         }
 
         [WorkItem(538558)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NegativeTestGlobalAlias()
         {
             TestMissing(
@@ -427,7 +427,7 @@ expectedDocumentName: "C.cs").ConfigureAwait(true);
         }
 
         [WorkItem(538069)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeFromArrayCreation1()
         {
             Test(
@@ -438,7 +438,7 @@ parseOptions: null);
         }
 
         [WorkItem(538069)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeFromArrayCreation2()
         {
             Test(
@@ -449,7 +449,7 @@ parseOptions: null);
         }
 
         [WorkItem(538069)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeFromArrayCreation3()
         {
             Test(
@@ -460,7 +460,7 @@ parseOptions: null);
         }
 
         [WorkItem(539329)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NegativeTestNotInUsingDirective()
         {
             TestMissing(
@@ -479,7 +479,7 @@ parseOptions: null);
 @"using X = [|A|];");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateSimpleConstructor()
         {
             Test(
@@ -488,7 +488,7 @@ parseOptions: null);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithValueParameter()
         {
             Test(
@@ -497,7 +497,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithTwoValueParameters()
         {
             Test(
@@ -506,7 +506,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithNamedParameter()
         {
             Test(
@@ -515,7 +515,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithRefParameter()
         {
             Test(
@@ -524,7 +524,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameter()
         {
             Test(
@@ -533,7 +533,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters1()
         {
             Test(
@@ -542,7 +542,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters2()
         {
             Test(
@@ -551,7 +551,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters3()
         {
             Test(
@@ -560,7 +560,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters4()
         {
             Test(
@@ -569,7 +569,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters5()
         {
             Test(
@@ -578,7 +578,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters6()
         {
             Test(
@@ -587,7 +587,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters7()
         {
             Test(
@@ -596,7 +596,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithOutParameters8()
         {
             Test(
@@ -605,7 +605,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithMethod()
         {
             Test(
@@ -614,7 +614,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithLambda()
         {
             Test(
@@ -623,7 +623,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithDelegatingConstructor1()
         {
             Test(
@@ -632,7 +632,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithDelegatingConstructor2()
         {
             Test(
@@ -641,7 +641,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithDelegatingConstructor3()
         {
             Test(
@@ -650,7 +650,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithDelegatingConstructor4()
         {
             Test(
@@ -659,7 +659,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithDelegatingConstructor5()
         {
             Test(
@@ -668,7 +668,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithDelegatingConstructor6()
         {
             Test(
@@ -677,7 +677,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithNonDelegatingConstructor1()
         {
             Test(
@@ -686,7 +686,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithNonDelegatingConstructor2()
         {
             Test(
@@ -695,7 +695,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithNonDelegatingConstructor3()
         {
             Test(
@@ -704,7 +704,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithNonDelegatingConstructor4()
         {
             Test(
@@ -713,7 +713,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField1()
         {
             Test(
@@ -722,7 +722,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField2()
         {
             Test(
@@ -731,7 +731,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField3()
         {
             Test(
@@ -740,7 +740,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField4()
         {
             Test(
@@ -749,7 +749,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField5()
         {
             Test(
@@ -758,7 +758,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField6()
         {
             Test(
@@ -767,7 +767,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField7()
         {
             Test(
@@ -776,7 +776,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField7WithQualification()
         {
             Test(
@@ -786,7 +786,7 @@ index: 1,
 options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField8()
         {
             Test(
@@ -795,7 +795,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptio
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField9()
         {
             Test(
@@ -804,7 +804,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToField10()
         {
             Test(
@@ -813,7 +813,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToProperty1()
         {
             Test(
@@ -822,7 +822,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToProperty2()
         {
             Test(
@@ -831,7 +831,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToProperty2WithQualification()
         {
             Test(
@@ -841,7 +841,7 @@ index: 1,
 options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToProperty3()
         {
             Test(
@@ -850,7 +850,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptio
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateWithCallToProperty3WithQualification()
         {
             Test(
@@ -861,7 +861,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptio
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void GenerateTypeWithPreferIntrinsicPredefinedKeywordFalse()
         {
             Test(
@@ -896,7 +896,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptio
 
         #region Generate Interface
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInterfaceFromTypeConstraint()
         {
             Test(
@@ -905,7 +905,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptio
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInterfaceFromTypeConstraints()
         {
             Test(
@@ -914,14 +914,14 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NegativeTestGenerateInterfaceFromTypeConstraint()
         {
             TestMissing(
 @"using System; class EmployeeList<T> where T : Employee, IEmployee, [|IComparable<T>|], new() { }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInterfaceFromBaseList1()
         {
             Test(
@@ -931,7 +931,7 @@ index: 1);
         }
 
         [WorkItem(538519)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInterfaceFromBaseList2()
         {
             Test(
@@ -941,7 +941,7 @@ index: 1);
         }
 
         [WorkItem(538519)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInterfaceFromTypeConstraints2()
         {
             Test(
@@ -950,7 +950,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInterfaceFromBaseList3()
         {
             Test(
@@ -962,7 +962,7 @@ index: 1);
         #endregion
 
         [WorkItem(539339)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NotInLeftSideOfAssignment()
         {
             TestMissing(
@@ -970,7 +970,7 @@ index: 1);
         }
 
         [WorkItem(539339)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void InLeftSideOfAssignment()
         {
             Test(
@@ -980,7 +980,7 @@ index: 1);
         }
 
         [WorkItem(539339)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void NotInRightSideOfAssignment()
         {
             TestMissing(
@@ -988,7 +988,7 @@ index: 1);
         }
 
         [WorkItem(539339)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void InRightSideOfAssignment()
         {
             Test(
@@ -998,7 +998,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestEscapedName()
         {
             Test(
@@ -1008,7 +1008,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestEscapedKeyword()
         {
             Test(
@@ -1029,7 +1029,7 @@ expectedDocumentName: "Bar.cs").ConfigureAwait(true);
         }
 
         [WorkItem(539620)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestDeclarationSpan()
         {
             TestSpans(
@@ -1039,7 +1039,7 @@ index: 1);
         }
 
         [WorkItem(539674)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestNotInEnumBaseList()
         {
             TestMissing(
@@ -1047,14 +1047,14 @@ index: 1);
         }
 
         [WorkItem(539681)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestNotInConditional()
         {
             TestMissing(
 @"class Program { static void Main ( string [ ] args ) { if ( [|IsTrue|] ) { } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestInUsing()
         {
             Test(
@@ -1063,7 +1063,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestNotInDelegateConstructor()
         {
             TestMissing(
@@ -1071,7 +1071,7 @@ index: 1);
         }
 
         [WorkItem(539754)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestMissingOnVar()
         {
             TestMissing(
@@ -1079,7 +1079,7 @@ index: 1);
         }
 
         [WorkItem(539765)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestElideDefaultConstructor()
         {
             Test(
@@ -1088,7 +1088,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         [WorkItem(539783)]
         public void RegressionFor5867ErrorToleranceTopLevel()
         {
@@ -1098,7 +1098,7 @@ GetScriptOptions());
         }
 
         [WorkItem(539799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestOnInaccessibleType()
         {
             TestMissing(
@@ -1106,7 +1106,7 @@ GetScriptOptions());
         }
 
         [WorkItem(539794)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestDefaultConstructorInTypeDerivingFromInterface()
         {
             Test(
@@ -1115,7 +1115,7 @@ GetScriptOptions());
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateWithThrow()
         {
             Test(
@@ -1124,7 +1124,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInTryCatch()
         {
             Test(
@@ -1134,14 +1134,14 @@ index: 1);
         }
 
         [WorkItem(539739)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void TestNotGenerateInDelegateConstructor()
         {
             TestMissing(
 @"using System ; delegate void D ( int x ) ; class C { void M ( ) { D d = new D ( [|Test|] ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestInStructBaseList()
         {
             Test(
@@ -1151,7 +1151,7 @@ index: 1);
         }
 
         [WorkItem(539870)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenericWhenNonGenericExists()
         {
             Test(
@@ -1161,7 +1161,7 @@ index: 1);
         }
 
         [WorkItem(539930)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestInheritedTypeParameters()
         {
             Test(
@@ -1171,7 +1171,7 @@ index: 1);
         }
 
         [WorkItem(539971)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestDoNotUseOuterTypeParameters()
         {
             Test(
@@ -1181,7 +1181,7 @@ index: 2);
         }
 
         [WorkItem(539970)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestReferencingTypeParameters1()
         {
             Test(
@@ -1191,7 +1191,7 @@ index: 1);
         }
 
         [WorkItem(539970)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestReferencingTypeParameters2()
         {
             Test(
@@ -1201,7 +1201,7 @@ index: 2);
         }
 
         [WorkItem(539972)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestReferencingTypeParameters3()
         {
             Test(
@@ -1211,7 +1211,7 @@ index: 1);
         }
 
         [WorkItem(539972)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestReferencingTypeParameters4()
         {
             Test(
@@ -1221,7 +1221,7 @@ index: 2);
         }
 
         [WorkItem(539992)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestNotPassingEmptyIssueListToCtor()
         {
             TestMissing(
@@ -1229,7 +1229,7 @@ index: 2);
         }
 
         [WorkItem(540644)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateWithVoidArg()
         {
             Test(
@@ -1239,7 +1239,7 @@ index: 1);
         }
 
         [WorkItem(540989)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestMissingOnInaccessibleType()
         {
             TestMissing(
@@ -1247,7 +1247,7 @@ index: 1);
         }
 
         [WorkItem(540766)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestMissingOnInvalidGlobalCode()
         {
             TestMissing(
@@ -1256,7 +1256,7 @@ parseOptions: null);
         }
 
         [WorkItem(539985)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestDoNotInferTypeWithWrongArity()
         {
             Test(
@@ -1265,7 +1265,7 @@ parseOptions: null);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestMissingOnInvalidConstructorToExistingType()
         {
             TestMissing(
@@ -1273,7 +1273,7 @@ index: 1);
         }
 
         [WorkItem(541263)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityConstraint()
         {
             Test(
@@ -1282,7 +1282,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestBaseTypeAccessibilityConstraint()
         {
             Test(
@@ -1291,7 +1291,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestBaseInterfaceAccessibilityConstraint1()
         {
             Test(
@@ -1300,7 +1300,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityConstraint2()
         {
             Test(
@@ -1309,7 +1309,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityConstraint3()
         {
             Test(
@@ -1318,7 +1318,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestDelegateReturnTypeAccessibilityConstraint()
         {
             Test(
@@ -1327,7 +1327,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestDelegateParameterAccessibilityConstraint()
         {
             Test(
@@ -1336,7 +1336,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestMethodParameterAccessibilityConstraint()
         {
             Test(
@@ -1345,7 +1345,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestMethodReturnTypeAccessibilityConstraint()
         {
             Test(
@@ -1354,7 +1354,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestPropertyTypeAccessibilityConstraint()
         {
             Test(
@@ -1363,7 +1363,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestFieldEventTypeAccessibilityConstraint()
         {
             Test(
@@ -1372,7 +1372,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestEventTypeAccessibilityConstraint()
         {
             Test(
@@ -1382,7 +1382,7 @@ index: 1);
         }
 
         [WorkItem(541654)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateVarType()
         {
             Test(
@@ -1392,7 +1392,7 @@ index: 1);
         }
 
         [WorkItem(541641)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestOnBadAttribute()
         {
             Test(
@@ -1410,7 +1410,7 @@ index: 1);
         }
 
         [WorkItem(542528)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateStruct1()
         {
             Test(
@@ -1420,7 +1420,7 @@ index: 1);
         }
 
         [WorkItem(542480)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestCopyConstraints1()
         {
             Test(
@@ -1430,7 +1430,7 @@ index: 1);
         }
 
         [WorkItem(542528)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateStruct2()
         {
             Test(
@@ -1440,7 +1440,7 @@ index: 0);
         }
 
         [WorkItem(542528)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateStruct3()
         {
             Test(
@@ -1450,7 +1450,7 @@ index: 0);
         }
 
         [WorkItem(542761)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateOpenType1()
         {
             Test(
@@ -1460,7 +1460,7 @@ index: 1);
         }
 
         [WorkItem(542766)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateAttributeInGenericType()
         {
             TestActionCount(
@@ -1475,7 +1475,7 @@ count: 3);
         }
 
         [WorkItem(543061)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestNestedGenericAccessibility()
         {
             Test(
@@ -1485,7 +1485,7 @@ index: 1);
         }
 
         [WorkItem(543493)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void MissingIfNotInTypeStatementOrExpressionContext()
         {
             TestMissing(@"class C { void M ( ) { a [|b|] c d } } ");
@@ -1494,7 +1494,7 @@ index: 1);
         }
 
         [WorkItem(542641)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAttributeSuffixOnAttributeSubclasses()
         {
             Test(
@@ -1504,7 +1504,7 @@ index: 1);
         }
 
         [WorkItem(543853)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestDisplayStringForGlobalNamespace()
         {
             TestSmartTagText(
@@ -1524,7 +1524,7 @@ Array.Empty<string>(),
         }
 
         [WorkItem(543886)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestVerbatimAttribute()
         {
             Test(
@@ -1534,7 +1534,7 @@ index: 1);
         }
 
         [WorkItem(531220)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void CompareIncompleteMembersToEqual()
         {
             Test(
@@ -1551,7 +1551,7 @@ index: 2);
         }
 
         [WorkItem(544168)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestNotOnAbstractClassCreation()
         {
             TestMissing(
@@ -1559,7 +1559,7 @@ index: 2);
         }
 
         [WorkItem(545362)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateInVenus1()
         {
             var code = @"
@@ -1605,7 +1605,7 @@ class Program
         }
 
         [WorkItem(869506)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateTypeOutsideCurrentProject()
         {
             var code = @"<Workspace>
@@ -1718,7 +1718,7 @@ namespace Namespace1.Namespace2.Namespace3
         }
 
         [WorkItem(612700)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestGenerateTypeWithNoBraces()
         {
             var code = @"class Test : [|Base|]";
@@ -1732,7 +1732,7 @@ internal class Base
         }
 
         [WorkItem(940003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithProperties1()
         {
             var code = @"using System;
@@ -1774,7 +1774,7 @@ internal class Customer
         }
 
         [WorkItem(940003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithProperties2()
         {
             var code = @"using System;
@@ -1816,7 +1816,7 @@ internal class Customer
         }
 
         [WorkItem(940003)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithProperties3()
         {
             var code = @"using System;
@@ -1858,7 +1858,7 @@ internal class Customer
         }
 
         [WorkItem(1082031)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithProperties4()
         {
             var code = @"using System;
@@ -1891,7 +1891,7 @@ internal class Customer
         }
 
         [WorkItem(1032176), WorkItem(1073099)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithNameOf()
         {
             var code = @"class C
@@ -1919,7 +1919,7 @@ internal class Z
         }
 
         [WorkItem(1032176), WorkItem(1073099)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithNameOf2()
         {
             var code = @"class C
@@ -1945,7 +1945,7 @@ internal class Z
             Test(code, expected, index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithUsingStatic()
         {
             Test(
@@ -1954,14 +1954,14 @@ internal class Z
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestWithUsingStatic2()
         {
             TestMissing(@"using [|Sample|] ; ");
         }
 
         [WorkItem(1107929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityForPublicFields()
         {
             Test(
@@ -1971,7 +1971,7 @@ index: 0);
         }
 
         [WorkItem(1107929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityForPublicFields2()
         {
             Test(
@@ -1981,7 +1981,7 @@ index: 1);
         }
 
         [WorkItem(1107929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityForPublicFields3()
         {
             Test(
@@ -1991,7 +1991,7 @@ index: 2);
         }
 
         [WorkItem(1107929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityForPublicFields4()
         {
             Test(
@@ -2001,7 +2001,7 @@ index: 0);
         }
 
         [WorkItem(1107929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityForPublicFields5()
         {
             Test(
@@ -2011,7 +2011,7 @@ index: 1);
         }
 
         [WorkItem(1107929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestAccessibilityForPublicFields6()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests_Dialog.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests_Dialog.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateTyp
     {
         #region SameProject
         #region SameProject_SameFile 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeDefaultValues()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -42,7 +42,7 @@ class Foo
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInsideNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -76,7 +76,7 @@ namespace A
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInsideQualifiedNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -108,7 +108,7 @@ namespace A.B
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithinQualifiedNestedNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -146,7 +146,7 @@ namespace A.B
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithinNestedQualifiedNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -184,7 +184,7 @@ namespace A
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithConstructorMembers()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -219,7 +219,7 @@ class Foo
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithBaseTypes()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -248,7 +248,7 @@ class Foo : List<int>
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithPublicInterface()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -288,7 +288,7 @@ typeKind: TypeKind.Interface,
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithInternalStruct()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -328,7 +328,7 @@ typeKind: TypeKind.Struct,
 isNewFile: false).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithDefaultEnum()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -369,7 +369,7 @@ isNewFile: false).ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithDefaultEnum_DefaultNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -405,7 +405,7 @@ isNewFile: false).ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithDefaultEnum_DefaultNamespace_NotSimpleName()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -449,7 +449,7 @@ isNewFile: false).ConfigureAwait(true);
 
         // Working is very similar to the adding to the same file
         #region SameProject_ExistingFile
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInExistingEmptyFile()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -488,7 +488,7 @@ existingFilename: "Test2.cs").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInExistingEmptyFile_Usings_Folders()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -534,7 +534,7 @@ existingFilename: "Test2.cs").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInExistingEmptyFile_Usings_DefaultNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -581,7 +581,7 @@ existingFilename: "Test2.cs").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInExistingEmptyFile_Usings_Folders_DefaultNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -628,7 +628,7 @@ existingFilename: "Test2.cs").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInExistingEmptyFile_NoUsings_Folders_NotSimpleName()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1036,7 +1036,7 @@ newFileName: "Test2.cs").ConfigureAwait(true);
         #endregion
         #region SameLanguageDifferentProject
         #region SameLanguageDifferentProject_ExistingFile
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeIntoSameLanguageDifferentProjectEmptyFile()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1077,7 +1077,7 @@ projectName: "Assembly2").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeIntoSameLanguageDifferentProjectExistingFile()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1128,7 +1128,7 @@ projectName: "Assembly2").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeIntoSameLanguageDifferentProjectExistingFile_Usings_Folders()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1708,7 +1708,7 @@ projectName: "Assembly2").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeIntoDifferentLanguageExistingEmptyFile()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1749,7 +1749,7 @@ projectName: "Assembly2").ConfigureAwait(true);
         }
 
         [WorkItem(850101)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeIntoDifferentLanguageExistingEmptyFile_Usings_Folder()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1795,7 +1795,7 @@ existingFilename: "Test2.vb",
 projectName: "Assembly2").ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeIntoDifferentLanguageExistingNonEmptyFile()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1840,7 +1840,7 @@ existingFilename: "Test2.vb",
 projectName: "Assembly2").ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeIntoDifferentLanguageExistingNonEmptyTargetFile()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1937,7 +1937,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         #region Bugfix 
         [WorkItem(861462)]
         [WorkItem(873066)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithProperAccessibilityAndTypeKind_1()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1961,7 +1961,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOpt
         }
 
         [WorkItem(861462)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithProperAccessibilityAndTypeKind_2()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -1984,7 +1984,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOpt
         }
 
         [WorkItem(861462)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithProperAccessibilityAndTypeKind_3()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2007,7 +2007,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOpt
         }
 
         [WorkItem(861362)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInMemberAccessExpression()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2038,7 +2038,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
 
         [WorkItem(861362)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInMemberAccessExpressionInNamespace()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2076,7 +2076,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
 
         [WorkItem(861600)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithoutEnumForGenericsInMemberAccess()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2115,7 +2115,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
 
         [WorkItem(861600)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithoutEnumForGenericsInNameContext()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2154,7 +2154,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
 
         [WorkItem(861600)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInMemberAccessWithNSForModule()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2192,7 +2192,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
 
         [WorkItem(861600)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInMemberAccessWithGlobalNSForModule()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2223,7 +2223,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
 
         [WorkItem(861600)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeInMemberAccessWithoutNS()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2245,7 +2245,7 @@ isMissing: true).ConfigureAwait(true);
 
         [WorkItem(876202)]
         [WorkItem(883531)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_NoParameterLessConstructorForStruct()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2276,7 +2276,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
         #endregion
         #region Delegates
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_MethodGroup()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2311,7 +2311,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_MethodGroup_Generics()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2346,7 +2346,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_Delegate()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2379,7 +2379,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_Action()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2412,7 +2412,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_Func()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2445,7 +2445,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_ParenLambda()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2474,7 +2474,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_SimpleLambda()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2504,7 +2504,7 @@ assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOp
         }
 
         [WorkItem(872935)]
-        [WpfFact(Skip = "872935"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact(Skip = "872935"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_ObjectCreationExpression_SimpleLambdaEmpty()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2533,7 +2533,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_VarDecl_MethodGroup()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2568,7 +2568,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_VarDecl_Delegate()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2603,7 +2603,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_VarDecl_Action()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2636,7 +2636,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_VarDecl_Func()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2669,7 +2669,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_VarDecl_ParenLambda()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2699,7 +2699,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_VarDecl_SimpleLambda()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2728,7 +2728,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_Cast_MethodGroup()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2763,7 +2763,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_Cast_Delegate()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2798,7 +2798,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_Cast_Action()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2831,7 +2831,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_Cast_Func()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2864,7 +2864,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_Cast_ParenLambda()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2894,7 +2894,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.AllOptions)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_Cast_SimpleLambda()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2961,7 +2961,7 @@ projectName: "Assembly2").ConfigureAwait(true);
         }
 
         [WorkItem(860210)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_NoInfo()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -2990,7 +2990,7 @@ isNewFile: false).ConfigureAwait(true);
         }
         #endregion 
         #region Dev12Filtering
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_NoEnum_InvocationExpression_0()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3020,7 +3020,7 @@ isNewFile: false,
 assertTypeKindAbsent: new[] { TypeKindOptions.Enum }).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateDelegateType_NoEnum_InvocationExpression_1()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3057,7 +3057,7 @@ isNewFile: false,
 assertTypeKindAbsent: new[] { TypeKindOptions.Enum }).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_TypeConstraint_1()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3094,7 +3094,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOptions.BaseList)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_TypeConstraint_2()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3137,7 +3137,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.BaseList)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_TypeConstraint_3()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3186,7 +3186,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOptions.BaseList)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithProperAccessibilityWithNesting_1()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3215,7 +3215,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOptions.BaseList, false)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithProperAccessibilityWithNesting_2()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3244,7 +3244,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.BaseList, false)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateTypeWithProperAccessibilityWithNesting_3()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3279,7 +3279,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.BaseList, false)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_1()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3312,7 +3312,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_2()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3337,7 +3337,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_3()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3372,7 +3372,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_4()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3399,7 +3399,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_5()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3440,7 +3440,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Module)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_6()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3473,7 +3473,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(false, TypeKindOptions.Class | TypeKindOptions.Structure | TypeKindOptions.Module)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_7()
         {
             await TestWithMockedGenerateTypeDialog(
@@ -3506,7 +3506,7 @@ isNewFile: false,
 assertGenerateTypeDialogOptions: new GenerateTypeDialogOptions(true, TypeKindOptions.Delegate)).ConfigureAwait(true);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GenerateType_Event_8()
         {
             await TestWithMockedGenerateTypeDialog(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateVar
                 null, new GenerateVariableCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleLowercaseIdentifier1()
         {
             Test(
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateVar
 @"class Class { private object foo; void Method() { foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleLowercaseIdentifier2()
         {
             Test(
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateVar
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestTestSimpleLowercaseIdentifier3()
         {
             Test(
@@ -46,7 +46,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleUppercaseIdentifier1()
         {
             Test(
@@ -54,7 +54,7 @@ index: 2);
 @"class Class { public object Foo { get; private set; } void Method() { Foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleUppercaseIdentifier2()
         {
             Test(
@@ -63,7 +63,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleUppercaseIdentifier3()
         {
             Test(
@@ -72,7 +72,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleRead1()
         {
             Test(
@@ -80,7 +80,7 @@ index: 2);
 @"class Class { private int foo; void Method(int i) { Method(foo); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleWriteCount()
         {
             TestExactActionSetOffered(
@@ -88,7 +88,7 @@ index: 2);
 new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string.Format(FeaturesResources.GeneratePropertyIn, "foo", "Class"), string.Format(FeaturesResources.GenerateLocal, "foo") });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleWrite1()
         {
             Test(
@@ -96,7 +96,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string
 @"class Class { private int foo; void Method(int i) { foo = 1; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSimpleWrite2()
         {
             Test(
@@ -105,7 +105,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInRefCodeActionCount()
         {
             TestExactActionSetOffered(
@@ -113,7 +113,7 @@ index: 1);
 new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string.Format(FeaturesResources.GenerateLocal, "foo") });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInRef1()
         {
             Test(
@@ -121,7 +121,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string
 @"class Class { private int foo; void Method(ref int i) { Method(ref foo); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInOutCodeActionCount()
         {
             TestExactActionSetOffered(
@@ -129,7 +129,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string
 new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string.Format(FeaturesResources.GenerateLocal, "foo") });
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInOut1()
         {
             Test(
@@ -137,7 +137,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string
 @"class Class { private int foo; void Method(out int i) { Method(out foo); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInStaticMember1()
         {
             Test(
@@ -145,7 +145,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string
 @"class Class { private static object foo; static void Method() { foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInStaticMember2()
         {
             Test(
@@ -154,7 +154,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "foo", "Class"), string
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInStaticMember3()
         {
             Test(
@@ -163,7 +163,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffInstance1()
         {
             Test(
@@ -171,7 +171,7 @@ index: 2);
 @"class Class { private object foo; void Method() { this.foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffInstance2()
         {
             Test(
@@ -180,7 +180,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffInstance3()
         {
             Test(
@@ -189,7 +189,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffWrittenInstance1()
         {
             Test(
@@ -197,7 +197,7 @@ index: 2);
 @"class Class { private int foo; void Method() { this.foo = 1; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffWrittenInstance2()
         {
             Test(
@@ -206,7 +206,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffStatic1()
         {
             Test(
@@ -214,7 +214,7 @@ index: 1);
 @"class Class { private static object foo; void Method() { Class.foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffStatic2()
         {
             Test(
@@ -223,7 +223,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffStatic3()
         {
             Test(
@@ -232,7 +232,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffWrittenStatic1()
         {
             Test(
@@ -240,7 +240,7 @@ index: 2);
 @"class Class { private static int foo; void Method() { Class.foo = 1; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateOffWrittenStatic2()
         {
             Test(
@@ -249,7 +249,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInstanceIntoSibling1()
         {
             Test(
@@ -257,7 +257,7 @@ index: 1);
 @"class Class { void Method() { new D().foo; } } class D { internal object foo; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInstanceIntoOuter1()
         {
             Test(
@@ -265,7 +265,7 @@ index: 1);
 @"class Outer { private object foo; class Class { void Method() { new Outer().foo; } } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInstanceIntoDerived1()
         {
             Test(
@@ -273,7 +273,7 @@ index: 1);
 @"class Class : Base { void Method(Base b) { b.foo; } } class Base { internal object foo; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateStaticIntoDerived1()
         {
             Test(
@@ -281,7 +281,7 @@ index: 1);
 @"class Class : Base { void Method(Base b) { Base.foo; } } class Base { protected static object foo; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateIntoInterfaceFixCount()
         {
             TestActionCount(
@@ -289,7 +289,7 @@ index: 1);
 count: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateIntoInterface1()
         {
             Test(
@@ -297,7 +297,7 @@ count: 2);
 @"class Class { void Method(I i) { i.Foo; } } interface I { object Foo { get; set; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateIntoInterface2()
         {
             Test(
@@ -306,14 +306,14 @@ count: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateStaticIntoInterfaceMissing()
         {
             TestMissing(
 @"class Class { void Method(I i) { I.[|Foo|]; } } interface I { }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateWriteIntoInterfaceFixCount()
         {
             TestActionCount(
@@ -321,7 +321,7 @@ index: 1);
 count: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateWriteIntoInterface1()
         {
             Test(
@@ -329,7 +329,7 @@ count: 1);
 @"class Class { void Method(I i) { i.Foo = 1; } } interface I { int Foo { get; set; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInGenericType()
         {
             Test(
@@ -337,7 +337,7 @@ count: 1);
 @"class Class<T> { private T foo; void Method(T t) { foo = t; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInGenericMethod1()
         {
             Test(
@@ -345,7 +345,7 @@ count: 1);
 @"class Class { private object foo; void Method<T>(T t) { foo = t; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInGenericMethod2()
         {
             Test(
@@ -353,7 +353,7 @@ count: 1);
 @"class Class { private IList<object> foo; void Method<T>(IList<T> t) { foo = t; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldBeforeFirstField()
         {
             Test(
@@ -361,7 +361,7 @@ count: 1);
 @"class Class { private object foo; int i; void Method() { foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldAfterLastField()
         {
             Test(
@@ -369,7 +369,7 @@ count: 1);
 @"class Class { void Method() { foo; } int i; private object foo; }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyAfterLastField1()
         {
             Test(
@@ -377,7 +377,7 @@ count: 1);
 @"class Class { int Bar; public object Foo { get; private set; } void Method() { Foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyAfterLastField2()
         {
             Test(
@@ -385,7 +385,7 @@ count: 1);
 @"class Class { void Method() { Foo; } int Bar; public object Foo { get; private set; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyBeforeFirstProperty()
         {
             Test(
@@ -393,7 +393,7 @@ count: 1);
 @"class Class { public object Foo { get; private set; } int Quux { get; } void Method() { Foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyBeforeFirstPropertyEvenWithField1()
         {
             Test(
@@ -401,7 +401,7 @@ count: 1);
 @"class Class { int Bar; public object Foo { get; private set; } int Quux { get; } void Method() { Foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyAfterLastPropertyEvenWithField2()
         {
             Test(
@@ -409,21 +409,21 @@ count: 1);
 @"class Class { int Quux { get; } public object Foo { get; private set; } int Bar; void Method() { Foo; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingInInvocation()
         {
             TestMissing(
 @"class Class { void Method() { [|Foo|](); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingInObjectCreation()
         {
             TestMissing(
 @"class Class { void Method() { new [|Foo|](); } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingInTypeDeclaration()
         {
             TestMissing(
@@ -455,7 +455,7 @@ count: 1);
         }
 
         [WorkItem(539336)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingInAttribute()
         {
             TestMissing(
@@ -487,7 +487,7 @@ count: 1);
         }
 
         [WorkItem(539340)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestSpansField()
         {
             TestSpans(
@@ -520,7 +520,7 @@ count: 1);
         }
 
         [WorkItem(539427)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFromLambda()
         {
             Test(
@@ -530,7 +530,7 @@ count: 1);
 
         // TODO: Move to TypeInferrer.InferTypes, or something
         [WorkItem(539466)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInMethodOverload1()
         {
             Test(
@@ -540,7 +540,7 @@ count: 1);
 
         // TODO: Move to TypeInferrer.InferTypes, or something
         [WorkItem(539466)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInMethodOverload2()
         {
             Test(
@@ -549,7 +549,7 @@ count: 1);
         }
 
         [WorkItem(539468)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestExplicitProperty1()
         {
             Test(
@@ -558,7 +558,7 @@ count: 1);
         }
 
         [WorkItem(539468)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestExplicitProperty2()
         {
             Test(
@@ -567,7 +567,7 @@ count: 1);
         }
 
         [WorkItem(539468)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestExplicitProperty3()
         {
             Test(
@@ -577,7 +577,7 @@ index: 1);
         }
 
         [WorkItem(539468)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestExplicitProperty4()
         {
             TestMissing(
@@ -585,7 +585,7 @@ index: 1);
         }
 
         [WorkItem(539468)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestExplicitProperty5()
         {
             TestMissing(
@@ -593,7 +593,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestEscapedName()
         {
             Test(
@@ -602,7 +602,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestEscapedKeyword()
         {
             Test(
@@ -611,7 +611,7 @@ index: 1);
         }
 
         [WorkItem(539529)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestRefLambda()
         {
             Test(
@@ -620,7 +620,7 @@ index: 1);
         }
 
         [WorkItem(539595)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOnError()
         {
             TestMissing(
@@ -628,7 +628,7 @@ index: 1);
         }
 
         [WorkItem(539571)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNameSimplification()
         {
             Test(
@@ -637,7 +637,7 @@ index: 1);
         }
 
         [WorkItem(539717)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestPostIncrement()
         {
             Test(
@@ -646,7 +646,7 @@ index: 1);
         }
 
         [WorkItem(539717)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestPreDecrement()
         {
             Test(
@@ -655,7 +655,7 @@ index: 1);
         }
 
         [WorkItem(539738)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateIntoScript()
         {
             Test(
@@ -665,7 +665,7 @@ parseOptions: Options.Script);
         }
 
         [WorkItem(539558)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void BugFix5565()
         {
             Test(
@@ -697,7 +697,7 @@ compareTokens: false);
         }
 
         [WorkItem(539536)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void BugFix5538()
         {
             Test(
@@ -707,7 +707,7 @@ index: 2);
         }
 
         [WorkItem(539665)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void BugFix5697()
         {
             Test(
@@ -736,7 +736,7 @@ compareTokens: false);
         }
 
         [WorkItem(539793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestIncrement()
         {
             TestExactActionSetOffered(
@@ -749,7 +749,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "p", "Program"), string
         }
 
         [WorkItem(539834)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void TestNotInGoto()
         {
             TestMissing(
@@ -757,7 +757,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "p", "Program"), string
         }
 
         [WorkItem(539826)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestOnLeftOfDot()
         {
             Test(
@@ -766,7 +766,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "p", "Program"), string
         }
 
         [WorkItem(539840)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotBeforeAlias()
         {
             TestMissing(
@@ -774,7 +774,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "p", "Program"), string
         }
 
         [WorkItem(539871)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingOnGenericName()
         {
             TestMissing(
@@ -782,7 +782,7 @@ new[] { string.Format(FeaturesResources.GenerateFieldIn, "p", "Program"), string
         }
 
         [WorkItem(539934)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestOnDelegateAddition()
         {
             Test(
@@ -792,7 +792,7 @@ parseOptions: null);
         }
 
         [WorkItem(539986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestReferenceTypeParameter1()
         {
             Test(
@@ -801,7 +801,7 @@ parseOptions: null);
         }
 
         [WorkItem(539986)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestReferenceTypeParameter2()
         {
             Test(
@@ -810,7 +810,7 @@ parseOptions: null);
         }
 
         [WorkItem(540159)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestEmptyIdentifierName()
         {
             TestMissing(
@@ -820,7 +820,7 @@ parseOptions: null);
         }
 
         [WorkItem(541194)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestForeachVar()
         {
             Test(
@@ -829,7 +829,7 @@ parseOptions: null);
         }
 
         [WorkItem(541265)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestExtensionMethodUsedAsInstance()
         {
             Test(
@@ -839,7 +839,7 @@ parseOptions: null);
         }
 
         [WorkItem(541549)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestDelegateInvoke()
         {
             Test(
@@ -848,7 +848,7 @@ parseOptions: null);
         }
 
         [WorkItem(541597)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestComplexAssign1()
         {
             Test(
@@ -857,7 +857,7 @@ parseOptions: null);
         }
 
         [WorkItem(541597)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestComplexAssign2()
         {
             Test(
@@ -866,7 +866,7 @@ parseOptions: null);
         }
 
         [WorkItem(541659)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestTypeNamedVar()
         {
             Test(
@@ -875,7 +875,7 @@ parseOptions: null);
         }
 
         [WorkItem(541675)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestStaticExtensionMethodArgument()
         {
             Test(
@@ -884,7 +884,7 @@ parseOptions: null);
         }
 
         [WorkItem(539675)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void AddBlankLineBeforeCommentBetweenMembers1()
         {
             Test(
@@ -910,7 +910,7 @@ compareTokens: false);
         }
 
         [WorkItem(539675)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void AddBlankLineBeforeCommentBetweenMembers2()
         {
             Test(
@@ -937,7 +937,7 @@ compareTokens: false);
         }
 
         [WorkItem(543813)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void AddBlankLineBetweenMembers1()
         {
             Test(
@@ -962,7 +962,7 @@ compareTokens: false);
         }
 
         [WorkItem(543813)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void AddBlankLineBetweenMembers2()
         {
             Test(
@@ -987,7 +987,7 @@ compareTokens: false);
         }
 
         [WorkItem(543813)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void DontAddBlankLineBetweenFields()
         {
             Test(
@@ -1017,7 +1017,7 @@ compareTokens: false);
         }
 
         [WorkItem(543813)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void DontAddBlankLineBetweenAutoProperties()
         {
             Test(
@@ -1047,7 +1047,7 @@ compareTokens: false);
         }
 
         [WorkItem(539665)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestIntoEmptyClass()
         {
             Test(
@@ -1074,7 +1074,7 @@ compareTokens: false);
         }
 
         [WorkItem(540595)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInScript()
         {
             Test(
@@ -1087,7 +1087,7 @@ compareTokens: false);
         }
 
         [WorkItem(542535)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConstantInParameterValue()
         {
             const string Initial = @"class C { const int y = 1 ; public void Foo ( bool x = [|undeclared|] ) { } } ";
@@ -1102,7 +1102,7 @@ Initial,
         }
 
         [WorkItem(542900)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFromAttributeNamedArgument1()
         {
             Test(
@@ -1111,7 +1111,7 @@ Initial,
         }
 
         [WorkItem(542900)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFromAttributeNamedArgument2()
         {
             Test(
@@ -1121,7 +1121,7 @@ index: 1);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility1_InternalPrivate()
         {
             Test(
@@ -1131,7 +1131,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility2_InternalProtected()
         {
             Test(
@@ -1141,7 +1141,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility3_InternalInternal()
         {
             Test(
@@ -1151,7 +1151,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility4_InternalProtectedInternal()
         {
             Test(
@@ -1161,7 +1161,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility5_InternalPublic()
         {
             Test(
@@ -1171,7 +1171,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility6_PublicInternal()
         {
             Test(
@@ -1181,7 +1181,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility7_PublicProtectedInternal()
         {
             Test(
@@ -1191,7 +1191,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility8_PublicProtected()
         {
             Test(
@@ -1201,7 +1201,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility9_PublicPrivate()
         {
             Test(
@@ -1211,7 +1211,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility10_PrivatePrivate()
         {
             Test(
@@ -1221,7 +1221,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility11_PrivateProtected()
         {
             Test(
@@ -1231,7 +1231,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility12_PrivateProtectedInternal()
         {
             Test(
@@ -1241,7 +1241,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility13_PrivateInternal()
         {
             Test(
@@ -1251,7 +1251,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility14_ProtectedPrivate()
         {
             Test(
@@ -1261,7 +1261,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility15_ProtectedInternal()
         {
             Test(
@@ -1271,7 +1271,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility16_ProtectedInternalProtected()
         {
             Test(
@@ -1281,7 +1281,7 @@ parseOptions: null);
         }
 
         [WorkItem(541698)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMinimalAccessibility17_ProtectedInternalInternal()
         {
             Test(
@@ -1291,7 +1291,7 @@ parseOptions: null);
         }
 
         [WorkItem(543153)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestAnonymousObjectInitializer1()
         {
             Test(
@@ -1301,7 +1301,7 @@ index: 1);
         }
 
         [WorkItem(543124)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNoGenerationIntoAnonymousType()
         {
             TestMissing(
@@ -1309,7 +1309,7 @@ index: 1);
         }
 
         [WorkItem(543543)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOfferedForBoundParametersOfOperators()
         {
             TestMissing(
@@ -1317,7 +1317,7 @@ index: 1);
         }
 
         [WorkItem(544175)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOnNamedParameterName1()
         {
             TestMissing(
@@ -1325,7 +1325,7 @@ index: 1);
         }
 
         [WorkItem(544271)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOnNamedParameterName2()
         {
             TestMissing(
@@ -1333,7 +1333,7 @@ index: 1);
         }
 
         [WorkItem(544164)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestPropertyOnObjectInitializer()
         {
             Test(
@@ -1341,7 +1341,7 @@ index: 1);
 @"class Foo { public int Gibberish { get ; internal set ; } } class Bar { void foo ( ) { var c = new Foo { Gibberish = 24 } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestPropertyOnObjectInitializer1()
         {
             Test(
@@ -1349,7 +1349,7 @@ index: 1);
 @"class Foo { public object Gibberish { get ; internal set ; } } class Bar { void foo ( ) { var c = new Foo { Gibberish = Gibberish } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestPropertyOnObjectInitializer2()
         {
             Test(
@@ -1357,7 +1357,7 @@ index: 1);
 @"class Foo { } class Bar { public object Gibberish { get ; private set ; } void foo ( ) { var c = new Foo { Gibberish = Gibberish } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestFieldOnObjectInitializer()
         {
             Test(
@@ -1366,7 +1366,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestFieldOnObjectInitializer1()
         {
             Test(
@@ -1375,7 +1375,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestFieldOnObjectInitializer2()
         {
             Test(
@@ -1384,7 +1384,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestOnlyPropertyAndFieldOfferedForObjectInitializer()
         {
             TestActionCount(
@@ -1392,7 +1392,7 @@ index: 1);
 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateLocalInObjectInitializerValue()
         {
             Test(
@@ -1402,7 +1402,7 @@ index: 3);
         }
 
         [WorkItem(544319)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOnIncompleteMember1()
         {
             TestMissing(
@@ -1410,7 +1410,7 @@ index: 3);
         }
 
         [WorkItem(544319)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOnIncompleteMember2()
         {
             TestMissing(
@@ -1418,7 +1418,7 @@ index: 3);
         }
 
         [WorkItem(544319)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOnIncompleteMember3()
         {
             TestMissing(
@@ -1426,7 +1426,7 @@ index: 3);
         }
 
         [WorkItem(544384)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestPointerType()
         {
             Test(
@@ -1435,7 +1435,7 @@ index: 3);
         }
 
         [WorkItem(544510)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNotOnUsingAlias()
         {
             TestMissing(
@@ -1443,7 +1443,7 @@ index: 3);
         }
 
         [WorkItem(544907)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestExpressionTLambda()
         {
             Test(
@@ -1451,7 +1451,7 @@ index: 3);
 @"using System ; using System . Linq . Expressions ; class C { public static int Foo { get ; private set ; } static void Main ( ) { Expression < Func < int , int > > e = x => Foo ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNoGenerationIntoEntirelyHiddenType()
         {
             TestMissing(
@@ -1472,7 +1472,7 @@ class D
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInReturnStatement()
         {
             Test(
@@ -1480,7 +1480,7 @@ class D
 @"class Program { private object foo ; void Main ( ) { return foo ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestLocal1()
         {
             Test(
@@ -1489,14 +1489,14 @@ class D
 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestLocalMissingForVar()
         {
             TestMissing(
 @"class Program { void Main ( ) { var x = [|var|] ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestOutLocal1()
         {
             Test(
@@ -1506,7 +1506,7 @@ index: 1);
         }
 
         [WorkItem(809542)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestLocalBeforeComment()
         {
             Test(
@@ -1537,7 +1537,7 @@ index: 1);
         }
 
         [WorkItem(809542)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestLocalAfterComment()
         {
             Test(
@@ -1568,7 +1568,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateIntoVisiblePortion()
         {
             Test(
@@ -1599,7 +1599,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingWhenNoAvailableRegionToGenerateInto()
         {
             TestMissing(
@@ -1618,7 +1618,7 @@ class Program
 #line default");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateLocalAvailableIfBlockIsNotHidden()
         {
             Test(
@@ -1653,7 +1653,7 @@ compareTokens: false);
         }
 
         [WorkItem(545217)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateLocalNameSimplification()
         {
             Test(
@@ -1662,7 +1662,7 @@ compareTokens: false);
 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestParenthesizedExpression()
         {
             Test(
@@ -1670,7 +1670,7 @@ index: 3);
 @"class Program { private int k ; void Main ( ) { int v = 1 + ( k ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInSelect()
         {
             Test(
@@ -1678,7 +1678,7 @@ index: 3);
 @"using System . Linq ; class Program { private object v ; void Main ( string [ ] args ) { var q = from a in args select v ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInChecked()
         {
             Test(
@@ -1686,7 +1686,7 @@ index: 3);
 @"class Program { private int [ ] foo ; void Main ( ) { int [ ] a = null ; int [ ] temp = checked ( foo ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInArrayRankSpecifier()
         {
             Test(
@@ -1694,7 +1694,7 @@ index: 3);
 @"class Program { private int k ; void Main ( ) { var v = new int [ k ] ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInConditional1()
         {
             Test(
@@ -1702,7 +1702,7 @@ index: 3);
 @"class Program { private static bool foo ; static void Main ( ) { int i = foo ? bar : baz ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInConditional2()
         {
             Test(
@@ -1710,7 +1710,7 @@ index: 3);
 @"class Program { private static int bar ; static void Main ( ) { int i = foo ? bar : baz ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInConditional3()
         {
             Test(
@@ -1718,7 +1718,7 @@ index: 3);
 @"class Program { private static int baz ; static void Main ( ) { int i = foo ? bar : baz ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInCast()
         {
             Test(
@@ -1726,7 +1726,7 @@ index: 3);
 @"class Program { private int y ; void Main ( ) { var x = ( int ) y ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInIf()
         {
             Test(
@@ -1734,7 +1734,7 @@ index: 3);
 @"class Program { private bool foo ; void Main ( ) { if ( foo ) { } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInSwitch()
         {
             Test(
@@ -1742,21 +1742,21 @@ index: 3);
 @"class Program { private int foo ; void Main ( ) { switch ( foo ) { } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingOnNamespace()
         {
             TestMissing(
 @"class Program { void Main ( ) { [|System|] . Console . WriteLine ( 4 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingOnType()
         {
             TestMissing(
 @"class Program { void Main ( ) { [|System . Console|] . WriteLine ( 4 ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestMissingOnBase()
         {
             TestMissing(
@@ -1764,7 +1764,7 @@ index: 3);
         }
 
         [WorkItem(545273)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFromAssign1()
         {
             Test(
@@ -1773,7 +1773,7 @@ index: 3);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestFuncAssignment()
         {
             Test(
@@ -1783,7 +1783,7 @@ index: 2);
         }
 
         [WorkItem(545273)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFromAssign1NotAsVar()
         {
             Test(
@@ -1794,7 +1794,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         }
 
         [WorkItem(545273)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFromAssign2()
         {
             Test(
@@ -1804,7 +1804,7 @@ index: 2);
         }
 
         [WorkItem(545269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInVenus1()
         {
             TestMissing(
@@ -1823,7 +1823,7 @@ class C
         }
 
         [WorkItem(545269)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInVenus2()
         {
             var code = @"
@@ -1856,7 +1856,7 @@ class C
         }
 
         [WorkItem(546027)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyFromAttribute()
         {
             Test(
@@ -1865,7 +1865,7 @@ class C
         }
 
         [WorkItem(545232)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestNewLinePreservationBeforeInsertingLocal()
         {
             Test(
@@ -1911,7 +1911,7 @@ compareTokens: false);
         }
 
         [WorkItem(863346)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInGenericMethod_Local()
         {
             Test(
@@ -1953,7 +1953,7 @@ compareTokens: false);
         }
 
         [WorkItem(863346)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateInGenericMethod_Property()
         {
             Test(
@@ -1995,7 +1995,7 @@ compareTokens: false);
         }
 
         [WorkItem(865067)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestWithYieldReturn()
         {
             Test(
@@ -2004,7 +2004,7 @@ compareTokens: false);
         }
 
         [WorkItem(877580)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestWithThrow()
         {
             Test(
@@ -2013,7 +2013,7 @@ compareTokens: false);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeField()
         {
             Test(
@@ -2022,7 +2022,7 @@ compareTokens: false);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeField2()
         {
             Test(
@@ -2031,7 +2031,7 @@ compareTokens: false);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeFieldInUnsafeClass()
         {
             Test(
@@ -2040,7 +2040,7 @@ compareTokens: false);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeFieldInNestedClass()
         {
             Test(
@@ -2049,7 +2049,7 @@ compareTokens: false);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeFieldInNestedClass2()
         {
             Test(
@@ -2058,7 +2058,7 @@ compareTokens: false);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeReadOnlyField()
         {
             Test(
@@ -2068,7 +2068,7 @@ index: 1);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeReadOnlyField2()
         {
             Test(
@@ -2078,7 +2078,7 @@ index: 1);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeReadOnlyFieldInUnsafeClass()
         {
             Test(
@@ -2088,7 +2088,7 @@ index: 1);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeReadOnlyFieldInNestedClass()
         {
             Test(
@@ -2098,7 +2098,7 @@ index: 1);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeReadOnlyFieldInNestedClass2()
         {
             Test(
@@ -2108,7 +2108,7 @@ index: 1);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeProperty()
         {
             Test(
@@ -2118,7 +2118,7 @@ index: 2);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafeProperty2()
         {
             Test(
@@ -2128,7 +2128,7 @@ index: 2);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafePropertyInUnsafeClass()
         {
             Test(
@@ -2138,7 +2138,7 @@ index: 2);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafePropertyInNestedClass()
         {
             Test(
@@ -2148,7 +2148,7 @@ index: 2);
         }
 
         [WorkItem(530177)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestUnsafePropertyInNestedClass2()
         {
             Test(
@@ -2158,7 +2158,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfProperty()
         {
             Test(
@@ -2167,7 +2167,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfField()
         {
             Test(
@@ -2177,7 +2177,7 @@ index: 1);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfReadonlyField()
         {
             Test(
@@ -2187,7 +2187,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfLocal()
         {
             Test(
@@ -2197,7 +2197,7 @@ index: 3);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfProperty2()
         {
             Test(
@@ -2206,7 +2206,7 @@ index: 3);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfField2()
         {
             Test(
@@ -2216,7 +2216,7 @@ index: 1);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfReadonlyField2()
         {
             Test(
@@ -2226,7 +2226,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfLocal2()
         {
             Test(
@@ -2236,7 +2236,7 @@ index: 3);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfProperty3()
         {
             Test(
@@ -2245,7 +2245,7 @@ index: 3);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfField3()
         {
             Test(
@@ -2255,7 +2255,7 @@ index: 1);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfReadonlyField3()
         {
             Test(
@@ -2265,7 +2265,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfLocal3()
         {
             Test(
@@ -2275,28 +2275,28 @@ index: 3);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfMissing()
         {
             TestMissing(@"class C { void M() { var x = [|nameof(1 + 2)|]; } }");
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfMissing2()
         {
             TestMissing(@"class C { void M() { var y = 1 + 2; var x = [|nameof(y)|]; } }");
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfMissing3()
         {
             TestMissing(@"class C { void M() { var y = 1 + 2; var z = """"; var x = [|nameof(y, z)|]; } }");
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfProperty4()
         {
             Test(
@@ -2306,7 +2306,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfField4()
         {
             Test(
@@ -2315,7 +2315,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfReadonlyField4()
         {
             Test(
@@ -2325,7 +2325,7 @@ index: 1);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfLocal4()
         {
             Test(
@@ -2335,7 +2335,7 @@ index: 3);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfProperty5()
         {
             Test(
@@ -2345,7 +2345,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfField5()
         {
             Test(
@@ -2354,7 +2354,7 @@ index: 2);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfReadonlyField5()
         {
             Test(
@@ -2364,7 +2364,7 @@ index: 1);
         }
 
         [WorkItem(1032176)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestInsideNameOfLocal5()
         {
             Test(
@@ -2374,7 +2374,7 @@ index: 3);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessProperty()
         {
             Test(
@@ -2383,7 +2383,7 @@ index: 3);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessField()
         {
             Test(
@@ -2393,7 +2393,7 @@ index: 1);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessReadonlyField()
         {
             Test(
@@ -2403,7 +2403,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessVarProperty()
         {
             Test(
@@ -2412,7 +2412,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessVarField()
         {
             Test(
@@ -2422,7 +2422,7 @@ index: 1);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessVarReadOnlyField()
         {
             Test(
@@ -2432,7 +2432,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessNullableProperty()
         {
             Test(
@@ -2441,7 +2441,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessNullableField()
         {
             Test(
@@ -2451,7 +2451,7 @@ index: 1);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestConditionalAccessNullableReadonlyField()
         {
             Test(
@@ -2461,7 +2461,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInConditionalAccessExpression()
         {
             Test(
@@ -2470,7 +2470,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInConditionalAccessExpression2()
         {
             Test(
@@ -2479,7 +2479,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInConditionalAccessExpression3()
         {
             Test(
@@ -2488,7 +2488,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInConditionalAccessExpression4()
         {
             Test(
@@ -2497,7 +2497,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInConditionalAccessExpression()
         {
             Test(
@@ -2507,7 +2507,7 @@ index: 1);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInConditionalAccessExpression2()
         {
             Test(
@@ -2517,7 +2517,7 @@ index: 1);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInConditionalAccessExpression3()
         {
             Test(
@@ -2527,7 +2527,7 @@ index: 1);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInConditionalAccessExpression4()
         {
             Test(
@@ -2537,7 +2537,7 @@ index: 1);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadonlyFieldInConditionalAccessExpression()
         {
             Test(
@@ -2547,7 +2547,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadonlyFieldInConditionalAccessExpression2()
         {
             Test(
@@ -2557,7 +2557,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadonlyFieldInConditionalAccessExpression3()
         {
             Test(
@@ -2567,7 +2567,7 @@ index: 2);
         }
 
         [WorkItem(1064748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadonlyFieldInConditionalAccessExpression4()
         {
             Test(
@@ -2576,7 +2576,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInPropertyInitializers()
         {
             Test(
@@ -2584,7 +2584,7 @@ index: 2);
 @"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; class Program { private static int y ; public int MyProperty { get ; } = y ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadonlyFieldInPropertyInitializers()
         {
             Test(
@@ -2593,7 +2593,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInPropertyInitializers()
         {
             Test(
@@ -2602,7 +2602,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInExpressionBodyMember()
         {
             Test(
@@ -2610,7 +2610,7 @@ index: 2);
 @"class Program { private int y ; public int Y => y ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadonlyFieldInExpressionBodyMember()
         {
             Test(
@@ -2619,7 +2619,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInExpressionBodyMember()
         {
             Test(
@@ -2628,7 +2628,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInExpressionBodyMember2()
         {
             Test(
@@ -2636,7 +2636,7 @@ index: 2);
 @"class C { private static C x ; public static C operator -- ( C p ) => x ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadOnlyFieldInExpressionBodyMember2()
         {
             Test(
@@ -2645,7 +2645,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInExpressionBodyMember2()
         {
             Test(
@@ -2654,7 +2654,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInExpressionBodyMember3()
         {
             Test(
@@ -2662,7 +2662,7 @@ index: 2);
 @"class C { private static C x ; public static C GetValue ( C p ) => x ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadOnlyFieldInExpressionBodyMember3()
         {
             Test(
@@ -2671,7 +2671,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInExpressionBodyMember3()
         {
             Test(
@@ -2680,7 +2680,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInDictionaryInitializer()
         {
             Test(
@@ -2688,7 +2688,7 @@ index: 2);
 @"using System . Collections . Generic ; class Program { private static string key ; static void Main ( string [ ] args ) { var x = new Dictionary < string , int > { [ key ] = 0 } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInDictionaryInitializer()
         {
             Test(
@@ -2696,7 +2696,7 @@ index: 2);
 @"using System . Collections . Generic ; class Program { public static string One { get ; private set ; } static void Main ( string [ ] args ) { var x = new Dictionary < string , int > { [ ""Zero"" ] = 0 , [ One ] = 1 , [ ""Two"" ] = 2 } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInDictionaryInitializer2()
         {
             Test(
@@ -2704,7 +2704,7 @@ index: 2);
 @"using System . Collections . Generic ; class Program { private static int i ; static void Main ( string [ ] args ) { var x = new Dictionary < string , int > { [ ""Zero"" ] = i } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadOnlyFieldInDictionaryInitializer()
         {
             Test(
@@ -2713,7 +2713,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateFieldInDictionaryInitializer3()
         {
             Test(
@@ -2722,7 +2722,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadOnlyFieldInDictionaryInitializer2()
         {
             Test(
@@ -2731,7 +2731,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInDictionaryInitializer2()
         {
             Test(
@@ -2740,7 +2740,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateReadOnlyFieldInDictionaryInitializer3()
         {
             Test(
@@ -2749,7 +2749,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGeneratePropertyInDictionaryInitializer3()
         {
             Test(
@@ -2758,7 +2758,7 @@ index: 2);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateLocalInDictionaryInitializer()
         {
             Test(
@@ -2767,7 +2767,7 @@ index: 2);
 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateLocalInDictionaryInitializer2()
         {
             Test(
@@ -2776,7 +2776,7 @@ index: 3);
 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateLocalInDictionaryInitializer3()
         {
             Test(
@@ -2785,7 +2785,7 @@ index: 3);
 index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateVariableFromLambda()
         {
             Test(
@@ -2793,7 +2793,7 @@ index: 3);
 @"using System ; class Program { private static Func < int > foo ; static void Main ( string [ ] args ) { foo = ( ) => { return 0 ; } ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateVariableFromLambda2()
         {
             Test(
@@ -2802,7 +2802,7 @@ index: 3);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public void TestGenerateVariableFromLambda3()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 null, new ImplementAbstractClassCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestSimpleMethods()
         {
             Test(
@@ -26,14 +26,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
         }
 
         [WorkItem(543234)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestNotAvailableForStruct()
         {
             TestMissing(
 @"abstract class Foo { public abstract void Bar ( ) ; } struct [|Program|] : Foo { } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalIntParameter()
         {
             Test(
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( int x = 3 ) ; } class b : d { public override void foo ( int x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalCharParameter()
         {
             Test(
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( char x = 'a' ) ; } class b : d { public override void foo ( char x = 'a' ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalStringParameter()
         {
             Test(
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( string x = ""x"" ) ; } class b : d { public override void foo ( string x = ""x"" ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalShortParameter()
         {
             Test(
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( short x = 3 ) ; } class b : d { public override void foo ( short x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalDecimalParameter()
         {
             Test(
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( decimal x = 3 ) ; } class b : d { public override void foo ( decimal x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalDoubleParameter()
         {
             Test(
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( double x = 3 ) ; } class b : d { public override void foo ( double x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalLongParameter()
         {
             Test(
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( long x = 3 ) ; } class b : d { public override void foo ( long x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalFloatParameter()
         {
             Test(
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( float x = 3 ) ; } class b : d { public override void foo ( float x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalUshortParameter()
         {
             Test(
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( ushort x = 3 ) ; } class b : d { public override void foo ( ushort x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalUintParameter()
         {
             Test(
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( uint x = 3 ) ; } class b : d { public override void foo ( uint x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalUlongParameter()
         {
             Test(
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
                 @"using System ; abstract class d { public abstract void foo ( ulong x = 3 ) ; } class b : d { public override void foo ( ulong x = 3 ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalStructParameter()
         {
             Test(
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
         }
 
         [WorkItem(916114)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalNullableStructParameter()
         {
             Test(
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
         }
 
         [WorkItem(916114)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalNullableIntParameter()
         {
             Test(
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
 @"using System ; abstract class d { public abstract void m ( int? x = 5, int? y = default(int?) ) ; } class c : d { public override void m ( int? x = 5, int? y = default(int?) ) { throw new NotImplementedException ( ) ; } }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOptionalObjectParameter()
         {
             Test(
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
         }
 
         [WorkItem(543883)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestDifferentAccessorAccessibility()
         {
             Test(
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
 @"using System ; abstract class c1 { public abstract c1 this [ c1 x ] { get ; internal set ; } } class c2 : c1 { public override c1 this [ c1 x ] { get { throw new NotImplementedException ( ) ; } internal set { throw new NotImplementedException ( ) ; } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestEvent1()
         {
             Test(
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
 @"using System ; abstract class C { public abstract event Action E ; } class D : C { public override event Action E ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestIndexer1()
         {
             Test(
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
 @"using System ; abstract class C { public abstract int this [ string s ] { get { } internal set { } } } class D : C { public override int this [ string s ] { get { throw new NotImplementedException ( ) ; } internal set { throw new NotImplementedException ( ) ; } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestMissingInHiddenType()
         {
             TestMissing(
@@ -195,7 +195,7 @@ class [|Program|] : Foo
 #line default");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestGenerateIntoNonHiddenPart()
         {
             Test(
@@ -231,7 +231,7 @@ partial class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestGenerateIfLocationAvailable()
         {
             Test(
@@ -272,7 +272,7 @@ compareTokens: false);
         }
 
         [WorkItem(545585)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestOnlyGenerateUnimplementedAccessors()
         {
             Test(
@@ -281,7 +281,7 @@ compareTokens: false);
         }
 
         [WorkItem(545615)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestParamsArray()
         {
             Test(
@@ -290,7 +290,7 @@ compareTokens: false);
         }
 
         [WorkItem(545636)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestNullPointerType()
         {
             Test(
@@ -299,7 +299,7 @@ compareTokens: false);
         }
 
         [WorkItem(545637)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void TestErrorTypeCalledVar()
         {
             Test(
@@ -308,7 +308,7 @@ compareTokens: false);
         }
 
         [WorkItem(581500)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void Bugfix_581500()
         {
             Test(
@@ -341,7 +341,7 @@ abstract class A<T>
         }
 
         [WorkItem(625442)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         public void Bugfix_625442()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests_FixAllTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementAb
     {
         #region "Fix all occurrences tests"
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInDocument()
@@ -115,7 +115,7 @@ class B3 : A1
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInProject()
@@ -231,7 +231,7 @@ class B3 : A1
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution()
@@ -360,7 +360,7 @@ class B3 : A1
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution_DifferentAssemblyWithSameTypeName()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
             return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(null, new ImplementInterfaceCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMethod()
         {
             Test(
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface { void Method1 ( ) ; } class Class : IInterface { public void Method1 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMethodWhenClassBracesAreMissing()
         {
             Test(
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface { void Method1 ( ) ; } class Class : IInterface { public void Method1 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestInheritance1()
         {
             Test(
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 { void Method1 ( ) ; } interface IInterface2 : IInterface1 { } class Class : IInterface2 { public void Method1 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestInheritance2()
         {
             Test(
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 { } interface IInterface2 : IInterface1 { void Method1 ( ) ; } class Class : IInterface2 { public void Method1 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestInheritance3()
         {
             Test(
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 { void Method1 ( ) ; } interface IInterface2 : IInterface1 { void Method2 ( ) ; } class Class : IInterface2 { public void Method1 ( ) { throw new NotImplementedException ( ) ; } public void Method2 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestInheritanceMatchingMethod()
         {
             Test(
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 { void Method1 ( ) ; } interface IInterface2 : IInterface1 { void Method1 ( ) ; } class Class : IInterface2 { public void Method1 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestExistingConflictingMethodReturnType()
         {
             Test(
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 { void Method1 ( ) ; } class Class : IInterface1 { public int Method1 ( ) { return 0 ; } void IInterface1 . Method1 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestExistingConflictingMethodParameters()
         {
             Test(
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 { void Method1 ( int i ) ; } class Class : IInterface1 { public void Method1 ( int i ) { throw new NotImplementedException ( ) ; } public void Method1 ( string i ) { } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementGenericType()
         {
             Test(
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 < T > { void Method1 ( T t ) ; } class Class : IInterface1 < int > { public void Method1 ( int t ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementGenericTypeWithGenericMethod()
         {
             Test(
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 < T > { void Method1 < U > ( T t , U u ) ; } class Class : IInterface1 < int > { public void Method1 < U > ( int t , U u ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementGenericTypeWithGenericMethodWithNaturalConstraint()
         {
             Test(
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 < T > { void Method1 < U > ( T t , U u ) where U : IList < T > ; } class Class : IInterface1 < int > { public void Method1 < U > ( int t , U u ) where U : IList<int> { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementGenericTypeWithGenericMethodWithUnexpressibleConstraint()
         {
             Test(
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface1 < T > { void Method1 < U > ( T t , U u ) where U : T ; } class Class : IInterface1 < int > { void IInterface1 < int > . Method1 < U > ( int t , U u ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestArrayType()
         {
             Test(
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface I { string [ ] M ( ) ; } class C : I { public string [ ] M ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementThroughFieldMember()
         {
             Test(
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementThroughFieldMemberInterfaceWithIndexer()
         {
             Test(
@@ -142,7 +142,7 @@ index: 1);
         }
 
         [WorkItem(472, "https://github.com/dotnet/roslyn/issues/472")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementThroughFieldMemberRemoveUnnecessaryCast()
         {
             Test(
@@ -152,7 +152,7 @@ index: 1);
         }
 
         [WorkItem(472, "https://github.com/dotnet/roslyn/issues/472")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementThroughFieldMemberRemoveUnnecessaryCastAndThis()
         {
             Test(
@@ -161,7 +161,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementAbstract()
         {
             Test(
@@ -170,7 +170,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceWithRefOutParameters()
         {
             Test(
@@ -179,7 +179,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestConflictingMethods1()
         {
             Test(
@@ -187,7 +187,7 @@ index: 1);
 @"using System; class B { public int Method1 ( ) { } } class C : B , I { void I.Method1 ( ) { throw new NotImplementedException ( ) ; } } interface I { void Method1 ( ) ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestConflictingProperties()
         {
             Test(
@@ -196,7 +196,7 @@ index: 1);
         }
 
         [WorkItem(539043)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestExplicitProperties()
         {
             TestMissing(
@@ -204,7 +204,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEscapedMethodName()
         {
             Test(
@@ -213,7 +213,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEscapedMethodKeyword()
         {
             Test(
@@ -222,7 +222,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEscapedInterfaceName1()
         {
             Test(
@@ -231,7 +231,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEscapedInterfaceName2()
         {
             Test(
@@ -240,7 +240,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEscapedInterfaceKeyword1()
         {
             Test(
@@ -249,7 +249,7 @@ index: 1);
         }
 
         [WorkItem(539489)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEscapedInterfaceKeyword2()
         {
             Test(
@@ -258,7 +258,7 @@ index: 1);
         }
 
         [WorkItem(539522)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestPropertyFormatting()
         {
             Test(
@@ -293,7 +293,7 @@ public class A : DD
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestCommentPlacement()
         {
             Test(
@@ -323,7 +323,7 @@ compareTokens: false);
         }
 
         [WorkItem(539991)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestBracePlacement()
         {
             Test(
@@ -342,7 +342,7 @@ compareTokens: false);
         }
 
         [WorkItem(540318)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMissingWithIncompleteMember()
         {
             TestMissing(
@@ -350,7 +350,7 @@ compareTokens: false);
         }
 
         [WorkItem(541380)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestExplicitProperty()
         {
             Test(
@@ -360,7 +360,7 @@ index: 1);
         }
 
         [WorkItem(541981)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoDelegateThroughField1()
         {
             TestActionCount(
@@ -381,7 +381,7 @@ index: 2);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIReadOnlyListThroughField()
         {
             Test(
@@ -396,7 +396,7 @@ index: 1);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIReadOnlyListThroughProperty()
         {
             Test(
@@ -411,7 +411,7 @@ index: 1);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceThroughField()
         {
             Test(
@@ -421,7 +421,7 @@ index: 1);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceThroughField_FieldImplementsMultipleInterfaces()
         {
             TestActionCount(
@@ -441,7 +441,7 @@ index: 1);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceThroughField_MultipleFieldsCanImplementInterface()
         {
             TestActionCount(
@@ -458,7 +458,7 @@ index: 2);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceThroughField_MultipleFieldsForMultipleInterfaces()
         {
             TestActionCount(
@@ -478,7 +478,7 @@ index: 1);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoImplementThroughIndexer()
         {
             TestActionCount(
@@ -487,7 +487,7 @@ count: 2);
         }
 
         [WorkItem(768799)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoImplementThroughWriteOnlyProperty()
         {
             TestActionCount(
@@ -495,7 +495,7 @@ count: 2);
 count: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementEvent()
         {
             Test(
@@ -504,7 +504,7 @@ count: 2);
 index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementEventAbstractly()
         {
             Test(
@@ -513,7 +513,7 @@ index: 0);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementEventExplicitly()
         {
             Test(
@@ -522,7 +522,7 @@ index: 1);
 index: 2);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestFaultToleranceInStaticMembers()
         {
             Test(
@@ -530,7 +530,7 @@ index: 2);
 @"using System ; interface IFoo { static string Name { set ; get ; } static int Foo ( string s ) ; } class Program : IFoo { public string Name { get { throw new NotImplementedException ( ) ; } set { throw new NotImplementedException ( ) ; } } public int Foo ( string s ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestIndexers()
         {
             Test(
@@ -538,7 +538,7 @@ index: 2);
 @"using System ; public interface ISomeInterface { int this [ int index ] { get ; set ; } } class IndexerClass : ISomeInterface { public int this [ int index ] { get { throw new NotImplementedException ( ) ; } set { throw new NotImplementedException ( ) ; } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestIndexersExplicit()
         {
             Test(
@@ -547,7 +547,7 @@ index: 2);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestIndexersWithASingleAccessor()
         {
             Test(
@@ -556,7 +556,7 @@ index: 1);
         }
 
         [WorkItem(542357)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestConstraints1()
         {
             Test(
@@ -565,7 +565,7 @@ index: 1);
         }
 
         [WorkItem(542357)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestConstraintsExplicit()
         {
             Test(
@@ -575,7 +575,7 @@ index: 1);
         }
 
         [WorkItem(542357)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUsingAddedForConstraint()
         {
             Test(
@@ -584,7 +584,7 @@ index: 1);
         }
 
         [WorkItem(542379)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestIndexer()
         {
             Test(
@@ -593,7 +593,7 @@ index: 1);
         }
 
         [WorkItem(542588)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestRecursiveConstraint1()
         {
             Test(
@@ -602,7 +602,7 @@ index: 1);
         }
 
         [WorkItem(542588)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestRecursiveConstraint2()
         {
             Test(
@@ -612,7 +612,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint1()
         {
             Test(
@@ -621,7 +621,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint2()
         {
             Test(
@@ -630,7 +630,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint3()
         {
             Test(
@@ -640,7 +640,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint4()
         {
             Test(
@@ -649,7 +649,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint5()
         {
             Test(
@@ -658,7 +658,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint6()
         {
             Test(
@@ -667,7 +667,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint7()
         {
             Test(
@@ -676,7 +676,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint8()
         {
             Test(
@@ -685,7 +685,7 @@ index: 1);
         }
 
         [WorkItem(542587)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint9()
         {
             Test(
@@ -694,7 +694,7 @@ index: 1);
         }
 
         [WorkItem(542621)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnexpressibleConstraint10()
         {
             Test(
@@ -703,7 +703,7 @@ index: 1);
         }
 
         [WorkItem(542669)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestArrayConstraint()
         {
             Test(
@@ -712,7 +712,7 @@ index: 1);
         }
 
         [WorkItem(542743)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMultipleClassConstraints()
         {
             Test(
@@ -721,7 +721,7 @@ index: 1);
         }
 
         [WorkItem(542751)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestClassConstraintAndRefConstraint()
         {
             Test(
@@ -730,7 +730,7 @@ index: 1);
         }
 
         [WorkItem(542505)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestRenameConflictingTypeParameters1()
         {
             Test(
@@ -739,7 +739,7 @@ index: 1);
         }
 
         [WorkItem(542505)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestRenameConflictingTypeParameters2()
         {
             Test(
@@ -749,7 +749,7 @@ index: 1);
         }
 
         [WorkItem(542505)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestRenameConflictingTypeParameters3()
         {
             Test(
@@ -758,7 +758,7 @@ index: 1);
         }
 
         [WorkItem(542505)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestRenameConflictingTypeParameters4()
         {
             Test(
@@ -768,7 +768,7 @@ index: 1);
         }
 
         [WorkItem(542506)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNameSimplification()
         {
             Test(
@@ -777,7 +777,7 @@ index: 1);
         }
 
         [WorkItem(542506)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNameSimplification2()
         {
             Test(
@@ -786,7 +786,7 @@ index: 1);
         }
 
         [WorkItem(542506)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNameSimplification3()
         {
             Test(
@@ -795,7 +795,7 @@ index: 1);
         }
 
         [WorkItem(544166)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementAbstractProperty()
         {
             Test(
@@ -805,7 +805,7 @@ index: 1);
         }
 
         [WorkItem(544210)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMissingOnWrongArity()
         {
             TestMissing(
@@ -813,7 +813,7 @@ index: 1);
         }
 
         [WorkItem(544281)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplicitDefaultValue()
         {
             Test(
@@ -822,7 +822,7 @@ index: 1);
         }
 
         [WorkItem(544281)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestExplicitDefaultValue()
         {
             Test(
@@ -831,7 +831,7 @@ index: 1);
 index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMissingInHiddenType()
         {
             TestMissing(
@@ -844,7 +844,7 @@ class Program : [|IComparable|]
 #line default");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestGenerateIntoVisiblePart()
         {
             Test(
@@ -878,7 +878,7 @@ partial class Program : IComparable
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestGenerateIfAvailableRegionExists()
         {
             Test(
@@ -912,7 +912,7 @@ compareTokens: false);
         }
 
         [WorkItem(545334)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoGenerateInVenusCase1()
         {
             TestMissing(
@@ -925,7 +925,7 @@ class Foo : [|IComparable|]
         }
 
         [WorkItem(545476)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestOptionalDateTime1()
         {
             Test(
@@ -934,7 +934,7 @@ class Foo : [|IComparable|]
         }
 
         [WorkItem(545476)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestOptionalDateTime2()
         {
             Test(
@@ -944,7 +944,7 @@ index: 1);
         }
 
         [WorkItem(545477)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestIUnknownIDispatchAttributes1()
         {
             Test(
@@ -953,7 +953,7 @@ index: 1);
         }
 
         [WorkItem(545477)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestIUnknownIDispatchAttributes2()
         {
             Test(
@@ -963,7 +963,7 @@ index: 1);
         }
 
         [WorkItem(545464)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestTypeNameConflict()
         {
             Test(
@@ -971,7 +971,7 @@ index: 1);
 @"using System ; interface IFoo { void Foo ( ) ; } public class Foo : IFoo { void IFoo . Foo ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestStringLiteral()
         {
             Test(
@@ -980,7 +980,7 @@ index: 1);
         }
 
         [WorkItem(916114)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestOptionalNullableStructParameter1()
         {
             Test(
@@ -989,7 +989,7 @@ index: 1);
         }
 
         [WorkItem(916114)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestOptionalNullableStructParameter2()
         {
             Test(
@@ -998,7 +998,7 @@ index: 1);
         }
 
         [WorkItem(916114)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestOptionalNullableIntParameter()
         {
             Test(
@@ -1007,7 +1007,7 @@ index: 1);
         }
 
         [WorkItem(545613)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestOptionalWithNoDefaultValue()
         {
             Test(
@@ -1015,7 +1015,7 @@ index: 1);
 @"using System ; using System . Runtime . InteropServices ; interface I { void Foo ( [ Optional ] I o ) ; } class C : I { public void Foo ( [ Optional ] I o ) { throw new NotImplementedException ( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestIntegralAndFloatLiterals()
         {
             Test(
@@ -1205,7 +1205,7 @@ class C : I
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEnumLiterals()
         {
             Test(
@@ -1269,7 +1269,7 @@ class C : I
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestCharLiterals()
         {
             Test(
@@ -1371,7 +1371,7 @@ compareTokens: false);
         }
 
         [WorkItem(545695)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestRemoveParenthesesAroundTypeReference1()
         {
             Test(
@@ -1380,7 +1380,7 @@ compareTokens: false);
         }
 
         [WorkItem(545696)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDecimalConstants1()
         {
             Test(
@@ -1389,7 +1389,7 @@ compareTokens: false);
         }
 
         [WorkItem(545711)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNullablePrimitiveLiteral()
         {
             Test(
@@ -1398,7 +1398,7 @@ compareTokens: false);
         }
 
         [WorkItem(545715)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNullableEnumType()
         {
             Test(
@@ -1407,7 +1407,7 @@ compareTokens: false);
         }
 
         [WorkItem(545752)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestByteLiterals()
         {
             Test(
@@ -1416,7 +1416,7 @@ compareTokens: false);
         }
 
         [WorkItem(545736)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestCastedOptionalParameter1()
         {
             const string code = @"
@@ -1449,7 +1449,7 @@ class C : I
         }
 
         [WorkItem(545737)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestCastedEnumValue()
         {
             Test(
@@ -1458,7 +1458,7 @@ class C : I
         }
 
         [WorkItem(545785)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoCastFromZeroToEnum()
         {
             Test(
@@ -1467,7 +1467,7 @@ class C : I
         }
 
         [WorkItem(545793)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMultiDimArray()
         {
             Test(
@@ -1476,7 +1476,7 @@ class C : I
         }
 
         [WorkItem(545794)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestParametersAfterOptionalParameter()
         {
             Test(
@@ -1485,7 +1485,7 @@ class C : I
         }
 
         [WorkItem(545605)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestAttributeInParameter()
         {
             Test(
@@ -1521,7 +1521,7 @@ compareTokens: false);
         }
 
         [WorkItem(545897)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNameConflictBetweenMethodAndTypeParameter()
         {
             Test(
@@ -1530,7 +1530,7 @@ compareTokens: false);
         }
 
         [WorkItem(545895)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestTypeParameterReplacementWithOuterType()
         {
             Test(
@@ -1539,7 +1539,7 @@ compareTokens: false);
         }
 
         [WorkItem(545864)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestFloatConstant()
         {
             Test(
@@ -1548,7 +1548,7 @@ compareTokens: false);
         }
 
         [WorkItem(544640)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestKeywordForTypeParameterName()
         {
             Test(
@@ -1557,7 +1557,7 @@ compareTokens: false);
         }
 
         [WorkItem(545922)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestExtremeDecimals()
         {
             Test(
@@ -1566,7 +1566,7 @@ compareTokens: false);
         }
 
         [WorkItem(544659)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNonZeroScaleDecimals()
         {
             Test(
@@ -1575,7 +1575,7 @@ compareTokens: false);
         }
 
         [WorkItem(544639)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnterminatedComment()
         {
             Test(
@@ -1599,7 +1599,7 @@ class C : IServiceProvider /*
         }
 
         [WorkItem(529920)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNewLineBeforeDirective()
         {
             Test(
@@ -1624,7 +1624,7 @@ class C : IServiceProvider
         }
 
         [WorkItem(529947)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestCommentAfterInterfaceList1()
         {
             Test(
@@ -1645,7 +1645,7 @@ class C : IServiceProvider // Implement interface
         }
 
         [WorkItem(529947)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestCommentAfterInterfaceList2()
         {
             Test(
@@ -1669,7 +1669,7 @@ class C : IServiceProvider
 
         [WorkItem(994456)]
         [WorkItem(958699)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposable_NoDisposePattern()
         {
             Test(
@@ -1688,7 +1688,7 @@ class C : IDisposable
 
         [WorkItem(994456)]
         [WorkItem(958699)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposable_DisposePattern()
         {
             Test(
@@ -1704,7 +1704,7 @@ class C : IDisposable
 
         [WorkItem(994456)]
         [WorkItem(958699)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableExplicitly_NoDisposePattern()
         {
             Test(
@@ -1723,7 +1723,7 @@ class C : IDisposable
 
         [WorkItem(994456)]
         [WorkItem(941469)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableExplicitly_DisposePattern()
         {
             Test(
@@ -1747,7 +1747,7 @@ class C : System.IDisposable
 
         [WorkItem(994456)]
         [WorkItem(958699)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableAbstractly_NoDisposePattern()
         {
             Test(
@@ -1763,7 +1763,7 @@ abstract class C : IDisposable
 
         [WorkItem(994456)]
         [WorkItem(958699)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableThroughMember_NoDisposePattern()
         {
             Test(
@@ -1785,7 +1785,7 @@ class C : IDisposable
         }
 
         [WorkItem(941469)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableExplicitly_NoNamespaceImportForSystem()
         {
             Test(
@@ -1798,7 +1798,7 @@ $@"class C : System.IDisposable
         }
 
         [WorkItem(951968)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableViaBaseInterface_NoDisposePattern()
         {
             Test(
@@ -1830,7 +1830,7 @@ class C : I
         }
 
         [WorkItem(951968)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableViaBaseInterface()
         {
             Test(
@@ -1859,7 +1859,7 @@ class C : I
         }
 
         [WorkItem(951968)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementIDisposableExplicitlyViaBaseInterface()
         {
             Test(
@@ -1888,7 +1888,7 @@ class C : I
         }
 
         [WorkItem(941469)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDontImplementDisposePatternForLocallyDefinedIDisposable()
         {
             Test(
@@ -1918,7 +1918,7 @@ class C : I
 }", index: 1, compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDontImplementDisposePatternForStructures1()
         {
             Test(
@@ -1935,7 +1935,7 @@ struct S : IDisposable
 ", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDontImplementDisposePatternForStructures2()
         {
             Test(
@@ -1953,7 +1953,7 @@ struct S : IDisposable
         }
 
         [WorkItem(545924)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestEnumNestedInGeneric()
         {
             Test(
@@ -1962,7 +1962,7 @@ struct S : IDisposable
         }
 
         [WorkItem(545939)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnterminatedString1()
         {
             Test(
@@ -1971,7 +1971,7 @@ struct S : IDisposable
         }
 
         [WorkItem(545939)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnterminatedString2()
         {
             Test(
@@ -1980,7 +1980,7 @@ struct S : IDisposable
         }
 
         [WorkItem(545939)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnterminatedString3()
         {
             Test(
@@ -1989,7 +1989,7 @@ struct S : IDisposable
         }
 
         [WorkItem(545939)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnterminatedString4()
         {
             Test(
@@ -1998,7 +1998,7 @@ struct S : IDisposable
         }
 
         [WorkItem(545940)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDecimalENotation()
         {
             Test(
@@ -2048,7 +2048,7 @@ class C : I
         }
 
         [WorkItem(545938)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestGenericEnumWithRenamedTypeParameters()
         {
             Test(
@@ -2057,7 +2057,7 @@ class C : I
         }
 
         [WorkItem(545919)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDoNotRenameTypeParameterToParameterName()
         {
             Test(
@@ -2066,7 +2066,7 @@ class C : I
         }
 
         [WorkItem(530265)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestAttributes()
         {
             Test(
@@ -2075,7 +2075,7 @@ class C : I
         }
 
         [WorkItem(530265)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestAttributesExplicit()
         {
             Test(
@@ -2085,7 +2085,7 @@ index: 1);
         }
 
         [WorkItem(546443)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestParameterNameWithTypeName()
         {
             Test(
@@ -2094,7 +2094,7 @@ index: 1);
         }
 
         [WorkItem(530521)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestUnboundGeneric()
         {
             Test(
@@ -2103,7 +2103,7 @@ index: 1);
         }
 
         [WorkItem(752436)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestQualifiedNameImplicitInterface()
         {
             Test(
@@ -2112,7 +2112,7 @@ index: 1);
         }
 
         [WorkItem(752436)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestQualifiedNameExplicitInterface()
         {
             Test(
@@ -2121,7 +2121,7 @@ index: 1);
         }
 
         [WorkItem(847464)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForPartialType()
         {
             Test(
@@ -2145,7 +2145,7 @@ partial class C : I
         }
 
         [WorkItem(847464)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForPartialType2()
         {
             Test(
@@ -2169,7 +2169,7 @@ partial class C { }
         }
 
         [WorkItem(847464)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForPartialType3()
         {
             Test(
@@ -2195,7 +2195,7 @@ partial class C : I2 { }
         }
 
         [WorkItem(752447)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestExplicitImplOfIndexedProperty()
         {
             var initial = @"
@@ -2238,7 +2238,7 @@ public class Test : IFoo
         }
 
         [WorkItem(602475)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplicitImplOfIndexedProperty()
         {
             var initial = @"
@@ -2284,7 +2284,7 @@ class C : I
 
 #if false
         [WorkItem(13677)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoGenerateInVenusCase2()
         {
             TestMissing(
@@ -2296,7 +2296,7 @@ class Foo : [|IComparable|]
         }
 #endif
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForImplicitIDisposable()
         {
             Test(
@@ -2317,7 +2317,7 @@ class Program : IDisposable
 ", index: 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForExplicitIDisposable()
         {
             Test(
@@ -2340,7 +2340,7 @@ class Program : IDisposable
 ", index: 3);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForIDisposableNonApplicable1()
         {
             Test(
@@ -2367,7 +2367,7 @@ class Program : IDisposable
 ", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForIDisposableNonApplicable2()
         {
             Test(
@@ -2398,7 +2398,7 @@ class Program : IDisposable
 ", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestImplementInterfaceForExplicitIDisposableWithSealedClass()
         {
             Test(
@@ -2420,7 +2420,7 @@ sealed class Program : IDisposable
         }
 
         [WorkItem(939123)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoComAliasNameAttributeOnMethodParameters()
         {
             Test(
@@ -2432,7 +2432,7 @@ class C : I { public void M(int p) { throw new NotImplementedException(); } }");
         }
 
         [WorkItem(939123)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoComAliasNameAttributeOnMethodReturnType()
         {
             Test(
@@ -2446,7 +2446,7 @@ class C : I { public long M(int p) { throw new NotImplementedException(); } }");
         }
 
         [WorkItem(939123)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestNoComAliasNameAttributeOnIndexerParameters()
         {
             Test(
@@ -2458,7 +2458,7 @@ class C : I { public long this[int p] { get { throw new NotImplementedException(
         }
 
         [WorkItem(947819)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestMissingOpenBrace()
         {
             Test(
@@ -2492,7 +2492,7 @@ namespace Scenarios
         }
 
         [WorkItem(994328)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDisposePatternWhenAdditionalUsingsAreIntroduced1()
         {
             //CSharpFeaturesResources.DisposePattern
@@ -2545,7 +2545,7 @@ partial class C : I<System.Exception, System.AggregateException>, System.IDispos
         }
 
         [WorkItem(994328)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestDisposePatternWhenAdditionalUsingsAreIntroduced2()
         {
             Test(
@@ -2635,7 +2635,7 @@ partial class C
         }
 
         [WorkItem(1132014)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public void TestInaccessibleAttributes()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests_FixAllTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
     {
         #region "Fix all occurrences tests"
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInDocument()
@@ -117,7 +117,7 @@ class B3 : I1, I2
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionEquivalenceKey);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInProject()
@@ -235,7 +235,7 @@ class B3 : I1, I2
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionEquivalenceKey);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution()
@@ -364,7 +364,7 @@ class B3 : I1, I2
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionEquivalenceKey);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution_DifferentAssemblyWithSameTypeName()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
                 new InvokeDelegateWithConditionalAccessCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void Test1()
         {
             Test(
@@ -47,7 +47,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestInvertedIf()
         {
             Test(
@@ -74,7 +74,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestIfWithNoBraces()
         {
             Test(
@@ -99,7 +99,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestWithComplexExpression()
         {
             Test(
@@ -128,7 +128,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestMissingWithElseClause()
         {
             TestMissing(
@@ -147,7 +147,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestMissingWithMultipleVariables()
         {
             TestMissing(
@@ -166,7 +166,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestMissingIfUsedOutside()
         {
             TestMissing(
@@ -186,7 +186,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestSimpleForm1()
         {
             Test(
@@ -217,7 +217,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestInElseClause1()
         {
             Test(
@@ -257,7 +257,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestInElseClause2()
         {
             Test(
@@ -292,7 +292,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestTrivia1()
         {
             Test(
@@ -320,7 +320,7 @@ class C
 }", compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvokeDelegateWithConditionalAccess)]
         public void TestTrivia2()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Iterator/AddYieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Iterator/AddYieldTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Iterator
             return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(null, new CSharpAddYieldCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldIEnumerableReturnNull()
         {
             var initial =
@@ -33,7 +33,7 @@ class Program
             TestMissing(initial);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldIEnumerableReturnObject()
         {
             var initial =
@@ -61,7 +61,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldIEnumeratorReturnObject()
         {
             var initial =
@@ -89,7 +89,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldIEnumeratorReturnGenericList()
         {
             var initial =
@@ -119,7 +119,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldGenericIEnumeratorReturnObject()
         {
             var initial =
@@ -149,7 +149,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldGenericIEnumerableReturnObject()
         {
             var initial =
@@ -179,7 +179,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldIEnumerableReturnGenericList()
         {
             var initial =
@@ -197,7 +197,7 @@ class Program
             TestMissing(initial);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldGenericIEnumeratorReturnDefault()
         {
             var initial =
@@ -227,7 +227,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldGenericIEnumerableReturnConvertibleToObject()
         {
             var initial =
@@ -257,7 +257,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldGenericIEnumerableReturnConvertibleToFloat()
         {
             var initial =
@@ -287,7 +287,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldGenericIEnumeratorNonConvertableType()
         {
             var initial =
@@ -305,7 +305,7 @@ class Program
             TestMissing(initial);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldGenericIEnumeratorConvertableTypeDateTime()
         {
             var initial =
@@ -335,7 +335,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)]
         public void TestAddYieldNoTypeArguments()
         {
             var initial =

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Iterator/ChangeToIEnumerableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Iterator/ChangeToIEnumerableTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Iterator
             return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(null, new CSharpChangeToIEnumerableCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableObjectMethod()
         {
             var initial =
@@ -45,7 +45,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableTupleMethod()
         {
             var initial =
@@ -74,7 +74,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableListMethod()
         {
             var initial =
@@ -103,7 +103,7 @@ class Program
             Test(initial, expected);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableGenericIEnumerableMethod()
         {
             var initial =
@@ -120,7 +120,7 @@ class Program
             TestMissing(initial);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableGenericIEnumeratorMethod()
         {
             var initial =
@@ -137,7 +137,7 @@ class Program
             TestMissing(initial);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableIEnumeratorMethod()
         {
             var initial =
@@ -154,7 +154,7 @@ class Program
             TestMissing(initial);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableIEnumerableMethod()
         {
             var initial =
@@ -171,7 +171,7 @@ class Program
             TestMissing(initial);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToIEnumerable)]
         public void TestChangeToIEnumerableVoidMethod()
         {
             var initial =

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MockDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MockDiagnosticAnalyzerTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.MockDiagnos
         }
 
         [WorkItem(906919)]
-        [WpfFact]
+        [Fact]
         public void Bug906919()
         {
             string source = "[|class C { }|]";

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
         }
 
         [WorkItem(545979)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToErrorType()
         {
             TestMissing(
@@ -36,7 +36,7 @@ class Program
         }
 
         [WorkItem(545137), WorkItem(870550)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void ParenthesizeToKeepParseTheSame1()
         {
             Test(
@@ -71,7 +71,7 @@ class Program
         }
 
         [WorkItem(545146)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void ParenthesizeToKeepParseTheSame2()
         {
             Test(
@@ -104,7 +104,7 @@ class C
         }
 
         [WorkItem(545160)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void ParenthesizeToKeepParseTheSame3()
         {
             Test(
@@ -135,7 +135,7 @@ class Program
         }
 
         [WorkItem(545138)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveTypeParameterCastToObject()
         {
             TestMissing(
@@ -151,7 +151,7 @@ class Ð¡
         }
 
         [WorkItem(545139)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastInIsTest()
         {
             TestMissing(
@@ -170,7 +170,7 @@ class Ð¡
         }
 
         [WorkItem(545142)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastNeedForUserDefinedOperator()
         {
             TestMissing(
@@ -194,7 +194,7 @@ class Program
         }
 
         [WorkItem(545143)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemovePointerCast1()
         {
             TestMissing(
@@ -210,7 +210,7 @@ unsafe class C
         }
 
         [WorkItem(545144)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToObjectFromDelegateComparison()
         {
             // The cast below can't be removed because it would result in the Delegate
@@ -233,7 +233,7 @@ class Program
         }
 
         [WorkItem(545145)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToAnonymousMethodWhenOnLeftOfAsCast()
         {
             TestMissing(
@@ -251,7 +251,7 @@ class C
         }
 
         [WorkItem(545147)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastInFloatingPointOperation()
         {
             TestMissing(
@@ -268,7 +268,7 @@ class C
         }
 
         [WorkItem(545157)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveIdentityCastWhichAffectsOverloadResolution1()
         {
             TestMissing(
@@ -289,7 +289,7 @@ class Program
         }
 
         [WorkItem(545158)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveIdentityCastWhichAffectsOverloadResolution2()
         {
             TestMissing(
@@ -311,7 +311,7 @@ class Program
         }
 
         [WorkItem(545158)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveIdentityCastWhichAffectsOverloadResolution3()
         {
             TestMissing(
@@ -334,7 +334,7 @@ class Program
         }
 
         [WorkItem(545747)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastWhichChangesTypeOfInferredLocal()
         {
             TestMissing(
@@ -351,7 +351,7 @@ class C
         }
 
         [WorkItem(545159)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNeededCastToIListOfObject()
         {
             TestMissing(
@@ -377,7 +377,7 @@ class C
         }
 
         [WorkItem(545287), WorkItem(880752)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInParameterDefaultValue()
         {
             Test(
@@ -401,7 +401,7 @@ class Program
         }
 
         [WorkItem(545289)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInReturnStatement()
         {
             Test(
@@ -427,7 +427,7 @@ class Program
         }
 
         [WorkItem(545288)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInLambda1()
         {
             Test(
@@ -455,7 +455,7 @@ class Program
         }
 
         [WorkItem(545288)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInLambda2()
         {
             Test(
@@ -483,7 +483,7 @@ class Program
         }
 
         [WorkItem(545288)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInLambda3()
         {
             Test(
@@ -511,7 +511,7 @@ class Program
         }
 
         [WorkItem(545288)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInLambda4()
         {
             Test(
@@ -539,7 +539,7 @@ class Program
         }
 
         [WorkItem(545291)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInConditionalExpression1()
         {
             Test(
@@ -569,7 +569,7 @@ class Test
         }
 
         [WorkItem(545291)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInConditionalExpression2()
         {
             Test(
@@ -599,7 +599,7 @@ class Test
         }
 
         [WorkItem(545291)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInConditionalExpression3()
         {
             Test(
@@ -629,7 +629,7 @@ class Test
         }
 
         [WorkItem(545291)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNeededCastInConditionalExpression()
         {
             TestMissing(
@@ -646,7 +646,7 @@ class Test
         }
 
         [WorkItem(545291)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInConditionalExpression4()
         {
             Test(
@@ -676,7 +676,7 @@ class Test
         }
 
         [WorkItem(545459)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInsideADelegateConstructor()
         {
             Test(
@@ -712,7 +712,7 @@ class Test
         }
 
         [WorkItem(545419)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveTriviaWhenRemovingCast()
         {
             Test(
@@ -746,7 +746,7 @@ class Test
         }
 
         [WorkItem(545422)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInsideCaseLabel()
         {
             Test(
@@ -780,7 +780,7 @@ class Test
         }
 
         [WorkItem(545578)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInsideGotoCaseStatement()
         {
             Test(
@@ -816,7 +816,7 @@ class Test
         }
 
         [WorkItem(545595)]
-        [WpfFact(Skip = "529787"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact(Skip = "529787"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInCollectionInitializer()
         {
             Test(
@@ -846,7 +846,7 @@ class Program
         }
 
         [WorkItem(529787)]
-        [WpfFact(Skip = "529787"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact(Skip = "529787"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastWhichInCollectionInitializer1()
         {
             TestMissing(
@@ -868,7 +868,7 @@ class X : List<int>
         }
 
         [WorkItem(529787)]
-        [WpfFact(Skip = "529787"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact(Skip = "529787"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastWhichInCollectionInitializer2()
         {
             TestMissing(
@@ -890,7 +890,7 @@ class X : List<int>
         }
 
         [WorkItem(545607)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastInArrayInitializer()
         {
             Test(
@@ -918,7 +918,7 @@ class X
         }
 
         [WorkItem(545616)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnneededCastWithOverloadedBinaryOperator()
         {
             Test(
@@ -958,7 +958,7 @@ class MyAction
         }
 
         [WorkItem(545822)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastShouldInsertWhitespaceWhereNeededToKeepCorrectParsing()
         {
             Test(
@@ -990,7 +990,7 @@ class Program
         }
 
         [WorkItem(545560)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastWithExplicitUserDefinedConversion()
         {
             TestMissing(
@@ -1022,7 +1022,7 @@ class A
         }
 
         [WorkItem(545608)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastWithImplicitUserDefinedConversion()
         {
             TestMissing(
@@ -1043,7 +1043,7 @@ class X
         }
 
         [WorkItem(545941)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastWithImplicitConversionInThrow()
         {
             // The cast below can't be removed because the throw statement expects
@@ -1070,7 +1070,7 @@ class E
         }
 
         [WorkItem(545981)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInThrow()
         {
             // The cast below can't be removed because the throw statement expects
@@ -1093,7 +1093,7 @@ class C
         }
 
         [WorkItem(545941)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastInThrow()
         {
             Test(
@@ -1125,7 +1125,7 @@ class E
         }
 
         [WorkItem(545945)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryDowncast()
         {
             TestMissing(
@@ -1141,7 +1141,7 @@ class C
         }
 
         [WorkItem(545591)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastWithinLambda()
         {
             TestMissing(
@@ -1163,7 +1163,7 @@ class Program
         }
 
         [WorkItem(545606)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastFromNullToTypeParameter()
         {
             TestMissing(
@@ -1179,7 +1179,7 @@ class X
         }
 
         [WorkItem(545744)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInImplicitlyTypedArray()
         {
             TestMissing(
@@ -1197,7 +1197,7 @@ class X
         }
 
         [WorkItem(545750)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastToBaseType()
         {
             Test(
@@ -1233,7 +1233,7 @@ class X
         }
 
         [WorkItem(545855)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryLambdaToDelegateCast()
         {
             Test(
@@ -1292,7 +1292,7 @@ static class Program
         }
 
         [WorkItem(529816)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastInQueryExpression()
         {
             Test(
@@ -1326,7 +1326,7 @@ class A
         }
 
         [WorkItem(529816)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInQueryExpression()
         {
             TestMissing(
@@ -1347,7 +1347,7 @@ class A
         }
 
         [WorkItem(545848)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInConstructorInitializer()
         {
             TestMissing(
@@ -1370,7 +1370,7 @@ class C
         }
 
         [WorkItem(529831)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastFromTypeParameterToInterface()
         {
             TestMissing(
@@ -1417,7 +1417,7 @@ static class Program
         }
 
         [WorkItem(529831)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastFromTypeParameterToInterface()
         {
             Test(
@@ -1506,7 +1506,7 @@ static class Program
         }
 
         [WorkItem(545877)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontCrashOnIncompleteMethodDeclaration()
         {
             TestMissing(
@@ -1527,7 +1527,7 @@ class A
         }
 
         [WorkItem(545777)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveImportantTrailingTrivia()
         {
             Test(
@@ -1563,7 +1563,7 @@ class Program
         }
 
         [WorkItem(529791)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastToNullable1()
         {
             Test(
@@ -1593,7 +1593,7 @@ class X
         }
 
         [WorkItem(545842)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastToNullable2()
         {
             Test(
@@ -1625,7 +1625,7 @@ static class C
         }
 
         [WorkItem(545850)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveSurroundingParentheses()
         {
             Test(
@@ -1655,7 +1655,7 @@ class Program
         }
 
         [WorkItem(529846)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastFromTypeParameterToObject()
         {
             TestMissing(
@@ -1671,7 +1671,7 @@ class C
         }
 
         [WorkItem(545858)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastFromDelegateTypeToMulticastDelegate()
         {
             TestMissing(
@@ -1691,7 +1691,7 @@ class C
         }
 
         [WorkItem(545857)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInSizeOfArrayCreationExpression1()
         {
             // The cast below can't be removed because it would result in the implicit
@@ -1722,7 +1722,7 @@ class C
         }
 
         [WorkItem(545980)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInSizeOfArrayCreationExpression2()
         {
             // Array bounds must be an int, so the cast below can't be removed.
@@ -1740,7 +1740,7 @@ class C
         }
 
         [WorkItem(529842)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInTernaryExpression()
         {
             TestMissing(
@@ -1765,7 +1765,7 @@ class X
         }
 
         [WorkItem(545882), WorkItem(880752)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastInConstructorInitializer1()
         {
             Test(
@@ -1789,7 +1789,7 @@ class C
         }
 
         [WorkItem(545958), WorkItem(880752)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastInConstructorInitializer2()
         {
             Test(
@@ -1819,7 +1819,7 @@ class C
         }
 
         [WorkItem(545957)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastInConstructorInitializer3()
         {
             TestMissing(
@@ -1833,7 +1833,7 @@ class C
         }
 
         [WorkItem(545842)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToNullableInArithmeticExpression()
         {
             Test(
@@ -1865,7 +1865,7 @@ static class C
         }
 
         [WorkItem(545942)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastFromValueTypeToObjectInReferenceEquality()
         {
             // Note: The cast below can't be removed because it would result in an
@@ -1887,7 +1887,7 @@ class Program
         }
 
         [WorkItem(545962)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastWhenExpressionDoesntBind()
         {
             // Note: The cast below can't be removed because its expression doesn't bind.
@@ -1908,7 +1908,7 @@ class Program
         }
 
         [WorkItem(545944)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastBeforePointerDereference1()
         {
             // Note: The cast below can't be removed because it would result in *null,
@@ -1924,7 +1924,7 @@ unsafe class C
         }
 
         [WorkItem(545978)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastBeforePointerDereference2()
         {
             // Note: The cast below can't be removed because it would result in dereferencing
@@ -1945,7 +1945,7 @@ unsafe class C
 
         [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
         [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastBeforePointerDereference3()
         {
             // Conservatively disable cast simplifications for casts involving pointer conversions.
@@ -1965,7 +1965,7 @@ class C
 
         [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
         [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNumericCastInUncheckedExpression()
         {
             // Conservatively disable cast simplifications within explicit checked/unchecked expressions.
@@ -1990,7 +1990,7 @@ class C
 
         [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
         [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNumericCastInUncheckedStatement()
         {
             // Conservatively disable cast simplifications within explicit checked/unchecked statements.
@@ -2018,7 +2018,7 @@ class C
 
         [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
         [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNumericCastInCheckedExpression()
         {
             // Conservatively disable cast simplifications within explicit checked/unchecked expressions.
@@ -2043,7 +2043,7 @@ class C
 
         [WorkItem(2691, "https://github.com/dotnet/roslyn/issues/2691")]
         [WorkItem(2987, "https://github.com/dotnet/roslyn/issues/2987")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNumericCastInCheckedStatement()
         {
             // Conservatively disable cast simplifications within explicit checked/unchecked statements.
@@ -2070,7 +2070,7 @@ class C
         }
 
         [WorkItem(545894)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInAttribute()
         {
             TestMissing(
@@ -2088,7 +2088,7 @@ class A : Attribute
         #region Interface Casts
 
         [WorkItem(545889)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToInterfaceForUnsealedType()
         {
             // Note: The cast below can't be removed because X is not sealed.
@@ -2121,7 +2121,7 @@ class Y : X, IDisposable
         }
 
         [WorkItem(545890)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToInterfaceForSealedType1()
         {
             // Note: The cast below can be removed because C is sealed and the
@@ -2177,7 +2177,7 @@ sealed class C : I
         }
 
         [WorkItem(545890)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToInterfaceForSealedType2()
         {
             // Note: The cast below can be removed because C is sealed and the
@@ -2238,7 +2238,7 @@ sealed class C : I
         }
 
         [WorkItem(545890)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToInterfaceForSealedType3()
         {
             // Note: The cast below can be removed because C is sealed and the
@@ -2303,7 +2303,7 @@ sealed class C : I
         }
 
         [WorkItem(545890)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToInterfaceForSealedType4()
         {
             // Note: The cast below can't be removed (even though C is sealed)
@@ -2334,7 +2334,7 @@ sealed class C : I
         }
 
         [WorkItem(545890)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToInterfaceForSealedType5()
         {
             // Note: The cast below can be removed (even though C is sealed)
@@ -2390,7 +2390,7 @@ sealed class C : I
         }
 
         [WorkItem(545888)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToInterfaceForSealedType6()
         {
             // Note: The cast below can't be removed (even though C is sealed)
@@ -2422,7 +2422,7 @@ sealed class C : I
         }
 
         [WorkItem(545888)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToInterfaceForSealedType7()
         {
             Test(
@@ -2480,7 +2480,7 @@ sealed class C : I
         }
 
         [WorkItem(545888)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToInterfaceForSealedType8()
         {
             // Note: The cast below can't be removed (even though C is sealed)
@@ -2515,7 +2515,7 @@ sealed class C : I
         }
 
         [WorkItem(545883)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToInterfaceForSealedType9()
         {
             // Note: The cast below can't be removed (even though C is sealed)
@@ -2544,7 +2544,7 @@ sealed class C : MemoryStream
         }
 
         [WorkItem(545887)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToInterfaceForStruct1()
         {
             // Note: The cast below can't be removed because the cast boxes 's' and
@@ -2576,7 +2576,7 @@ struct S : IIncrementable
         }
 
         [WorkItem(545834)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToInterfaceForStruct2()
         {
             // Note: The cast below can be removed because we are sure to have
@@ -2625,7 +2625,7 @@ class Program
         }
 
         [WorkItem(544655)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToICloneableForDelegate()
         {
             // Note: The cast below can be removed because delegates are implicitly
@@ -2662,7 +2662,7 @@ class C
         }
 
         [WorkItem(545926)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToICloneableForArray()
         {
             // Note: The cast below can be removed because arrays are implicitly
@@ -2699,7 +2699,7 @@ class C
         }
 
         [WorkItem(529897)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToIConvertibleForEnum()
         {
             // Note: The cast below can be removed because enums are implicitly
@@ -2740,7 +2740,7 @@ class Program
         #region ParamArray Parameter Casts
 
         [WorkItem(545141)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToObjectInParamArrayArg1()
         {
             TestMissing(
@@ -2763,7 +2763,7 @@ class C
         }
 
         [WorkItem(529911)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToIntArrayInParamArrayArg2()
         {
             TestMissing(
@@ -2786,7 +2786,7 @@ class C
         }
 
         [WorkItem(529911)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToObjectArrayInParamArrayArg3()
         {
             TestMissing(
@@ -2809,7 +2809,7 @@ class C
         }
 
         [WorkItem(529911)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToObjectArrayInParamArrayArg1()
         {
             Test(
@@ -2841,7 +2841,7 @@ class C
         }
 
         [WorkItem(529911)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToStringArrayInParamArrayArg2()
         {
             Test(
@@ -2873,7 +2873,7 @@ class C
         }
 
         [WorkItem(529911)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToIntArrayInParamArrayArg3()
         {
             Test(
@@ -2905,7 +2905,7 @@ class C
         }
 
         [WorkItem(529911)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToObjectArrayInParamArrayArg4()
         {
             Test(
@@ -2937,7 +2937,7 @@ class C
         }
 
         [WorkItem(529911)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToObjectInParamArrayArg5()
         {
             Test(
@@ -2968,7 +2968,7 @@ class C
             compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastToObjectArrayInParamArrayWithNamedArgument()
         {
             Test(
@@ -3003,7 +3003,7 @@ class C
         #region ForEach Statements
 
         [WorkItem(545961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInForEach1()
         {
             // The cast below can't be removed because it would result an error
@@ -3025,7 +3025,7 @@ class Program
         }
 
         [WorkItem(545961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInForEach2()
         {
             // The cast below can't be removed because it would result an error
@@ -3047,7 +3047,7 @@ class Program
         }
 
         [WorkItem(545961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInForEach3()
         {
             // The cast below can't be removed because it would result an error
@@ -3082,7 +3082,7 @@ class C
         }
 
         [WorkItem(545961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInForEach4()
         {
             // The cast below can't be removed because it would result in
@@ -3125,7 +3125,7 @@ class C
         }
 
         [WorkItem(545961)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInForEach5()
         {
             // The cast below can't be removed because it would change the
@@ -3153,7 +3153,7 @@ class Program
         #endregion
 
         [WorkItem(545925)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastIfOverriddenMethodHasIncompatibleParameterList()
         {
             // Note: The cast below can't be removed because the parameter list
@@ -3184,7 +3184,7 @@ class X : Y
         }
 
         [WorkItem(545925)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastIfOverriddenMethodHaveCompatibleParameterList()
         {
             // Note: The cast below can be removed because the parameter list
@@ -3239,7 +3239,7 @@ class X : Y
         }
 
         [WorkItem(529916)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveCastInReceiverForMethodGroup()
         {
             // Note: The cast below can be removed because the it results in
@@ -3278,7 +3278,7 @@ static class Program
         }
 
         [WorkItem(609497)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void Bugfix_609497()
         {
             TestMissing(
@@ -3304,7 +3304,7 @@ class Program
         }
 
         [WorkItem(545995)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToDifferentTypeWithSameName()
         {
             // Note: The cast below cannot be removed because the it results in
@@ -3339,7 +3339,7 @@ class A
         }
 
         [WorkItem(545921)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastWhichWouldChangeAttributeOverloadResolution1()
         {
             // Note: The cast below cannot be removed because it would result in
@@ -3375,7 +3375,7 @@ class MyAttributeAttribute : Attribute
 
         [WorkItem(608180)]
         [WorkItem(624252)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastIfArgumentIsRestricted_TypedReference()
         {
             TestMissing(
@@ -3404,7 +3404,7 @@ class Program
         }
 
         [WorkItem(627107)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastOnArgumentsWithOtherDynamicArguments()
         {
             TestMissing(
@@ -3434,7 +3434,7 @@ class C<T>
         }
 
         [WorkItem(627107)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastOnArgumentsWithOtherDynamicArguments_Bracketed()
         {
             TestMissing(
@@ -3454,7 +3454,7 @@ class C<T>
         }
 
         [WorkItem(627107)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastOnArgumentsWithDynamicReceiverOpt()
         {
             TestMissing(
@@ -3471,7 +3471,7 @@ class C
         }
 
         [WorkItem(627107)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastOnArgumentsWithDynamicReceiverOpt_1()
         {
             TestMissing(
@@ -3488,7 +3488,7 @@ class C
         }
 
         [WorkItem(627107)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastOnArgumentsWithDynamicReceiverOpt_2()
         {
             TestMissing(
@@ -3505,7 +3505,7 @@ class C
         }
 
         [WorkItem(627107)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastOnArgumentsWithDynamicReceiverOpt_3()
         {
             TestMissing(
@@ -3522,7 +3522,7 @@ class C
         }
 
         [WorkItem(627107)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastOnArgumentsWithOtherDynamicArguments_1()
         {
             TestMissing(
@@ -3552,7 +3552,7 @@ class C<T>
         }
 
         [WorkItem(545998)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastWhichWouldChangeAttributeOverloadResolution2()
         {
             // Note: The cast below cannot be removed because it would result in
@@ -3571,7 +3571,7 @@ class A : Attribute
         }
 
         [WorkItem(529894)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontUnnecessaryCastFromEnumToUint()
         {
             TestMissing(
@@ -3595,7 +3595,7 @@ class C
         }
 
         [WorkItem(529846)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontUnnecessaryCastFromTypeParameterToObject()
         {
             TestMissing(
@@ -3612,7 +3612,7 @@ class C
         }
 
         [WorkItem(640136)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void RemoveUnnecessaryCastAndParseCorrect()
         {
             Test(
@@ -3646,7 +3646,7 @@ class C
         }
 
         [WorkItem(626026)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastIfUserDefinedExplicitCast()
         {
             TestMissing(
@@ -3676,7 +3676,7 @@ public struct B
         }
 
         [WorkItem(768895)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInTernary()
         {
             TestMissing(
@@ -3693,7 +3693,7 @@ class Program
         }
 
         [WorkItem(770187)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveNecessaryCastInSwitchExpression()
         {
             TestMissing(
@@ -3725,7 +3725,7 @@ namespace ConsoleApplication23
 
         [WorkItem(844482)]
         [WorkItem(2761, "https://github.com/dotnet/roslyn/issues/2761")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastFromBaseToDerivedWithExplicitReference()
         {
             TestMissing(
@@ -3751,7 +3751,7 @@ class D : C
         }
 
         [WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToTypeParameterWithExceptionConstraint()
         {
             TestMissing(
@@ -3771,7 +3771,7 @@ class Program
         }
 
         [WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public void DontRemoveCastToTypeParameterWithExceptionSubTypeConstraint()
         {
             TestMissing(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests_FixAllTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
     {
         #region "Fix all occurrences tests"
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInDocument()
@@ -182,7 +182,7 @@ class Program3
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: null);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInProject()
@@ -326,7 +326,7 @@ class Program3
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: null);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryUsings/RemoveUnnecessaryUsingsTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryUsings/RemoveUnnecessaryUsingsTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
                 new CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer(), new RemoveUnnecessaryUsingsCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestNoReferences()
         {
             Test(
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
 @"class Program { static void Main ( string [ ] args ) { } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestIdentifierReferenceInTypeContext()
         {
             Test(
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
 @"using System ; class Program { static void Main ( string [ ] args ) { DateTime d ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestGenericReferenceInTypeContext()
         {
             Test(
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
 @"using System . Collections . Generic ; class Program { static void Main ( string [ ] args ) { List < int > list ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestMultipleReferences()
         {
             Test(
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
 @"using System ; using System . Collections . Generic ; class Program { static void Main ( string [ ] args ) { List < int > list ; DateTime d ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestExtensionMethodReference()
         {
             Test(
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
         }
 
         [WorkItem(541827)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestExtensionMethodLinq()
         {
             // NOTE: Intentionally not running this test with Script options, because in Script,
@@ -99,7 +99,7 @@ namespace SomeNS
 }|]");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestAliasQualifiedAliasReference()
         {
             Test(
@@ -107,7 +107,7 @@ namespace SomeNS
 @"using G = System . Collections . Generic ; class Program { static void Main ( string [ ] args ) { G :: List < int > list ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestQualifiedAliasReference()
         {
             Test(
@@ -115,7 +115,7 @@ namespace SomeNS
 @"using G = System . Collections . Generic ; class Program { static void Main ( string [ ] args ) { G . List < int > list ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestNestedUnusedUsings()
         {
             Test(
@@ -123,7 +123,7 @@ namespace SomeNS
 @"namespace N { using System ; class Program { static void Main ( string [ ] args ) { DateTime d ; } } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestNestedUsedUsings()
         {
             Test(
@@ -132,7 +132,7 @@ namespace SomeNS
         }
 
         [WorkItem(712656)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestNestedUsedUsings2()
         {
             Test(
@@ -140,21 +140,21 @@ namespace SomeNS
 @"using System ; namespace N { using System ; class Program { static void Main ( string [ ] args ) { DateTime d ; } } } class F { DateTime d ; } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestAttribute()
         {
             TestMissing(
 @"[|using SomeNamespace ; [ SomeAttr ] class Foo { } namespace SomeNamespace { public class SomeAttrAttribute : System . Attribute { } } |]");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestAttributeArgument()
         {
             TestMissing(
 @"[|using foo ; [ SomeAttribute ( typeof ( SomeClass ) ) ] class Program { static void Main ( ) { } } public class SomeAttribute : System . Attribute { public SomeAttribute ( object f ) { } } namespace foo { public class SomeClass { } } |]");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveAllWithSurroundingPreprocessor()
         {
             Test(
@@ -185,7 +185,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveFirstWithSurroundingPreprocessor()
         {
             Test(
@@ -219,7 +219,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveAllWithSurroundingPreprocessor2()
         {
             Test(
@@ -256,7 +256,7 @@ compareTokens: false);
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveOneWithSurroundingPreprocessor2()
         {
             Test(
@@ -297,7 +297,7 @@ compareTokens: false);
         }
 
         [WorkItem(541817)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestComments8718()
         {
             Test(
@@ -354,7 +354,7 @@ compareTokens: false);
         }
 
         [WorkItem(528609)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestComments()
         {
             Test(
@@ -378,7 +378,7 @@ class Program
 compareTokens: false);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestUnusedUsing()
         {
             Test(
@@ -400,7 +400,7 @@ compareTokens: false);
         }
 
         [WorkItem(541827)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestSimpleQuery()
         {
             Test(
@@ -408,7 +408,7 @@ compareTokens: false);
 @"using System . Linq ; class Program { static void Main ( string [ ] args ) { var q = from a in args where a . Length > 21 select a ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestUsingStaticClassAccessField1()
         {
             Test(
@@ -417,14 +417,14 @@ compareTokens: false);
                 CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestUsingStaticClassAccessField2()
         {
             TestMissing(
 @"[|using static SomeNS . Foo ; class Program { static void Main ( ) { var q = x ; } } namespace SomeNS { static class Foo { public static int x ; } } |]");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestUsingStaticClassAccessMethod1()
         {
             Test(
@@ -433,7 +433,7 @@ compareTokens: false);
                 CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestUsingStaticClassAccessMethod2()
         {
             TestMissing(
@@ -441,7 +441,7 @@ compareTokens: false);
         }
 
         [WorkItem(8846, "DevDiv_Projects/Roslyn")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestUnusedTypeImportIsRemoved()
         {
             Test(
@@ -477,7 +477,7 @@ namespace SomeNS
         }
 
         [WorkItem(541817)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveTrailingComment()
         {
             Test(
@@ -503,7 +503,7 @@ compareTokens: false);
         }
 
         [WorkItem(541914)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemovingUnbindableUsing()
         {
             Test(
@@ -512,7 +512,7 @@ compareTokens: false);
         }
 
         [WorkItem(541937)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestAliasInUse()
         {
             TestMissing(
@@ -535,7 +535,7 @@ namespace Foo
         }
 
         [WorkItem(541914)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveUnboundUsing()
         {
             Test(
@@ -544,7 +544,7 @@ namespace Foo
         }
 
         [WorkItem(542016)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestLeadingNewlines1()
         {
             Test(
@@ -570,7 +570,7 @@ compareTokens: false);
         }
 
         [WorkItem(542016)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveLeadingNewLines2()
         {
             Test(
@@ -602,7 +602,7 @@ compareTokens: false);
         }
 
         [WorkItem(542134)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestImportedTypeUsedAsGenericTypeArgument()
         {
             TestMissing(
@@ -628,7 +628,7 @@ public class Program
         }
 
         [WorkItem(542723)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveCorrectUsing1()
         {
             Test(
@@ -638,7 +638,7 @@ parseOptions: null);
         }
 
         [WorkItem(542723)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestRemoveCorrectUsing2()
         {
             TestMissing(
@@ -646,7 +646,7 @@ parseOptions: null);
 parseOptions: null);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestSpan()
         {
             TestSpans(
@@ -661,7 +661,7 @@ parseOptions: null);
         }
 
         [WorkItem(543000)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestMissingWhenErrorsWouldBeGenerated()
         {
             TestMissing(
@@ -669,7 +669,7 @@ parseOptions: null);
         }
 
         [WorkItem(544976)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestMissingWhenMeaningWouldChangeInLambda()
         {
             TestMissing(
@@ -708,7 +708,7 @@ namespace Y
         }
 
         [WorkItem(544976)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestCasesWithLambdas1()
         {
             // NOTE: Y is used when speculatively binding "x => x.Foo()".  As such, it is marked as
@@ -748,7 +748,7 @@ namespace Y
         }
 
         [WorkItem(545646)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestCasesWithLambdas2()
         {
             TestMissing(
@@ -782,7 +782,7 @@ namespace N
         }
 
         [WorkItem(545741)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestMissingOnAliasedVar()
         {
             TestMissing(
@@ -790,7 +790,7 @@ namespace N
         }
 
         [WorkItem(546115)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestBrokenCode()
         {
             TestMissing(
@@ -808,7 +808,7 @@ public class QueryExpressionTest
         }
 
         [WorkItem(530980)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestReferenceInCref()
         {
             // parsing doc comments as simple trivia; System is unnecessary
@@ -826,7 +826,7 @@ public class QueryExpressionTest
         }
 
         [WorkItem(751283)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         public void TestUnusedUsingOverLinq()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryUsings/RemoveUnnecessaryUsingsTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryUsings/RemoveUnnecessaryUsingsTests_FixAllTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveUnnec
     {
         #region "Fix all occurrences tests"
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInDocument()
@@ -86,7 +86,7 @@ class Program3
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: null);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInProject()
@@ -162,7 +162,7 @@ class Program3
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: null);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.SimplifyTyp
                 new CSharpSimplifyTypeNamesDiagnosticAnalyzer(), new SimplifyTypeNamesCodeFixProvider());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyGenericName()
         {
             Test(
@@ -49,7 +49,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias0()
         {
             Test(
@@ -79,7 +79,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias00()
         {
             Test(
@@ -103,7 +103,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias()
         {
             var source =
@@ -132,7 +132,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias1()
         {
             Test(
@@ -156,7 +156,7 @@ class A
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias2()
         {
             Test(
@@ -180,7 +180,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias3()
         {
             Test(
@@ -210,7 +210,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias4()
         {
             Test(
@@ -228,7 +228,7 @@ class A
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias5()
         {
             Test(
@@ -252,7 +252,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias6()
         {
             Test(
@@ -276,7 +276,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias7()
         {
             Test(
@@ -306,7 +306,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void UseAlias8()
         {
             Test(
@@ -337,7 +337,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TwoAliases()
         {
             Test(
@@ -365,7 +365,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TwoAliases2()
         {
             Test(
@@ -393,7 +393,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TwoAliasesConflict()
         {
             TestMissing(
@@ -410,7 +410,7 @@ namespace Root
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TwoAliasesConflict2()
         {
             Test(
@@ -438,7 +438,7 @@ namespace Root
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void AliasInSiblingNamespace()
         {
             var content =
@@ -457,7 +457,7 @@ namespace Root
             TestMissing(content);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void KeywordInt32()
         {
             var source =
@@ -479,7 +479,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Keywords()
         {
             var builtInTypeMap = new Dictionary<string, string>()
@@ -516,7 +516,7 @@ class A
             }
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName()
         {
             var content =
@@ -530,7 +530,7 @@ class A
             TestMissing(content);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName1()
         {
             var source =
@@ -567,7 +567,7 @@ namespace Root
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName2()
         {
             Test(
@@ -587,7 +587,7 @@ namespace System
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName3()
         {
             Test(
@@ -617,7 +617,7 @@ namespace N1
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName4()
         {
             // this is failing since we can't speculatively bind namespace yet
@@ -648,7 +648,7 @@ namespace N1
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName5()
         {
             Test(
@@ -678,7 +678,7 @@ namespace N1
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName6()
         {
             var content =
@@ -700,7 +700,7 @@ namespace N1
             TestMissing(content);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeName7()
         {
             var source =
@@ -734,7 +734,7 @@ namespace N1
             TestActionCount(source, 1);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyGenericTypeName1()
         {
             var content =
@@ -749,7 +749,7 @@ namespace N1
             TestMissing(content);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyGenericTypeName2()
         {
             var source =
@@ -777,7 +777,7 @@ namespace N1
             TestActionCount(source, 1);
         }
 
-        [WpfFact(Skip = "1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact(Skip = "1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void SimplifyGenericTypeName3()
         {
@@ -803,7 +803,7 @@ namespace N1
 }", fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyGenericTypeName4()
         {
             var content =
@@ -820,7 +820,7 @@ namespace N1
             TestMissing(content);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyGenericTypeName5()
         {
             var source =
@@ -857,7 +857,7 @@ namespace N1
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyGenericTypeName6()
         {
             Test(
@@ -899,7 +899,7 @@ namespace N1
 }", index: 0);
         }
 
-        [WpfFact(Skip = "1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact(Skip = "1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void SimplifyGenericTypeName7()
         {
@@ -942,7 +942,7 @@ namespace N1
 }", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Array1()
         {
             Test(
@@ -988,7 +988,7 @@ namespace N1
             ////}", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Array2()
         {
             Test(
@@ -1013,7 +1013,7 @@ namespace N1
         }
 
         [WorkItem(995168), WorkItem(1073099)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyToPredefinedTypeNameShouldNotBeOfferedInsideNameOf1()
         {
             TestMissing(
@@ -1028,7 +1028,7 @@ class Program
         }
 
         [WorkItem(995168)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyToPredefinedTypeNameShouldNotBeOfferedInsideNameOf2()
         {
             TestMissing(
@@ -1043,7 +1043,7 @@ class Program
         }
 
         [WorkItem(995168), WorkItem(1073099)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyToPredefinedTypeNameShouldNotBeOfferedInsideNameOf3()
         {
             TestMissing(
@@ -1058,7 +1058,7 @@ class Program
         }
 
         [WorkItem(995168), WorkItem(1073099)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyToPredefinedTypeNameShouldNotBeOfferedInsideNameOf4()
         {
             Test(
@@ -1092,7 +1092,7 @@ class Program
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyTypeNameInsideNameOf()
         {
             Test(
@@ -1117,7 +1117,7 @@ class Program
         }
 
         [WorkItem(995168)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyCrefAliasPredefinedType()
         {
             Test(
@@ -1145,7 +1145,7 @@ class Program
         }
 
         [WorkItem(538727)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyAlias1()
         {
             var content =
@@ -1162,7 +1162,7 @@ namespace N1
         }
 
         [WorkItem(538727)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyAlias2()
         {
             Test(
@@ -1187,7 +1187,7 @@ namespace N1
         }
 
         [WorkItem(538727)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyAlias3()
         {
             Test(
@@ -1218,7 +1218,7 @@ namespace Outer
         }
 
         [WorkItem(538727)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyAlias4()
         {
             Test(
@@ -1251,7 +1251,7 @@ namespace Outer
         }
 
         [WorkItem(544631)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyAlias5()
         {
             var content =
@@ -1273,7 +1273,7 @@ namespace N
         }
 
         [WorkItem(919815)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyReturnTypeOnMethodCallToAlias()
         {
             Test(
@@ -1295,7 +1295,7 @@ class A
         }
 
         [WorkItem(538949)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyComplexGeneric1()
         {
             TestMissing(
@@ -1310,7 +1310,7 @@ interface I<T> { }");
         }
 
         [WorkItem(538949)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyComplexGeneric2()
         {
             TestMissing(
@@ -1325,7 +1325,7 @@ interface I<T> { }");
         }
 
         [WorkItem(538991)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyMissingOnGeneric()
         {
             var content =
@@ -1338,7 +1338,7 @@ interface I<T> { }");
         }
 
         [WorkItem(539000)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyMissingOnUnmentionableTypeParameter1()
         {
             var content =
@@ -1356,7 +1356,7 @@ interface I<T> { }");
             TestMissing(content);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyErrorTypeParameter()
         {
             TestMissing(
@@ -1369,7 +1369,7 @@ class C
 
         [WorkItem(539000)]
         [WorkItem(838109)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyUnmentionableTypeParameter2()
         {
             TestMissing(
@@ -1386,7 +1386,7 @@ class C
         }
 
         [WorkItem(539000)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SimplifyUnmentionableTypeParameter2_1()
         {
             TestMissing(
@@ -1402,7 +1402,7 @@ class C
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestGlobalAlias()
         {
             Test(
@@ -1412,7 +1412,7 @@ index: 0);
         }
 
         [WorkItem(541748)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnErrorInScript()
         {
             TestMissing(
@@ -1420,7 +1420,7 @@ index: 0);
 Options.Script);
         }
 
-        [WpfFact(Skip = "1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact(Skip = "1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestConflicts()
         {
@@ -1580,7 +1580,7 @@ compareTokens: false);
         }
 
         [WorkItem(542100)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestPreventSimplificationThatWouldCauseConflict()
         {
             Test(
@@ -1592,7 +1592,7 @@ compareTokens: false);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnOpenType1()
         {
             TestMissing(
@@ -1600,7 +1600,7 @@ compareTokens: false);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnOpenType2()
         {
             Test(
@@ -1609,7 +1609,7 @@ compareTokens: false);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnOpenType3()
         {
             TestMissing(
@@ -1617,14 +1617,14 @@ compareTokens: false);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnOpenType4()
         {
             TestMissing(@"class Program < X > { public class Inner < Y > { [ Bar ( typeof ( [|Program <X > . Inner < >|] ) ) ] void Foo ( ) { } } } ");
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnOpenType5()
         {
             TestMissing(
@@ -1632,7 +1632,7 @@ compareTokens: false);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnOpenType6()
         {
             TestMissing(
@@ -1640,7 +1640,7 @@ compareTokens: false);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnNonOpenType1()
         {
             Test(
@@ -1650,7 +1650,7 @@ index: 0);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnNonOpenType2()
         {
             Test(
@@ -1660,7 +1660,7 @@ index: 0);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnNonOpenType3()
         {
             Test(
@@ -1670,7 +1670,7 @@ index: 0);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnNonOpenType4()
         {
             Test(
@@ -1680,7 +1680,7 @@ index: 0);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnNonOpenType5()
         {
             Test(
@@ -1690,7 +1690,7 @@ index: 0);
         }
 
         [WorkItem(541929)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestOnNonOpenType6()
         {
             TestMissing(
@@ -1698,7 +1698,7 @@ index: 0);
         }
 
         [WorkItem(542650)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestWithInterleavedDirective1()
         {
             TestMissing(
@@ -1723,7 +1723,7 @@ class B
         }
 
         [WorkItem(542719)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestGlobalMissing1()
         {
             TestMissing(
@@ -1731,7 +1731,7 @@ class B
         }
 
         [WorkItem(544615)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMissingOnAmbiguousCast()
         {
             TestMissing(
@@ -1739,7 +1739,7 @@ class B
         }
 
         [WorkItem(544616)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void ParenthesizeIfParseChanges()
         {
             Test(
@@ -1764,7 +1764,7 @@ class C
         }
 
         [WorkItem(544974)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplification1()
         {
             Test(
@@ -1774,7 +1774,7 @@ index: 0);
         }
 
         [WorkItem(544974)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplification3()
         {
             Test(
@@ -1783,7 +1783,7 @@ index: 0);
         }
 
         [WorkItem(544974)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplification4()
         {
             Test(
@@ -1792,7 +1792,7 @@ index: 0);
         }
 
         [WorkItem(544977)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplification5()
         {
             Test(
@@ -1818,7 +1818,7 @@ class Program
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMissingNullableSimplificationInsideCref()
         {
             TestMissing(
@@ -1830,7 +1830,7 @@ class A { }");
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMissingNullableSimplificationInsideCref2()
         {
             TestMissing(
@@ -1841,7 +1841,7 @@ class A { }");
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMissingNullableSimplificationInsideCref3()
         {
             TestMissing(
@@ -1852,7 +1852,7 @@ class A { }");
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableInsideCref_AllowedIfReferencingActualTypeParameter()
         {
             Test(
@@ -1869,7 +1869,7 @@ class C<T> {  }");
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMissingNullableSimplificationInsideCref5()
         {
             TestMissing(
@@ -1883,7 +1883,7 @@ class A
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableInsideCref_AllowedIfReferencingActualType()
         {
             Test(
@@ -1900,7 +1900,7 @@ class A { }");
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableInsideCref_AllowedIfReferencingActualType_AsTypeArgument()
         {
             Test(
@@ -1917,7 +1917,7 @@ class C<T> { }");
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMissingNullableSimplificationInsideCref8()
         {
             TestMissing(
@@ -1931,7 +1931,7 @@ class A
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplificationInsideCref()
         {
             Test(
@@ -1952,7 +1952,7 @@ struct A
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplificationInsideCref2()
         {
             Test(
@@ -1977,7 +1977,7 @@ class A
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplificationInsideCref3()
         {
             Test(
@@ -2002,7 +2002,7 @@ class A
         }
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestNullableSimplificationInsideCref4()
         {
             Test(
@@ -2026,7 +2026,7 @@ class A
 }");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestColorColorCase1()
         {
             Test(
@@ -2034,14 +2034,14 @@ class A
 @"using N ; namespace N { class Color { public static void Foo ( ) { } public void Bar ( ) { } } } class Program { Color Color ; void Main ( ) { Color . Foo ( ) ; } } ", index: 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestColorColorCase2()
         {
             TestMissing(
 @"using N ; namespace N { class Color { public static void Foo ( ) { } public void Bar ( ) { } } } class Program { Color Color ; void Main ( ) { [|Color . Foo |]( ) ; } } ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestAliasQualifiedType()
         {
             var source =
@@ -2065,7 +2065,7 @@ class Program
             TestMissing(source, GetScriptOptions());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyExpression()
         {
             Test(
@@ -2090,7 +2090,7 @@ class Program
         }
 
         [WorkItem(551040)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyStaticMemberAccess()
         {
             var source =
@@ -2130,7 +2130,7 @@ static class M
         }
 
         [WorkItem(551040)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyNestedType()
         {
             var source =
@@ -2176,7 +2176,7 @@ class M
         }
 
         [WorkItem(568043)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void DontSimplifyNamesWhenThereAreParseErrors()
         {
             var markup =
@@ -2198,7 +2198,7 @@ class Program
         }
 
         [WorkItem(566749)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMethodGroups1()
         {
             TestMissing(@"
@@ -2214,7 +2214,7 @@ class Program
         }
 
         [WorkItem(566749)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMethodGroups2()
         {
             TestMissing(@"
@@ -2230,7 +2230,7 @@ class Program
         }
 
         [WorkItem(554010)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestMethodGroups3()
         {
             Test(@"
@@ -2255,7 +2255,7 @@ class Program
         }
 
         [WorkItem(578686)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void FixAllOccurrences1()
         {
             Test(
@@ -2314,7 +2314,7 @@ namespace C
         }
 
         [WorkItem(578686)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void DontUseAlias1()
         {
             TestMissing(
@@ -2352,7 +2352,7 @@ namespace NoAlias{
         }
 
         [WorkItem(577169)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SuitablyReplaceNullables1()
         {
             TestMissing(
@@ -2369,7 +2369,7 @@ class Program
         }
 
         [WorkItem(577169)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void SuitablyReplaceNullables2()
         {
             TestMissing(
@@ -2386,7 +2386,7 @@ class Program
         }
 
         [WorkItem(608190)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Bugfix_608190()
         {
             TestMissing(
@@ -2413,7 +2413,7 @@ struct S
         }
 
         [WorkItem(608190)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Bugfix_608190_1()
         {
             TestMissing(
@@ -2440,7 +2440,7 @@ struct S
         }
 
         [WorkItem(608932)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Bugfix_608932()
         {
             TestMissing(
@@ -2470,7 +2470,7 @@ namespace X
         }
 
         [WorkItem(635933)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Bugfix_635933()
         {
             TestMissing(@"
@@ -2505,7 +2505,7 @@ class C<T> : B
         }
 
         [WorkItem(547246)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void CodeIssueAtRightSpan()
         {
             var code = @"
@@ -2529,7 +2529,7 @@ class Program
         }
 
         [WorkItem(579172)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Bugfix_579172()
         {
             TestMissing(
@@ -2542,7 +2542,7 @@ class C<T, S>
         }
 
         [WorkItem(633182)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Bugfix_633182()
         {
             TestMissing(
@@ -2558,7 +2558,7 @@ class C
         }
 
         [WorkItem(627102)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void Bugfix_627102()
         {
             TestMissing(
@@ -2592,7 +2592,7 @@ class C<T> : B
         }
 
         [WorkItem(629572)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void DoNotIncludeAliasNameIfLastTargetNameIsTheSame_1()
         {
             var code = @"
@@ -2628,7 +2628,7 @@ class Program
         }
 
         [WorkItem(629572)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void DoNotIncludeAliasNameIfLastTargetNameIsTheSame_2()
         {
             var code = @"
@@ -2664,7 +2664,7 @@ class Program
         }
 
         [WorkItem(736377)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void DontSimplifyTypeNameBrokenCode()
         {
             TestMissing(
@@ -2686,7 +2686,7 @@ class Program
         }
 
         [WorkItem(813385)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void DontSimplifyAliases()
         {
             TestMissing(
@@ -2700,7 +2700,7 @@ class C
         }
 
         [WorkItem(825541)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void ShowOnlyRelevantSpanForReductionOfGenericName()
         {
             var code = @"
@@ -2731,7 +2731,7 @@ namespace A
         }
 
         [WorkItem(878773)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void DontSimplifyAttributeNameWithJustAttribute()
         {
             TestMissing(
@@ -2744,7 +2744,7 @@ class Attribute : System.Attribute
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void ThisQualificationOption()
         {
             TestMissing(
@@ -2761,7 +2761,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInLocalDeclarationDefaultValue1()
         {
             Test(
@@ -2783,7 +2783,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInLocalDeclarationDefaultValue2()
         {
             Test(
@@ -2805,7 +2805,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_Default_1()
         {
             Test(
@@ -2829,7 +2829,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_Default_2()
         {
             Test(
@@ -2851,7 +2851,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_Default_3()
         {
             Test(
@@ -2876,7 +2876,7 @@ class C
 
         [WorkItem(942568)]
         [WorkItem(954536)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_NonDefault_1()
         {
             TestMissing(
@@ -2893,7 +2893,7 @@ class C
 
         [WorkItem(942568)]
         [WorkItem(954536)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_NonDefault_2()
         {
             Test(
@@ -2919,7 +2919,7 @@ class C
 
         [WorkItem(942568)]
         [WorkItem(954536)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_NonDefault_3()
         {
             TestMissing(
@@ -2935,7 +2935,7 @@ class C
         }
 
         [WorkItem(954536)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_NonDefault_4()
         {
             Test(
@@ -2961,7 +2961,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptio
         }
 
         [WorkItem(954536)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_NonDefault_5()
         {
             TestMissing(
@@ -2976,7 +2976,7 @@ class C
         }
 
         [WorkItem(954536)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInsideCref_NonDefault_6()
         {
             Test(
@@ -3000,7 +3000,7 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptio
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInLocalDeclarationNonDefaultValue_1()
         {
             TestMissing(
@@ -3017,7 +3017,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInLocalDeclarationNonDefaultValue_2()
         {
             TestMissing(
@@ -3034,7 +3034,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInLocalDeclarationNonDefaultValue_3()
         {
             TestMissing(
@@ -3051,7 +3051,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInMemberAccess_Default_1()
         {
             Test(
@@ -3073,7 +3073,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInMemberAccess_Default_2()
         {
             Test(
@@ -3097,7 +3097,7 @@ class C
         }
 
         [WorkItem(956667)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInMemberAccess_Default_3()
         {
             TestMissing(
@@ -3118,7 +3118,7 @@ class C2
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInMemberAccess_NonDefault_1()
         {
             TestMissing(
@@ -3135,7 +3135,7 @@ class C
         }
 
         [WorkItem(942568)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestIntrinsicTypesInMemberAccess_NonDefault_2()
         {
             TestMissing(
@@ -3151,7 +3151,7 @@ class C
         }
 
         [WorkItem(965208)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyDiagnosticId()
         {
             var source =
@@ -3208,7 +3208,7 @@ class C
         }
 
         [WorkItem(1019276)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyTypeNameDoesNotAddUnnecessaryParens()
         {
             Test(
@@ -3240,7 +3240,7 @@ class Program
         }
 
         [WorkItem(1068445)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyTypeNameInPropertyLambda()
         {
             Test(
@@ -3260,7 +3260,7 @@ class Program
         }
 
         [WorkItem(1068445)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyTypeNameInMethodLambda()
         {
             Test(
@@ -3274,7 +3274,7 @@ class Program
         }
 
         [WorkItem(1068445)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         public void TestSimplifyTypeNameInIndexerLambda()
         {
             Test(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests_FixAllTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.SimplifyTyp
     {
         #region "Fix all occurrences tests"
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInDocument()
@@ -122,7 +122,7 @@ class Program2
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInProject()
@@ -232,7 +232,7 @@ class Program2
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution()
@@ -342,7 +342,7 @@ class Program2
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution_RemoveThis()
@@ -596,7 +596,7 @@ class ProgramB3
             Test(input, expected, compareTokens: false, fixAllActionEquivalenceKey: fixAllActionId);
         }
 
-        [WpfFact]
+        [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public void TestFixAllInSolution_SimplifyMemberAccess()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionAllCodeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionAllCodeTests.cs
@@ -27,13 +27,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Suppression
 
         [WorkItem(956453)]
         [WorkItem(1007071)]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
         public void TestPragmaWarningOnEveryNodes()
         {
             TestPragma(TestResource.AllInOneCSharpCode, CSharpParseOptions.Default, verifier: t => t.IndexOf("#pragma warning disable", StringComparison.Ordinal) >= 0);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
         public void TestSuppressionWithAttributeOnEveryNodes()
         {
             TestSuppressionWithAttribute(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Suppression
                     return Tuple.Create<DiagnosticAnalyzer, ISuppressionFixProvider>(null, new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirective()
                 {
                     Test(
@@ -80,7 +80,7 @@ class Class
 }}");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestMultilineStatementPragmaWarningDirective()
                 {
                     Test(
@@ -106,7 +106,7 @@ class Class
 }}");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirectiveWithExistingTrivia()
                 {
                     Test(
@@ -135,7 +135,7 @@ class Class
 }}");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestMultipleInstancesOfPragmaWarningDirective()
                 {
                     Test(
@@ -159,7 +159,7 @@ class Class
 }}");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 [WorkItem(3311, "https://github.com/dotnet/roslyn/issues/3311")]
                 public void TestNoDuplicateSuppressionCodeFixes()
                 {
@@ -211,7 +211,7 @@ class Class
                     }
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestErrorAndWarningScenario()
                 {
                     Test(
@@ -238,7 +238,7 @@ class Class
                 }
 
                 [WorkItem(956453)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestWholeFilePragmaWarningDirective()
                 {
                     Test(
@@ -249,7 +249,7 @@ class Class {{ void Method() {{ int x = 0; }} }}
                 }
 
                 [WorkItem(970129)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionAroundSingleToken()
                 {
                     Test(
@@ -280,7 +280,7 @@ class Program
                 }
 
                 [WorkItem(1066576)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirectiveAroundTrivia1()
                 {
                     Test(
@@ -319,7 +319,7 @@ class Class
                 }
 
                 [WorkItem(1066576)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirectiveAroundTrivia2()
                 {
                     Test(
@@ -330,7 +330,7 @@ class Class
                 }
 
                 [WorkItem(1066576)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirectiveAroundTrivia3()
                 {
                     Test(
@@ -341,7 +341,7 @@ class Class
                 }
 
                 [WorkItem(1066576)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirectiveAroundTrivia4()
                 {
                     Test(
@@ -362,7 +362,7 @@ class C {{ }}
                 }
 
                 [WorkItem(1066576)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirectiveAroundTrivia5()
                 {
                     Test(
@@ -379,7 +379,7 @@ class C3 {{ }}");
                 }
 
                 [WorkItem(1066576)]
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestPragmaWarningDirectiveAroundTrivia6()
                 {
                     Test(
@@ -407,7 +407,7 @@ class C3 { } // comment
                         new CSharpSimplifyTypeNamesDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestHiddenDiagnosticCannotBeSuppressed()
                 {
                     TestMissing(
@@ -458,7 +458,7 @@ int Method()
                         new UserDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestInfoDiagnosticSuppressed()
                 {
                     Test(
@@ -520,7 +520,7 @@ class Class
                         new UserDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestErrorDiagnosticCanBeSuppressed()
                 {
                     Test(
@@ -585,7 +585,7 @@ class Class
                         new UserDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestDiagnosticWithBadIdSuppressed()
                 {
                     // Diagnostics with bad/invalid ID are not reported.
@@ -674,7 +674,7 @@ class Class
                     return Tuple.Create<DiagnosticAnalyzer, ISuppressionFixProvider>(null, new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestCompilerDiagnosticsCannotBeSuppressed()
                 {
                     // Another test verifies we have a pragma warning action for this source, this verifies there are no other suppression actions.
@@ -698,7 +698,7 @@ class Class
                         new CSharpSimplifyTypeNamesDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestHiddenDiagnosticsCannotBeSuppressed()
                 {
                     TestMissing(
@@ -787,7 +787,7 @@ class Class
                         new UserDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnSimpleType()
                 {
                     Test(
@@ -827,7 +827,7 @@ using System;
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnNamespace()
                 {
                     Test(
@@ -873,7 +873,7 @@ using System;
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnTypeInsideNamespace()
                 {
                     Test(
@@ -925,7 +925,7 @@ namespace N1
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnNestedType()
                 {
                     Test(
@@ -977,7 +977,7 @@ namespace N
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnMethod()
                 {
                     Test(
@@ -1029,7 +1029,7 @@ namespace N
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnOverloadedMethod()
                 {
                     Test(
@@ -1125,7 +1125,7 @@ namespace N
 ");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnGenericMethod()
                 {
                     Test(
@@ -1177,7 +1177,7 @@ namespace N
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnProperty()
                 {
                     Test(
@@ -1229,7 +1229,7 @@ namespace N
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnField()
                 {
                     Test(
@@ -1263,7 +1263,7 @@ class Class
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 [WorkItem(6379, "https://github.com/dotnet/roslyn/issues/6379")]
                 public void TestSuppressionOnTriviaBetweenFields()
                 {
@@ -1308,7 +1308,7 @@ enum E
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnField2()
                 {
                     Test(
@@ -1342,7 +1342,7 @@ class Class
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionOnEvent()
                 {
                     Test(
@@ -1404,7 +1404,7 @@ class Class
 }");
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionWithExistingGlobalSuppressionsDocument()
                 {
                     var initialMarkup = @"<Workspace>
@@ -1443,7 +1443,7 @@ class Class { }
                     Test(initialMarkup, expectedText);
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionWithExistingGlobalSuppressionsDocument2()
                 {
                     // Own custom file named GlobalSuppressions.cs
@@ -1479,7 +1479,7 @@ class Class { }
                     Test(initialMarkup, expectedText);
                 }
 
-                [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public void TestSuppressionWithExistingGlobalSuppressionsDocument3()
                 {
                     // Own custom file named GlobalSuppressions.cs + existing GlobalSuppressions2.cs with global suppressions
@@ -1571,7 +1571,7 @@ class Class { }
                 }
             }
 
-            [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
             [WorkItem(1073825)]
             public void TestDiagnosticWithoutLocationCanBeSuppressed()
             {

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.E
             Return New EncapsulateFieldRefactoringProvider()
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulatePrivateFieldAndUpdateReferences()
             Dim text = <File>
 Class C
@@ -48,7 +48,7 @@ End Class</File>.ConvertTestSourceTag()
 
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateDimField()
             Dim text = <File>
 Class C
@@ -81,7 +81,7 @@ End Class</File>.ConvertTestSourceTag()
 
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateGenericField()
             Dim text = <File>
 Class C(Of T)
@@ -114,7 +114,7 @@ End Class</File>.ConvertTestSourceTag()
 
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulatePublicFieldIgnoringReferences()
             Dim text = <File>
 Class C
@@ -146,7 +146,7 @@ End Class</File>.ConvertTestSourceTag()
             Test(text, expected, compareTokens:=False, index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulatePublicFieldUpdatingReferences()
             Dim text = <File>
 Class C
@@ -178,7 +178,7 @@ End Class</File>.ConvertTestSourceTag()
             Test(text, expected, compareTokens:=False, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateMultiplePrivateFieldsWithReferences()
             Dim text = <File>
 Class C
@@ -221,7 +221,7 @@ End Class</File>.ConvertTestSourceTag()
             Test(text, expected, compareTokens:=False, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateMultiplePublicFieldsWithReferences()
             Dim text = <File>
 Class C
@@ -266,7 +266,7 @@ End Class</File>.ConvertTestSourceTag()
             Test(text, expected, compareTokens:=False, index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub NoSetterForConstField()
             Dim text = <File>
 Class Program
@@ -288,7 +288,7 @@ End Class</File>.ConvertTestSourceTag()
 
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateEscapedIdentifier()
             Dim text = <File>
 Class C
@@ -313,7 +313,7 @@ End Class</File>.ConvertTestSourceTag()
 
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateFieldNamedValue()
             Dim text = <File>
 Class C
@@ -338,7 +338,7 @@ End Class</File>.ConvertTestSourceTag()
 
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateFieldName__()
             Dim text = <File>
 Class D
@@ -365,7 +365,7 @@ End Class
         End Sub
 
         <WorkItem(694262)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub PreserveTrivia()
             Dim text = <File>
 Class AA
@@ -392,7 +392,7 @@ End Class
         End Sub
 
         <WorkItem(694241)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub NewPropertyNameIsUnique()
             Dim text = <File>
 Class AA
@@ -435,7 +435,7 @@ End Class
         End Sub
 
         <WorkItem(695046)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub AvailableNotJustOnVariableName()
             Dim text = <File>
 Class C
@@ -446,7 +446,7 @@ End Class</File>.ConvertTestSourceTag()
         End Sub
 
         <WorkItem(705898)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub CopyAccessibility()
             Dim text = <File>
 Class C
@@ -471,7 +471,7 @@ End Class</File>.ConvertTestSourceTag()
         End Sub
 
         <WorkItem(707080)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub BackingFieldStartsWithUnderscore()
             Dim text = <File>
 Public Class Class1
@@ -503,7 +503,7 @@ End Class</File>.ConvertTestSourceTag()
             Test(text, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub EncapsulateShadowingField()
             Dim text = <File>
 Class C
@@ -559,7 +559,7 @@ End Class</File>.ConvertTestSourceTag()
         End Sub
 
         <WorkItem(1096007, "https://github.com/dotnet/roslyn/issues/282")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        <Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
         Public Sub DoNotEncapsulateOutsideTypeDeclaration()
             Dim globalField = <File>
 Dim [|x|] = 1

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.E
         End Function
 
         <WorkItem(540686)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestExtractReturnExpression()
             Test(
 NewLines("Class Module1 \n Private Delegate Function Func(i As Integer) \n Shared Sub Main(args As String()) \n Dim temp As Integer = 2 \n Dim fnc As Func = Function(arg As Integer) \n temp = arg \n Return [|arg|] \n End Function \n End Sub \n End Class"),
@@ -31,7 +31,7 @@ index:=0)
         End Sub
 
         <WorkItem(540755)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestExtractMultilineLambda()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Dim q As Action = [|Sub() \n End Sub|] \n End Sub \n End Module"),
@@ -40,7 +40,7 @@ index:=0)
         End Sub
 
         <WorkItem(541515)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestCollectionInitializerInObjectCollectionInitializer()
             Test(
 NewLines("Class Program \n Sub Main() \n [|Dim x As New List(Of Program) From {New Program}|] \n End Sub \n Public Property Name As String \n End Class"),
@@ -50,7 +50,7 @@ index:=0)
 
         <WorkItem(542251)>
         <WorkItem(543030)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestLambdaSelection()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim q As Object \n If True Then q = [|Sub() \n End Sub|] \n End Sub \n End Module"),
@@ -58,7 +58,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(542904)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub FormatBeforeAttribute()
             Test(
 <Text>Module Program
@@ -89,7 +89,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(545262)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestInTernaryConditional()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim p As Object = Nothing \n Dim Obj1 = If(New With {.a = True}.a, p, [|Nothing|]) \n End Sub \n End Module"),
@@ -97,7 +97,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim p As Object = Noth
         End Sub
 
         <WorkItem(545547)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestInRangeArgumentUpperBound()
             Test(
 NewLines("Module Program \n Sub Main() \n Dim x(0 To [|1 + 2|]) ' Extract method \n End Sub \n End Module"),
@@ -105,14 +105,14 @@ NewLines("Module Program \n Sub Main() \n Dim x(0 To {|Rename:NewMethod|}()) ' E
         End Sub
 
         <WorkItem(545655)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestInWhileUntilCondition()
             Test(
 NewLines("Module M \n Sub Main() \n Dim x = 0 \n Do While [|x * x < 100|] \n x += 1 \n Loop \n End Sub \n End Module"),
 NewLines("Module M \n Sub Main() \n Dim x = 0 \n Do While {|Rename:NewMethod|}(x) \n x += 1 \n Loop \n End Sub \n Private Function NewMethod(x As Integer) As Boolean \n Return x * x < 100 \n End Function \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestInInterpolation1()
             Test(
 NewLines("Module M \n Sub Main() \n Dim v As New Object \n [|System.Console.WriteLine($""{v}"")|] \n System.Console.WriteLine(v) \n End Sub \n End Module"),
@@ -130,7 +130,7 @@ End Module"),
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestInInterpolation2()
             Test(
 NewLines("Module M \n Sub Main() \n Dim v As New Object \n System.Console.WriteLine([|$""{v}""|]) \n System.Console.WriteLine(v) \n End Sub \n End Module"),
@@ -149,7 +149,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(545829)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestMissingOnImplicitMemberAccess()
             Test(
 NewLines("Module Program \n Sub Main() \n With """""""" \n Dim x = [|.GetHashCode|] Xor &H7F3E ' Introduce Local \n End With \n End Sub \n End Module"),
@@ -157,7 +157,7 @@ NewLines("Module Program \n Sub Main() \n {|Rename:NewMethod|}() \n End Sub \n P
         End Sub
 
         <WorkItem(984831)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub PreserveCommentsBeforeDeclaration_1()
             Test(
 <Text>Class Program
@@ -202,7 +202,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(984831)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub PreserveCommentsBeforeDeclaration_2()
             Test(
 <Text>Class Program
@@ -251,7 +251,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(984831)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub PreserveCommentsBeforeDeclaration_3()
             Test(
 <Text>Class Program

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.G
             Return New GenerateDefaultConstructorsCodeRefactoringProvider()
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestException0()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits [||]Exception \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -26,7 +26,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestException1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits [||]Exception \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -34,7 +34,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestException2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits [||]Exception \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -42,7 +42,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestException3()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits [||]Exception \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -50,32 +50,32 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         <WorkItem(539676)>
         Public Sub TestNotOfferedOnResolvedBaseClassName()
             TestMissing(
 NewLines("Class Base \n End Class \n Class Derived \n Inherits B[||]ase \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestNotOfferedOnUnresolvedBaseClassName()
             TestMissing(
 NewLines("Class Derived \n Inherits [||]Base \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestNotOfferedOnInheritsStatementForStructures()
             TestMissing(
 NewLines("Structure Derived \n Inherits [||]Base \n End Structure"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestNotOfferedForIncorrectlyParentedInheritsStatement()
             TestMissing(
 NewLines("Inherits [||]Foo"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestWithDefaultConstructor()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits [||]Exception \n Public Sub New() \n End Sub \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -83,7 +83,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestWithDefaultConstructorMissing1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits [||]Exception \n Public Sub New(message As String) \n MyBase.New(message) \n End Sub \n Public Sub New(message As String, innerException As Exception) \n MyBase.New(message, innerException) \n End Sub \n Protected Sub New(info As Runtime.Serialization.SerializationInfo, context As Runtime.Serialization.StreamingContext) \n MyBase.New(info, context) \n End Sub \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -91,7 +91,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestWithDefaultConstructorMissing2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits [||]Exception \n Public Sub New(message As String, innerException As Exception) \n MyBase.New(message, innerException) \n End Sub \n Protected Sub New(info As Runtime.Serialization.SerializationInfo, context As Runtime.Serialization.StreamingContext) \n MyBase.New(info, context) \n End Sub \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -100,7 +100,7 @@ index:=2)
         End Sub
 
         <WorkItem(540712)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestEndOfToken()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program \n Inherits Exception[||] \n Sub Main(args As String()) \n End Sub \n End Class"),
@@ -108,7 +108,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=0)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestFormattingInGenerateDefaultConstructor()
             Test(
 <Text>Imports System
@@ -141,7 +141,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(889349)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Sub TestDefaultConstructorGeneration()
             Test(
 <Text>Class C

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.G
         End Function
 
         <WorkItem(530592)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
         Public Sub TestAdd1()
             Test(
 NewLines("Class Program \n [|Private i As Integer \n Private s As String|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n End Class"),
@@ -24,7 +24,7 @@ NewLines("Class Program \n Private i As Integer \n Private s As String \n Public
         End Sub
 
         <WorkItem(530592)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
         Public Sub TestAddOptional1()
             Test(
 NewLines("Class Program \n [|Private i As Integer \n Private s As String|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n End Class"),
@@ -33,7 +33,7 @@ index:=1)
         End Sub
 
         <WorkItem(530592)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
         Public Sub TestAddToConstructorWithMostMatchingParameters1()
             Test(
 NewLines("Class Program \n [|Private i As Integer \n Private s As String \n Private b As Boolean|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n Public Sub New(i As Integer, s As String) \n Me.New(i) \n Me.s = s \n End Sub \n End Class"),
@@ -41,7 +41,7 @@ NewLines("Class Program \n Private i As Integer \n Private s As String \n Privat
         End Sub
 
         <WorkItem(530592)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)>
         Public Sub TestAddOptionalToConstructorWithMostMatchingParameters1()
             Test(
 NewLines("Class Program \n [|Private i As Integer \n Private s As String \n Private b As Boolean|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n Public Sub New(i As Integer, s As String) \n Me.New(i) \n Me.s = s \n End Sub \n End Class"),

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.G
             Return New GenerateConstructorCodeRefactoringProvider()
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestSingleField()
             Test(
 NewLines("Class Program \n [|Private i As Integer|] \n End Class"),
@@ -23,7 +23,7 @@ NewLines("Class Program \n Private i As Integer \n Public Sub New(i As Integer) 
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMultipleFields()
             Test(
 NewLines("Class Program \n [|Private i As Integer \n Private b As String|] \n End Class"),
@@ -31,7 +31,7 @@ NewLines("Class Program \n Private i As Integer \n Private b As String \n Public
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestSecondField()
             Test(
 NewLines("Class Program \n Private i As Integer \n [|Private b As String|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n End Class"),
@@ -39,7 +39,7 @@ NewLines("Class Program \n Private i As Integer \n Private b As String \n Public
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestFieldAssigningConstructor()
             Test(
 NewLines("Class Program \n [|Private i As Integer \n Private b As String|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n End Class"),
@@ -47,13 +47,13 @@ NewLines("Class Program \n Private i As Integer \n Private b As String \n Public
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMissingWithExistingConstructor()
             TestMissing(
 NewLines("Class Program \n [|Private i As Integer \n Private b As String|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n Public Sub New(i As Integer, b As String) \n Me.i = i \n Me.b = b \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestStruct()
             Test(
 NewLines("Structure S \n [|Private i As Integer|] \n End Structure"),
@@ -61,7 +61,7 @@ NewLines("Structure S \n Private i As Integer \n Public Sub New(i As Integer) \n
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenericType()
             Test(
 NewLines("Class Program ( Of T ) \n [|Private i As Integer|] \n End Class"),
@@ -70,7 +70,7 @@ index:=0)
         End Sub
 
         <WorkItem(541995)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestSimpleDelegatingConstructor()
             Test(
 NewLines("Class Program \n [|Private i As Integer \n Private b As String|] \n Public Sub New(i As Integer) \n Me.i = i \n End Sub \n End Class"),
@@ -79,7 +79,7 @@ index:=1)
         End Sub
 
         <WorkItem(542008)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateFromNormalProperties()
             Test(
 NewLines("Class Z \n [|Public Property A As Integer \n Public Property B As String|] \n End Class"),

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.G
         End Function
 
         <WorkItem(541991)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
         Public Sub TestEqualsOnSingleField()
             Test(
 NewLines("Class Z \n [|Private a As Integer|] \n End Class"),
@@ -25,7 +25,7 @@ index:=0)
         End Sub
 
         <WorkItem(541991)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
         Public Sub TestGetHashCodeOnSingleField()
             Test(
 NewLines("Class Z \n [|Private a As Integer|] \n End Class"),
@@ -34,7 +34,7 @@ index:=1)
         End Sub
 
         <WorkItem(541991)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
         Public Sub TestBothOnSingleField()
             Test(
 NewLines("Class Z \n [|Private a As Integer|] \n End Class"),
@@ -43,7 +43,7 @@ index:=2)
         End Sub
 
         <WorkItem(545205)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)>
         Public Sub TestTypeWithNumberInName()
             Test(
 NewLines("Partial Class c1(Of V As {New}, U) \n [|Dim x As New V|] \n End Class"),

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.I
             Return New InlineTemporaryCodeRefactoringProvider()
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NotWithNoInitializer1()
             Dim code =
 <MethodBody>
@@ -23,7 +23,7 @@ Console.WriteLine(i)
             TestMissing(code)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NotWithNoInitializer2()
             Dim code =
 <MethodBody>
@@ -34,7 +34,7 @@ Console.WriteLine(j)
             TestMissing(code)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NotWithNoInitializer3()
             Dim code =
 <MethodBody>
@@ -45,7 +45,7 @@ Console.WriteLine(k)
             TestMissing(code)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NotWithNoReference1()
             Dim code =
 <MethodBody>
@@ -56,7 +56,7 @@ Console.WriteLine(0)
             TestMissing(code)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NotWithNoReference2()
             Dim code =
 <MethodBody>
@@ -67,7 +67,7 @@ Console.WriteLine(i)
             TestMissing(code)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NotWithNoReference3()
             Dim code =
 <MethodBody>
@@ -78,7 +78,7 @@ Console.WriteLine(i + j)
             TestMissing(code)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NotOnField()
             Dim code =
 <ClassDeclaration>
@@ -92,7 +92,7 @@ End Sub
             TestMissing(code)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub SingleDeclarator()
             Dim code =
 <MethodBody>
@@ -108,7 +108,7 @@ Console.WriteLine(0)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub SingleDeclaratorDontRemoveLeadingTrivia1()
             Dim code =
 <File>
@@ -143,7 +143,7 @@ End Class
         End Sub
 
         <WorkItem(545259)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub SingleDeclaratorDontRemoveLeadingTrivia2()
             Dim code =
 <File>
@@ -174,7 +174,7 @@ End Class
         End Sub
 
         <WorkItem(540330)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub SingleDeclaratorDontMoveNextStatement()
             Dim code =
 <File>
@@ -199,7 +199,7 @@ End Module
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub SingleDeclaratorInPropertyGetter()
             Dim code =
 <PropertyGetter>
@@ -215,7 +215,7 @@ Console.WriteLine(0)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TwoDeclarators1()
             Dim code =
 <MethodBody>
@@ -232,7 +232,7 @@ Console.WriteLine(0)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TwoDeclarators2()
             Dim code =
 <MethodBody>
@@ -249,7 +249,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ThreeDeclarators1()
             Dim code =
 <MethodBody>
@@ -266,7 +266,7 @@ Console.WriteLine(0)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ThreeDeclarators2()
             Dim code =
 <MethodBody>
@@ -283,7 +283,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ThreeDeclarators3()
             Dim code =
 <MethodBody>
@@ -301,7 +301,7 @@ Console.WriteLine(2)
         End Sub
 
         <WorkItem(545704)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ThreeDeclarators4()
             Dim code =
 <MethodBody>
@@ -321,7 +321,7 @@ Call New Integer.ToString()
         End Sub
 
         <WorkItem(16601, "DevDiv_Projects/Roslyn")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoNextDeclarator()
             Dim code =
 <MethodBody>
@@ -336,7 +336,7 @@ Dim y = CType(Sub() Console.WriteLine(), Action)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TwoNames1()
             Dim code =
 <MethodBody>
@@ -353,7 +353,7 @@ Console.WriteLine(New String(" "c, 10))
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TwoNames2()
             Dim code =
 <MethodBody>
@@ -370,7 +370,7 @@ Console.WriteLine(New String(" "c, 10))
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ThreeNames1()
             Dim code =
 <MethodBody>
@@ -387,7 +387,7 @@ Console.WriteLine(New String(" "c, 10))
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ThreeNames2()
             Dim code =
 <MethodBody>
@@ -404,7 +404,7 @@ Console.WriteLine(New String(" "c, 10))
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ThreeNames3()
             Dim code =
 <MethodBody>
@@ -421,7 +421,7 @@ Console.WriteLine(New String(" "c, 10))
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoExpression1()
             Dim code =
 <MethodBody>
@@ -441,7 +441,7 @@ Console.WriteLine(0 + j * k)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoExpression2()
             Dim code =
 <MethodBody>
@@ -461,7 +461,7 @@ Console.WriteLine(i + 1 * k)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact(Skip:="551797"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(Skip:="551797"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         <WorkItem(551797)>
         Public Sub InlineIntoExpression3()
             Dim code =
@@ -478,7 +478,7 @@ Console.Write(New Int32 + 10)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoExpressionAsParenthesized()
             Dim code =
 <MethodBody>
@@ -498,7 +498,7 @@ Console.WriteLine(i + j * (2 + 3))
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess1()
             Dim code =
 <MethodBody>
@@ -514,7 +514,7 @@ Console.WriteLine(New String(" "c, 10).Length)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess2()
             Dim code =
 <MethodBody>
@@ -531,7 +531,7 @@ Console.WriteLine(("a" &amp; "b").Length)
         End Sub
 
         <WorkItem(540374)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess3()
             Dim code =
 <MethodBody>
@@ -549,7 +549,7 @@ Console.Write(New String(" "c, 10).Length)
 
         <WorkItem(541965)>
         <WorkItem(551797)>
-        <WpfFact(Skip:="551797"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(Skip:="551797"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess4()
             Dim code =
 <MethodBody>
@@ -565,7 +565,7 @@ Call New Int32().ToString
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess5()
             Dim code =
 <ClassDeclaration>
@@ -593,7 +593,7 @@ End Sub
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess6()
             Dim code =
 <ClassDeclaration>
@@ -622,7 +622,7 @@ End Sub
         End Sub
 
         <WorkItem(542060)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess7()
             Dim code =
 <MethodBody>
@@ -639,7 +639,7 @@ Console.WriteLine((From x In "ABC" Select x).First())
         End Sub
 
         <WorkItem(546726)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoMemberAccess8()
             Dim code =
 <MethodBody>
@@ -655,7 +655,7 @@ Call New List(Of Integer)().ToString()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast1()
             Dim code =
 <ClassDeclaration>
@@ -685,7 +685,7 @@ End Sub
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast2()
             Dim code =
 <ClassDeclaration>
@@ -715,7 +715,7 @@ End Sub
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast3()
             Dim code =
 <ClassDeclaration>
@@ -745,7 +745,7 @@ End Sub
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast4()
             Dim code =
 <ClassDeclaration>
@@ -775,7 +775,7 @@ End Sub
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast5()
             Dim code =
 <ClassDeclaration>
@@ -807,7 +807,7 @@ End Sub
 
         <WorkItem(544981)>
         <WorkItem(568917)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast6()
             Dim code =
 <File>
@@ -836,7 +836,7 @@ End Class
         End Sub
 
         <WorkItem(544982)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast7()
             Dim code =
 <File>
@@ -868,7 +868,7 @@ End Module
 
         <WorkItem(545130)>
         <WorkItem(568917)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast8()
             Dim code =
 <File>
@@ -895,7 +895,7 @@ End Class
         End Sub
 
         <WorkItem(545162)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast9()
             Dim code =
 <File>
@@ -922,7 +922,7 @@ End Module
         End Sub
 
         <WorkItem(545177)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast10()
             Dim code =
 <File>
@@ -950,7 +950,7 @@ End Module
 
         <WorkItem(545600)>
         <WorkItem(568917)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast11()
             Dim code =
 <File>
@@ -989,7 +989,7 @@ End Class
         End Sub
 
         <WorkItem(545601)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast12()
             Dim code =
 <File>
@@ -1018,7 +1018,7 @@ End Module
         End Sub
 
         <WorkItem(568917)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineWithCast13()
             Dim code =
 <File>
@@ -1051,7 +1051,7 @@ End Module
         End Sub
 
         <WorkItem(546700)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoExpressionHole1()
             Dim code =
 <MethodBody>
@@ -1067,7 +1067,7 @@ Dim x = &lt;x &lt;%= Sub() If True Then Else %&gt;/&gt;
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoExpressionHole2()
             Dim code =
 <MethodBody>
@@ -1083,7 +1083,7 @@ Dim x = &lt;x &lt;%= Sub() If True Then Else %&gt;/&gt;
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineLambda1()
             Dim code =
 <MethodBody>
@@ -1099,7 +1099,7 @@ Dim i = (Function() 1).Invoke()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineLambda2()
             Dim code =
 <MethodBody>
@@ -1119,7 +1119,7 @@ Dim i = Function()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineInsideLambda()
             Dim code =
 <MethodBody>
@@ -1139,7 +1139,7 @@ Dim f As Func(Of Integer) = Function()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineIntoLambda()
             Dim code =
 <MethodBody>
@@ -1159,7 +1159,7 @@ Dim f As Func(Of Integer) = Function()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInlineTrailingComment()
             Dim code =
 <MethodBody>
@@ -1177,7 +1177,7 @@ Console.WriteLine((1 + 1) * 2)
         End Sub
 
         <WorkItem(545544)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontRemoveLineBreakAfterComment()
             Dim code =
 <MethodBody>
@@ -1194,7 +1194,7 @@ Dim y = 1
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub RemoveTrailingColon()
             Dim code =
 <MethodBody>
@@ -1211,7 +1211,7 @@ Console.WriteLine((1 + 1) * j)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast1()
             Dim code =
 <MethodBody>
@@ -1227,7 +1227,7 @@ Dim j As Integer = 1 + 1
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast2()
             Dim code =
 <MethodBody>
@@ -1245,7 +1245,7 @@ Console.WriteLine(j)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast3()
             Dim code =
 <MethodBody>
@@ -1264,7 +1264,7 @@ Dim y As Action = Sub()
         End Sub
 
         <WorkItem(543215)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast4()
             Dim code =
 <ClassDeclaration>
@@ -1291,7 +1291,7 @@ End Sub
         End Sub
 
         <WorkItem(543280)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast5()
             Dim code =
 <File>
@@ -1322,7 +1322,7 @@ End Module
         End Sub
 
         <WorkItem(544973)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast6()
             Dim code =
 <File>
@@ -1355,7 +1355,7 @@ End Module
         End Sub
 
         <WorkItem(545975)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast7()
             Dim code =
 <File>
@@ -1382,7 +1382,7 @@ End Module
         End Sub
 
         <WorkItem(545846)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast8()
             Dim markup =
 <File>
@@ -1411,7 +1411,7 @@ End Module
         End Sub
 
         <WorkItem(545624), WorkItem(799045)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInsertUnnecessaryCast9()
             Dim markup =
 <File>
@@ -1442,7 +1442,7 @@ End Module
         End Sub
 
         <WorkItem(530068)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Sub DontInsertUnnecessaryCast10()
             Dim markup =
 <File>
@@ -1474,7 +1474,7 @@ End Class
             Test(markup, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary1()
             Dim code =
 <MethodBody>
@@ -1490,7 +1490,7 @@ Call New Exception().ToString
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary2()
             Dim code =
 <MethodBody>
@@ -1506,7 +1506,7 @@ Call New Exception().ToString
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary3()
             Dim code =
 <MethodBody>
@@ -1522,7 +1522,7 @@ Call (Sub() Exit Sub)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary4()
             Dim code =
 <MethodBody>
@@ -1538,7 +1538,7 @@ Call (From x in "abc").Distinct()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary5()
             Dim code =
 <MethodBody>
@@ -1554,7 +1554,7 @@ Call "abc".ToLower()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary6()
             Dim code =
 <MethodBody>
@@ -1570,7 +1570,7 @@ Call 1.ToString()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary7()
             Dim code =
 <MethodBody>
@@ -1586,7 +1586,7 @@ Call (1 + 1).ToString()
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary8()
             Dim code =
 <MethodBody>
@@ -1603,7 +1603,7 @@ Call New Exception().Message.ToString
         End Sub
 
         <WorkItem(542819)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary9()
             Dim code =
 <MethodBody>
@@ -1620,7 +1620,7 @@ Call If(True, 1, 2).ToString
         End Sub
 
         <WorkItem(542819)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallIfNecessary10()
             Dim code =
 <MethodBody>
@@ -1637,7 +1637,7 @@ Call If(Nothing, "").ToString
         End Sub
 
         <WorkItem(542667)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary1()
             Dim code =
 <MethodBody>
@@ -1654,7 +1654,7 @@ Dim a = (From y In "" Select y), b
         End Sub
 
         <WorkItem(542667)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary2()
             Dim code =
 <MethodBody>
@@ -1671,7 +1671,7 @@ Dim a = Nothing, b = From y In "" Select y
         End Sub
 
         <WorkItem(542667)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary3()
             Dim code =
 <MethodBody>
@@ -1687,7 +1687,7 @@ Dim a = CType((Function() From y In "" Select y), Func(Of IEnumerable(Of Char)))
         End Sub
 
         <WorkItem(542096)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary4()
             Dim code =
 <MethodBody>
@@ -1704,7 +1704,7 @@ Dim y = New IEnumerable(Of Char)() {(From x In "ABC" Select x), From x In "ABC" 
         End Sub
 
         <WorkItem(542096)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary5()
             Dim code =
 <MethodBody>
@@ -1721,7 +1721,7 @@ Dim y = New IEnumerable(Of Char)() {(From x In "ABC" Select x), From x In "ABC" 
         End Sub
 
         <WorkItem(542096)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary6()
             Dim code =
 <ModuleDeclaration>
@@ -1749,7 +1749,7 @@ End Sub
         End Sub
 
         <WorkItem(542795)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary7()
             Dim code =
 <ModuleDeclaration>
@@ -1776,7 +1776,7 @@ End Sub
         End Sub
 
         <WorkItem(542667)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary8()
             Dim code =
 <MethodBody>
@@ -1793,7 +1793,7 @@ Dim a = (From y In "" Select y Order By y), b
         End Sub
 
         <WorkItem(542795)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary9()
             Dim code =
 <ModuleDeclaration>
@@ -1820,7 +1820,7 @@ End Sub
         End Sub
 
         <WorkItem(542840)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary10()
             Dim code =
 <MethodBody>
@@ -1837,7 +1837,7 @@ Dim y = (New Collections.ArrayList())(0)
         End Sub
 
         <WorkItem(542842)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary11()
             Dim code =
 <MethodBody>
@@ -1854,7 +1854,7 @@ Dim a As Action = (Sub() If True Then Dim x), b = a
         End Sub
 
         <WorkItem(542667)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary12()
             Dim code =
 <MethodBody>
@@ -1871,7 +1871,7 @@ Dim a = (From y In "" Select y Order By y Ascending), b
         End Sub
 
         <WorkItem(542840)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary13()
             Dim code =
 <MethodBody>
@@ -1888,7 +1888,7 @@ Dim y = (New Collections.ArrayList)(0)
         End Sub
 
         <WorkItem(542931)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary14()
             Dim code =
 <MethodBody>
@@ -1905,7 +1905,7 @@ Dim p = From y In "", z In (From x In "") Distinct
         End Sub
 
         <WorkItem(542989)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary15()
             Dim code =
 <MethodBody>
@@ -1922,7 +1922,7 @@ Dim y = (From x In "" Group By x Into Count)(0)
         End Sub
 
         <WorkItem(542990)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary16()
             Dim code =
 <MethodBody>
@@ -1939,7 +1939,7 @@ Dim y As String = (Function() Console.ReadLine)()
         End Sub
 
         <WorkItem(542997)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary17()
             Dim code =
 <MethodBody>
@@ -1956,7 +1956,7 @@ Dim q = From x In "" Select z = (Sub() Return) Distinct
         End Sub
 
         <WorkItem(542997)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary18()
             Dim code =
 <MethodBody>
@@ -1975,7 +1975,7 @@ Dim q = From x In "" Select z = (Sub() Return) _
         End Sub
 
         <WorkItem(542997)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary19()
             Dim code =
 <MethodBody>
@@ -1992,7 +1992,7 @@ Dim q = From x In "" Select z = Sub() Return
         End Sub
 
         <WorkItem(529694)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary20()
             Dim code =
 <MethodBody>
@@ -2017,7 +2017,7 @@ End With
         End Sub
 
         <WorkItem(545571)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary21()
             Dim code =
 <MethodBody>
@@ -2034,7 +2034,7 @@ Call (Sub() Exit Sub).Invoke()
         End Sub
 
         <WorkItem(545849)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary22()
             Dim code =
 <MethodBody>
@@ -2053,7 +2053,7 @@ Console.WriteLine(y.Rank)
         End Sub
 
         <WorkItem(531578)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary23()
             Dim code =
 <File>
@@ -2092,7 +2092,7 @@ End Module
         End Sub
 
         <WorkItem(531582)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeIfNecessary24()
             Dim code =
 <MethodBody>
@@ -2115,7 +2115,7 @@ End Select
         <WorkItem(549182)>
         <WorkItem(549191)>
         <WorkItem(545730)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub UnparenthesizeIfNecessary1()
             Dim code =
 <File>
@@ -2148,7 +2148,7 @@ End Module
         End Sub
 
         <WorkItem(542985)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub AddExplicitArgumentListIfNecessary1()
             Dim code =
 <ModuleDeclaration>
@@ -2181,7 +2181,7 @@ End Function
         End Sub
 
         <WorkItem(542985)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub AddExplicitArgumentListIfNecessary2()
             Dim code =
 <ModuleDeclaration>
@@ -2214,7 +2214,7 @@ End Function
         End Sub
 
         <WorkItem(542985)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub AddExplicitArgumentListIfNecessary3()
             Dim code =
 <ModuleDeclaration>
@@ -2249,7 +2249,7 @@ End Property
         End Sub
 
         <WorkItem(545174)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub AddExplicitArgumentListIfNecessary4()
             Dim code =
 <ModuleDeclaration>
@@ -2275,7 +2275,7 @@ End Module
         End Sub
 
         <WorkItem(529542)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub AddExplicitArgumentListIfNecessary5()
             Dim code =
 <ModuleDeclaration>
@@ -2303,7 +2303,7 @@ End Module
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_Assignment()
             Dim code =
 <MethodBody>
@@ -2322,7 +2322,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_AddAssignment()
             Dim code =
 <MethodBody>
@@ -2341,7 +2341,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_SubtractAssignment()
             Dim code =
 <MethodBody>
@@ -2360,7 +2360,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_MultiplyAssignment()
             Dim code =
 <MethodBody>
@@ -2379,7 +2379,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_DivideAssignment1()
             Dim code =
 <MethodBody>
@@ -2398,7 +2398,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_IntegerDivideAssignment()
             Dim code =
 <MethodBody>
@@ -2417,7 +2417,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_ConcatenateAssignment()
             Dim code =
 <MethodBody>
@@ -2436,7 +2436,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_LeftShiftAssignment()
             Dim code =
 <MethodBody>
@@ -2455,7 +2455,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_RightShiftAssignment()
             Dim code =
 <MethodBody>
@@ -2474,7 +2474,7 @@ Console.WriteLine(1)
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_PowerAssignment()
             Dim code =
 <MethodBody>
@@ -2494,7 +2494,7 @@ Console.WriteLine(1)
         End Sub
 
         <WorkItem(529627)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_ByRefLiteral()
             Dim code =
 <File>
@@ -2530,7 +2530,7 @@ End Module
         End Sub
 
         <WorkItem(545342)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConflict_UsedBeforeDeclaration()
 
             Dim code =
@@ -2558,7 +2558,7 @@ End Module
 
         <WorkItem(545398)>
         <WorkItem(568917)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCorrectCastsForAssignmentStatement1()
             Dim code =
 <File>
@@ -2588,7 +2588,7 @@ End Module
 
         <WorkItem(545398)>
         <WorkItem(568917)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCorrectCastsForAssignmentStatement2()
             Dim code =
 <File>
@@ -2617,7 +2617,7 @@ End Module
         End Sub
 
         <WorkItem(545398)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCorrectCastsForAssignmentStatement3()
             Dim code =
 <File>
@@ -2646,7 +2646,7 @@ End Module
         End Sub
 
         <WorkItem(545539)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontOverparenthesizeXmlAttributeAccessExpression()
             Dim code =
 <File>
@@ -2675,7 +2675,7 @@ End Module
         End Sub
 
         <WorkItem(546069)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestBrokenVariableDeclarator()
             Dim code =
 <File>
@@ -2691,7 +2691,7 @@ End Module
         End Sub
 
         <WorkItem(546658)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontInlineInUnterminatedBlock()
             Dim markup =
 <File>
@@ -2721,7 +2721,7 @@ End Module
         End Sub
 
         <WorkItem(547152)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub EscapeKeywordsIfNeeded1()
             Dim code =
 <File>
@@ -2755,7 +2755,7 @@ End Module
         End Sub
 
         <WorkItem(531473)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub EscapeKeywordsIfNeeded2()
             Dim code =
 <File>
@@ -2790,7 +2790,7 @@ End Module
         End Sub
 
         <WorkItem(531473)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub EscapeKeywordsIfNeeded3()
             Dim code =
 <File>
@@ -2825,7 +2825,7 @@ End Module
         End Sub
 
         <WorkItem(547153)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub EscapeKeywordsIfNeeded4()
             Dim code =
 <File>
@@ -2860,7 +2860,7 @@ End Module
         End Sub
 
         <WorkItem(531584)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub EscapeKeywordsIfNeeded5()
             Dim code =
 <File>
@@ -2897,7 +2897,7 @@ End Module
         End Sub
 
         <WorkItem(601123)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub EscapeKeywordsIfNeeded6()
             Dim code =
 <File>
@@ -2948,7 +2948,7 @@ End Module
         End Sub
 
         <WorkItem(580495)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded01()
             Dim code =
 <File>
@@ -2975,7 +2975,7 @@ End Module
         End Sub
 
         <WorkItem(607520)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded02()
             Dim code =
 <File>
@@ -3002,7 +3002,7 @@ End Module
         End Sub
 
         <WorkItem(607520)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded03()
             Dim code =
 <File>
@@ -3027,7 +3027,7 @@ End Module
         End Sub
 
         <WorkItem(621407)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded04()
             Dim code =
 <File>
@@ -3053,7 +3053,7 @@ End Module
         End Sub
 
         <WorkItem(608208)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded05()
             Dim code =
 <File>
@@ -3079,7 +3079,7 @@ End Module
         End Sub
 
         <WorkItem(621407)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded06()
             Dim code =
 <File>
@@ -3105,7 +3105,7 @@ End Module
         End Sub
 
         <WorkItem(621407)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded06_1()
             Dim code =
 <File>
@@ -3131,7 +3131,7 @@ End Module
         End Sub
 
         <WorkItem(608995)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeLambdaIfNeeded07()
             Dim code =
 <File>
@@ -3157,7 +3157,7 @@ End Module
         End Sub
 
         <WorkItem(588344)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeXmlLiteralExpressionIfNeeded()
             Dim code =
 <File>
@@ -3184,7 +3184,7 @@ End Module
         End Sub
 
         <WorkItem(608204)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeQueryExpressionIfFollowedBySelect()
             Dim code =
 <File>
@@ -3213,7 +3213,7 @@ End Module
         End Sub
 
         <WorkItem(635364)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeQueryExpressionIfFollowedBySelect_635364()
             Dim code =
 <File>
@@ -3248,7 +3248,7 @@ End Module
         End Sub
 
         <WorkItem(635373)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeQueryExpressionIfFollowedBySelect_635373()
             Dim code =
 <File>
@@ -3287,7 +3287,7 @@ End Module
         End Sub
 
         <WorkItem(608202)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ParenthesizeQueryExpressionIfEndingWithDistinct()
             Dim code =
 <File>
@@ -3324,7 +3324,7 @@ End Module
         End Sub
 
         <WorkItem(530129)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ConvertsDelegateInvocationToLabel()
             Dim code =
 <File>
@@ -3356,7 +3356,7 @@ End Module
         End Sub
 
         <WorkItem(529796)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ConvertExtensionMethodInvocationToPlainStaticMethodInvocationIfNecessaryToKeepCorrectOverloadResolution()
             Dim code =
 <File>
@@ -3419,7 +3419,7 @@ End Module
         End Sub
 
         <WorkItem(601907)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub EscapeContextualKeywordAfterQueryEndingWithXmlDocumentEvenWithMultipleEmptyLines()
             Dim code =
 <File>
@@ -3464,7 +3464,7 @@ End Module
         End Sub
 
         <WorkItem(530903)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineTempShouldParenthesizeExpressionIfNeeded()
             Dim code =
 <File>
@@ -3492,7 +3492,7 @@ End Module
         End Sub
 
         <WorkItem(530945)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineTempShouldParenthesizeLambdaExpressionIfNeeded()
             Dim code =
 <File>
@@ -3524,7 +3524,7 @@ End Module
         End Sub
 
         <WorkItem(530926)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineTempShouldNotAddUnnecessaryCallKeyword()
             Dim code =
 <File>
@@ -3549,7 +3549,7 @@ End Module
         End Sub
 
         <WorkItem(529833)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineTempChangesSymbolInfoForInlinedExpression()
             Dim code =
 <File>
@@ -3583,7 +3583,7 @@ End Module
         End Sub
 
         <WorkItem(529833)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineTempWithUserDefinedOperator()
             Dim code =
 <File>
@@ -3634,7 +3634,7 @@ End Class
         End Sub
 
         <WorkItem(529833)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineTempWithUserDefinedOperator2()
             Dim code =
 <File>
@@ -3685,7 +3685,7 @@ End Class
         End Sub
 
         <WorkItem(529840)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub Bugfix_529840_DetectSemanticChangesAtInlineSite()
             Dim code =
 <File>
@@ -3735,7 +3735,7 @@ End Class
         End Sub
 
         <WorkItem(718152)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub Bugfix_718152_DontRemoveParenthesisForAwaitExpression()
             Dim code =
 <File>
@@ -3770,7 +3770,7 @@ End Class
         End Sub
 
         <WorkItem(718152)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub Bugfix_718152_RemoveParenthesisForAwaitExpression()
             Dim code =
 <File>
@@ -3808,7 +3808,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub NameOfExpressionAtStartOfStatement()
             Dim code =
 <File>
@@ -3832,7 +3832,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestSimpleConditionalAccess()
             Dim code =
 <File>
@@ -3865,7 +3865,7 @@ End Class
         End Sub
 
         <WorkItem(1025, "https://github.com/dotnet/roslyn/issues/1025")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConditionalAccessWithConversion()
             Dim code =
 <File>
@@ -3889,7 +3889,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestConditionalAccessWithConditionalExpression()
             Dim code =
 <File>
@@ -3913,7 +3913,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
         Public Sub TestConditionalAccessWithExtensionMethodInvocation()
             Dim code =
@@ -3966,7 +3966,7 @@ End Class]]>
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         <WorkItem(2593, "https://github.com/dotnet/roslyn/issues/2593")>
         Public Sub TestConditionalAccessWithExtensionMethodInvocation_2()
             Dim code =
@@ -4025,7 +4025,7 @@ End Class]]>
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub TestXmlLiteral()
             Dim code =
 <File>
@@ -4052,7 +4052,7 @@ End Class
         End Sub
 
         <WorkItem(2671, "https://github.com/dotnet/roslyn/issues/2671")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub ReplaceReferencesInWithBlocks()
             Dim code =
 <MethodBody>
@@ -4073,7 +4073,7 @@ End With
         End Sub
 
         <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontParenthesizeInterpolatedStringWithNoInterpolation()
             Dim code =
 <MethodBody>
@@ -4090,7 +4090,7 @@ Dim s2 = AscW($"hello")
         End Sub
 
         <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub DontParenthesizeInterpolatedStringWithInterpolation()
             Dim code =
 <MethodBody>
@@ -4109,7 +4109,7 @@ Dim s2 = AscW($"hello {x}")
         End Sub
 
         <WorkItem(4583, "https://github.com/dotnet/roslyn/issues/4583")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineFormattableStringIntoCallSiteRequiringFormattableString()
             Dim code = "
 Imports System
@@ -4142,7 +4142,7 @@ End Class
         End Sub
 
         <WorkItem(4624, "https://github.com/dotnet/roslyn/issues/4624")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InlineFormattableStringIntoCallSiteWithFormattableStringOverload()
             Dim code = "
 Imports System

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.I
             Return New IntroduceVariableCodeRefactoringProvider()
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub Test1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Console.WriteLine([|1 + 1|]) \n End Sub \n End Module"),
@@ -20,7 +20,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub Test2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Console.WriteLine([|1 + 1|]) \n End Sub \n End Module"),
@@ -28,7 +28,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInSingleLineIfExpression1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If foo([|1 + 1|]) Then bar(1 + 1) \n End Sub \n End Module"),
@@ -36,7 +36,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInSingleLineIfExpression2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If foo([|1 + 1|]) Then bar(1 + 1) \n End Sub \n End Module"),
@@ -44,7 +44,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInSingleLineIfStatement1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If foo(1 + 1) Then bar([|1 + 1|]) \n End Sub \n End Module"),
@@ -52,7 +52,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInSingleLineIfStatement2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If foo(1 + 1) Then bar([|1 + 1|]) \n End Sub \n End Module"),
@@ -60,7 +60,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoIntroduceFieldOnMethodTypeParameter()
             Dim source = NewLines("Module Program \n Sub Main(Of T)() \n Foo([|CType(2.ToString(), T)|]) \n End Sub \n End Module")
             TestExactActionSetOffered(
@@ -72,7 +72,7 @@ index:=3)
             ' Verifies "Introduce field ..." is missing
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoIntroduceFieldOnMethodParameter()
             Dim source = NewLines("Module Program \n Sub Main(x As Integer) \n Foo([|x.ToString()|]) \n End Sub \n End Module")
             TestExactActionSetOffered(
@@ -84,69 +84,69 @@ index:=3)
             ' Verifies "Introduce field ..." is missing
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoRefactoringOnExpressionInAssignmentStatement()
             Dim source = NewLines("Module Program \n Sub Main(x As Integer) \n Dim r = [|x.ToString()|] \n End Sub \n End Module")
             TestMissing(source)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalGeneratedInInnerBlock1()
             Dim source = NewLines("Module Program \n Sub Main(x As Integer) \n If True Then \n Foo([|x.ToString()|]) \n End If \n End Sub \n End Module")
             Dim expected = NewLines("Module Program \n Sub Main(x As Integer) \n If True Then \n Dim {|Rename:v|} As String = x.ToString() \n Foo(v) \n End If \n End Sub \n End Module")
             Test(source, expected, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalGeneratedInInnerBlock2()
             Dim source = NewLines("Module Program \n Sub Main(x As Integer) \n If True Then \n Foo([|x.ToString()|]) \n End If \n End Sub \n End Module")
             Dim expected = NewLines("Module Program \n Sub Main(x As Integer) \n If True Then \n Dim {|Rename:v|} As String = x.ToString() \n Foo(v) \n End If \n End Sub \n End Module")
             Test(source, expected, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalFromSingleExpressionInAnonType()
             Dim source = NewLines("Module Program \n Sub Main(x As Integer) \n Dim f1 = New With {.SomeString = [|x.ToString()|]} \n End Sub \n End Module")
             Dim expected = NewLines("Module Program \n Sub Main(x As Integer) \n Dim {|Rename:v|} As String = x.ToString() \n Dim f1 = New With {.SomeString = v} \n End Sub \n End Module")
             Test(source, expected, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalFromMultipleExpressionsInAnonType()
             Dim source = NewLines("Module Program \n Sub Main(x As Integer) \n Dim f1 = New With {.SomeString = [|x.ToString()|], .SomeOtherString = x.ToString()} \n Dim f2 = New With {.SomeString = x.ToString(), .SomeOtherString = x.ToString()} \n Dim str As String = x.ToString() \n End Sub \n End Module")
             Dim expected = NewLines("Module Program \n Sub Main(x As Integer) \n Dim {|Rename:v|} As String = x.ToString() \n Dim f1 = New With {.SomeString = v, .SomeOtherString = v} \n Dim f2 = New With {.SomeString = v, .SomeOtherString = v} \n Dim str As String = v \n End Sub \n End Module")
             Test(source, expected, index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalFromInferredFieldInitializer()
             Dim source = NewLines("Imports System \n Class C \n Sub M() \n Dim a As New With {[|Environment.TickCount|]} \n End Sub \n End Class")
             Dim expected = NewLines("Imports System \n Class C \n Sub M() \n Dim {|Rename:tickCount|} As Integer = Environment.TickCount \n Dim a As New With {tickCount} \n End Sub \n End Class")
             Test(source, expected, index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalFromYieldStatement()
             Dim source = NewLines("Imports System \n Class C \n Iterator Function F() As IEnumerable(Of Integer) \n Yield [|Environment.TickCount * 2|] \n End Function \n End Class")
             Dim expected = NewLines("Imports System \n Class C \n Iterator Function F() As IEnumerable(Of Integer) \n Dim {|Rename:v|} As Integer = Environment.TickCount * 2 \n Yield v \n End Function \n End Class")
             Test(source, expected, index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalFromWhileStatement()
             Dim source = NewLines("Class C \n Sub M() \n Dim x = 1 \n While [|x = 1|] \n End While \n End Sub \n End Class")
             Dim expected = NewLines("Class C \n Sub M() \n Dim x = 1 \n Dim {|Rename:v|} As Boolean = x = 1 \n While v \n End While \n End Sub \n End Class")
             Test(source, expected, index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalFromSingleExpressionInObjectInitializer()
             Dim source = NewLines("Module Program \n Structure FooStruct \n Dim FooMember1 As String \n End Structure \n Sub Main(x As Integer) \n Dim f1 = New FooStruct With {.FooMember1 = [|""t"" + ""test""|]} \n End Sub \n End Module")
             Dim expected = NewLines("Module Program \n Structure FooStruct \n Dim FooMember1 As String \n End Structure \n Sub Main(x As Integer) \n Const {|Rename:V|} As String = ""t"" + ""test"" \n Dim f1 = New FooStruct With {.FooMember1 = V} \n End Sub \n End Module")
             Test(source, expected, index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestLocalFromMultipleExpressionsInObjectInitializer()
             Dim code =
 <File>
@@ -182,34 +182,34 @@ End Module
             Test(code, expected, index:=3, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestFieldFromMultipleExpressionsInAnonType()
             Dim source = NewLines("Class Program \n Dim q = New With {.str = [|""t"" + ""test""|]} \n Dim r = New With {.str = ""t"" + ""test""} \n Sub Foo() \n Dim x = ""t"" + ""test"" \n End Sub \n End Class")
             Dim expected = NewLines("Class Program \n Private Const {|Rename:V|} As String = ""t"" + ""test"" \n Dim q = New With {.str = V} \n Dim r = New With {.str = V} \n Sub Foo() \n Dim x = V \n End Sub \n End Class")
             Test(source, expected, index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestPrivateFieldFromExpressionInField()
             Dim source = NewLines("Class Program \n Dim x = Foo([|2 + 2|]) \n End Class")
             Dim expected = NewLines("Class Program \n Private Const {|Rename:V|} As Integer = 2 + 2 \n Dim x = Foo(V) \n End Class")
             Test(source, expected, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoLocalFromExpressionInField()
             Dim source = NewLines("Class Program \n Dim x = Foo([|2 + 2|]) \n End Class")
             TestExactActionSetOffered(source, {String.Format(FeaturesResources.IntroduceConstantFor, "2 + 2"), String.Format(FeaturesResources.IntroduceConstantForAllOccurrences, "2 + 2")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSharedModifierAbsentInGeneratedModuleFields()
             Dim source = NewLines("Module Program \n Dim x = Foo([|2 + y|]) \n End Module")
             Dim expected = NewLines("Module Program \n Private ReadOnly {|Rename:p|} As Object = 2 + y \n Dim x = Foo(p) \n End Module")
             Test(source, expected, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleLocalInsertLocation()
             Dim source = NewLines("Class Program \n Sub Method1() \n Dim v1 As String = ""TEST"" \n Dim v2 As Integer = 2 + 2 \n Foo([|2 + 2|]) \n End Sub \n End Class")
             Dim expected = NewLines("Class Program \n Sub Method1() \n Dim v1 As String = ""TEST"" \n Dim v2 As Integer = 2 + 2 \n Const {|Rename:V|} As Integer= 2 + 2 \n Foo(V) \n End Sub \n End Class")
@@ -218,7 +218,7 @@ End Module
 
 #Region "Parameter context"
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestConstantFieldGenerationForParameterSingleOccurrence()
             ' This is incorrect: the field type should be Integer, not Object
             Dim source = NewLines("Module Module1 \n Sub Foo(Optional x As Integer = [|42|]) \n End Sub \n End Module")
@@ -226,7 +226,7 @@ End Module
             Test(source, expected, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestConstantFieldGenerationForParameterAllOccurrences()
             ' This is incorrect: the field type should be Integer, not Object
             Dim source = NewLines("Module Module1 \n Sub Bar(Optional x As Integer = 42) \n End Sub \n Sub Foo(Optional x As Integer = [|42|]) \n End Sub \n End Module")
@@ -237,7 +237,7 @@ End Module
 #End Region
 
         <WorkItem(540269)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReplaceDottedExpression()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Console.WriteLine([|Foo.someVariable|]) \n Console.WriteLine(Foo.someVariable) \n End Sub \n End Module \n Friend Class Foo \n Shared Public someVariable As Integer \n End Class"),
@@ -246,7 +246,7 @@ index:=1)
         End Sub
 
         <WorkItem(540457)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReplaceSingleLineIfWithMultiLine1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo([|2 + 2|]) \n End Sub \n End Module"),
@@ -255,7 +255,7 @@ index:=2)
         End Sub
 
         <WorkItem(540457)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReplaceSingleLineIfWithMultiLine2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo([|1 + 1|]) Else Bar(1 + 1) \n End Sub \n End Module"),
@@ -264,7 +264,7 @@ index:=2)
         End Sub
 
         <WorkItem(540457)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReplaceSingleLineIfWithMultiLine3()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo([|1 + 1|]) Else Bar(1 + 1) \n End Sub \n End Module"),
@@ -273,7 +273,7 @@ index:=3)
         End Sub
 
         <WorkItem(540457)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReplaceSingleLineIfWithMultiLine4()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo(1 + 1) Else Bar([|1 + 1|]) \n End Sub \n End Module"),
@@ -282,7 +282,7 @@ index:=2)
         End Sub
 
         <WorkItem(540468)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestCantExtractMethodTypeParameterToFieldCount()
             TestActionCount(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(Of T)(x As Integer) \n Foo([|CType(2.ToString(), T)|]) \n End Sub \n End Module"),
@@ -290,7 +290,7 @@ count:=2)
         End Sub
 
         <WorkItem(540468)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestCantExtractMethodTypeParameterToField()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(Of T)(x As Integer) \n Foo([|CType(2.ToString(), T)|]) \n End Sub \n End Module"),
@@ -298,7 +298,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(540489)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestOnlyFieldsInsideConstructorInitializer()
             TestActionCount(
 NewLines("Class Foo \n Sub New() \n Me.New([|2 + 2|]) \n End Sub \n Sub New(v As Integer) \n End Sub \n End Class"),
@@ -311,7 +311,7 @@ index:=0)
         End Sub
 
         <WorkItem(540485)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroduceLocalForConstantExpression()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim s As String() = New String([|10|]) {} \n End Sub \n End Module"),
@@ -320,7 +320,7 @@ index:=3)
         End Sub
 
         <WorkItem(1065689)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroduceLocalForConstantExpressionWithTrailingTrivia()
             Test(
 <File>
@@ -348,7 +348,7 @@ index:=3,
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroduceFieldWithTrailingTrivia()
             Test(
 <File>
@@ -372,7 +372,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(540487)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestFormattingForPartialExpression()
             Dim code =
 <File>
@@ -397,7 +397,7 @@ End Module
         End Sub
 
         <WorkItem(540491)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInAttribute1()
             Test(
 NewLines("<Attr([|2 + 2|])> \n Class Foo \n End Class \n Friend Class AttrAttribute \n Inherits Attribute \n End Class"),
@@ -406,7 +406,7 @@ index:=0)
         End Sub
 
         <WorkItem(540490)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInMyClassNew()
             Test(
 NewLines("Class Foo \n Sub New() \n MyClass.New([|42|]) \n End Sub \n Sub New(x As Integer) \n End Sub \n End Class"),
@@ -414,7 +414,7 @@ NewLines("Class Foo \n Private Const {|Rename:V|} As Integer = 42 \n Sub New() \
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleToMultiLineIf1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo([|2 + 2|]) Else Bar(2 + 2) \n End Sub \n End Module"),
@@ -422,7 +422,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleToMultiLineIf2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo([|2 + 2|]) Else Bar(2 + 2) \n End Sub \n End Module"),
@@ -430,7 +430,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleToMultiLineIf3()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo(2 + 2) Else Bar([|2 + 2|]) \n End Sub \n End Module"),
@@ -438,7 +438,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleToMultiLineIf4()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If True Then Foo(2 + 2) Else Bar([|2 + 2|]) \n End Sub \n End Module"),
@@ -447,7 +447,7 @@ index:=3)
         End Sub
 
         <WorkItem(541604)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestAttribute()
             Test(
 NewLines("<Attr([|2 + 2|])> \n Class Foo \n End Class \n Friend Class AttrAttribute \n Inherits System.Attribute \n End Class"),
@@ -456,13 +456,13 @@ index:=0)
         End Sub
 
         <WorkItem(542092)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub RangeArgumentLowerBound1()
             TestMissing(NewLines("Module M \n Sub Main() \n Dim x() As Integer \n ReDim x([|0|] To 5) \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(542092)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub RangeArgumentLowerBound2()
             Dim code =
 <File>
@@ -491,7 +491,7 @@ End Module
         End Sub
 
         <WorkItem(543029), WorkItem(542963), WorkItem(542295)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestUntypedExpression()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim q As Object \n If True Then q = [|Sub() \n End Sub|] \n End Sub \n End Module"),
@@ -499,7 +499,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(542374)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestFieldConstantInAttribute1()
             Test(
 NewLines("<Foo(2 + 3 + 4)> \n Module Program \n Dim x = [|2 + 3|] + 4 \n End Module \n Friend Class FooAttribute \n Inherits Attribute \n Sub New(x As Integer) \n End Sub \n End Class"),
@@ -508,7 +508,7 @@ index:=0)
         End Sub
 
         <WorkItem(542374)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestFieldConstantInAttribute2()
             Test(
 NewLines("<Foo(2 + 3 + 4)> \n Module Program \n Dim x = [|2 + 3|] + 4 \n End Module \n Friend Class FooAttribute \n Inherits Attribute \n Sub New(x As Integer) \n End Sub \n End Class"),
@@ -518,21 +518,21 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(542783)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestMissingOnAttributeName()
             TestMissing(
 NewLines("<[|Obsolete|]> \n Class C \n End Class"))
         End Sub
 
         <WorkItem(542811)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestMissingOnFilterClause()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n Try \n Catch ex As Exception When [|+|] \n End Try \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(542906)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoIntroduceLocalInAttribute()
             Dim input =
 "Module Program \n <Obsolete([|""""|])> \n Sub Main(args As String()) \n End Sub \n End Module"
@@ -548,14 +548,14 @@ index:=0)
         End Sub
 
         <WorkItem(542947)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNotOnMyBase()
             TestMissing(
 NewLines("Class c1 \n Public res As String \n Sub Foo() \n res = ""1"" \n End Sub \n End Class \n Class c2 \n Inherits c1 \n Sub scen1() \n [|MyBase|].Foo() \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(541966)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNestedMultiLineIf1()
             Dim code =
 <File>
@@ -593,7 +593,7 @@ End Module
         End Sub
 
         <WorkItem(541966)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNestedMultiLineIf2()
             Dim code =
 <File>
@@ -631,7 +631,7 @@ End Module
         End Sub
 
         <WorkItem(541966)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNestedMultiLineIf3()
             Dim code =
 <File>
@@ -664,7 +664,7 @@ End Module
         End Sub
 
         <WorkItem(543273)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleLineLambda1()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main \n Dim a = Sub(x As Integer) Console.WriteLine([|x + 1|]) ' Introduce local \n End Sub \n End Module"),
@@ -673,7 +673,7 @@ index:=0)
         End Sub
 
         <WorkItem(543273)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleLineLambda2()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main \n Dim a = Sub(x As Integer) If True Then Console.WriteLine([|x + 1|]) Else Console.WriteLine() \n End Sub \n End Module"),
@@ -682,7 +682,7 @@ index:=0)
         End Sub
 
         <WorkItem(543273)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleLineLambda3()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main \n Dim a = Sub(x As Integer) If True Then Console.WriteLine() Else Console.WriteLine([|x + 1|]) \n End Sub \n End Module"),
@@ -691,7 +691,7 @@ index:=0)
         End Sub
 
         <WorkItem(543273)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleLineLambda4()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main \n Dim a = Sub(x As Integer) If True Then Console.WriteLine([|x + 1|]) Else Console.WriteLine(x + 1) \n End Sub \n End Module"),
@@ -700,7 +700,7 @@ index:=1)
         End Sub
 
         <WorkItem(543299)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleLineLambda5()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim query = Sub(a) a = New With {Key .Key = Function(ByVal arg As Integer) As Integer \n Return arg \n End Function}.Key.Invoke([|a Or a|]) \n End Sub \n End Module"),
@@ -709,35 +709,35 @@ index:=0)
         End Sub
 
         <WorkItem(542762)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNotInIntoClause()
             TestMissing(
 NewLines("Imports System.Linq \n Module \n Sub Main() \n Dim x = Aggregate y In New Integer() {1} \n Into [|Count()|] \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(543289)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNotOnAttribute1()
             TestMissing(
 NewLines("Option Explicit Off \n Module Program \n <Runtime.CompilerServices.[|Extension|]()> _ \n Function Extension(ByVal x As Integer) As Integer \n Return x \n End Function \n End Module"))
         End Sub
 
         <WorkItem(543289)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNotOnAttribute2()
             TestMissing(
 NewLines("Option Explicit Off \n Module Program \n <Runtime.CompilerServices.[|Extension()|]> _ \n Function Extension(ByVal x As Integer) As Integer \n Return x \n End Function \n End Module"))
         End Sub
 
         <WorkItem(543461)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestCollectionInitializer()
             TestMissing(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim i1 = New Integer() [|{4, 5}|] \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(543573)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestCaseInsensitiveNameConflict()
             Test(
 NewLines("Class M \n Public Function Foo() \n Return [|Me.Foo|] * 0 \n End Function \n End Class"),
@@ -745,7 +745,7 @@ NewLines("Class M \n Public Function Foo() \n Dim {|Rename:foo1|} As Object = Me
         End Sub
 
         <WorkItem(543590)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestQuery1()
             Test(
 NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByVal arg As Integer) As Integer \n Dim results = From s In New Integer() {1} \n Select [|Sample(s)|] \n Return 0 \n End Function \n End Class"),
@@ -753,7 +753,7 @@ NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByV
         End Sub
 
         <WorkItem(543590)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestQueryCount1()
             TestActionCount(
 NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByVal arg As Integer) As Integer \n Dim results = From s In New Integer() {1} \n Select [|Sample(s)|] \n Return 0 \n End Function \n End Class"),
@@ -761,7 +761,7 @@ count:=2)
         End Sub
 
         <WorkItem(543590)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestQuery2()
             Test(
 NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByVal arg As Integer) As Integer \n Dim results = From s In New Integer() {1} \n Where [|Sample(s)|] > 21 \n Select Sample(s) \n Return 0 \n End Function \n End Class"),
@@ -769,7 +769,7 @@ NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByV
         End Sub
 
         <WorkItem(543590)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestQuery3()
             Test(
 NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByVal arg As Integer) As Integer \n Dim results = From s In New Integer() {1} \n Where [|Sample(s)|] > 21 \n Select Sample(s) \n Return 0 \n End Function \n End Class"),
@@ -778,14 +778,14 @@ index:=1)
         End Sub
 
         <WorkItem(543590)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestQuery4()
             Test(
 NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByVal arg As Integer) As Integer \n Dim results = From s In New Integer() {1} \n Where Sample(s) > 21 \n Select [|Sample(s)|] \n Return 0 \n End Function \n End Class"),
 NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByVal arg As Integer) As Integer \n Dim results = From s In New Integer() {1} \n Where Sample(s) > 21 Let {|Rename:v|} = Sample(s) \n Select v \n Return 0 \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestQuery5()
             Test(
 NewLines("Imports System.Linq \n Public Class Base \n Public Function Sample(ByVal arg As Integer) As Integer \n Dim results = From s In New Integer() {1} \n Where Sample(s) > 21 \n Select [|Sample(s)|] \n Return 0 \n End Function \n End Class"),
@@ -795,20 +795,20 @@ index:=1)
 
         <WorkItem(543529)>
         <WorkItem(909152)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInStatementlessConstructorParameter()
             TestMissing(NewLines("Class C1 \n Sub New(Optional ByRef x As String = [|Nothing|]) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(543650)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReferenceToAnonymousTypeProperty()
             TestMissing(
 NewLines("Class AM \n Sub M(args As String()) \n Dim var1 As New AM \n Dim at1 As New With {var1, .friend = [|.var1|]} \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(543698)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntegerArrayExpression()
             Test(
 NewLines("Module Program \n Sub Main() \n Return [|New Integer() {}|] \n End Sub \n End Module"),
@@ -816,42 +816,42 @@ NewLines("Module Program \n Sub Main() \n Dim {|Rename:v|} As Integer() = New In
         End Sub
 
         <WorkItem(544273)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestAttributeNamedParameter()
             TestMissing(
 NewLines("Class TestAttribute \n Inherits Attribute \n Public Sub New(Optional a As Integer = 42) \n End Sub \n End Class \n <Test([|a|]:=5)> \n Class Foo \n End Class"))
         End Sub
 
         <WorkItem(544265)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestMissingOnWrittenToExpression()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n Dim x = New Integer() {1, 2} \n [|x(1)|] = 2 \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(543824)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestImplicitMemberAccess1()
             TestMissing(
 NewLines("Imports System \n Public Class C1 \n Public FieldInt As Long \n Public FieldStr As String \n Public Property PropInt As Integer \n End Class \n Public Class C2 \n Public Shared Sub Main() \n Dim x = 1 + New C1() With {.FieldStr = [|.FieldInt|].ToString()} \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(543824)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestImplicitMemberAccess2()
             TestMissing(
 NewLines("Imports System \n Public Class C1 \n Public FieldInt As Long \n Public FieldStr As String \n Public Property PropInt As Integer \n End Class \n Public Class C2 \n Public Shared Sub Main() \n Dim x = 1 + New C1() With {.FieldStr = [|.FieldInt.ToString|]()} \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(543824)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestImplicitMemberAccess3()
             TestMissing(
 NewLines("Imports System \n Public Class C1 \n Public FieldInt As Long \n Public FieldStr As String \n Public Property PropInt As Integer \n End Class \n Public Class C2 \n Public Shared Sub Main() \n Dim x = 1 + New C1() With {.FieldStr = [|.FieldInt.ToString()|]} \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(543824)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestImplicitMemberAccess4()
             Dim code =
 <File>
@@ -888,21 +888,21 @@ End Class
         End Sub
 
         <WorkItem(529510)>
-        <WpfFact(Skip:="529510"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact(Skip:="529510"), Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoRefactoringOnAddressOfExpression()
             Dim source = NewLines("Imports System \n Module Module1 \n Public Sub Foo(ByVal a1 As Exception) \n End Sub \n Public Sub foo(ByVal a1 As Action(Of ArgumentException)) \n End Sub \n Sub Main() \n Foo(New Action(Of Exception)([|AddressOf Foo|])) \n End Sub \n End Module")
             TestMissing(source)
         End Sub
 
         <WorkItem(529510)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestMissingOnAddressOfInDelegate()
             TestMissing(
 NewLines("Module Module1 \n Public Sub Foo(ByVal a1 As Exception) \n End Sub \n Public Sub foo(ByVal a1 As Action(Of ArgumentException)) \n End Sub \n Sub Main() \n foo(New Action(Of Exception)([|AddressOf Foo|])) \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(545168)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)>
         Public Sub TestMissingOnXmlName()
             TestMissing(
 NewLines("Module M \n Sub Main() \n Dim x = <[|x|]/> \n End Sub \n End Module"))
@@ -910,13 +910,13 @@ NewLines("Module M \n Sub Main() \n Dim x = <[|x|]/> \n End Sub \n End Module"))
 
         <WorkItem(545262)>
         <WorkItem(909152)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInTernaryConditional()
             TestMissing(NewLines("Module Program \n Sub Main(args As String()) \n Dim p As Object = Nothing \n Dim Obj1 = If(New With {.a = True}.a, p, [|Nothing|]) \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(545316)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInPropertyInitializer()
             Test(
 NewLines("Module Module1 \n Property Prop As New List(Of String) From {[|""One""|], ""two""} \n End Module"),
@@ -924,7 +924,7 @@ NewLines("Module Module1 \n Private Const {|Rename:V|} As String = ""One"" \n Pr
         End Sub
 
         <WorkItem(545308)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestDoNotMergeAmpersand()
             Dim code =
 <File>
@@ -948,7 +948,7 @@ End Module
         End Sub
 
         <WorkItem(545258)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestVenusGeneration1()
             Dim code =
 <File>
@@ -981,7 +981,7 @@ End Class
         End Sub
 
         <WorkItem(545258)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestVenusGeneration2()
             Dim code =
 <Text>
@@ -1002,7 +1002,7 @@ End Class
         End Sub
 
         <WorkItem(545258)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestVenusGeneration3()
             Dim code =
 <File>
@@ -1039,7 +1039,7 @@ End Class
         End Sub
 
         <WorkItem(545525)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInvocation()
             Test(
 NewLines("Option Strict On \n  \n Class C \n Shared Sub Main() \n Dim x = [|New C().Foo()|](0) \n End Sub \n Function Foo() As Integer() \n End Function \n End Class"),
@@ -1047,7 +1047,7 @@ NewLines("Option Strict On \n  \n Class C \n Shared Sub Main() \n Dim {|Rename:v
         End Sub
 
         <WorkItem(545829)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestOnImplicitMemberAccess()
             Test(
 NewLines("Module Program \n Sub Main() \n With """" \n Dim x = [|.GetHashCode|] Xor &H7F3E ' Introduce Local \n End With \n End Sub \n End Module"),
@@ -1061,7 +1061,7 @@ parseOptions:=GetScriptOptions())
         End Sub
 
         <WorkItem(545702)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestMissingInRefLocation()
             Dim markup =
 <File>
@@ -1080,7 +1080,7 @@ End Module
         End Sub
 
         <WorkItem(546139)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestAcrossPartialTypes()
             Test(
 NewLines("Partial Class C \n Sub foo1(Optional x As String = [|""HELLO""|]) \n End Sub \n End Class \n Partial Class C \n Sub foo3(Optional x As String = ""HELLO"") \n End Sub \n End Class"),
@@ -1089,7 +1089,7 @@ index:=1)
         End Sub
 
         <WorkItem(544669)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestFunctionBody1()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim a1 = Function(ByVal x) [|x!foo|] \n End Sub \n End Module"),
@@ -1097,7 +1097,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim a1 = Function(ByVa
         End Sub
 
         <WorkItem(1065689)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestTrailingTrivia()
             Dim code =
 <File>
@@ -1127,7 +1127,7 @@ End Module
         End Sub
 
         <WorkItem(546815)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestInIfStatement()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n If [|True|] Then \n End If \n End Sub \n End Module"),
@@ -1135,7 +1135,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(830928)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroduceLocalRemovesUnnecessaryCast()
             Test(
 NewLines("Imports System.Collections.Generic \n Class C \n Private Shared Sub Main(args As String()) \n Dim hSet = New HashSet(Of String)() \n hSet.Add([|hSet.ToString()|]) \n End Sub \n End Class"),
@@ -1143,7 +1143,7 @@ NewLines("Imports System.Collections.Generic \n Class C \n Private Shared Sub Ma
         End Sub
 
         <WorkItem(546691)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroLocalInSingleLineLambda()
             Dim code =
 <File>
@@ -1170,7 +1170,7 @@ End Module
         End Sub
 
         <WorkItem(530720)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestSingleToMultilineLambdaLineBreaks()
             Dim code =
 <File>
@@ -1197,7 +1197,7 @@ End Module
         End Sub
 
         <WorkItem(531478)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub EscapeKeywordsIfNeeded1()
             Dim code =
 <File>
@@ -1230,7 +1230,7 @@ End Module
         End Sub
 
         <WorkItem(632327)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub InsertAfterPreprocessor1()
             Dim code =
 <File>
@@ -1265,7 +1265,7 @@ End Class
         End Sub
 
         <WorkItem(632327)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub InsertAfterPreprocessor2()
             Dim code =
 <File>
@@ -1300,7 +1300,7 @@ End Class
         End Sub
 
         <WorkItem(682683)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub DontRemoveParenthesesIfOperatorPrecedenceWouldBeBroken()
             Dim code =
 <File>
@@ -1329,7 +1329,7 @@ End Module
         End Sub
 
         <WorkItem(1022458)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub DontSimplifyParentUnlessEntireInnerNodeIsSelected()
             Dim code =
 <File>
@@ -1366,7 +1366,7 @@ End Module
         End Sub
 
         <WorkItem(939259)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroduceLocalWithTriviaInMultiLineStatements()
             Dim code =
 <File>
@@ -1399,7 +1399,7 @@ End Module
         End Sub
 
         <WorkItem(909152)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestMissingOnNothingLiteral()
             TestMissing(
 <File>
@@ -1417,7 +1417,7 @@ End Module
         End Sub
 
         <WorkItem(1130990)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub InParentConditionalAccessExpressions()
             Dim code =
 <File>
@@ -1445,7 +1445,7 @@ End Class
 
         <WorkItem(1130990)>
         <WorkItem(3110, "https://github.com/dotnet/roslyn/issues/3110")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub MissingAcrossMultipleParentConditionalAccessExpressions()
             TestMissing(
 <File>
@@ -1460,7 +1460,7 @@ End Class
         End Sub
 
         <WorkItem(1130990)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub MissingOnInvocationExpressionInParentConditionalAccessExpressions()
             TestMissing(
 <File>
@@ -1475,7 +1475,7 @@ End Class
         End Sub
 
         <WorkItem(1130990)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub MissingOnMemberBindingExpressionInParentConditionalAccessExpressions()
             TestMissing(
 <File>
@@ -1490,7 +1490,7 @@ End Class
         End Sub
 
         <WorkItem(2026, "https://github.com/dotnet/roslyn/issues/2026")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestReplaceAllFromInsideIfBlock()
             Dim code =
 <File>
@@ -1557,7 +1557,7 @@ End Class
         End Sub
 
         <WorkItem(1065661)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestIntroduceVariableTextDoesntSpanLines()
             Dim code = "
 Class C
@@ -1572,7 +1572,7 @@ End Class"
         End Sub
 
         <WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoConstantForInterpolatedStrings1()
             Dim code =
 <File>
@@ -1599,7 +1599,7 @@ End Module
         End Sub
 
         <WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestNoConstantForInterpolatedStrings2()
             Dim code =
 <File>
@@ -1626,7 +1626,7 @@ End Module
         End Sub
 
         <WorkItem(3147, "https://github.com/dotnet/roslyn/issues/3147")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub HandleFormattableStringTargetTyping1()
             Const code = "
 Imports System
@@ -1659,7 +1659,7 @@ End Namespace"
         End Sub
 
         <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub InAutoPropertyInitializerEqualsClause()
             Dim code =
 <File>
@@ -1680,7 +1680,7 @@ End Class
         End Sub
 
         <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub InAutoPropertyWithCollectionInitializerAfterEqualsClause()
             Dim code =
 <File>
@@ -1701,7 +1701,7 @@ End Class
         End Sub
 
         <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub InAutoPropertyInitializerAsClause()
             Dim code =
 <File>
@@ -1722,7 +1722,7 @@ End Class
         End Sub
 
         <WorkItem(936, "https://github.com/dotnet/roslyn/issues/936")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub InAutoPropertyObjectCreationExpressionWithinAsClause()
             Dim code =
 <File>

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InvertIf/InvertIfTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InvertIf/InvertIfTests.vb
@@ -12,161 +12,161 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.I
             Return New InvertIfCodeRefactoringProvider()
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestSingleLineIdentifier()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMultiLineIdentifier()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n a() \n Else \n b() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Then \n b() \n Else \n a() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestCall()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a.Foo() Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a.Foo() Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestNotIdentifier()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If Not a Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestTrueLiteral()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If True Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If False Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestFalseLiteral()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If False Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If True Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestEquals()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a = b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a <> b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestNotEquals()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a <> b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a = b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestLessThan()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a < b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a >= b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestLessThanOrEqual()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a <= b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a > b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestGreaterThan()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a > b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a <= b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestGreaterThanOrEqual()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a >= b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a < b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestIs()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Is b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a IsNot b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestIsNot()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a IsNot b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a Is b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestOr()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Or b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a And Not b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestAnd()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a And b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Or Not b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestOrElse()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a OrElse b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a AndAlso Not b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestAndAlso()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a AndAlso b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a OrElse Not b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestOr2()
             Test(
 NewLines("Module Program \n Sub Main() \n I[||]f Not a Or Not b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a And b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestOrElse2()
             Test(
 NewLines("Module Program \n Sub Main() \n I[||]f Not a OrElse Not b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a AndAlso b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestAnd2()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If Not a And Not b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a Or b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestAndAlso2()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If Not a AndAlso Not b Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a OrElse b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestXor()
             Test(
 NewLines("Module Program \n Sub Main() \n I[||]f a Xor b Then a() Else b() \n End Sub \n End Module"),
@@ -174,54 +174,54 @@ NewLines("Module Program \n Sub Main() \n If Not (a Xor b) Then b() Else a() \n 
         End Sub
 
         <WorkItem(545411)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestXor2()
             Test(
 NewLines("Module Program \n Sub Main() \n I[||]f Not (a Xor b) Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a Xor b Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestNested()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If (((a = b) AndAlso (c <> d)) OrElse ((e < f) AndAlso (Not g))) Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If (a <> b OrElse c = d) AndAlso (e >= f OrElse g) Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestElseIf()
             Test(
 NewLines("Module Program \n Sub Main() \n If a Then \n a() \n [||]ElseIf b Then \n b() \n Else \n c() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a Then \n a() \n ElseIf Not b Then \n c() \n Else \n b() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestKeepElseIfKeyword()
             Test(
 NewLines("Module Program \n Sub Main() \n If a Then \n a() \n [||]ElseIf b Then \n b() \n Else \n c() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If a Then \n a() \n ElseIf Not b Then \n c() \n Else \n b() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnIfElseIfElse()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n I[||]f a Then \n a() \n Else If b Then \n b() \n Else \n c() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnNonEmptySpan()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n [|If a Then \n a() \n Else \n b() \n End If|] \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestDoesNotOverlapHiddenPosition1()
             Test(
 NewLines("Module Program \n Sub Main() \n #End ExternalSource \n foo() \n #ExternalSource File.vb 1 \n [||]If a Then \n a() \n Else \n b() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n #End ExternalSource \n foo() \n #ExternalSource File.vb 1 \n If Not a Then \n b() \n Else \n a() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestDoesNotOverlapHiddenPosition2()
             Test(
 NewLines("Module Program \n Sub Main() \n #ExternalSource File.vb 1 \n [||]If a Then \n a() \n Else \n b() \n End If \n #End ExternalSource \n End Sub \n End Module"),
@@ -229,144 +229,144 @@ NewLines("Module Program \n Sub Main() \n #ExternalSource File.vb 1 \n If Not a 
         End Sub
 
         <WorkItem(529624)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnOverlapsHiddenPosition1()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n #ExternalSource File.vb 1 \n a() \n #End ExternalSource \n Else \n b() \n End If \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(529624)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnOverlapsHiddenPosition2()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n If a Then \n a() \n [||]Else If b Then \n #ExternalSource File.vb 1 \n b() \n #End ExternalSource \n Else \n c() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnOverlapsHiddenPosition3()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n a() \n #ExternalSource File.vb 1 \n Else If b Then \n b() \n #End ExternalSource \n Else \n c() \n End If \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(529624)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnOverlapsHiddenPosition4()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n a() \n Else \n #ExternalSource File.vb 1 \n b() \n #End ExternalSource \n End If \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(529624)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnOverlapsHiddenPosition5()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n #ExternalSource File.vb 1 \n a() \n Else \n b() \n #End ExternalSource \n End If \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(529624)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnOverlapsHiddenPosition6()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n a() \n #ExternalSource File.vb 1 \n Else \n #End ExternalSource \n b() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMissingOnNonEmptyTextSpan()
             TestMissing(
 NewLines("Module Program \n Sub Main() \n [|If a Th|]en a() Else b() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMultipleStatementsSingleLineIfStatement()
             Test(
 NewLines("Module Program \n Sub Main() \n If[||] a Then a() : b() Else c() : d() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Then c() : d() Else a() : b() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestMultipleStatementsMultiLineIfBlock()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n foo() \n bar() \n Else \n you() \n too() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Then \n you() \n too() \n Else \n foo() \n bar() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestTriviaAfterSingleLineIfStatement()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Then a() Else b() ' I will stay put \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Then b() Else a() ' I will stay put \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestTriviaAfterMultiLineIfBlock()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n a() \n Else \n b() \n End If ' I will stay put \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Then \n b() \n Else \n a() \n End If ' I will stay put \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestParenthesizeForLogicalExpressionPrecedence()
             Test(
 NewLines("Sub Main() \n I[||]f a AndAlso b Or c Then a() Else b() \n End Sub \n End Module"),
 NewLines("Sub Main() \n If (Not a OrElse Not b) And Not c Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestKeepExplicitLineContinuationTrivia()
             Test(
 NewLines("Module Program \n Sub Main() \n I[||]f a And b _ \n Or c Then \n a() \n Else \n b() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If (Not a Or Not b) _ \n And Not c Then \n b() \n Else \n a() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestKeepTriviaInStatementsInMultiLineIfBlock()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If a Then \n a() \n \n Else \n b() \n \n \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If Not a Then \n b() \n \n \n Else \n a() \n \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestParenthesizeComparisonOperands()
             Test(
 NewLines("Module Program \n Sub Main() \n [||]If 0 <= <x/>.GetHashCode Then a() Else b() \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main() \n If 0 > (<x/>.GetHashCode) Then b() Else a() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestSimplifyToLengthEqualsZero()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n [||]If x.Length > 0 Then \n GreaterThanZero() \n Else \n EqualsZero() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n If x.Length = 0 Then \n EqualsZero() \n Else \n GreaterThanZero() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestSimplifyToLengthEqualsZero2()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x() As String \n [||]If x.Length > 0 Then \n GreaterThanZero() \n Else \n EqualsZero() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x() As String \n If x.Length = 0 Then \n EqualsZero() \n Else \n GreaterThanZero() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestSimplifyToLengthEqualsZero4()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x() As String \n [||]If x.Length > 0x0 Then \n GreaterThanZero() \n Else \n EqualsZero() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x() As String \n If x.Length = 0x0 Then \n EqualsZero() \n Else \n GreaterThanZero() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestSimplifyToLengthEqualsZero5()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n [||]If 0 < x.Length Then \n GreaterThanZero() \n Else \n EqualsZero() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n If 0 = x.Length Then \n EqualsZero() \n Else \n GreaterThanZero() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestDoesNotSimplifyToLengthEqualsZero()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n [||]If x.Length >= 0 Then \n a() \n Else \n b() \n End If \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n If x.Length < 0 Then \n b() \n Else \n a() \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TestDoesNotSimplifyToLengthEqualsZero2()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n [||]If x.Length > 0.0 Then \n a() \n Else \n b() \n End If \n End Sub \n End Module"),
@@ -375,7 +375,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim x As String \n If 
 
         <WorkItem(529748)>
         <WorkItem(530593)>
-        <WpfFact(Skip:="Bug 530593"), Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact(Skip:="Bug 530593"), Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub ColonAfterSingleLineIfWithEmptyElse()
             Test(
 NewLines("Module Program \n Sub Main() \n ' Invert If \n I[||]f False Then Return Else : Console.WriteLine(1) \n End Sub \n End Module"),
@@ -384,7 +384,7 @@ NewLines("Module Program \n Sub Main() \n ' Invert If \n If True Then  Else Retu
 
         <WorkItem(529749)>
         <WorkItem(530593)>
-        <WpfFact(Skip:="Bug 530593"), Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact(Skip:="Bug 530593"), Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub NestedSingleLineIfs()
             Test(
 NewLines("Module Program \n Sub Main() \n ' Invert the 1st If \n I[||]f True Then Console.WriteLine(1) Else If True Then Return \n End Sub \n End Module"),
@@ -392,7 +392,7 @@ NewLines("Module Program \n Sub Main() \n ' Invert the 1st If \n If False Then I
         End Sub
 
         <WorkItem(529747)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub TryToParenthesizeAwkwardSyntaxInsideSingleLineLambda()
             Test(
 NewLines("Module Program \n Sub Main() \n ' Invert If \n Dim x = Sub() I[||]f True Then Dim y Else Console.WriteLine(), z = 1 \n End Sub \n End Module"),
@@ -400,28 +400,28 @@ NewLines("Module Program \n Sub Main() \n ' Invert If \n Dim x = (Sub() If False
         End Sub
 
         <WorkItem(529756)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub OnlyOnIfOfSingleLineIf()
             TestMissing(
 NewLines("Module Program \n Sub Main(args As String()) \n If True [||] Then Return Else Console.WriteLine(""a"")\n End Sub \n End Module"))
         End Sub
 
         <WorkItem(529756)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub OnlyOnElseIf()
             TestMissing(
 NewLines("Module Program \n Sub Main(args As String()) \n If False Then \n Return \n ElseIf True [||] Then \n Console.WriteLine(""b"") \n Else \n Console.WriteLine(""a"") \n End If \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(529756)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub OnlyOnIfOfMultiLine()
             TestMissing(
 NewLines("Module Program \n Sub Main(args As String()) \n If [||]False Then \n Return \n Else \n Console.WriteLine(""a"") \n End If \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(531101)>
-        <WpfFact(Skip:="531101"), Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact(Skip:="531101"), Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub ImplicitLineContinuationBeforeClosingParenIsRemoved()
             Dim markup =
 <MethodBody>
@@ -442,7 +442,7 @@ End If
         End Sub
 
         <WorkItem(529746)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub EscapeKeywordsIfNeeded1()
             Dim markup =
 <File>
@@ -474,7 +474,7 @@ End Module
         End Sub
 
         <WorkItem(531471)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub EscapeKeywordsIfNeeded2()
             Dim markup =
 <File>
@@ -506,7 +506,7 @@ End Module
         End Sub
 
         <WorkItem(531471)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub EscapeKeywordsIfNeeded3()
             Dim markup =
 <File>
@@ -538,7 +538,7 @@ End Module
         End Sub
 
         <WorkItem(531472)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub EscapeKeywordsIfNeeded4()
             Dim markup =
 <File>
@@ -566,7 +566,7 @@ End Module
         End Sub
 
         <WorkItem(531475)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub EscapeKeywordsIfNeeded5()
             Dim markup =
 <File>
@@ -598,7 +598,7 @@ End Module
         End Sub
 
         <WorkItem(545700)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub AddEmptyArgumentListIfNeeded()
             Dim markup =
 <File>
@@ -630,7 +630,7 @@ End Module
         End Sub
 
         <WorkItem(531474)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub DoNotRemoveTypeCharactersDuringComplexification()
             Dim markup =
 <File>
@@ -670,7 +670,7 @@ End Module
         End Sub
 
         <WorkItem(530758)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub ParenthesizeToKeepParseTheSame1()
             Dim markup =
 <File>
@@ -694,7 +694,7 @@ End Module
         End Sub
 
         <WorkItem(607862)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
         Public Sub ParenthesizeToKeepParseTheSame2()
             Dim markup =
 <File>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -17,124 +17,124 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
                 New VisualBasicAddImportCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestSimpleImportFromSameFile()
             Test(
 NewLines("Class Class1 \n Dim v As [|SomeClass1|] \n End Class \n Namespace SomeNamespace \n Public Class SomeClass1 \n End Class \n End Namespace"),
 NewLines("Imports SomeNamespace \n Class Class1 \n Dim v As SomeClass1 \n End Class \n Namespace SomeNamespace \n Public Class SomeClass1 \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestSimpleImportFromReference()
             Test(
 NewLines("Class Class1 \n Dim v As [|Thread|] \n End Class"),
 NewLines("Imports System.Threading \n Class Class1 \n Dim v As Thread \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestSmartTagDisplay()
             TestSmartTagText(
 NewLines("Class Class1 \n Dim v As [|Thread|] \n End Class"),
 "Imports System.Threading")
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericClassDefinitionAsClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class Base \n End Class \n End Namespace \n Class SomeClass(Of x As [|Base|]) \n End Class"),
 NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class Base \n End Class \n End Namespace \n Class SomeClass(Of x As Base) \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericClassInstantiationOfClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class GenericClass(Of T) \n End Class \n Class Foo \n Sub Method1() \n Dim q As GenericClass(Of [|SomeClass|]) \n End Sub \n End Class"),
 NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class GenericClass(Of T) \n End Class \n Class Foo \n Sub Method1() \n Dim q As GenericClass(Of SomeClass) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericMethodDefinitionAsClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T As [|SomeClass|]) \n End Sub \n End Class"),
 NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T As SomeClass) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericMethodInvocationOfClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T) \n End Sub \n Sub Method2() \n Method1(Of [|SomeClass|]) \n End Sub \n End Class"),
 NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T) \n End Sub \n Sub Method2() \n Method1(Of SomeClass) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAttributeApplication()
             Test(
 NewLines("<[|Something|]()> \n Class Foo \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"),
 NewLines("Imports SomeNamespace \n <Something()> \n Class Foo \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestMultipleAttributeApplicationBelow()
             Test(
 NewLines("<Existing()> \n <[|Something|]()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"),
 NewLines("Imports SomeNamespace \n <Existing()> \n <Something()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestMultipleAttributeApplicationAbove()
             Test(
 NewLines("<[|Something|]()> \n <Existing()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"),
 NewLines("Imports SomeNamespace \n <Something()> \n <Existing()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestImportsIsEscapedWhenNamespaceMatchesKeyword()
             Test(
 NewLines("Class SomeClass \n Dim x As [|Something|] \n End Class \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace"),
 NewLines("Imports [Namespace] \n Class SomeClass \n Dim x As Something \n End Class \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestImportsIsNOTEscapedWhenNamespaceMatchesKeywordButIsNested()
             Test(
 NewLines("Class SomeClass \n Dim x As [|Something|] \n End Class \n Namespace Outer \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace \n End Namespace"),
 NewLines("Imports Outer.Namespace \n Class SomeClass \n Dim x As Something \n End Class \n Namespace Outer \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportsNotSuggestedForImportsStatement()
             TestMissing(
 NewLines("Imports [|InnerNamespace|] \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportsNotSuggestedForGenericTypeParametersOfClause()
             TestMissing(
 NewLines("Class SomeClass \n Sub Foo(Of [|SomeClass|])(x As SomeClass) \n End Sub \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportsNotSuggestedForGenericTypeParametersAsClause()
             TestMissing(
 NewLines("Class SomeClass \n Sub Foo(Of SomeClass)(x As [|SomeClass|]) \n End Sub \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"))
         End Sub
 
         <WorkItem(540543)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestCaseSensitivity1()
             Test(
 NewLines("Class Foo \n Dim x As [|someclass|] \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"),
 NewLines("Imports SomeNamespace \n Class Foo \n Dim x As SomeClass \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestTypeFromMultipleNamespaces1()
             Test(
 NewLines("Class Foo \n Function F() As [|IDictionary|] \n End Function \n End Class"),
 NewLines("Imports System.Collections \n Class Foo \n Function F() As IDictionary \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestTypeFromMultipleNamespaces2()
             Test(
 NewLines("Class Foo \n Function F() As [|IDictionary|] \n End Function \n End Class"),
@@ -142,48 +142,48 @@ NewLines("Imports System.Collections.Generic \n Class Foo \n Function F() As IDi
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericWithNoArgs()
             Test(
 NewLines("Class Foo \n Function F() As [|List|] \n End Function \n End Class"),
 NewLines("Imports System.Collections.Generic \n Class Foo \n Function F() As List \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericWithCorrectArgs()
             Test(
 NewLines("Class Foo \n Function F() As [|List(Of Integer)|] \n End Function \n End Class"),
 NewLines("Imports System.Collections.Generic \n Class Foo \n Function F() As List(Of Integer) \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericWithWrongArgs()
             TestMissing(
 NewLines("Class Foo \n Function F() As [|List(Of Integer, String)|] \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericInLocalDeclaration()
             Test(
 NewLines("Class Foo \n Sub Test() \n Dim x As New [|List(Of Integer)|] \n End Sub \n End Class"),
 NewLines("Imports System.Collections.Generic \n Class Foo \n Sub Test() \n Dim x As New List(Of Integer) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericItemType()
             Test(
 NewLines("Class Foo \n Sub Test() \n Dim x As New List(Of [|Int32|]) \n End Sub \n End Class"),
 NewLines("Imports System \n Class Foo \n Sub Test() \n Dim x As New List(Of Int32) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenerateWithExistingUsings()
             Test(
 NewLines("Imports System \n Class Foo \n Sub Test() \n Dim x As New [|List(Of Integer)|] \n End Sub \n End Class"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Class Foo \n Sub Test() \n Dim x As New List(Of Integer) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenerateInNamespace()
             Test(
 NewLines("Imports System \n Namespace NS \n Class Foo \n Sub Test() \n Dim x As New [|List(Of Integer)|] \n End Sub \n End Class \n End Namespace"),
@@ -191,7 +191,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Namespace NS \
         End Sub
 
         <WorkItem(540519)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestCodeIssueCountInExistingUsing()
             TestActionCount(
 NewLines("Imports System.Collections.Generic \n Namespace NS \n Class Foo \n Function Test() As [|IDictionary|] \n End Function \n End Class \n End Namespace"),
@@ -199,7 +199,7 @@ count:=1)
         End Sub
 
         <WorkItem(540519)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestFixInExistingUsing()
             Test(
 NewLines("Imports System.Collections.Generic \n Namespace NS \n Class Foo \n Function Test() As [|IDictionary|] \n End Function \n End Class \n End Namespace"),
@@ -207,14 +207,14 @@ NewLines("Imports System.Collections \n Imports System.Collections.Generic \n Na
         End Sub
 
         <WorkItem(541731)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestGenericExtensionMethod()
             Test(
 NewLines("Imports System.Collections.Generic \n Class Test \n Private Sub Method(args As IList(Of Integer)) \n args.[|Where|]() \n End Sub \n End Class"),
 NewLines("Imports System.Collections.Generic \n Imports System.Linq \n Class Test \n Private Sub Method(args As IList(Of Integer)) \n args.Where() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestParameterType()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String(), f As [|FileMode|]) \n End Sub \n End Module"),
@@ -222,7 +222,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(540519)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddWithExistingConflictWithDifferentArity()
             Test(
 NewLines("Imports System.Collections.Generic \n Namespace NS \n Class Foo \n Function Test() As [|IDictionary|] \n End Function \n End Class \n End Namespace"),
@@ -230,14 +230,14 @@ NewLines("Imports System.Collections \n Imports System.Collections.Generic \n Na
         End Sub
 
         <WorkItem(540673)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestImportNamespace()
             Test(
 NewLines("Class FOo \n Sub bar() \n Dim q As [|innernamespace|].someClass \n End Sub \n End Class \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"),
 NewLines("Imports SomeNamespace \n Class FOo \n Sub bar() \n Dim q As InnerNamespace.SomeClass \n End Sub \n End Class \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestCaseSensitivity2()
             Test(
 NewLines("Class FOo \n Sub bar() \n Dim q As [|innernamespace|].someClass \n End Sub \n End Class \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"),
@@ -245,7 +245,7 @@ NewLines("Imports SomeNamespace \n Class FOo \n Sub bar() \n Dim q As InnerNames
         End Sub
 
         <WorkItem(540745)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestCaseSensitivity3()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As [|foo|] \n End Sub \n End Module \n Namespace OUTER \n Namespace INNER \n Friend Class FOO \n End Class \n End Namespace \n End Namespace"),
@@ -253,7 +253,7 @@ NewLines("Imports OUTER.INNER \n Module Program \n Sub Main(args As String()) \n
         End Sub
 
         <WorkItem(541746)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub AddBlankLineAfterLastImports()
             Test(
 <Text>Imports System
@@ -295,14 +295,14 @@ index:=0,
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestSimpleWhereClause()
             Test(
 NewLines("Class Program \n Public Sub Linq1() \n Dim numbers() As Integer = New Integer(9) {5, 4, 1, 3, 9, 8, 6, 7, 2, 0} \n Dim lowNums = [|From n In numbers _ \n Where n < 5 _ \n Select n|] \n End Sub \n End Class"),
 NewLines("Imports System.Linq \n Class Program \n Public Sub Linq1() \n Dim numbers() As Integer = New Integer(9) {5, 4, 1, 3, 9, 8, 6, 7, 2, 0} \n Dim lowNums = From n In numbers _ \n Where n < 5 _ \n Select n \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAggregateClause()
             Test(
 NewLines("Imports System.Collections.Generic \n Class Program \n Public Sub Linq1() \n Dim numbers() As Integer = New Integer(9) {5, 4, 1, 3, 9, 8, 6, 7, 2, 0} \n Dim greaterNums = [|Aggregate n In numbers \n Into greaterThan5 = All(n > 5)|] \n End Sub \n End Class"),
@@ -310,35 +310,35 @@ NewLines("Imports System.Collections.Generic \n Imports System.Linq \n Class Pro
         End Sub
 
         <WorkItem(543107)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestNoCrashOnMissingLeftSide()
             TestMissing(
 NewLines("Imports System \n Class C1 \n Sub foo() \n Dim s = .[|first|] \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(544335)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestOnCallWithoutArgumentList()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|File|] \n End Sub \n End Module"),
 NewLines("Imports System.IO \n Module Program \n Sub Main(args As String()) \n File \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddToVisibleRegion()
             Test(
 NewLines("#ExternalSource (""Default.aspx"", 1) \n Imports System \n #End ExternalSource \n #ExternalSource (""Default.aspx"", 2) \n Class C \n Sub Foo() \n Dim x As New [|StreamReader|] \n #End ExternalSource \n End Sub \n End Class"),
 NewLines("#ExternalSource (""Default.aspx"", 1) \n Imports System \n Imports System.IO \n #End ExternalSource \n #ExternalSource (""Default.aspx"", 2) \n Class C \n Sub Foo() \n Dim x As New [|StreamReader|] \n #End ExternalSource \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestDoNotAddIntoHiddenRegion()
             TestMissing(
 NewLines("Imports System \n #ExternalSource (""Default.aspx"", 2) \n Class C \n Sub Foo() \n Dim x As New [|StreamReader|] \n #End ExternalSource \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(546369)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestFormattingAfterImports()
             Test(
 <Text>Imports B
@@ -363,7 +363,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(775448)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub ShouldTriggerOnBC32045()
             ' BC32045: 'A' has no type parameters and so cannot have type arguments.
             Test(
@@ -387,7 +387,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(867425)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestUnknownIdentifierInModule()
             Test(
     NewLines("Module Foo \n Sub Bar(args As String()) \n Dim a = From f In args \n Let ext = [|Path|] \n End Sub \n End Module"),
@@ -395,7 +395,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(872908)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestConflictedGenericName()
             Test(
     NewLines("Module Foo \n Sub Bar(args As String()) \n Dim a = From f In args \n Let ext = [|Path|] \n End Sub \n End Module"),
@@ -403,7 +403,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(838253)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestConflictedInaccessibleType()
             Test(
     NewLines("Imports System.Diagnostics \n Namespace N \n Public Class Log \n End Class \n End Namespace \n Class C \n Public Function Foo() \n [|Log|] \n End Function \n End Class"),
@@ -411,7 +411,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(858085)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestConflictedAttributeName()
             Test(
     NewLines("<[|Description|]> Public Class Description \n End Class"),
@@ -419,7 +419,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(772321)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestExtensionWithThePresenceOfTheSameNameNonExtensionMethod()
             Test(
     NewLines("Option Strict On \n Imports System.Runtime.CompilerServices \n Namespace NS1 \n Class Program \n Sub main() \n Dim c = New C() \n [|c.Foo(4)|] \n End Sub \n End Class \n Class C \n Sub Foo(ByVal m As String) \n End Sub \n End Class \n End Namespace \n Namespace NS2 \n Module A \n <Extension()> \n Sub Foo(ByVal ec As NS1.C, ByVal n As Integer) \n End Sub \n End Module \n End Namespace "),
@@ -428,7 +428,7 @@ compareTokens:=False)
 
         <WorkItem(772321)>
         <WorkItem(920398)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestExtensionWithThePresenceOfTheSameNameNonExtensionPrivateMethod()
             Test(
     NewLines("Option Strict On \n Imports System.Runtime.CompilerServices \n Namespace NS1 \n Class Program \n Sub main() \n Dim c = New C() \n [|c.Foo(4)|] \n End Sub \n End Class \n Class C \n Private Sub Foo(ByVal m As Integer) \n End Sub \n End Class \n End Namespace \n Namespace NS2 \n Module A \n <Extension()> \n Sub Foo(ByVal ec As NS1.C, ByVal n As Integer) \n End Sub \n End Module \n End Namespace "),
@@ -437,7 +437,7 @@ compareTokens:=False)
 
         <WorkItem(772321)>
         <WorkItem(920398)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestExtensionWithThePresenceOfTheSameNameExtensionPrivateMethod()
             Test(
     NewLines("Option Strict On \n Imports System.Runtime.CompilerServices \n Imports NS2 \n Namespace NS1 \n Class Program \n Sub main() \n Dim c = New C() \n [|c.Foo(4)|] \n End Sub \n End Class \n Class C \n Sub Foo(ByVal m As String) \n End Sub \n End Class \n End Namespace \n Namespace NS2 \n Module A \n <Extension()> \n Private Sub Foo(ByVal ec As NS1.C, ByVal n As Integer) \n End Sub \n End Module \n End Namespace \n \n Namespace NS3 \n Module A \n <Extension()> \n Sub Foo(ByVal ec As NS1.C, ByVal n As Integer) \n End Sub \n End Module \n End Namespace "),
@@ -445,7 +445,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(916368)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForCref()
             Dim initialText As String = NewLines("''' <summary>\n''' This is just like <see cref=[|""INotifyPropertyChanged""|]/>, but this one is mine.\n''' </summary>\nInterface IMyInterface\nEnd Interface")
             Dim expectedText As String = NewLines("Imports System.ComponentModel\n''' <summary>\n''' This is just like <see cref=""INotifyPropertyChanged""/>, but this one is mine.\n''' </summary>\nInterface IMyInterface\nEnd Interface")
@@ -457,7 +457,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(916368)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForCref2()
             Dim initialText As String = NewLines("''' <summary>\n''' This is just like <see cref=[|""INotifyPropertyChanged.PropertyChanged""|]/>, but this one is mine.\n''' </summary>\nInterface IMyInterface\nEnd Interface")
             Dim expectedText As String = NewLines("Imports System.ComponentModel\n''' <summary>\n''' This is just like <see cref=""INotifyPropertyChanged.PropertyChanged""/>, but this one is mine.\n''' </summary>\nInterface IMyInterface\nEnd Interface")
@@ -469,7 +469,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(916368)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForCref3()
             Dim initialText =
 "
@@ -525,7 +525,7 @@ End Module
         End Sub
 
         <WorkItem(916368)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForCref4()
             Dim initialText =
 "
@@ -584,7 +584,7 @@ End Module
         End Sub
 
         <WorkItem(916368)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForCref5()
             Dim initialText =
 "
@@ -622,7 +622,7 @@ End Class
         End Sub
 
         <WorkItem(772321)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestExtensionMethodNoMemberAccessOverload()
             Test(
 "Option Strict On
@@ -666,7 +666,7 @@ End Namespace",)
         End Sub
 
         <WorkItem(772321)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestExtensionMethodNoMemberAccess()
             Test(
 "Option Strict On
@@ -706,7 +706,7 @@ End Namespace",)
         End Sub
 
         <WorkItem(1003618)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub AddImportsTypeParsedAsNamespace()
             Test(
 "Imports System
@@ -745,7 +745,7 @@ End Namespace")
         End Sub
 
         <WorkItem(773614)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub AddImportsForTypeAttribute()
             Test(
 "Imports System
@@ -776,7 +776,7 @@ End Namespace", compareTokens:=False)
         End Sub
 
         <WorkItem(773614)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub AddImportsForTypeAttributeMultipleNestedClasses()
             Test(
 "Imports System
@@ -811,7 +811,7 @@ End Namespace", compareTokens:=False)
         End Sub
 
         <WorkItem(773614)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub AddImportsForTypeAttributePartiallyQualified()
             Test(
 "Imports System
@@ -846,7 +846,7 @@ End Namespace", compareTokens:=False)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestConditionalAccessExtensionMethod()
             Dim initial = <Workspace>
                               <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
@@ -875,7 +875,7 @@ End Namespace
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestConditionalAccessExtensionMethod2()
             Dim initial = <Workspace>
                               <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
@@ -911,7 +911,7 @@ End Namespace
             Test(initial, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddUsingInDirective()
             Test(
 NewLines("#Const Debug\nImports System\nImports System.Collections.Generic\n#If Debug Then\nImports System.Linq\n#End If\nModule Program\n    Sub Main(args As String()) \n        Dim a = [|File|].OpenRead("""") \n    End Sub \n End Module"),
@@ -919,7 +919,7 @@ NewLines("#Const Debug\nImports System\nImports System.Collections.Generic\nImpo
 compareTokens:=False)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddUsingInDirective2()
             Test(
 NewLines("#Const Debug\n#If Debug Then\nImports System\n#End If\nImports System.Collections.Generic\nImports System.Linq\n Module Program\n    Sub Main(args As String())\n        Dim a = [|File|].OpenRead("""")\n End Sub\n End Module"),
@@ -927,7 +927,7 @@ NewLines("#Const Debug\n#If Debug Then\nImports System\n#End If\nImports System.
 compareTokens:=False)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddUsingInDirective3()
             Test(
 NewLines("#Const Debug\n#If Debug Then\nImports System\nImports System.Collections.Generic\nImports System.Linq\n#End If\nModule Program\n    Sub Main(args As String())\n        Dim a = [|File|].OpenRead("""") \n End Sub \n End Module"),
@@ -935,7 +935,7 @@ NewLines("#Const Debug\n#If Debug Then\nImports System\nImports System.Collectio
 compareTokens:=False)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestInaccessibleExtensionMethod()
             Dim initial = <Workspace>
                               <Project Language="Visual Basic" AssemblyName="lib" CommonReferences="true">
@@ -970,7 +970,7 @@ End Module
             Test(initial, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestInaccessibleExtensionMethod2()
             Dim initial = <Workspace>
                               <Project Language="Visual Basic" AssemblyName="lib" CommonReferences="true">
@@ -1005,7 +1005,7 @@ End Module
         End Sub
 
         <WorkItem(269)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForAddExtentionMethod()
             Test(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime.CompilerServices \n Class X \n Implements IEnumerable \n Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Dim a = New X [|From {1}|] \n Return a.GetEnumerator() \n End Function \n End Class \n Namespace Ext \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Integer) \n End Sub \n End Module \n End Namespace"),
@@ -1014,7 +1014,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(269)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForAddExtentionMethod2()
             Test(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime.CompilerServices \n Class X \n Implements IEnumerable \n Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Dim a = New X [|From {1, 2, 3}|] \n Return a.GetEnumerator() \n End Function \n End Class \n Namespace Ext \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Integer) \n End Sub \n End Module \n End Namespace"),
@@ -1023,7 +1023,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(269)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForAddExtentionMethod3()
             Test(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime.CompilerServices \n Class X \n Implements IEnumerable \n Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Dim a = New X [|From {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}|] \n Return a.GetEnumerator() \n End Function \n End Class \n Namespace Ext \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Integer) \n End Sub \n End Module \n End Namespace"),
@@ -1032,7 +1032,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(269)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForAddExtentionMethod4()
             Test(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime.CompilerServices \n Class X \n Implements IEnumerable \n Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Dim a = New X [|From {{1, 2, 3}, {""Four"", ""Five"", ""Six""}, {7, 8, 9}}|] \n Return a.GetEnumerator() \n End Function \n End Class \n Namespace Ext \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Integer) \n End Sub \n End Module \n End Namespace"),
@@ -1041,7 +1041,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(269)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForAddExtentionMethod5()
             Test(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime.CompilerServices \n Class X \n Implements IEnumerable \n Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Dim a = New X [|From {""This""}|] \n Return a.GetEnumerator() \n End Function \n End Class \n Namespace Ext \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Integer) \n End Sub \n End Module \n End Namespace"),
@@ -1050,7 +1050,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(269)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForAddExtentionMethod6()
             Test(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime.CompilerServices \n Class X \n Implements IEnumerable \n Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Dim a = New X [|From {""This""}|] \n Return a.GetEnumerator() \n End Function \n End Class \n Namespace Ext \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Integer) \n End Sub \n End Module \n End Namespace \n Namespace Ext2 \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Object()) \n End Sub \n End Module \n End Namespace"),
@@ -1059,7 +1059,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(269)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddImportForAddExtentionMethod7()
             Test(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Runtime.CompilerServices \n Class X \n Implements IEnumerable \n Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Dim a = New X [|From {""This""}|] \n Return a.GetEnumerator() \n End Function \n End Class \n Namespace Ext \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Integer) \n End Sub \n End Module \n End Namespace \n Namespace Ext2 \n Module Extensions \n <Extension> \n Public Sub Add(x As X, i As Object()) \n End Sub \n End Module \n End Namespace"),
@@ -1069,7 +1069,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddUsingWithOtherExtensionsInScope()
             Test(
 NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Module Program \n Sub Main(args As String()) \n Dim i = [|0.All|]() \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"),
@@ -1077,7 +1077,7 @@ NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Impo
         End Sub
 
         <WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddUsingWithOtherExtensionsInScope2()
             Test(
 NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Module Program \n Sub Main(args As String()) \n Dim a = New Integer? \n Dim i = a?[|.All|]() \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer?) As Integer \n Return 0 \n End Function \n End Module \n End Namespace"),
@@ -1085,7 +1085,7 @@ NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Impo
         End Sub
 
         <WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddUsingWithOtherExtensionsInScope3()
             Test(
 NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Module Program \n Sub Main(args As String()) \n Dim a = 0 \n Dim i = [|a.All|](0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer, v As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"),
@@ -1093,7 +1093,7 @@ NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n M
         End Sub
 
         <WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestAddUsingWithOtherExtensionsInScope4()
             Test(
 NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Module Program \n Sub Main(args As String()) \n Dim a = New Integer? \n Dim i = a?[|.All|](0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer?) As Integer \n Return 0 \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer?, v As Integer) As Integer \n Return 0 \n End Function \n End Module \n End Namespace"),
@@ -1110,7 +1110,7 @@ NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n M
             End Function
 
             <WorkItem(829970)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
                 Test(
     NewLines("Class Class1 \n <[|Extension|]> \n End Class"),
@@ -1118,7 +1118,7 @@ NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n M
             End Sub
 
             <WorkItem(829970)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestUnknownIdentifierGenericName()
                 Test(
     NewLines("Class C \n    Inherits Attribute \n    Public Sub New(x As System.Type) \n    End Sub \n    <C([|List(Of Integer)|])> \n End Class"),
@@ -1126,7 +1126,7 @@ NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n M
             End Sub
 
             <WorkItem(829970)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestUnknownIdentifierAddNamespaceImport()
                 Test(
     NewLines("Class Class1 \n <[|Tasks.Task|]> \n End Class"),
@@ -1134,7 +1134,7 @@ NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n M
             End Sub
 
             <WorkItem(829970)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestUnknownAttributeInModule()
                 Test(
     NewLines("Module Foo \n <[|Extension|]> \n End Module"),
@@ -1146,7 +1146,7 @@ NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n M
             End Sub
 
             <WorkItem(938296)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestNullParentInNode()
                 TestMissing(
 "Imports System.Collections.Generic
@@ -1161,7 +1161,7 @@ End Class")
             End Sub
 
             <WorkItem(1744, "https://github.com/dotnet/roslyn/issues/1744")>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestImportIncompleteSub()
                 Test(
     NewLines("Class A \n Dim a As Action = Sub() \n Try \n Catch ex As [|TestException|] \n End Sub \n End Class \n Namespace T \n Class TestException \n Inherits Exception \n End Class \n End Namespace"),
@@ -1169,7 +1169,7 @@ End Class")
             End Sub
 
             <WorkItem(1239, "https://github.com/dotnet/roslyn/issues/1239")>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestImportIncompleteSub2()
                 Test(
     NewLines("Imports System.Linq \n Namespace X \n Class Test \n End Class \n End Namespace \n Class C \n Sub New() \n Dim s As Action = Sub() \n Dim a = New [|Test|]()"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAsyncTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAsyncTests.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
     Public Class AddAsyncTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub AwaitInSubNoModifiers()
             Test(
                 NewLines("Imports System \n Imports System.Threading.Tasks \n Module Program \n Sub Test() \n [|Await Task.Delay(1)|] \n End Sub \n End Module"),
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
                 )
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub AwaitInSubWithModifiers()
             Test(
                 NewLines("Imports System \n Imports System.Threading.Tasks \n Module Program \n Public Shared Sub Test() \n [|Await Task.Delay(1)|] \n End Sub \n End Module"),
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
                 )
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub AwaitInFunctionNoModifiers()
             Test(
                 NewLines("Imports System \n Imports System.Threading.Tasks \n Module Program \n Function Test() As Integer \n [|Await Task.Delay(1)|] \n Function Sub \n End Module"),
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
                 )
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub AwaitInFunctionWithModifiers()
             Test(
                 NewLines("Imports System \n Imports System.Threading.Tasks \n Module Program \n Public Shared Function Test() As Integer \n [|Await Task.Delay(1)|] \n Function Sub \n End Module"),
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
                 )
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub AwaitInLambdaFunction()
             Dim initial =
 <ModuleDeclaration>
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub AwaitInLambdaSub()
             Dim initial =
 <ModuleDeclaration>
@@ -76,12 +76,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub AwaitInMember()
             TestMissing(NewLines("Imports System \n Imports System.Threading.Tasks \n Module Program \n Dim x =[| Await Task.Delay(3)|] \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncMethod()
             Dim initial =
 <ModuleDeclaration>
@@ -98,7 +98,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncVoidMethod()
             Dim initial =
 <ModuleDeclaration>
@@ -115,7 +115,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction()
             Dim initial =
 <ModuleDeclaration>
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction2()
             Dim initial =
 <ModuleDeclaration>
@@ -149,7 +149,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction3()
             Dim initial =
 <ModuleDeclaration>
@@ -166,7 +166,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction4()
             Dim initial =
 <File>
@@ -187,7 +187,7 @@ End Class
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction5()
             Dim initial =
 <File>
@@ -208,7 +208,7 @@ End Class
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction6()
             Dim initial =
 <File>
@@ -229,7 +229,7 @@ End Class
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction7()
             Dim initial =
 <File>
@@ -250,7 +250,7 @@ End Class
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub BadAwaitInNonAsyncFunction8()
             Dim initial =
 <File>
@@ -272,7 +272,7 @@ End Class
         End Sub
 
         <WorkItem(6477, "https://github.com/dotnet/roslyn/issues/6477")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAsync)>
         Public Sub NullNodeCrash()
             Dim initial =
 <File>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAwaitTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAwaitTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
     Public Class AddAwaitTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
         Public Sub TaskNotAwaited()
             Test(
                 NewLines("Imports System \n Imports System.Threading.Tasks \n Module Program \n Async Sub MySub() \n [|Task.Delay(3)|] \n End Sub \n End Module"),
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
 )
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
         Public Sub TaskNotAwaited_WithLeadingTrivia()
             Dim initial =
 <File>
@@ -46,7 +46,7 @@ End Module
             Test(initial, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
         Public Sub BadAsyncReturnOperand1()
             Dim initial =
 <File>
@@ -85,7 +85,7 @@ End Module
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
         Public Sub FunctionNotAwaited()
             Dim initial =
 <File>
@@ -125,7 +125,7 @@ End Module
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
         Public Sub FunctionNotAwaited_WithLeadingTrivia()
             Dim initial =
 <File>
@@ -169,7 +169,7 @@ End Module
             Test(initial, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
         Public Sub SubLambdaNotAwaited()
             Dim initial =
 <File>
@@ -205,7 +205,7 @@ End Module
             Test(initial, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAwait)>
         Public Sub FunctionLambdaNotAwaited()
             Dim initial =
 <File>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/ChangeToAsyncTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/ChangeToAsyncTests.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
     Public Class ChangeToAsyncTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToAsync)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToAsync)>
         Public Sub CantAwaitAsyncSub1()
             Dim initial =
     <ModuleDeclaration>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/CorrectNextControlVariable/CorrectNextControlVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/CorrectNextControlVariable/CorrectNextControlVariableTests.vb
@@ -13,118 +13,118 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Correc
                 Nothing, New CorrectNextControlVariableCodeFixProvider)
         End Function
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForLoopBoundIdentifier()
             Test(
 NewLines("Module M1 \n Sub Main() \n Dim y As Integer \n For x = 1 To 10 \n Next [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n Dim y As Integer \n For x = 1 To 10 \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForLoopUnboundIdentifier()
             Test(
 NewLines("Module M1 \n Sub Main() \n For x = 1 To 10 \n Next [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For x = 1 To 10 \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForEachLoopBoundIdentifier()
             Test(
 NewLines("Module M1 \n Sub Main() \n Dim y As Integer \n For Each x In {1, 2, 3} \n Next [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n Dim y As Integer \n For Each x In {1, 2, 3} \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForEachLoopUnboundIdentifier()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x In {1, 2, 3} \n Next [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x In {1, 2, 3} \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForEachNested()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x In {1, 2, 3} \n For Each y In {1, 2, 3} \n Next [|x|] \n Next x \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x In {1, 2, 3} \n For Each y In {1, 2, 3} \n Next y \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForEachNestedOuter()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x In {1, 2, 3} \n For Each y In {1, 2, 3} \n Next y \n Next [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x In {1, 2, 3} \n For Each y In {1, 2, 3} \n Next y \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForLoopWithDeclarator()
             Test(
 NewLines("Module M1 \n Sub Main() \n Dim y As Integer \n For x As Integer = 1 To 10 \n Next [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n Dim y As Integer \n For x As Integer = 1 To 10 \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestForEachLoopWithDeclarator()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n Next [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestMultipleControl1()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For Each y In {1, 2, 3} \n Next [|x|], y \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For Each y In {1, 2, 3} \n Next y, y \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestMultipleControl2()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For Each y In {1, 2, 3} \n Next x, [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For Each y In {1, 2, 3} \n Next x, x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestMixedNestedLoop()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next y, [|y|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next y, x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestThreeLevels()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n For Each z As Integer In {1, 2, 3} \n Next z \n Next y, [|z|] \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n For Each z As Integer In {1, 2, 3} \n Next z \n Next y, x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestExtraVariable()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next y, [|z|], x \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next y, x, x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestMethodCall()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next y \n Next [|y|]() \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next y \n Next x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestLongExpressions()
             Test(
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next [|x + 10 + 11|], x \n End Sub \n End Module"),
 NewLines("Module M1 \n Sub Main() \n For Each x As Integer In {1, 2, 4} \n For y = 1 To 10 \n Next y, x \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestNoLoop()
             TestMissing(
 NewLines("Module M1 \n Sub Main() \n Next [|y|] \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectNextControlVariable)>
         Public Sub TestMissingNesting()
             TestMissing(
 NewLines("Module M1 \n Sub Main() \n For Each x In {1, 2, 3} \n Next x, [|y|] \n End Sub \n End Module"))

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
@@ -9,7 +9,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
 Public Class DiagnosticAnalyzerDriverTests
-    <WpfFact>
+    <Fact>
     Public Sub DiagnosticAnalyzerDriverAllInOne()
         Dim source = TestResource.AllInOneVisualBasicCode
         Dim analyzer = New BasicTrackingDiagnosticAnalyzer()
@@ -24,7 +24,7 @@ Public Class DiagnosticAnalyzerDriverTests
         End Using
     End Sub
 
-    <WpfFact, WorkItem(908658)>
+    <Fact, WorkItem(908658)>
     Public Sub DiagnosticAnalyzerDriverVsAnalyzerDriverOnCodeBlock()
         Dim methodNames As String() = {"Initialize", "AnalyzeCodeBlock"}
         Dim source = <file><![CDATA[
@@ -58,7 +58,7 @@ End Class
         End Using
     End Sub
 
-    <WpfFact>
+    <Fact>
     <WorkItem(759)>
     Public Sub DiagnosticAnalyzerDriverIsSafeAgainstAnalyzerExceptions()
         Dim source = TestResource.AllInOneVisualBasicCode
@@ -70,7 +70,7 @@ End Class
     End Sub
 
     <WorkItem(908621)>
-    <WpfFact>
+    <Fact>
     Public Sub DiagnosticServiceIsSafeAgainstAnalyzerExceptions()
         Dim analyzer = New ThrowingDiagnosticAnalyzer(Of SyntaxKind)()
         analyzer.ThrowOn(GetType(DiagnosticAnalyzer).GetProperties().Single().Name)
@@ -82,7 +82,7 @@ End Class
         diagnosticService.GetDiagnosticDescriptors(projectOpt:=Nothing)
     End Sub
 
-    <WpfFact>
+    <Fact>
     Public Sub AnalyzerOptionsArePassedToAllAnalyzers()
         Using workspace = VisualBasicWorkspaceFactory.CreateWorkspaceFromFile(TestResource.AllInOneVisualBasicCode)
             Dim currentProject = workspace.CurrentSolution.Projects.Single()

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ExitContinue/ExitContinueCodeActionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ExitContinue/ExitContinueCodeActionTests.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.ExitCo
                 Nothing, New IncorrectExitContinueCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedExitKind_Sub()
             Dim code =
 <File>
@@ -37,7 +37,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedExitKind_While()
             Dim code =
     <File>
@@ -64,7 +64,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedExitKind_For()
             Dim code =
     <File>
@@ -91,7 +91,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedExitKind_Do()
             Dim code =
     <File>
@@ -118,7 +118,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitPropNot()
             Dim code =
     <File>
@@ -149,7 +149,7 @@ Exit Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedExitKind_Try()
             Dim code =
     <File>
@@ -180,7 +180,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedExitKind_Function()
             Dim code =
     <File>
@@ -203,7 +203,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitSubOfFunc()
             Dim code =
     <File>
@@ -226,7 +226,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitFuncOfSub()
             Dim code =
     <File>
@@ -249,7 +249,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitDoNotWithinDo()
             Dim code =
     <File>
@@ -276,7 +276,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitDoNotWithinDo_For()
             Dim code =
     <File>
@@ -303,7 +303,7 @@ End Class
             Test(code, expected, compareTokens:=False, index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitWhileNotWithinWhile()
             Dim code =
     <File>
@@ -330,7 +330,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitDoNotWithinDo_Try()
             Dim code =
     <File>
@@ -363,7 +363,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitTryNotWithinTry()
             Dim code =
     <File>
@@ -386,7 +386,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExitChangeToSelect()
             Dim code =
     <File>
@@ -417,7 +417,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ContinueDoNotWithinDo()
             Dim code =
     <File>
@@ -447,7 +447,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ContinueForNotWithinFor()
             Dim code =
     <File>
@@ -477,7 +477,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ContinueWhileNotWithinWhile()
             Dim code =
     <File>
@@ -507,7 +507,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedContinueKindWhile()
             Dim code =
     <File>
@@ -534,7 +534,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedContinueKindFor()
             Dim code =
     <File>
@@ -561,7 +561,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedContinueKindForEach()
             Dim code =
     <File>
@@ -588,7 +588,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedContinueKindDo()
             Dim code =
     <File>
@@ -615,7 +615,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedContinueKindDo_ReplaceFor()
             Dim code =
     <File>
@@ -642,7 +642,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedExitKindDo_UseSub()
             Dim code =
     <File>
@@ -670,7 +670,7 @@ End Class
         End Sub
 
         <WorkItem(547094)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub DoNotTryToExitFinally()
             Dim code =
     <File>
@@ -706,7 +706,7 @@ End Class
         End Sub
 
         <WorkItem(547110)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub MissingExitTokenInNonExitableBlock()
             Dim code =
     <File>
@@ -745,14 +745,14 @@ End Class
         End Sub
 
         <WorkItem(547100)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub NotInValidCaseElse()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n For Each a In args \n Select a \n Case Else \n [|Exit Select|] ' here \n End Select \n Next \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(547099)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub CollapseDuplicateBlockKinds()
             TestActionCount(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Do \n Do While True \n [|Exit Function|] ' here \n Loop \n Loop \n End Sub \n End Module"),
@@ -760,7 +760,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(547092)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ReplaceInvalidTokenExit()
             Dim code =
     <File>
@@ -799,7 +799,7 @@ End Class
         End Sub
 
         <WorkItem(547092)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ReplaceInvalidTokenContinue()
             Dim code =
     <File>
@@ -827,7 +827,7 @@ End Class
             Test(code, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedActionDescriptions1()
             Dim code =
 <File>
@@ -842,7 +842,7 @@ End Class
         End Sub
 
         <WorkItem(531354)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsCorrectExitContinue)>
         Public Sub ExpectedActionDescriptions2()
             Dim code =
 <File>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/FixIncorrectFunctionReturnType/FixIncorrectFunctionReturnTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/FixIncorrectFunctionReturnType/FixIncorrectFunctionReturnTypeTests.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.FullyQ
         End Function
 
         <WorkItem(718494)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
         Public Sub TestAsyncFunction1()
             Test(
 NewLines("Imports System.Threading.Tasks \n Module Program \n [|Async Function F()|] \n Return Nothing \n End Function \n End Module"),
@@ -22,7 +22,7 @@ NewLines("Imports System.Threading.Tasks \n Module Program \n Async Function F()
         End Sub
 
         <WorkItem(718494)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
         Public Sub TestAsyncFunction2()
             Test(
 NewLines("Imports System.Threading.Tasks \n Module Program \n [|Async Function F() As   Integer|]   \n Return Nothing \n End Function \n End Module"),
@@ -30,7 +30,7 @@ NewLines("Imports System.Threading.Tasks \n Module Program \n Async Function F()
         End Sub
 
         <WorkItem(718494)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
         Public Sub TestAsyncFunction3()
             Test(
 NewLines("Imports System.Threading.Tasks \n Module Program \n Async Function F() As Task \n Dim a = [|Async Function() As Integer|] \n Return Nothing \n End Function\n Return Nothing \n End Function \n End Module"),
@@ -38,7 +38,7 @@ NewLines("Imports System.Threading.Tasks \n Module Program \n Async Function F()
         End Sub
 
         <WorkItem(718494)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
         Public Sub TestIteratorFunction1()
             Test(
 NewLines("Imports System.Collections \n Imports System.Collections.Generic \n Module Program \n [|Iterator Function F()|] \n Return Nothing \n End Function \n End Module"),
@@ -46,7 +46,7 @@ NewLines("Imports System.Collections \n Imports System.Collections.Generic \n Mo
         End Sub
 
         <WorkItem(718494)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
         Public Sub TestIteratorFunction2()
             Test(
 NewLines("Imports System.Collections \n Imports System.Collections.Generic \n Module Program \n [|Iterator Function F() As   Integer|]   \n Return Nothing \n End Function \n End Module"),
@@ -54,7 +54,7 @@ NewLines("Imports System.Collections \n Imports System.Collections.Generic \n Mo
         End Sub
 
         <WorkItem(718494)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsCorrectFunctionReturnType)>
         Public Sub TestIteratorFunction3()
             Test(
 NewLines("Imports System.Collections \n Imports System.Collections.Generic \n Module Program \n Async Function F() As Task \n Dim a = [|Iterator Function() As Integer|] \n Return Nothing \n End Function\n Return Nothing \n End Function \n End Module"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/FullyQualify/FullyQualifyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/FullyQualify/FullyQualifyTests.vb
@@ -14,77 +14,77 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.FullyQ
             Return Tuple.Create(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New VisualBasicFullyQualifyCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestParameterType()
             Test(
 NewLines("Module Program \n Sub Main(args As String(), f As [|FileMode|]) \n End Sub \n End Module"),
 NewLines("Module Program \n Sub Main(args As String(), f As System.IO.FileMode) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestSimpleQualifyFromSameFile()
             Test(
 NewLines("Class Class1 \n Dim v As [|SomeClass1|] \n End Class \n Namespace SomeNamespace \n Public Class SomeClass1 \n End Class \n End Namespace"),
 NewLines("Class Class1 \n Dim v As SomeNamespace.SomeClass1 \n End Class \n Namespace SomeNamespace \n Public Class SomeClass1 \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestSimpleQualifyFromReference()
             Test(
 NewLines("Class Class1 \n Dim v As [|Thread|] \n End Class"),
 NewLines("Class Class1 \n Dim v As System.Threading.Thread \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericClassDefinitionAsClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class Base \n End Class \n End Namespace \n Class SomeClass(Of x As [|Base|]) \n End Class"),
 NewLines("Namespace SomeNamespace \n Class Base \n End Class \n End Namespace \n Class SomeClass(Of x As SomeNamespace.Base) \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericClassInstantiationOfClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class GenericClass(Of T) \n End Class \n Class Foo \n Sub Method1() \n Dim q As GenericClass(Of [|SomeClass|]) \n End Sub \n End Class"),
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class GenericClass(Of T) \n End Class \n Class Foo \n Sub Method1() \n Dim q As GenericClass(Of SomeNamespace.SomeClass) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericMethodDefinitionAsClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T As [|SomeClass|]) \n End Sub \n End Class"),
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T As SomeNamespace.SomeClass) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericMethodInvocationOfClause()
             Test(
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T) \n End Sub \n Sub Method2() \n Method1(Of [|SomeClass|]) \n End Sub \n End Class"),
 NewLines("Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T) \n End Sub \n Sub Method2() \n Method1(Of SomeNamespace.SomeClass) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestAttributeApplication()
             Test(
 NewLines("<[|Something|]()> \n Class Foo \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"),
 NewLines("<SomeNamespace.Something()> \n Class Foo \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestMultipleAttributeApplicationBelow()
             Test(
 NewLines("Imports System \n <Existing()> \n <[|Something|]()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits Attribute \n End Class \n End Namespace"),
 NewLines("Imports System \n <Existing()> \n <SomeNamespace.Something()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits Attribute \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestMultipleAttributeApplicationAbove()
             Test(
 NewLines("<[|Something|]()> \n <Existing()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"),
 NewLines("<SomeNamespace.Something()> \n <Existing()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestQualifierIsEscapedWhenNamespaceMatchesKeyword()
             Test(
 NewLines("Class SomeClass \n Dim x As [|Something|] \n End Class \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace"),
@@ -92,7 +92,7 @@ NewLines("Class SomeClass \n Dim x As [Namespace].Something \n End Class \n Name
         End Sub
 
         <WorkItem(540559)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestQualifierIsNOTEscapedWhenNamespaceMatchesKeywordButIsNested()
             Test(
 NewLines("Class SomeClass \n Dim x As [|Something|] \n End Class \n Namespace Outer \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace \n End Namespace"),
@@ -100,27 +100,27 @@ NewLines("Class SomeClass \n Dim x As Outer.Namespace.Something \n End Class \n 
         End Sub
 
         <WorkItem(540560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestFullyQualifyInImportsStatement()
             Test(
 NewLines("Imports [|InnerNamespace|] \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"),
 NewLines("Imports SomeNamespace.InnerNamespace \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestFullyQualifyNotSuggestedForGenericTypeParametersOfClause()
             TestMissing(
 NewLines("Class SomeClass \n Sub Foo(Of [|SomeClass|])(x As SomeClass) \n End Sub \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestFullyQualifyNotSuggestedForGenericTypeParametersAsClause()
             TestMissing(
 NewLines("Class SomeClass \n Sub Foo(Of SomeClass)(x As [|SomeClass|]) \n End Sub \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"))
         End Sub
 
         <WorkItem(540673)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestCaseSensitivityForNestedNamespace()
             Test(
 NewLines("Class Foo \n Sub bar() \n Dim q As [|innernamespace|].someClass \n End Sub \n End Class \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"),
@@ -128,21 +128,21 @@ NewLines("Class Foo \n Sub bar() \n Dim q As SomeNamespace.InnerNamespace.someCl
         End Sub
 
         <WorkItem(540543)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestCaseSensitivity1()
             Test(
 NewLines("Class Foo \n Dim x As [|someclass|] \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"),
 NewLines("Class Foo \n Dim x As SomeNamespace.SomeClass \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestTypeFromMultipleNamespaces1()
             Test(
 NewLines("Class Foo \n Function F() As [|IDictionary|] \n End Function \n End Class"),
 NewLines("Class Foo \n Function F() As System.Collections.IDictionary \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestTypeFromMultipleNamespaces2()
             Test(
 NewLines("Class Foo \n Function F() As [|IDictionary|] \n End Function \n End Class"),
@@ -150,48 +150,48 @@ NewLines("Class Foo \n Function F() As System.Collections.Generic.IDictionary \n
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericWithNoArgs()
             Test(
 NewLines("Class Foo \n Function F() As [|List|] \n End Function \n End Class"),
 NewLines("Class Foo \n Function F() As System.Collections.Generic.List \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericWithCorrectArgs()
             Test(
 NewLines("Class Foo \n Function F() As [|List(Of Integer)|] \n End Function \n End Class"),
 NewLines("Class Foo \n Function F() As System.Collections.Generic.List(Of Integer) \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericWithWrongArgs()
             TestMissing(
 NewLines("Class Foo \n Function F() As [|List(Of Integer, String)|] \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericInLocalDeclaration()
             Test(
 NewLines("Class Foo \n Sub Test() \n Dim x As New [|List(Of Integer)|] \n End Sub \n End Class"),
 NewLines("Class Foo \n Sub Test() \n Dim x As New System.Collections.Generic.List(Of Integer) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenericItemType()
             Test(
 NewLines("Class Foo \n Sub Test() \n Dim x As New List(Of [|Int32|]) \n End Sub \n End Class"),
 NewLines("Class Foo \n Sub Test() \n Dim x As New List(Of System.Int32) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestGenerateInNamespace()
             Test(
 NewLines("Imports System \n Namespace NS \n Class Foo \n Sub Test() \n Dim x As New [|List(Of Integer)|] \n End Sub \n End Class \n End Namespace"),
 NewLines("Imports System \n Namespace NS \n Class Foo \n Sub Test() \n Dim x As New Collections.Generic.List(Of Integer) \n End Sub \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestMinimalQualify()
             Test(
 NewLines("Imports System \n Module Program \n Dim q As [|List(Of Integer)|] \n End Module"),
@@ -199,7 +199,7 @@ NewLines("Imports System \n Module Program \n Dim q As Collections.Generic.List(
         End Sub
 
         <WorkItem(540559)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestEscaping1()
             Test(
 NewLines("Class SomeClass \n Dim x As [|Something|] \n End Class \n Namespace Outer \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace \n End Namespace"),
@@ -207,7 +207,7 @@ NewLines("Class SomeClass \n Dim x As Outer.Namespace.Something \n End Class \n 
         End Sub
 
         <WorkItem(540559)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestEscaping2()
             Test(
 NewLines("Class SomeClass \n Dim x As [|Something|] \n End Class \n Namespace [Namespace] \n Namespace Inner \n Class Something \n End Class \n End Namespace \n End Namespace"),
@@ -215,7 +215,7 @@ NewLines("Class SomeClass \n Dim x As [Namespace].Inner.Something \n End Class \
         End Sub
 
         <WorkItem(540559)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestEscaping3()
             Test(
 NewLines("Class SomeClass \n Dim x As [|[Namespace]|] \n End Class \n Namespace Outer \n Namespace Inner \n Class [Namespace] \n End Class \n End Namespace \n End Namespace"),
@@ -223,7 +223,7 @@ NewLines("Class SomeClass \n Dim x As Outer.Inner.[Namespace] \n End Class \n Na
         End Sub
 
         <WorkItem(540560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestInImport()
             Test(
 NewLines("Imports [|InnerNamespace|] \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"),
@@ -231,7 +231,7 @@ NewLines("Imports SomeNamespace.InnerNamespace \n Namespace SomeNamespace \n Nam
         End Sub
 
         <WorkItem(540673)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestCaseInsensitivity()
             Test(
 NewLines("Class FOo \n Sub bar() \n Dim q As [|innernamespace|].someClass \n End Sub \n End Class \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace"),
@@ -239,7 +239,7 @@ NewLines("Class FOo \n Sub bar() \n Dim q As SomeNamespace.InnerNamespace.someCl
         End Sub
 
         <WorkItem(540706)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestStandaloneMethod()
             Test(
 NewLines("'Class [Class] \n Private Sub Method(i As Integer) \n [|[Enum]|] = 5 \n End Sub \n End Class"),
@@ -247,21 +247,21 @@ NewLines("'Class [Class] \n Private Sub Method(i As Integer) \n System.[Enum] = 
         End Sub
 
         <WorkItem(540736)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestMissingOnBoundFieldType()
             TestMissing(
 NewLines("Imports System.Collections.Generic \n Class A \n Private field As [|List(Of C)|] \n Sub Main() \n Dim local As List(Of C) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(540736)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestMissingOnBoundLocalType()
             TestMissing(
 NewLines("Imports System.Collections.Generic \n Class A \n Private field As [|List(Of C)|] \n Sub Main() \n Dim local As List(Of C) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(540745)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestCaseSensitivity2()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As [|foo|] \n End Sub \n End Module \n Namespace OUTER \n Namespace INNER \n Friend Class FOO \n End Class \n End Namespace \n End Namespace"),
@@ -269,7 +269,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim x As OUTER.INNER.F
         End Sub
 
         <WorkItem(821292)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestCaseSensitivity3()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Dim x As [|stream|] \n End Sub \n End Module"),
@@ -277,20 +277,20 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Dim 
         End Sub
 
         <WorkItem(545993)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestNotOnNamedArgument()
             TestMissing(
 NewLines("Module Program \n <MethodImpl([|methodImplOptions|]:=MethodImplOptions.ForwardRef) \n Sub Main(args As String()) \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(546107)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestDoNotQualifyNestedTypeOfGenericType()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n  \n Class Program \n Shared Sub Main() \n CType(GetEnumerator(), IDisposable).Dispose() \n End Sub \n  \n Shared Function GetEnumerator() As [|Enumerator|] \n Return Nothing \n End Function \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub TestFormattingInFullyQualify()
             Test(
 <Text>Module Program
@@ -307,7 +307,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(775448)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub ShouldTriggerOnBC32045()
             ' BC32045: 'A' has no type parameters and so cannot have type arguments.
             Test(
@@ -330,7 +330,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(947579)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)>
         Public Sub AmbiguousTypeFix()
             Test(
 <Text>Imports N1
@@ -383,7 +383,7 @@ compareTokens:=False)
             End Function
 
             <WorkItem(829970)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
                 Test(
     NewLines("Module Program \n <[|Extension|]> \n End Module"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -14,47 +14,47 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New GenerateConstructorCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateIntoContainingType()
             Test(
 NewLines("Class C \n Sub Main() \n Dim f = New C([|4|], 5, 6) \n End Sub \n End Class"),
 NewLines("Class C \n Private v1 As Integer \n Private v2 As Integer \n Private v3 As Integer \n Public Sub New(v1 As Integer, v2 As Integer, v3 As Integer) \n Me.v1 = v1 \n Me.v2 = v2 \n Me.v3 = v3 \n End Sub \n Sub Main() \n Dim f = New C(4, 5, 6) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestInvokingFromInsideAnotherConstructor()
             Test(
 NewLines("Class A \n Private v As B \n Public Sub New() \n Me.v = New B([|5|]) \n End Sub \n End Class \n Friend Class B \n End Class"),
 NewLines("Class A \n Private v As B \n Public Sub New() \n Me.v = New B(5) \n End Sub \n End Class \n Friend Class B \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMissingGenerateDefaultConstructor()
             TestMissing(
 NewLines("Class Test \n Sub Main() \n Dim a = New [|A|]() \n End Sub \n End Class \n Class A \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMissingGenerateDefaultConstructorInStructure()
             TestMissing(
 NewLines("Class Test \n Sub Main() \n Dim a = New [|A|]() \n End Sub \n End Class \n Structure A \n End Structure"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOfferDefaultConstructorWhenOverloadExists()
             Test(
 NewLines("Class Test \n Sub Main() \n Dim a = [|New A()|] \n End Sub \n End Class \n Class A \n Sub New(x As Integer) \n End Sub \n End Class"),
 NewLines("Class Test \n Sub Main() \n Dim a = New A() \n End Sub \n End Class \n Class A \n Public Sub New() \n End Sub \n Sub New(x As Integer) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestParameterizedConstructorOffered1()
             Test(
 NewLines("Class Test \n Sub Main() \n Dim a = New A([|1|]) \n End Sub \n End Class \n Class A \n End Class"),
 NewLines("Class Test \n Sub Main() \n Dim a = New A(1) \n End Sub \n End Class \n Class A \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestParameterizedConstructorOffered2()
             Test(
 NewLines("Class Test \n Sub Main() \n Dim a = New A([|1|]) \n End Sub \n End Class \n Class A \n Public Sub New() \n End Sub \n End Class"),
@@ -62,28 +62,28 @@ NewLines("Class Test \n Sub Main() \n Dim a = New A(1) \n End Sub \n End Class \
         End Sub
 
         <WorkItem(527627), WorkItem(539735), WorkItem(539735)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestInAsNewExpression()
             Test(
 NewLines("Class Test \n Sub Main() \n Dim a As New A([|1|]) \n End Sub \n End Class \n Class A \n Public Sub New() \n End Sub \n End Class"),
 NewLines("Class Test \n Sub Main() \n Dim a As New A(1) \n End Sub \n End Class \n Class A \n Private v As Integer \n Public Sub New() \n End Sub \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateInPartialClass1()
             Test(
 NewLines("Public Partial Class Test \n Public Sub S1() \n End Sub \n End Class \n Public Class Test \n Public Sub S2() \n End Sub \n End Class \n Public Class A \n Sub Main() \n Dim s = New Test([|5|]) \n End Sub \n End Class"),
 NewLines("Public Partial Class Test \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n Public Sub S1() \n End Sub \n End Class \n Public Class Test \n Public Sub S2() \n End Sub \n End Class \n Public Class A \n Sub Main() \n Dim s = New Test(5) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateInPartialClassWhenArityDoesntMatch()
             Test(
 NewLines("Public Partial Class Test \n Public Sub S1() \n End Sub \n End Class \n Public Class Test(Of T) \n Public Sub S2() \n End Sub \n End Class \n Public Class A \n Sub Main() \n Dim s = New Test([|5|]) \n End Sub \n End Class"),
 NewLines("Public Partial Class Test \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n Public Sub S1() \n End Sub \n End Class \n Public Class Test(Of T) \n Public Sub S2() \n End Sub \n End Class \n Public Class A \n Sub Main() \n Dim s = New Test(5) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateInPartialClassWithConflicts()
             Test(
 NewLines("Public Partial Class Test2 \n End Class \n Private Partial Class Test2 \n End Class \n Public Class A \n Sub Main() \n Dim s = New Test2([|5|]) \n End Sub \n End Class"),
@@ -91,48 +91,48 @@ NewLines("Public Partial Class Test2 \n Private v As Integer \n Public Sub New(v
         End Sub
 
         <WorkItem(528257)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateIntoInaccessibleType()
             TestMissing(
 NewLines("Class Foo \n Private Class Bar \n End Class \n End Class \n Class A \n Sub Main() \n Dim s = New Foo.Bar([|5|]) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOnNestedTypes()
             Test(
 NewLines("Class Foo \n Class Bar \n End Class \n End Class \n Class A \n Sub Main() \n Dim s = New Foo.Bar([|5|]) \n End Sub \n End Class"),
 NewLines("Class Foo \n Class Bar \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class \n End Class \n Class A \n Sub Main() \n Dim s = New Foo.Bar(5) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOnNestedPartialTypes()
             Test(
 NewLines("Public Partial Class Test \n Public Partial Class NestedTest \n Public Sub S1() \n End Sub \n End Class \n End Class \n Public Partial Class Test \n Public Partial Class NestedTest \n Public Sub S2() \n End Sub \n End Class \n End Class \n Class A \n Sub Main() \n Dim s = New Test.NestedTest([|5|]) \n End Sub \n End Class"),
 NewLines("Public Partial Class Test \n Public Partial Class NestedTest \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n Public Sub S1() \n End Sub \n End Class \n End Class \n Public Partial Class Test \n Public Partial Class NestedTest \n Public Sub S2() \n End Sub \n End Class \n End Class \n Class A \n Sub Main() \n Dim s = New Test.NestedTest(5) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOnNestedGenericType()
             Test(
 NewLines("Class Outer(Of T) \n Public Class Inner \n End Class \n Public i = New Inner([|5|]) \n End Class"),
 NewLines("Class Outer(Of T) \n Public Class Inner \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class \n Public i = New Inner(5) \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOnGenericTypes1()
             Test(
 NewLines("Class Base(Of T, V) \n End Class \n Class Test \n Sub Foo() \n Dim a = New Base(Of Integer, Integer)([|5|], 5) \n End Sub \n End Class"),
 NewLines("Class Base(Of T, V) \n Private v1 As Integer \n Private v2 As Integer \n Public Sub New(v1 As Integer, v2 As Integer) \n Me.v1 = v1 \n Me.v2 = v2 \n End Sub \n End Class \n Class Test \n Sub Foo() \n Dim a = New Base(Of Integer, Integer)(5, 5) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOnGenericTypes2()
             Test(
 NewLines("Class Base(Of T, V) \n End Class \n Class Derived(Of V) \n Inherits Base(Of Integer, V) \n End Class \n Class Test \n Sub Foo() \n Dim a = New Base(Of Integer, Integer)(5, 5) \n Dim b = New Derived(Of Integer)([|5|]) \n End Sub \n End Class"),
 NewLines("Class Base(Of T, V) \n End Class \n Class Derived(Of V) \n Inherits Base(Of Integer, V) \n Private v1 As Integer \n Public Sub New(v1 As Integer) \n Me.v1 = v1 \n End Sub \n End Class \n Class Test \n Sub Foo() \n Dim a = New Base(Of Integer, Integer)(5, 5) \n Dim b = New Derived(Of Integer)(5) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOnGenericTypes3()
             Test(
 NewLines("Class Base(Of T, V) \n End Class \n Class Derived(Of V) \n Inherits Base(Of Integer, V) \n End Class \n Class MoreDerived \n Inherits Derived(Of Double) \n End Class \n Class Test \n Sub Foo() \n Dim a = New Base(Of Integer, Integer)(5, 5) \n Dim b = New Derived(Of Integer)(5) \n Dim c = New MoreDerived([|5.5|]) \n End Sub \n End Class"),
@@ -140,21 +140,21 @@ NewLines("Class Base(Of T, V) \n End Class \n Class Derived(Of V) \n Inherits Ba
         End Sub
 
         <WorkItem(528244)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestDateTypeForInference()
             Test(
 NewLines("Class Foo \n End Class \n Class A \n Sub Main() \n Dim s = New Foo([|Date.Now|]) \n End Sub \n End Class"),
 NewLines("Class Foo \n Private now As Date \n Public Sub New(now As Date) \n Me.now = now \n End Sub \n End Class \n Class A \n Sub Main() \n Dim s = New Foo(Date.Now) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestBaseConstructor()
             Test(
 NewLines("Class Base \n End Class \n Class Derived \n Inherits Base \n Private x As Integer \n Public Sub New(x As Integer) \n MyBase.New([|x|]) \n Me.x = x \n End Sub \n End Class"),
 NewLines("Class Base \n Private x As Integer \n Public Sub New(x As Integer) \n Me.x = x \n End Sub \n End Class \n Class Derived \n Inherits Base \n Private x As Integer \n Public Sub New(x As Integer) \n MyBase.New(x) \n Me.x = x \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMustInheritBase()
             Test(
 NewLines("MustInherit Class Base \n End Class \n Class Derived \n Inherits Base \n Shared x As Integer \n Public Sub New(x As Integer) \n MyBase.New([|x|]) 'This should generate a protected ctor in Base \n Derived.x = x \n End Sub \n Sub Test1() \n Dim a As New Derived(1) \n End Sub \n End Class"),
@@ -162,14 +162,14 @@ NewLines("MustInherit Class Base \n  Private x As Integer \n Public Sub New(x As
         End Sub
 
         <WorkItem(540586)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMissingOnNoCloseParen()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim c = New [|foo|]( \n End Sub \n End Module \n Class foo \n End Class"))
         End Sub
 
         <WorkItem(540545)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestConversionError()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Dim i As Char \n Dim cObject As C = New C([|i|]) \n Console.WriteLine(cObject.v1) \n End Sub \n End Module \n Class C \n Public v1 As Integer \n Public Sub New(v1 As Integer) \n Me.v1 = v1 \n End Sub \n End Class"),
@@ -177,7 +177,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Dim 
         End Sub
 
         <WorkItem(540642)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestNotOnNestedConstructor()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As C = New C([|New C()|]) \n End Sub \n End Module \n Friend Class C \n End Class"),
@@ -185,7 +185,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim x As C = New C(New
         End Sub
 
         <WorkItem(540607)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestUnavailableTypeParameters()
             Test(
 NewLines("Class C(Of T1, T2) \n Sub M(x As T1, y As T2) \n Dim a As Test = New Test([|x|], y) \n End Sub \n End Class \n Friend Class Test \n End Class"),
@@ -193,7 +193,7 @@ NewLines("Class C(Of T1, T2) \n Sub M(x As T1, y As T2) \n Dim a As Test = New T
         End Sub
 
         <WorkItem(540748)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestKeywordArgument1()
             Test(
 NewLines("Class Test \n Private [Class] As Integer = 5 \n Sub Main() \n Dim a = New A([|[Class]|]) \n End Sub \n End Class \n Class A \n End Class"),
@@ -201,7 +201,7 @@ NewLines("Class Test \n Private [Class] As Integer = 5 \n Sub Main() \n Dim a = 
         End Sub
 
         <WorkItem(540747)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestKeywordArgument2()
             Test(
 NewLines("Class Test \n Sub Main() \n Dim a = New A([|Class|]) \n End Sub \n End Class \n Class A \n End Class"),
@@ -209,7 +209,7 @@ NewLines("Class Test \n Sub Main() \n Dim a = New A(Class) \n End Sub \n End Cla
         End Sub
 
         <WorkItem(540746)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestConflictWithTypeParameterName()
             Test(
 NewLines("Class Test \n Sub Foo() \n Dim a = New Bar(Of Integer)([|5|]) \n End Sub \n End Class \n Class Bar(Of V) \n End Class"),
@@ -217,14 +217,14 @@ NewLines("Class Test \n Sub Foo() \n Dim a = New Bar(Of Integer)(5) \n End Sub \
         End Sub
 
         <WorkItem(541174)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingReadonlyField()
             Test(
 NewLines("Class C \n ReadOnly x As Integer \n Sub Test() \n Dim x As Integer = 1 \n Dim obj As New C([|x|]) \n End Sub \n End Class"),
 NewLines("Class C \n ReadOnly x As Integer \n Public Sub New(x As Integer) \n Me.x = x \n End Sub \n Sub Test() \n Dim x As Integer = 1 \n Dim obj As New C(x) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingProperty()
             Test(
 NewLines("Class Program \n Sub Test() \n Dim x = New A([|P|]:=5) \n End Sub \n End Class \n Class A \n Public Property P As Integer \n End Class"),
@@ -232,7 +232,7 @@ NewLines("Class Program \n Sub Test() \n Dim x = New A(P:=5) \n End Sub \n End C
         End Sub
 
         <WorkItem(542055)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingMethod()
             Test(
 NewLines("Class A \n Sub Test() \n Dim t As New C([|u|]:=5) \n End Sub \n End Class \n Class C \n Public Sub u() \n End Sub \n End Class"),
@@ -240,7 +240,7 @@ NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class 
         End Sub
 
         <WorkItem(542055)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestDetectAssignmentToSharedFieldFromInstanceConstructor()
             Test(
 NewLines("Class Program \n Sub Test() \n Dim x = New A([|P|]:=5) \n End Sub \n End Class \n Class A \n Shared Property P As Integer \n End Class"),
@@ -248,14 +248,14 @@ NewLines("Class Program \n Sub Test() \n Dim x = New A(P:=5) \n End Sub \n End C
         End Sub
 
         <WorkItem(542055)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingFieldWithSameNameButIncompatibleType()
             Test(
 NewLines("Class A \n Sub Test() \n Dim t As New B([|x|]:=5) \n End Sub \n End Class \n Class B \n Private x As String \n End Class"),
 NewLines("Class A \n Sub Test() \n Dim t As New B(x:=5) \n End Sub \n End Class \n Class B \n Private x As String \n Private x1 As Integer \n Public Sub New(x As Integer) \n Me.x1 = x \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingFieldFromBaseClass()
             Test(
 NewLines("Class A \n Sub Test() \n Dim t As New C([|u|]:=5) \n End Sub \n End Class \n Class C \n Inherits B \n Private x As String \n End Class \n Class B \n Protected u As Integer \n End Class"),
@@ -263,7 +263,7 @@ NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class 
         End Sub
 
         <WorkItem(542098)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMeConstructorInitializer()
             Test(
 NewLines("Class C \n Sub New \n Me.New([|1|]) \n End Sub \n End Class"),
@@ -271,14 +271,14 @@ NewLines("Class C \n Private v As Integer \n Public Sub New(v As Integer) \n Me.
         End Sub
 
         <WorkItem(542098)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingMeConstructorInitializer()
             TestMissing(
 NewLines("Class C \n Private v As Integer \n Sub New \n Me.[|New|](1) \n End Sub \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(542098)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMyBaseConstructorInitializer()
             Test(
 NewLines("Class C \n Sub New \n MyClass.New([|1|]) \n End Sub \n End Class"),
@@ -286,14 +286,14 @@ NewLines("Class C \n Private v As Integer \n Public Sub New(v As Integer) \n Me.
         End Sub
 
         <WorkItem(542098)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingMyBaseConstructorInitializer()
             TestMissing(
 NewLines("Class C \n Private v As Integer \n Sub New \n MyClass.[|New|](1) \n End Sub \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(542098)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMyClassConstructorInitializer()
             Test(
 NewLines("Class C \n Inherits B \n Sub New \n MyBase.New([|1|]) \n End Sub \n End Class \n Class B \n End Class"),
@@ -301,14 +301,14 @@ NewLines("Class C \n Inherits B \n Sub New \n MyBase.New(1) \n End Sub \n End Cl
         End Sub
 
         <WorkItem(542098)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestExistingMyClassConstructorInitializer()
             TestMissing(
 NewLines("Class C \n Inherits B \n Sub New \n MyBase.New([|1|]) \n End Sub \n End Class \n Class B \n Protected Sub New(v As Integer) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(542056)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestConflictingFieldNameInSubclass()
             Test(
 NewLines("Class A \n Sub Test() \n Dim t As New C([|u|]:=5) \n End Sub \n End Class \n Class C \n Inherits B \n Private x As String \n End Class \n Class B \n Protected u As String \n End Class"),
@@ -316,27 +316,27 @@ NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class 
         End Sub
 
         <WorkItem(542442)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestNothingArgument()
             TestMissing(
 NewLines("Class C1 \n Public Sub New(ByVal accountKey As Integer) \n Me.new() \n Me.[|new|](accountKey, Nothing) \n End Sub \n Public Sub New(ByVal accountKey As Integer, ByVal accountName As String) \n Me.New(accountKey, accountName, Nothing) \n End Sub \n Public Sub New(ByVal accountKey As Integer, ByVal accountName As String, ByVal accountNumber As String) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(540641)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestMissingOnExistingConstructor()
             TestMissing(
 NewLines("Module Program \n Sub M() \n Dim x As C = New [|C|](P) \n End Sub \n End Module \n Class C \n Private v As Object \n Public Sub New(v As Object) \n Me.v = v \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerationIntoVisibleType()
             Test(
 NewLines("#ExternalSource (""Default.aspx"", 1) \n Class C \n Sub Foo() \n Dim x As New D([|5|]) \n End Sub \n End Class \n Class D \n End Class \n #End ExternalSource"),
 NewLines("#ExternalSource (""Default.aspx"", 1) \n Class C \n Sub Foo() \n Dim x As New D(5) \n End Sub \n End Class \n Class D \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class \n #End ExternalSource"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestNoGenerationIntoEntirelyHiddenType()
             TestMissing(
 <Text>#ExternalSource (""Default.aspx"", 1)
@@ -354,14 +354,14 @@ End Class
         End Sub
 
         <WorkItem(546030)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestConflictingDelegatedParameterNameAndNamedArgumentName1()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim objc As New C(1, [|prop|]:=""Property"") \n End Sub \n End Module \n  \n Class C \n Private prop As String \n  \n Public Sub New(prop As String) \n Me.prop = prop \n End Sub \n End Class"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim objc As New C(1, prop:=""Property"") \n End Sub \n End Module \n  \n Class C \n Private prop As String \n Private v As Integer \n Public Sub New(prop As String) \n Me.prop = prop \n End Sub \n Public Sub New(v As Integer, prop As String) \n Me.v = v \n Me.prop = prop \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestFormattingInGenerateConstructor()
             Test(
 <Text>Class C
@@ -384,7 +384,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(530003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestAttributesWithArgument()
             Test(
 NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \n Inherits System.Attribute \n End Class \n [|<MyAttribute(123)>|] \n Public Class D \n End Class"),
@@ -392,7 +392,7 @@ NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \
         End Sub
 
         <WorkItem(530003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestAttributesWithMultipleArguments()
             Test(
 NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \n Inherits System.Attribute \n End Class \n [|<MyAttribute(true, 1, ""hello"")>|] \n Public Class D \n End Class"),
@@ -400,7 +400,7 @@ NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \
         End Sub
 
         <WorkItem(530003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestAttributesWithNamedArguments()
             Test(
 NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \n Inherits System.Attribute \n End Class \n [|<MyAttribute(true, 1, Topic:= ""hello"")>|] \n Public Class D \n End Class"),
@@ -408,7 +408,7 @@ NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \
         End Sub
 
         <WorkItem(530003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestAttributesWithAdditionalConstructors()
             Test(
 NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \n Inherits System.Attribute \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class \n [|<MyAttribute(True, 2)>|] \n Public Class D \n End Class"),
@@ -416,7 +416,7 @@ NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \
         End Sub
 
         <WorkItem(530003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestAttributesWithAllValidArguments()
             Test(
 NewLines("Enum A \n A1 \n End Enum \n <AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \n Inherits System.Attribute \n End Class \n [|<MyAttribute(New Short(1) {1, 2, 3}, A.A1, True, 1, ""Z""c, 5S, 1I, 5L, 6.0R, 2.1F, ""abc"")>|] \n Public Class D End Class"),
@@ -424,14 +424,14 @@ NewLines("Enum A \n A1 \n End Enum \n <AttributeUsage(AttributeTargets.Class)> \
         End Sub
 
         <WorkItem(530003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestAttributesWithLambda()
             TestMissing(
 NewLines("<AttributeUsage(AttributeTargets.Class)> \n Public Class MyAttribute \n Inherits System.Attribute End Class \n [|<MyAttribute(Function(x) x+1)>|] \n Public Class D \n End Class"))
         End Sub
 
         <WorkItem(889349)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestConstructorGenerationForDifferentNamedParameter()
             Test(
 <Text>Class Program
@@ -462,7 +462,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(897355)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestOptionStrictOn()
             Test(
 NewLines("Option Strict On \n Module Module1 \n Sub Main() \n Dim int As Integer = 3 \n Dim obj As Object = New Object() \n Dim c1 As Classic = New Classic(int) \n Dim c2 As Classic = [|New Classic(obj)|] \n End Sub \n Class Classic \n Private int As Integer \n Public Sub New(int As Integer) \n Me.int = int \n End Sub \n End Class \n End Module"),
@@ -470,7 +470,7 @@ NewLines("Option Strict On \n Module Module1 \n Sub Main() \n Dim int As Integer
         End Sub
 
         <WorkItem(528257)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateInInaccessibleType()
             Test(
 NewLines("Class Foo \n Private Class Bar \n End Class \n End Class \n Class A \n Sub Main() \n Dim s = New [|Foo.Bar(5)|] \n End Sub \n End Class"),
@@ -485,7 +485,7 @@ NewLines("Class Foo \n Private Class Bar \n Private v As Integer \n Public Sub N
             End Function
 
             <WorkItem(1241, "https://github.com/dotnet/roslyn/issues/1241")>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
             Public Sub TestGenerateConstructorInIncompleteLambda()
                 Test(
 NewLines("Imports System.Linq \n Class C \n Sub New() \n Dim s As Action = Sub() \n Dim a = New [|C|](0)"),
@@ -502,7 +502,7 @@ NewLines("Imports System.Linq \n Class C \n Private v As Integer \n Sub New() \n
         End Class
 
         <WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateInDerivedType1()
             Test(
 "
@@ -533,7 +533,7 @@ End Class")
         End Sub
 
         <WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Sub TestGenerateInDerivedType2()
             Test(
 "

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New GenerateEndConstructCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestIf()
             Dim text = <MethodBody>
 If True Then[||]
@@ -26,7 +26,7 @@ End If</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestUsing()
             Dim text = <MethodBody>
 Using (foo)[||]
@@ -40,7 +40,7 @@ End Using</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestStructure()
             Dim text = <File>
 Structure Foo[||]</File>
@@ -50,7 +50,7 @@ Structure Foo[||]</File>
             Test(text.ConvertTestSourceTag(), expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestModule()
             Dim text = <File>
 Module Foo[||]
@@ -61,7 +61,7 @@ Module Foo[||]
             Test(text.ConvertTestSourceTag(), expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestNamespace()
             Dim text = <File>
 Namespace Foo[||]
@@ -72,7 +72,7 @@ Namespace Foo[||]
             Test(text.ConvertTestSourceTag(), expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestClass()
             Dim text = <File>
 Class Foo[||]
@@ -83,7 +83,7 @@ Class Foo[||]
             Test(text.ConvertTestSourceTag(), expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestInterface()
             Dim text = <File>
 Interface Foo[||]
@@ -94,7 +94,7 @@ Interface Foo[||]
             Test(text.ConvertTestSourceTag(), expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestEnum()
             Dim text = <File>
 Enum Foo[||]
@@ -105,7 +105,7 @@ Enum Foo[||]
             Test(text.ConvertTestSourceTag(), expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestWhile()
             Dim text = <MethodBody>
 While True[||]</MethodBody>
@@ -118,7 +118,7 @@ End While</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestWith()
             Dim text = <MethodBody>
 With True[||]</MethodBody>
@@ -131,7 +131,7 @@ End With</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestSyncLock()
             Dim text = <MethodBody>
 SyncLock Me[||]</MethodBody>
@@ -144,7 +144,7 @@ End SyncLock</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestDoLoop()
             Dim text = <MethodBody>
 Do While True[||]</MethodBody>
@@ -157,7 +157,7 @@ Loop</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestForNext()
             Dim text = <MethodBody>
 For x = 1 to 3[||]</MethodBody>
@@ -170,7 +170,7 @@ Next</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestForEachNext()
             Dim text = <MethodBody>
 For Each x in {}[||]</MethodBody>
@@ -183,7 +183,7 @@ Next</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestEndTry()
             Dim text = <MethodBody>
 Try[||]</MethodBody>
@@ -196,7 +196,7 @@ End Try</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestEndTryCatch()
             Dim text = <MethodBody>
 Try[||]
@@ -211,7 +211,7 @@ End Try</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestEndTryCatchFinally()
             Dim text = <MethodBody>
 Try[||]
@@ -228,7 +228,7 @@ End Try</MethodBody>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestProperty()
             Dim text = <File>
 Class C
@@ -249,7 +249,7 @@ End Class</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestReadOnlyProperty()
             Dim text = <File>
 Class C
@@ -268,7 +268,7 @@ End Class</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestWriteOnlyProperty()
             Dim text = <File>
 Class C
@@ -287,7 +287,7 @@ End Class</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestWriteOnlyPropertyFromSet()
             Dim text = <File>
 Class C
@@ -306,7 +306,7 @@ End Class</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub InvInsideEndsEnum()
             Dim text = <File>
 Public Enum e[||]
@@ -325,7 +325,7 @@ End Class</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub MissingEndSub()
             Dim text = <File>
 Class C
@@ -342,7 +342,7 @@ End Class</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag(), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub MissingEndFunction()
             Dim text = <File>
 Class C
@@ -360,7 +360,7 @@ End Class</File>
         End Sub
 
         <WorkItem(576176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub FormatWrappedBlock()
             Dim text = <File>
 Class C
@@ -392,7 +392,7 @@ End Class</File>
         End Sub
 
         <WorkItem(578253)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub DoNotWrapCLass()
             Dim text = <File>
 Class C[||]
@@ -424,14 +424,14 @@ End Module</File>
         End Sub
 
         <WorkItem(578260)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub NotOnLambda()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n End Sub \n Function foo() \n Dim op = Sub[||](c) \n Dim kl = Sub(g) \n End Sub \n End Function \n End Module"))
         End Sub
 
         <WorkItem(578271)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEndConstruct)>
         Public Sub TestNamespaceThatEndsAtFile()
             Dim text = <File>
 Namespace N[||]

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.vb
@@ -13,35 +13,35 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New GenerateEnumMemberCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoEmpty()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Red|]) \n End Sub \n End Module \n Enum Color \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Red) \n End Sub \n End Module \n Enum Color \n Red \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoEnumWithSingleMember()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Green|]) \n End Sub \n End Module \n Enum Color \n Red \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Green) \n End Sub \n End Module \n Enum Color \n Red \n Green \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithValue()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Green|]) \n End Sub \n End Module \n Enum Color \n Red = 1 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Green) \n End Sub \n End Module \n Enum Color \n Red = 1 \n Green = 2 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoLinearIncreasingSequence()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Blue|]) \n End Sub \n End Module \n Enum Color \n Red = 1 \n Green = 2 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Blue) \n End Sub \n End Module \n Enum Color \n Red = 1 \n Green = 2 \n Blue = 3 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoGeometricSequence()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Purple|]) \n End Sub \n End Module \n Enum Color \n Red = 1 \n Green = 2 \n Blue = 4 \n End Enum"),
@@ -49,14 +49,14 @@ NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Purple) \n E
         End Sub
 
         <WorkItem(540540)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithIntegerMaxValue()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Blue|]) \n End Sub \n End Module \n Enum Color \n Red \n Green = Integer.MaxValue \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Blue) \n End Sub \n End Module \n Enum Color \n Red  \n Green = Integer.MaxValue \n Blue = Integer.MinValue \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestUnsigned16BitEnums()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|Color.Green|] \n End Sub \n End Module \n Enum Color As UShort \n Red = 65535 \n End Enum"),
@@ -64,7 +64,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Color.Green \n End Sub
         End Sub
 
         <WorkItem(540546)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateEnumMemberOfTypeLong()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Blue|]) \n End Sub \n End Module \n Enum Color As Long \n Red = Long.MinValue \n End Enum"),
@@ -72,7 +72,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Blue) \n End
         End Sub
 
         <WorkItem(540636)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithLongMaxValueInHex()
             Test(
 NewLines("Class Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = &H7FFFFFFFFFFFFFFF \n End Enum"),
@@ -80,28 +80,28 @@ NewLines("Class Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \
         End Sub
 
         <WorkItem(540638)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithLongMinValueInHex()
             Test(
 NewLines("Class Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = &H8000000000000000 \n End Enum"),
 NewLines("Class Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As Long \n Red = &H8000000000000000 \n Blue = &H8000000000000001 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterNegativeLongInHex()
             Test(
 NewLines("Class Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = &HFFFFFFFFFFFFFFFF \n End Enum"),
 NewLines("Class Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As Long \n Red = &HFFFFFFFFFFFFFFFF \n Blue = &H0 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterPositiveLongInHex()
             Test(
 NewLines("Class Program \n Sub Main(args As String()) \n [|Color.Orange|] \n End Sub \n End Class \n Enum Color As Long \n Red = &HFFFFFFFFFFFFFFFF \n Blue = &H0 \n End Enum"),
 NewLines("Class Program \n Sub Main(args As String()) \n Color.Orange \n End Sub \n End Class \n Enum Color As Long \n Red = &HFFFFFFFFFFFFFFFF \n Blue = &H0 \n Orange = &H1 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterPositiveLongExprInHex()
             Test(
 NewLines("Class Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = &H414 / 2 \n End Enum"),
@@ -109,42 +109,42 @@ NewLines("Class Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \
         End Sub
 
         <WorkItem(540632)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithULongMaxValue()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As ULong \n Red = ULong.MaxValue \n End Enum"),
 NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As ULong \n Red = ULong.MaxValue \n Blue = 0 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestNegativeRangeIn64BitSignedEnums()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|Color.Green|] \n End Sub \n End Module \n Enum Color As Long \n Red = -10 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Color.Green \n End Sub \n End Module \n Enum Color As Long \n Red = -10 \n Green = -9 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestUnaryMinusOnUInteger1()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As UInteger \n Red = -(0 - UInteger.MaxValue) \n End Enum"),
 NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As UInteger \n Red = -(0 - UInteger.MaxValue) \n Blue = 0 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestDoubleUnaryMinusOnUInteger()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As UInteger \n Red = --(UInteger.MaxValue - 1) \n End Enum"),
 NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As UInteger \n Red = --(UInteger.MaxValue - 1) \n Blue = UInteger.MaxValue \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestDoubleUnaryMinusOnUInteger1()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Green|] \n End Sub \n End Class \n Enum Color As UInteger \n Red = --(UInteger.MaxValue - 1) \n Blue = 4294967295 \n End Enum"),
 NewLines("Class A \n Sub Main(args As String()) \n Color.Green \n End Sub \n End Class \n Enum Color As UInteger \n Red = --(UInteger.MaxValue - 1) \n Blue = 4294967295 \n Green = 0 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateWithImplicitValues()
             ' Red is implicitly assigned to 0, Green is implicitly Red + 1, So Blue must be 2.
             Test(
@@ -152,7 +152,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End 
 NewLines("Module Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Module \n Enum Color \n Red \n Green \n Yellow = -1 \n Blue = 2 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateWithImplicitValues2()
             Test(
 NewLines("Class B \n Sub Main(args As String()) \n [|Color.Grey|] \n End Sub \n End Class \n Enum Color \n Red \n Green = 10 \n Blue \n End Enum"),
@@ -160,7 +160,7 @@ NewLines("Class B \n Sub Main(args As String()) \n Color.Grey \n End Sub \n End 
         End Sub
 
         <WorkItem(540549)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestNoExtraneousStatementTerminatorBeforeCommentedMember()
             Dim code = <Text>Module Program
     Sub Main(args As String())
@@ -191,7 +191,7 @@ End Enum</Text>.Value.Replace(vbLf, vbCrLf)
         End Sub
 
         <WorkItem(540552)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithMinValue()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Blue|]) \n End Sub \n End Module \n Enum Color \n Red = Integer.MinValue \n End Enum"),
@@ -199,7 +199,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Blue) \n End
         End Sub
 
         <WorkItem(540553)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithMinValuePlusConstant()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Blue|]) \n End Sub \n End Module \n Enum Color \n Red = Integer.MinValue + 100 \n End Enum"),
@@ -207,28 +207,28 @@ NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Blue) \n End
         End Sub
 
         <WorkItem(540556)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithByteMaxValue()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Blue|]) \n End Sub \n End Module \n Enum Color As Byte\n Red = 255 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Blue) \n End Sub \n End Module \n Enum Color As Byte\n Red = 255 \n Blue = 0 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoNegativeSByteInOctal()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As SByte \n Red = &O1777777777777777777777 \n End Enum"),
 NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As SByte \n Red = &O1777777777777777777777 \n Blue = &O0 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoPositiveSByteInOctal1()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As SByte \n Red = &O0 \n End Enum"),
 NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As SByte \n Red = &O0 \n Blue = &O1 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoPositiveSByteInOctal2()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As SByte \n Red = &O176 \n End Enum"),
@@ -236,7 +236,7 @@ NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End 
         End Sub
 
         <WorkItem(540631)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateAfterEnumWithSByteMaxValueInOctal()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As SByte \n Red = &O177 \n End Enum"),
@@ -244,13 +244,13 @@ NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End 
         End Sub
 
         <WorkItem(528207)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestAbsenceOfFixWhenImportingEnums()
             TestMissing(
 NewLines("Imports Color \n Module Program \n Sub Main(args As String()) \n Foo([|Blue|]) \n End Sub \n End Module \n Enum Color As Byte \n Red \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestPresenceOfFixWhenImportingEnumsYetFullyQualifyingThem()
             Test(
 NewLines("Imports Color \n Module Program \n Sub Main(args As String()) \n Foo([|Color.Green|]) \n End Sub \n End Module \n Enum Color As Long \n Red = -10 \n End Enum"),
@@ -258,7 +258,7 @@ NewLines("Imports Color \n Module Program \n Sub Main(args As String()) \n Foo(C
         End Sub
 
         <WorkItem(540585)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoBitshiftEnum()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Color.Blue|]) \n End Sub \n Enum Color \n Red = 1 << 0 \n Green = 1 << 1 \n Orange = 1 << 2 \n End Enum \n End Module"),
@@ -266,7 +266,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Foo(Color.Blue) \n End
         End Sub
 
         <WorkItem(540566)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestKeywordName()
             Test(
 NewLines("Imports Color \n Module Program \n Sub Main(args As String()) \n Foo([|Color.Enum|]) \n End Sub \n End Module \n Enum Color As Byte \n Red \n End Enum"),
@@ -274,98 +274,98 @@ NewLines("Imports Color \n Module Program \n Sub Main(args As String()) \n Foo(C
         End Sub
 
         <WorkItem(540547)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestStandaloneReference()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Module \n Enum Color As Integer \n Red = Integer.MinValue \n Green = 1 \n End Enum"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Module \n Enum Color As Integer \n Red = Integer.MinValue \n Green = 1 \n Blue = 2 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestCircularEnumsForErrorTolerance()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|Circular.C|] \n End Sub \n End Module \n Enum Circular \n A = B \n B \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Circular.C \n End Sub \n End Module \n Enum Circular \n A = B \n B \n C \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestEnumWithIncorrectValueForErrorTolerance()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|Color.Green|] \n End Sub \n End Module \n Enum Color As Byte \n Red = -2 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Color.Green \n End Sub \n End Module \n Enum Color As Byte \n Red = -2 \n Green \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestHexValues()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|RenderType.LastViewedPage|] \n End Sub \n End Module \n <FlagsAttribute()> \n Enum RenderType \n None = &H0 \n DataUri = &H1 \n GZip = &H2 \n ContentPage = &H4 \n ViewPage = &H8 \n HomePage = &H10 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n RenderType.LastViewedPage \n End Sub \n End Module \n <FlagsAttribute()> \n Enum RenderType \n None = &H0 \n DataUri = &H1 \n GZip = &H2 \n ContentPage = &H4 \n ViewPage = &H8 \n HomePage = &H10 \n LastViewedPage = &H20 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoShadowedEnum()
             Test(
 NewLines("Class B \n Inherits A \n Sub Main(args As String()) \n [|BaseColors.Blue|] \n End Sub \n Shadows Enum BaseColors \n Orange = 3 \n End Enum \n End Class \n Public Class A \n Public Enum BaseColors \n Red = 1 \n Green = 2 \n End Enum \n End Class"),
 NewLines("Class B \n Inherits A \n Sub Main(args As String()) \n BaseColors.Blue \n End Sub \n Shadows Enum BaseColors \n Orange = 3 \n Blue = 4 \n End Enum \n End Class \n Public Class A \n Public Enum BaseColors \n Red = 1 \n Green = 2 \n End Enum \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoDerivedEnumMissingShadowsKeyword()
             Test(
 NewLines("Class B \n Inherits A \n Sub Main(args As String()) \n [|BaseColors.Blue|] \n End Sub \n Enum BaseColors \n Orange = 3 \n End Enum \n End Class \n Public Class A \n Public Enum BaseColors \n Red = 1 \n Green = 2 \n End Enum \n End Class"),
 NewLines("Class B \n Inherits A \n Sub Main(args As String()) \n BaseColors.Blue \n End Sub \n Enum BaseColors \n Orange = 3 \n Blue = 4 \n End Enum \n End Class \n Public Class A \n Public Enum BaseColors \n Red = 1 \n Green = 2 \n End Enum \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerateIntoBaseEnum()
             Test(
 NewLines("Class B \n Inherits A \n Sub Main(args As String()) \n [|BaseColors.Blue|] \n End Sub \n End Class \n Public Class A \n Public Enum BaseColors \n Red = 1 \n Green = 2 \n End Enum \n End Class"),
 NewLines("Class B \n Inherits A \n Sub Main(args As String()) \n BaseColors.Blue \n End Sub \n End Class \n Public Class A \n Public Enum BaseColors \n Red = 1 \n Green = 2 \n Blue = 3 \n End Enum \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestErrorToleranceWithStrictSemantics()
             Test(
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = 1.5 \n Green = 2.3 \n Orange = 3.3 \n End Enum"),
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As Long \n Red = 1.5 \n Green = 2.3 \n Orange = 3.3 \n Blue = 4 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGeometricSequenceWithTypeConversions()
             Test(
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = CLng(1.5) \n Green = CLng(2.3) \n Orange = CLng(3.9) \n End Enum"),
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As Long \n Red = CLng(1.5) \n Green = CLng(2.3) \n Orange = CLng(3.9) \n Blue = 8 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestLinearSequenceWithTypeConversions()
             Test(
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = CLng(1.5) \n Green = CLng(2.3) \n Orange = CLng(4.9) \n End Enum"),
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As Long \n Red = CLng(1.5) \n Green = CLng(2.3) \n Orange = CLng(4.9) \n Blue = 6 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestGenerationWhenMembersShareValues()
             Test(
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n [|Color.Grey|] \n End Sub \n End Class \n Enum Color \n Red \n Green \n Blue \n Max = Blue \n End Enum"),
 NewLines("Option Strict On \n Class B \n Sub Main(args As String()) \n Color.Grey \n End Sub \n End Class \n Enum Color \n Red \n Green \n Blue \n Max = Blue \n Grey = 3 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestInvokeFromAddAssignmentStatement()
             Test(
 NewLines("Class B \n Sub Main(args As String()) \n Dim a As Integer = 1 \n a += [|Color.Grey|] \n End Sub \n End Class \n Enum Color \n Red \n Green = 10 \n Blue \n End Enum"),
 NewLines("Class B \n Sub Main(args As String()) \n Dim a As Integer = 1 \n a += Color.Grey \n End Sub \n End Class \n Enum Color \n Red \n Green = 10 \n Blue \n Grey \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestMissingOnEnumsFromMetaData()
             TestMissing(
 NewLines("Imports Microsoft.VisualBasic \n Module Program \n Sub Main(args As String()) \n Dim a = [|FirstDayOfWeek.EigthDay|] \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(540638)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestMaxHex()
             Test(
 NewLines("Class Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n  \n Enum Color As Long \n Red = &H8000000000000000 \n End Enum"),
@@ -373,7 +373,7 @@ NewLines("Class Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \
         End Sub
 
         <WorkItem(540636)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestMinHex()
             Test(
 NewLines("Class Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As Long \n Red = &H7FFFFFFFFFFFFFFF \n End Enum"),
@@ -381,14 +381,14 @@ NewLines("Class Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \
         End Sub
 
         <WorkItem(540631)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestOctalBounds1()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As SByte \n Red = &O177 \n End Enum"),
 NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Class \n Enum Color As SByte \n Red = &O177 \n Blue = &O1777777777777777777600 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestULongMax()
             Test(
 NewLines("Class A \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Class \n Enum Color As ULong \n Red = ULong.MaxValue \n End Enum"),
@@ -396,27 +396,27 @@ NewLines("Class A \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End 
         End Sub
 
         <WorkItem(540604)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestWrapAround1()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|Color.Blue|] \n End Sub \n End Module \n Enum Color As Integer \n Green = Integer.MaxValue \n Orange = -2147483648 \n End Enum"),
 NewLines("Module Program \n Sub Main(args As String()) \n Color.Blue \n End Sub \n End Module \n Enum Color As Integer \n Green = Integer.MaxValue \n Orange = -2147483648 \n Blue = -2147483647 \n End Enum"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestMissingOnHiddenEnum()
             TestMissing(
 NewLines("#ExternalSource (""Default.aspx"", 1) \n Imports System \n Enum E \n #End ExternalSource \n End Enum \n #ExternalSource (""Default.aspx"", 2) \n Class C \n Sub Foo() \n Console.Write([|E.x|]) \n End Sub \n End Class \n #End ExternalSource"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestMissingOnPartiallyHiddenEnum()
             TestMissing(
 NewLines("#ExternalSource (""Default.aspx"", 1) \n Imports System \n Enum E \n A \n B \n C \n #End ExternalSource \n End Enum \n #ExternalSource (""Default.aspx"", 2) \n Class C \n Sub Foo() \n Console.Write([|E.x|]) \n End Sub \n End Class \n #End ExternalSource"))
         End Sub
 
         <WorkItem(544656)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestShortHexidecimalLiterals()
             Test(
 NewLines("Module M \n Dim y = [|E.Y|] ' Generate Y \n End Module \n Enum E As Short \n X = &H4000S \n End Enum"),
@@ -424,7 +424,7 @@ NewLines("Module M \n Dim y = E.Y ' Generate Y \n End Module \n Enum E As Short 
         End Sub
 
         <WorkItem(545937)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEnumMember)>
         Public Sub TestUShortEnums()
             Test(
 NewLines("Module M \n Dim y = [|E.Y|] ' Generate Y \n End Module \n  \n Enum E As UShort \n X = &H4000US \n End Enum"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEvent/GenerateEventTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEvent/GenerateEventTests.vb
@@ -13,47 +13,47 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New GenerateEventCodeFixProvider())
         End Function
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestGenerateEventIntoInterface1()
             Test(
 NewLines("Interface MyInterface \n End Interface \n Class C \n Implements MyInterface \n Event foo() Implements [|MyInterface.E|] \n End Class"),
 NewLines("Interface MyInterface \n Event E() \n End Interface \n Class C \n Implements MyInterface \n Event foo() Implements MyInterface.E \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestNotIfIdentifierMissing()
             TestMissing(
 NewLines("Interface MyInterface \n End Interface \n Class C \n Implements MyInterface \n Event foo() Implements [|MyInterface.|] \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestNotIfAlreadyPresent()
             TestMissing(
 NewLines("Interface MyInterface \n Event E() \n End Interface \n Class C \n Implements MyInterface \n Event foo() Implements [|MyInterface.E|] \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestGenerateEventWithParameter()
             Test(
 NewLines("Interface MyInterface \n End Interface \n Class C \n Implements MyInterface \n Event foo(x As Integer) Implements [|MyInterface.E|] \n End Class"),
 NewLines("Interface MyInterface \n Event E(x As Integer) \n End Interface \n Class C \n Implements MyInterface \n Event foo(x As Integer) Implements MyInterface.E \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestHandlesClause()
             Test(
 NewLines("Class D \n End Class \n Class C \n WithEvents a As D \n Sub bar(x As Integer, e As Object) Handles [|a.E|] \n End Sub \n End Class"),
 NewLines("Class D \n Public Event E(x As Integer, e As Object) \n End Class \n Class C \n WithEvents a As D \n Sub bar(x As Integer, e As Object) Handles a.E \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestHandlesClauseWithExistingEvent()
             TestMissing(
 NewLines("Class D \n Public Event E(x As Integer, e As Object) \n End Class \n Class C \n WithEvents a As D \n Sub bar(x As Integer, e As Object) Handles [|a.E|] \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(531210)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestMyBase()
             Test(
 NewLines("Public Class BaseClass \n ' Place methods and properties here. \n End Class \n  \n Public Class DerivedClass \n Inherits BaseClass \n Sub EventHandler(ByVal x As Integer) Handles [|MyBase.BaseEvent|] \n ' Place code to handle events from BaseClass here. \n End Sub \n End Class"),
@@ -61,7 +61,7 @@ NewLines("Public Class BaseClass \n Public Event BaseEvent(x As Integer) \n ' Pl
         End Sub
 
         <WorkItem(531210)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestMe()
             Test(
 NewLines("Public Class C \n Sub EventHandler(ByVal x As Integer) Handles [|Me.MyEvent|] \n ' Place code to handle events from BaseClass here. \n End Sub \n End Class"),
@@ -69,7 +69,7 @@ NewLines("Public Class C \n Public Event MyEvent(x As Integer) \n Sub EventHandl
         End Sub
 
         <WorkItem(531210)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub TestMyClass()
             Test(
 NewLines("Public Class C \n Sub EventHandler(ByVal x As Integer) Handles [|MyClass.MyEvent|] \n ' Place code to handle events from BaseClass here. \n End Sub \n End Class"),
@@ -77,14 +77,14 @@ NewLines("Public Class C \n Public Event MyEvent(x As Integer) \n Sub EventHandl
         End Sub
 
         <WorkItem(531251)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub NotIfEventMemberMissing()
             TestMissing(
 NewLines("Public Class A \n End Class \n Public Class C \n Dim WithEvents x As A \n Sub Hello(i As Integer) Handles [|x.|]'mark \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(531267)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub MakeParamsNotOptional()
             Test(
 NewLines("Public Class B \n Dim WithEvents x As B \n Private Sub Test(Optional x As String = Nothing) Handles [|x.E1|] 'mark 1 \n End Sub \n Private Sub Test2(ParamArray x As String()) Handles x.E2 'mark 2 \n End Sub \n End Class"),
@@ -92,7 +92,7 @@ NewLines("Public Class B \n Dim WithEvents x As B \n Public Event E1(x As String
         End Sub
 
         <WorkItem(531267)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub MakeParamsNotParamArray()
             Test(
 NewLines("Public Class B \n Dim WithEvents x As B \n Private Sub Test(Optional x As String = Nothing) Handles x.E1 'mark 1 \n End Sub \n Private Sub Test2(ParamArray x As String()) Handles [|x.E2|] 'mark 2 \n End Sub \n End Class"),
@@ -100,7 +100,7 @@ NewLines("Public Class B \n Dim WithEvents x As B \n Public Event E2(x() As Stri
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventStaticClass()
             Test(
 NewLines("Class EventClass \n Public Event ZEvent() \n End Class \n Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n AddHandler [|EventClass.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -108,7 +108,7 @@ NewLines("Class EventClass \n Public Event XEvent() \n Public Event ZEvent() \n 
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventStaticClass()
             Test(
 NewLines("Class EventClass \n Public Event ZEvent() \n End Class \n Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n RemoveHandler [|EventClass.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -116,7 +116,7 @@ NewLines("Class EventClass \n Public Event XEvent() \n Public Event ZEvent() \n 
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventVariable()
             Test(
 NewLines("Class EventClass \n Public Event ZEvent() \n End Class \n Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n AddHandler [|EClass.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -124,7 +124,7 @@ NewLines("Class EventClass \n Public Event XEvent() \n Public Event ZEvent() \n 
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventVariable()
             Test(
 NewLines("Class EventClass \n Public Event ZEvent() \n End Class \n Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n RemoveHandler [|EClass.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -132,7 +132,7 @@ NewLines("Class EventClass \n Public Event XEvent() \n Public Event ZEvent() \n 
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEvent()
             Test(
 NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n AddHandler [|XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -140,7 +140,7 @@ NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEvent()
             Test(
 NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n RemoveHandler [|XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -148,7 +148,7 @@ NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventMe()
             Test(
 NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n AddHandler [|Me.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -156,7 +156,7 @@ NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventMe()
             Test(
 NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n RemoveHandler [|Me.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -164,7 +164,7 @@ NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventMyClass()
             Test(
 NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n AddHandler [|MyClass.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -172,7 +172,7 @@ NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventMyClass()
             Test(
 NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub New() \n RemoveHandler [|MyClass.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -180,7 +180,7 @@ NewLines("Public Class Test \n WithEvents EClass As New EventClass \n Public Sub
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventMyBase()
             Test(
 NewLines("Public Class EventClass \n End Class \n Public Class Test \n Inherits EventClass \n Public Sub New() \n AddHandler [|MyBase.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -188,7 +188,7 @@ NewLines("Public Class EventClass \n Public Event XEvent() \n End Class \n Publi
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventMyBase()
             Test(
 NewLines("Public Class EventClass \n End Class \n Public Class Test \n Inherits EventClass \n Public Sub New() \n RemoveHandler [|MyBase.XEvent|], AddressOf EClass_EventHandler \n End Sub \n Sub EClass_EventHandler() \n End Sub \n End Class"),
@@ -196,7 +196,7 @@ NewLines("Public Class EventClass \n Public Event XEvent() \n End Class \n Publi
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventDelegate()
             Test(
 NewLines("Imports System \n Public Class EventClass \n End Class \n Public Class Test\n WithEvents EClass As New EventClass \n Public Sub New() \n AddHandler [|EClass.XEvent|], EClass_EventHandler \n End Sub \n Dim EClass_EventHandler As Action = Sub() \n End Sub \n End Class"),
@@ -204,7 +204,7 @@ NewLines("Imports System \n Public Class EventClass \n Public Event XEvent() \n 
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventDelegate()
             Test(
 NewLines("Imports System \n Public Class EventClass \n End Class \n Public Class Test\n WithEvents EClass As New EventClass \n Public Sub New() \n RemoveHandler [|EClass.XEvent|], EClass_EventHandler \n End Sub \n Dim EClass_EventHandler As Action = Sub() \n End Sub \n End Class"),
@@ -212,7 +212,7 @@ NewLines("Imports System \n Public Class EventClass \n Public Event XEvent() \n 
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventMyBaseIntoCSharp()
             Dim initialMarkup =
                 <Workspace>
@@ -250,7 +250,7 @@ public delegate void XEventHandler(string argument);
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventMyBaseIntoCSharp()
             Dim initialMarkup =
                 <Workspace>
@@ -288,7 +288,7 @@ public delegate void XEventHandler(string argument);
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventMyBaseIntoCSharpGeneric()
             Dim initialMarkup =
                 <Workspace>
@@ -330,7 +330,7 @@ public delegate void XEventHandler(object sender, EventArgs e);
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventMyBaseIntoCSharpGeneric()
             Dim initialMarkup =
                 <Workspace>
@@ -372,7 +372,7 @@ public delegate void XEventHandler(object sender, EventArgs e);
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventMultiLineLambdaIntoCSharp()
             Dim initialMarkup =
                 <Workspace>
@@ -413,7 +413,7 @@ public delegate void XEventHandler(object a, EventArgs b);
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventMultiLineLambdaIntoCSharp()
             Dim initialMarkup =
                 <Workspace>
@@ -454,7 +454,7 @@ public delegate void XEventHandler(object a, EventArgs b);
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForAddEventMyBaseIntoCSharpGenericExistingDelegate()
             Dim initialMarkup =
                 <Workspace>
@@ -490,7 +490,7 @@ public delegate void XEventHandler(object sender, EventArgs e);
         End Sub
 
         <WorkItem(774321)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEvent)>
         Public Sub GenerateEventForRemoveEventMyBaseIntoCSharpGenericExistingDelegate()
             Dim initialMarkup =
                 <Workspace>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -13,147 +13,147 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New GenerateParameterizedMemberCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestSimpleInvocationIntoSameType()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|]() \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo() \n End Sub \n Private Sub Foo() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestSimpleInvocationOffOfMe()
             Test(
 NewLines("Class C \n Sub M() \n Me.[|Foo|]() \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Me.Foo() \n End Sub \n Private Sub Foo() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestSimpleInvocationOffOfType()
             Test(
 NewLines("Class C \n Sub M() \n C.[|Foo|]() \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n C.Foo() \n End Sub \n Private Shared Sub Foo() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestSimpleInvocationValueExpressionArg()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|](0) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo(0) \n End Sub \n Private Sub Foo(v As Integer) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestSimpleInvocationMultipleValueExpressionArg()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|](0, 0) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo(0, 0) \n End Sub \n Private Sub Foo(v1 As Integer, v2 As Integer) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestSimpleInvocationValueArg()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](i) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(i) \n End Sub \n Private Sub Foo(i As Integer) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestSimpleInvocationNamedValueArg()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](bar:= i) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(bar:= i) \n End Sub \n Private Sub Foo(bar As Integer) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateAfterMethod()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|]() \n End Sub \n Sub NextMethod() \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo() \n End Sub \n Private Sub Foo() \n Throw New NotImplementedException() \n End Sub \n Sub NextMethod() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInterfaceNaming()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](NextMethod()) \n End Sub \n Function NextMethod() As IFoo \n End Function \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(NextMethod()) \n End Sub \n Private Sub Foo(foo As IFoo) \n Throw New NotImplementedException() \n End Sub \n Function NextMethod() As IFoo \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestFuncArg0()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](NextMethod) \n End Sub \n Function NextMethod() As String \n End Function \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(NextMethod) \n End Sub \n Private Sub Foo(nextMethod As String) \n Throw New NotImplementedException() \n End Sub \n Function NextMethod() As String \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestFuncArg1()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](NextMethod) \n End Sub \n Function NextMethod(i As Integer) As String \n End Function \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(NextMethod) \n End Sub \n Private Sub Foo(nextMethod As Func(Of Integer, String)) \n Throw New NotImplementedException() \n End Sub \n Function NextMethod(i As Integer) As String \n End Function \n End Class"))
         End Sub
 
-        <WpfFact(Skip:="528229"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(Skip:="528229"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestAddressOf1()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](AddressOf NextMethod) \n End Sub \n Function NextMethod(i As Integer) As String \n End Function \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(AddressOf NextMethod) \n End Sub \n Private Sub Foo(nextMethod As Global.System.Func(Of Integer, String)) \n Throw New NotImplementedException() \n End Sub \n Function NextMethod(i As Integer) As String \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestActionArg()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](NextMethod) End Sub \n Sub NextMethod() \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(NextMethod) \n End Sub \n Private Sub Foo(nextMethod As Object) \n Throw New NotImplementedException() \n End Sub \n Sub NextMethod() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestActionArg1()
             Test(
 NewLines("Class C \n Sub M(i As Integer) \n [|Foo|](NextMethod) \n End Sub \n Sub NextMethod(i As Integer) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(i As Integer) \n Foo(NextMethod) \n End Sub \n Private Sub Foo(nextMethod As Action(Of Integer)) \n Throw New NotImplementedException() \n End Sub \n Sub NextMethod(i As Integer) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeInference()
             Test(
 NewLines("Class C \n Sub M() \n If [|Foo|]() \n End If \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n If Foo() \n End If \n End Sub \n Private Function Foo() As Boolean \n Throw New NotImplementedException() \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestMemberAccessArgumentName()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|](Me.Bar) \n End Sub \n Dim Bar As Integer \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo(Me.Bar) \n End Sub \n Private Sub Foo(bar As Integer) \n Throw New NotImplementedException() \n End Sub \n Dim Bar As Integer \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestParenthesizedArgumentName()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|]((Bar)) \n End Sub \n Dim Bar As Integer \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo((Bar)) \n End Sub \n Private Sub Foo(bar As Integer) \n Throw New NotImplementedException() \n End Sub \n Dim Bar As Integer \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestCastedArgumentName()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|](DirectCast(Me.Baz, Bar)) \n End Sub \n End Class \n Class Bar \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo(DirectCast(Me.Baz, Bar)) \n End Sub \n Private Sub Foo(baz As Bar) \n Throw New NotImplementedException() \n End Sub \n End Class \n Class Bar \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDuplicateNames()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo|](DirectCast(Me.Baz, Bar), Me.Baz) \n End Sub \n Dim Baz As Integer \n End Class \n Class Bar \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo(DirectCast(Me.Baz, Bar), Me.Baz) \n End Sub \n Private Sub Foo(baz1 As Bar, baz2 As Integer) \n Throw New NotImplementedException() \n End Sub \n Dim Baz As Integer \n End Class \n Class Bar \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenericArgs1()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo(Of Integer)|]() \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M() \n Foo(Of Integer)() \n End Sub \n Private Sub Foo(Of T)() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenericArgs2()
             Test(
 NewLines("Class C \n Sub M() \n [|Foo(Of Integer, String)|]() \n End Sub \n End Class"),
@@ -161,21 +161,21 @@ NewLines("Imports System \n Class C \n Sub M() \n Foo(Of Integer, String)() \n E
         End Sub
 
         <WorkItem(539984)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenericArgsFromMethod()
             Test(
 NewLines("Class C \n Sub M(Of X,Y)(x As X, y As Y) \n [|Foo|](x) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(Of X,Y)(x As X, y As Y) \n Foo(x) \n End Sub \n Private Sub Foo(Of X)(x1 As X) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenericArgThatIsTypeParameter()
             Test(
 NewLines("Class C \n Sub M(Of X)(y1 As X(), x1 As System.Func(Of X)) \n [|Foo(Of X)|](y1, x1) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(Of X)(y1 As X(), x1 As System.Func(Of X)) \n Foo(Of X)(y1, x1) \n End Sub \n Private Sub Foo(Of X)(y1() As X, x1 As Func(Of X)) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestMultipleGenericArgsThatAreTypeParameters()
             Test(
 NewLines("Class C \n Sub M(Of X, Y)(y1 As Y(), x1 As System.Func(Of X)) \n [|Foo(Of X, Y)|](y1, x1) \n End Sub \n End Class"),
@@ -183,7 +183,7 @@ NewLines("Imports System \n Class C \n Sub M(Of X, Y)(y1 As Y(), x1 As System.Fu
         End Sub
 
         <WorkItem(539984)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestMultipleGenericArgsFromMethod()
             Test(
 NewLines("Class C \n Sub M(Of X, Y)(x As X, y As Y) \n [|Foo|](x, y) \n End Sub \n End Class"),
@@ -191,21 +191,21 @@ NewLines("Imports System \n Class C \n Sub M(Of X, Y)(x As X, y As Y) \n Foo(x, 
         End Sub
 
         <WorkItem(539984)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestMultipleGenericArgsFromMethod2()
             Test(
 NewLines("Class C \n Sub M(Of X, Y)(y As Y(), x As System.Func(Of X)) \n [|Foo|](y, x) \n End Sub \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(Of X, Y)(y As Y(), x As System.Func(Of X)) \n Foo(y, x) \n End Sub \n Private Sub Foo(Of Y, X)(y1() As Y, x1 As Func(Of X)) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateIntoOuterThroughInstance()
             Test(
 NewLines("Class Outer \n Class C \n Sub M(o As Outer) \n o.[|Foo|]() \n End Sub \n End Class \n End Class"),
 NewLines("Imports System \n Class Outer \n Class C \n Sub M(o As Outer) \n o.Foo() \n End Sub \n End Class \n Private Sub Foo() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateIntoOuterThroughClass()
             Test(
 NewLines("Class Outer \n Class C \n Sub M(o As Outer) \n Outer.[|Foo|]() \n End Sub \n End Class \n End Class"),
@@ -213,28 +213,28 @@ NewLines("Imports System \n Class Outer \n Class C \n Sub M(o As Outer) \n Outer
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateIntoSiblingThroughInstance()
             Test(
 NewLines("Class C \n Sub M(s As Sibling) \n s.[|Foo|]() \n End Sub \n End Class \n Class Sibling \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(s As Sibling) \n s.Foo() \n End Sub \n End Class \n Class Sibling \n Friend Sub Foo() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateIntoSiblingThroughClass()
             Test(
 NewLines("Class C \n Sub M(s As Sibling) \n [|Sibling.Foo|]() \n End Sub \n End Class \n Class Sibling \n End Class"),
 NewLines("Imports System \n Class C \n Sub M(s As Sibling) \n Sibling.Foo() \n End Sub \n End Class \n Class Sibling \n Friend Shared Sub Foo() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateIntoInterfaceThroughInstance()
             Test(
 NewLines("Class C \n Sub M(s As ISibling) \n s.[|Foo|]() \n End Sub \n End Class \n Interface ISibling \n End Interface"),
 NewLines("Class C \n Sub M(s As ISibling) \n s.Foo() \n End Sub \n End Class \n Interface ISibling \n Sub Foo() \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateAbstractIntoSameType()
             Test(
 NewLines("MustInherit Class C \n Sub M() \n [|Foo|]() \n End Sub \n End Class"),
@@ -243,7 +243,7 @@ index:=1)
         End Sub
 
         <WorkItem(539297)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateIntoModule()
             Test(
 NewLines("Module Class C \n Sub M() \n [|Foo|]() \n End Sub \n End Module"),
@@ -251,7 +251,7 @@ NewLines("Imports System \n Module Class C \n Sub M() \n Foo() \n End Sub \n Pri
         End Sub
 
         <WorkItem(539506)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInference1()
             Test(
 NewLines("Class C \n Sub M() \n Do While [|Foo|]() \n Loop \n End Sub \n End Class"),
@@ -259,7 +259,7 @@ NewLines("Imports System \n Class C \n Sub M() \n Do While Foo() \n Loop \n End 
         End Sub
 
         <WorkItem(539505)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestEscaping1()
             Test(
 NewLines("Class C \n Sub M() \n [|[Sub]|]() \n End Sub \n End Class"),
@@ -267,7 +267,7 @@ NewLines("Imports System \n Class C \n Sub M() \n [Sub]() \n End Sub \n Private 
         End Sub
 
         <WorkItem(539504)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestExplicitCall()
             Test(
 NewLines("Class C \n Sub M() \n Call [|S|] \n End Sub \n End Class"),
@@ -275,7 +275,7 @@ NewLines("Imports System \n Class C \n Sub M() \n Call S \n End Sub \n Private S
         End Sub
 
         <WorkItem(539504)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestImplicitCall()
             Test(
 NewLines("Class C \n Sub M() \n [|S|] \n End Sub \n End Class"),
@@ -283,13 +283,13 @@ NewLines("Imports System \n Class C \n Sub M() \n S \n End Sub \n Private Sub S(
         End Sub
 
         <WorkItem(539537)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestArrayAccess1()
             TestMissing(NewLines("Class C \n Sub M(x As Integer()) \n Foo([|x|](4)) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(539560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeCharacterInteger()
             Test(
 NewLines("Class C \n Sub M() \n [|S%|]() \n End Sub \n End Class"),
@@ -297,7 +297,7 @@ NewLines("Imports System \n Class C \n Sub M() \n S%() \n End Sub \n Private Fun
         End Sub
 
         <WorkItem(539560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeCharacterLong()
             Test(
 NewLines("Class C \n Sub M() \n [|S&|]() \n End Sub \n End Class"),
@@ -305,7 +305,7 @@ NewLines("Imports System \n Class C \n Sub M() \n S&() \n End Sub \n Private Fun
         End Sub
 
         <WorkItem(539560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeCharacterDecimal()
             Test(
 NewLines("Class C \n Sub M() \n [|S@|]() \n End Sub \n End Class"),
@@ -313,7 +313,7 @@ NewLines("Imports System \n Class C \n Sub M() \n S@() \n End Sub \n Private Fun
         End Sub
 
         <WorkItem(539560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeCharacterSingle()
             Test(
 NewLines("Class C \n Sub M() \n [|S!|]() \n End Sub \n End Class"),
@@ -321,7 +321,7 @@ NewLines("Imports System \n Class C \n Sub M() \n S!() \n End Sub \n Private Fun
         End Sub
 
         <WorkItem(539560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeCharacterDouble()
             Test(
 NewLines("Class C \n Sub M() \n [|S#|]() \n End Sub \n End Class"),
@@ -329,7 +329,7 @@ NewLines("Imports System \n Class C \n Sub M() \n S#() \n End Sub \n Private Fun
         End Sub
 
         <WorkItem(539560)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeCharacterString()
             Test(
 NewLines("Class C \n Sub M() \n [|S$|]() \n End Sub \n End Class"),
@@ -337,7 +337,7 @@ NewLines("Imports System \n Class C \n Sub M() \n S$() \n End Sub \n Private Fun
         End Sub
 
         <WorkItem(539283)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestNewLines()
             Test(
                 <text>Public Class C
@@ -360,7 +360,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(539283)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestNewLines2()
             Test(
                 <text>Public Class C
@@ -387,14 +387,14 @@ End Class</text>.Value.Replace(vbLf, vbCrLf),
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestArgumentTypeVoid()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n Dim v As Void \n [|Foo|](v) \n End Sub \n End Module"),
 NewLines("Imports System \n Module Program \n Sub Main() \n Dim v As Void \n Foo(v) \n End Sub \n Private Sub Foo(v As Object) \n Throw New NotImplementedException() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateFromImplementsClause()
             Test(
 NewLines("Class Program \n Implements IFoo \n Public Function Bip(i As Integer) As String Implements [|IFoo.Snarf|] \n End Function \n End Class \n Interface IFoo \n End Interface"),
@@ -402,7 +402,7 @@ NewLines("Class Program \n Implements IFoo \n Public Function Bip(i As Integer) 
         End Sub
 
         <WorkItem(537929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInScript1()
             Test(
 NewLines("Imports System \n Shared Sub Main ( args As String() ) \n [|Foo|] ( ) \n End Sub"),
@@ -410,61 +410,61 @@ NewLines("Imports System \n Shared Sub Main ( args As String() ) \n Foo ( ) \n E
             parseOptions:=GetScriptOptions())
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInTopLevelImplicitClass1()
             Test(
 NewLines("Imports System \n Shared Sub Main ( args As String() ) \n [|Foo|] ( ) \n End Sub"),
 NewLines("Imports System \n Shared Sub Main ( args As String() ) \n Foo ( ) \n End Sub \n Private Shared Sub Foo() \n Throw New NotImplementedException() \n End Sub"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInNamespaceImplicitClass1()
             Test(
 NewLines("Imports System \n Namespace N \n Shared Sub Main ( args As String() ) \n [|Foo|] ( ) \n End Sub \n End Namespace"),
 NewLines("Imports System \n Namespace N \n Shared Sub Main ( args As String() ) \n Foo ( ) \n End Sub \n Private Shared Sub Foo() \n Throw New NotImplementedException() \n End Sub \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInNamespaceImplicitClass_FieldInitializer()
             Test(
 NewLines("Imports System \n Namespace N \n Dim a As Integer = [|Foo|]() \n End Namespace"),
 NewLines("Imports System \n Namespace N \n Dim a As Integer = Foo() \n Private Function Foo() As Integer \n Throw New NotImplementedException() \n End Function \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestClashesWithMethod1()
             TestMissing(
 NewLines("Class Program \n Implements IFoo \n Public Function Blah() As String Implements [|IFoo.Blah|] \n End Function \n End Class \n Interface IFoo \n Sub Blah() \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestClashesWithMethod2()
             TestMissing(
 NewLines("Class Program \n Implements IFoo \n Public Function Blah() As String Implements [|IFoo.Blah|] \n End Function \n End Class \n Interface IFoo \n Sub Blah() \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestClashesWithMethod3()
             Test(
 NewLines("Class C \n Implements IFoo \n Sub Snarf() Implements [|IFoo.Blah|] \n End Sub \n End Class \n Interface IFoo \n Sub Blah(ByRef i As Integer) \n End Interface"),
 NewLines("Class C \n Implements IFoo \n Sub Snarf() Implements IFoo.Blah \n End Sub \n End Class \n Interface IFoo \n Sub Blah(ByRef i As Integer) \n Sub Blah() \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestClashesWithMethod4()
             Test(
 NewLines("Class C \n Implements IFoo \n Sub Snarf(i As String) Implements [|IFoo.Blah|] \n End Sub \n End Class \n Interface IFoo \n Sub Blah(ByRef i As Integer) \n End Interface"),
 NewLines("Class C \n Implements IFoo \n Sub Snarf(i As String) Implements IFoo.Blah \n End Sub \n End Class \n Interface IFoo \n Sub Blah(ByRef i As Integer) \n Sub Blah(i As String) \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestClashesWithMethod5()
             Test(
 NewLines("Class C \n Implements IFoo \n Sub Blah(i As Integer) Implements [|IFoo.Snarf|] \n End Sub \n End Class \n Friend Interface IFoo \n Sub Snarf(i As String) \n End Interface"),
 NewLines("Class C \n Implements IFoo \n Sub Blah(i As Integer) Implements IFoo.Snarf \n End Sub \n End Class \n Friend Interface IFoo \n Sub Snarf(i As String) \n Sub Snarf(i As Integer) \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestClashesWithMethod6()
             Test(
 NewLines("Class C \n Implements IFoo \n Sub Blah(i As Integer, s As String) Implements [|IFoo.Snarf|] \n End Sub \n End Class \n Friend Interface IFoo \n Sub Snarf(i As Integer, b As Boolean) \n End Interface"),
@@ -472,14 +472,14 @@ NewLines("Class C \n Implements IFoo \n Sub Blah(i As Integer, s As String) Impl
         End Sub
 
         <WorkItem(539708)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestNoStaticGenerationIntoInterface()
             TestMissing(
 NewLines("Interface IFoo \n End Interface \n Class Program \n Sub Main \n IFoo.[|Bar|] \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(539821)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestEscapeParametername()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim [string] As String = ""hello"" \n [|[Me]|]([string]) \n End Sub \n End Module"),
@@ -487,7 +487,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Dim 
         End Sub
 
         <WorkItem(539810)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDoNotUseUnavailableTypeParameter()
             Test(
 NewLines("Class Test \n Sub M(Of T)(x As T) \n [|Foo(Of Integer)|](x) \n End Sub \n End Class"),
@@ -495,14 +495,14 @@ NewLines("Imports System \n Class Test \n Sub M(Of T)(x As T) \n Foo(Of Integer)
         End Sub
 
         <WorkItem(539808)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDoNotUseTypeParametersFromContainingType()
             Test(
 NewLines("Class Test(Of T) \n Sub M() \n [|Method(Of T)|]() \n End Sub \n End Class"),
 NewLines("Imports System \n Class Test(Of T) \n Sub M() \n Method(Of T)() \n End Sub \n Private Sub Method(Of T1)() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestNameSimplification1()
             Test(
 NewLines("Imports System \n Class C \n Sub M() \n [|Foo|]() \n End Sub \n End Class"),
@@ -510,7 +510,7 @@ NewLines("Imports System \n Class C \n Sub M() \n Foo() \n End Sub \n Private Su
         End Sub
 
         <WorkItem(539809)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestFormattingOfMembers()
             Test(
 <Text>Class Test
@@ -543,7 +543,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(540013)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInAddressOfExpression1()
             Test(
 NewLines("Delegate Sub D(x As Integer) \n Class C \n Public Sub Foo() \n Dim x As D = New D(AddressOf [|Method|]) \n End Sub \n End Class"),
@@ -551,14 +551,14 @@ NewLines("Imports System \n Delegate Sub D(x As Integer) \n Class C \n Public Su
         End Sub
 
         <WorkItem(527986)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestNotOfferedForInferredGenericMethodArgs()
             TestMissing(
 NewLines("Class Foo(Of T) \n Sub Main(Of T, X)(k As Foo(Of T)) \n [|Bar|](k) \n End Sub \n Private Sub Bar(Of T)(k As Foo(Of T)) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(540740)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDelegateInAsClause()
             Test(
 NewLines("Delegate Sub D(x As Integer) \n Class C \n Private Sub M() \n Dim d As New D(AddressOf [|Test|]) \n End Sub \n End Class"),
@@ -566,21 +566,21 @@ NewLines("Imports System \n Delegate Sub D(x As Integer) \n Class C \n Private S
         End Sub
 
         <WorkItem(541405)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestMissingOnImplementedInterfaceMethod()
             TestMissing(
 NewLines("Class C(Of U) \n Implements ITest \n Public Sub Method(x As U) Implements [|ITest.Method|] \n End Sub \n End Class \n Friend Interface ITest \n Sub Method(x As Object) \n End Interface"))
         End Sub
 
         <WorkItem(542098)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestNotOnConstructorInitializer()
             TestMissing(
 NewLines("Class C \n Sub New \n Me.[|New|](1) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(542838)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestMultipleImportsAdded()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n For Each v As Integer In [|HERE|]() : Next \n End Sub \n End Module"),
@@ -588,7 +588,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Module Program
         End Sub
 
         <WorkItem(543007)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestCompilationMemberImports()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n For Each v As Integer In [|HERE|]() : Next \n End Sub \n End Module"),
@@ -598,7 +598,7 @@ compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplicat
         End Sub
 
         <WorkItem(531301)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestForEachWithNoControlVariableType()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n For Each v In [|HERE|] : Next \n End Sub \n End Module"),
@@ -608,7 +608,7 @@ compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplicat
         End Sub
 
         <WorkItem(531301)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestElseIfStatement()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n If x Then \n ElseIf [|HERE|] Then \n End If \n End Sub \n End Module"),
@@ -618,7 +618,7 @@ compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplicat
         End Sub
 
         <WorkItem(531301)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestForStatement()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n For x As Integer = 1 To [|HERE|] \n End Sub \n End Module"),
@@ -628,14 +628,14 @@ compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplicat
         End Sub
 
         <WorkItem(543216)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestArrayOfAnonymousTypes()
             Test(
 NewLines("Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim product = New With {Key .Name = """", Key .Price = 0} \n Dim products = ToList(product) \n [|HERE|](products) \n End Sub \n Function ToList(Of T)(a As T) As IEnumerable(Of T) \n Return Nothing \n End Function \n End Module"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim product = New With {Key .Name = """", Key .Price = 0} \n Dim products = ToList(product) \n HERE(products) \n End Sub \n Private Sub HERE(products As IEnumerable(Of Object)) \n Throw New NotImplementedException() \n End Sub \n Function ToList(Of T)(a As T) As IEnumerable(Of T) \n Return Nothing \n End Function \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestMissingOnHiddenType()
             TestMissing(
 <text>
@@ -652,7 +652,7 @@ EndClass
 </text>.Value)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDoNotGenerateIntoHiddenRegion1_NoImports()
             Test(
 <text>
@@ -679,7 +679,7 @@ End Class
 </text>.Value.Replace(vbLf, vbCrLf), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDoNotGenerateIntoHiddenRegion1_WithImports()
             Test(
 <text>
@@ -715,7 +715,7 @@ End Class
 </text>.Value.Replace(vbLf, vbCrLf), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDoNotGenerateIntoHiddenRegion2()
             Test(
 <text>
@@ -752,7 +752,7 @@ End Class
 </text>.Value.Replace(vbLf, vbCrLf), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestDoNotGenerateIntoHiddenRegion3()
             Test(
 <text>
@@ -795,7 +795,7 @@ End Class
 </text>.Value.Replace(vbLf, vbCrLf), compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestAddressOfInference1()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main(ByVal args As String()) \n Dim v As Func(Of String) = Nothing \n Dim a1 = If(False, v, AddressOf [|TestMethod|]) \n End Sub \n End Module"),
@@ -803,7 +803,7 @@ NewLines("Imports System \n Module Program \n Sub Main(ByVal args As String()) \
         End Sub
 
         <WorkItem(544641)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestClassStatementTerminators1()
             Test(
 NewLines("Class C : End Class \n Class B \n Sub Foo() \n C.[|Bar|]() \n End Sub \n End Class"),
@@ -811,7 +811,7 @@ NewLines("Imports System \n Class C \n Friend Shared Sub Bar() \n Throw New NotI
         End Sub
 
         <WorkItem(546037)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestOmittedArguments1()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|foo|](,,) \n End Sub \n End Module"),
@@ -819,7 +819,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n foo(
         End Sub
 
         <WorkItem(546037)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestOmittedArguments2()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|foo|](1,,) \n End Sub \n End Module"),
@@ -827,7 +827,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n foo(
         End Sub
 
         <WorkItem(546037)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestOmittedArguments3()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|foo|](,1,) \n End Sub \n End Module"),
@@ -835,7 +835,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n foo(
         End Sub
 
         <WorkItem(546037)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestOmittedArguments4()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|foo|](,,1) \n End Sub \n End Module"),
@@ -843,7 +843,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n foo(
         End Sub
 
         <WorkItem(546037)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestOmittedArguments5()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|foo|](1,, 1) \n End Sub \n End Module"),
@@ -851,7 +851,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n foo(
         End Sub
 
         <WorkItem(546037)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestOmittedArguments6()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|foo|](1, 1, ) \n End Sub \n End Module"),
@@ -859,13 +859,13 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n foo(
         End Sub
 
         <WorkItem(546683)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestNotOnMissingMethodName()
             TestMissing(NewLines("Class C \n Sub M() \n Me.[||] \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(546684)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateFromEventHandler()
             Test(
 NewLines("Module Module1 \n Sub Main() \n Dim c1 As New Class1 \n AddHandler c1.AnEvent, AddressOf [|EventHandler1|] \n End Sub \n Public Class Class1 \n Public Event AnEvent() \n End Class \n End Module"),
@@ -873,14 +873,14 @@ NewLines("Imports System \n Module Module1 \n Sub Main() \n Dim c1 As New Class1
         End Sub
 
         <WorkItem(530814)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestCapturedMethodTypeParameterThroughLambda()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Module M \n Sub Foo(Of T, S)(x As List(Of T), y As List(Of S)) \n [|Bar|](x, Function() y) ' Generate Bar \n End Sub \n End Module"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Module M \n Sub Foo(Of T, S)(x As List(Of T), y As List(Of S)) \n Bar(x, Function() y) ' Generate Bar \n End Sub \n Private Sub Bar(Of T, S)(x As List(Of T), p As Func(Of List(Of S))) \n Throw New NotImplementedException() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeParameterAndParameterConflict1()
             Test(
 NewLines("Imports System \n Class C(Of T) \n Sub Foo(x As T) \n M.[|Bar|](T:=x) \n End Sub \n End Class \n  \n Module M \n End Module"),
@@ -888,7 +888,7 @@ NewLines("Imports System \n Class C(Of T) \n Sub Foo(x As T) \n M.Bar(T:=x) \n E
         End Sub
 
         <WorkItem(530968)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestTypeParameterAndParameterConflict2()
             Test(
 NewLines("Imports System \n Class C(Of T) \n Sub Foo(x As T) \n M.[|Bar|](t:=x) ' Generate Bar \n End Sub \n End Class \n  \n Module M \n End Module"),
@@ -896,7 +896,7 @@ NewLines("Imports System \n Class C(Of T) \n Sub Foo(x As T) \n M.Bar(t:=x) ' Ge
         End Sub
 
         <WorkItem(546850)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestCollectionInitializer1()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n [|Bar|](1, {1}) \n End Sub \n End Module"),
@@ -904,7 +904,7 @@ NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Bar(
         End Sub
 
         <WorkItem(546925)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestCollectionInitializer2()
             Test(
 NewLines("Imports System \n Module M \n Sub Main() \n [|Foo|]({{1}}) \n End Sub \n End Module"),
@@ -912,7 +912,7 @@ NewLines("Imports System \n Module M \n Sub Main() \n Foo({{1}}) \n End Sub \n P
         End Sub
 
         <WorkItem(530818)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestParameterizedProperty1()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n [|Prop|](1) = 2 \n End Sub \n End Module"),
@@ -920,7 +920,7 @@ NewLines("Imports System \n Module Program \n Sub Main() \n Prop(1) = 2 \n End S
         End Sub
 
         <WorkItem(530818)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestParameterizedProperty2()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n [|Prop|](1) = 2 \n End Sub \n End Module"),
@@ -929,7 +929,7 @@ index:=1)
         End Sub
 
         <WorkItem(907612)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodWithLambda_1()
             Test(
 <text>
@@ -967,7 +967,7 @@ End Module
         End Sub
 
         <WorkItem(907612)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodWithLambda_2()
             Test(
 <text>
@@ -1005,7 +1005,7 @@ End Module
         End Sub
 
         <WorkItem(907612)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodWithLambda_3()
             Test(
 <text>
@@ -1043,7 +1043,7 @@ End Module
         End Sub
 
         <WorkItem(889349)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodForDifferentParameterName()
             Test(
 <text>
@@ -1077,7 +1077,7 @@ End Class
         End Sub
 
         <WorkItem(769760)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodForSameNamedButGenericUsage_1()
             Test(
 <text>
@@ -1113,7 +1113,7 @@ End Class
         End Sub
 
         <WorkItem(769760)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodForSameNamedButGenericUsage_2()
             Test(
 <text>Imports System
@@ -1155,7 +1155,7 @@ End Class
         End Sub
 
         <WorkItem(935731)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodForAwaitWithoutParenthesis()
             Test(
 <text>Module Module1
@@ -1180,7 +1180,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodTooManyArgs1()
             Test(
 <text>Module M1
@@ -1209,7 +1209,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodNamespaceNotExpression1()
             Test(
 <text>Imports System
@@ -1233,7 +1233,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodNoArgumentCountOverloadCandidates1()
             Test(
 <text>Module Module1
@@ -1285,7 +1285,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodFunctionResultCannotBeIndexed1()
             Test(
 <text>Imports Microsoft.VisualBasic.FileSystem
@@ -1312,7 +1312,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodNoCallableOverloadCandidates2()
             Test(
 <text>Class M1
@@ -1344,7 +1344,7 @@ End Class
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodNoNonNarrowingOverloadCandidates2()
             Test(
 <text>Module Module1
@@ -1436,7 +1436,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodNoNonNarrowingOverloadCandidates3()
             Test(
 <text>Module Module1
@@ -1506,7 +1506,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodNoNonNarrowingOverloadCandidates4()
             Test(
 <text>Module Module1
@@ -1578,7 +1578,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodArgumentNarrowing()
             Test(
 <text>Option Strict Off
@@ -1646,7 +1646,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodArgumentNarrowing2()
             Test(
 <text>Option Strict Off
@@ -1714,7 +1714,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodArgumentNarrowing3()
             Test(
 <text>Option Strict Off
@@ -1782,7 +1782,7 @@ End Module
         End Sub
 
         <WorkItem(939941)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodNoMostSpecificOverload2()
             Test(
 <text>Module Module1
@@ -1842,7 +1842,7 @@ End Module
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodInsideNameOf()
             Test(
 <text>
@@ -1870,7 +1870,7 @@ End Class
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodInsideNameOf2()
             Test(
 <text>
@@ -1907,7 +1907,7 @@ End Namespace
 </text>.Value.Replace(vbLf, vbCrLf))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodWithNameOfArgument()
             Test(
 <text>
@@ -1932,7 +1932,7 @@ End Class
 </text>.Value.Replace(vbLf, vbCrLf))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodWithLambdaAndNameOfArgument()
             Test(
 <text>
@@ -1958,7 +1958,7 @@ End Class
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B|] \n End Sub \n End Class"),
@@ -1966,7 +1966,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis2()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B|] \n End Sub \n End Class"),
@@ -1974,7 +1974,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?.B \
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis3()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B|] \n End Sub \n End Class"),
@@ -1982,7 +1982,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integ
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis4()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C? = a?[|.B|] \n End Sub \n End Class"),
@@ -1990,7 +1990,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C? = 
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis5()
             Test(
 NewLines("Option Strict On \n Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -1998,7 +1998,7 @@ NewLines("Option Strict On \n Imports System \n Public Class C \n Sub Main(a As 
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis6()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -2006,7 +2006,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integ
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis7()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -2014,7 +2014,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?.B.Z
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis8()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -2022,7 +2022,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis9()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -2030,7 +2030,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integ
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis10()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -2038,7 +2038,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integ
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccessNoParenthesis11()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -2046,7 +2046,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?.B.Z
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccess()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B|]() \n End Sub \n End Class"),
@@ -2054,7 +2054,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccess2()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B|]() \n End Sub \n End Class"),
@@ -2062,7 +2062,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?.B()
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccess3()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B|]() \n End Sub \n End Class"),
@@ -2070,7 +2070,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integ
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalAccess4()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C? = a?[|.B|]() \n End Sub \n End Class"),
@@ -2078,7 +2078,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C? = 
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyConditionalAccess()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B|]() \n End Sub \n End Class"),
@@ -2087,7 +2087,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyConditionalAccess2()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B|]() \n End Sub \n End Class"),
@@ -2096,7 +2096,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyConditionalAccess3()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B|]() \n End Sub \n End Class"),
@@ -2105,7 +2105,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyConditionalAccess4()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C? = a?[|.B|]() \n End Sub \n End Class"),
@@ -2113,28 +2113,28 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C? = 
 index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalInPropertyInitializer()
             Test(
 NewLines("Module Program \n Property a As Integer = [|y|] \n End Module"),
 NewLines("Imports System\n\nModule Program\nProperty a As Integer = y\n\nPrivate Function y() As Integer\nThrow New NotImplementedException()\nEnd Function\nEnd Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConditionalInPropertyInitializer2()
             Test(
 NewLines("Module Program \n Property a As Integer = [|y|]() \n End Module"),
 NewLines("Imports System\n\nModule Program\nProperty a As Integer = y()\n\n Private Function y() As Integer\nThrow New NotImplementedException()\nEnd Function\nEnd Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodTypeOf()
             Test(
 NewLines("Module C \n Sub Test() \n If TypeOf [|B|] Is String Then \n End If \n End Sub \n End Module"),
 NewLines("Imports System \n Module C \n Sub Test() \n If TypeOf B Is String Then \n End If \n End Sub \n Private Function B() As String \n Throw New NotImplementedException() \n End Function \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodTypeOf2()
             Test(
 NewLines("Module C \n Sub Test() \n If TypeOf [|B|]() Is String Then \n End If \n End Sub \n End Module"),
@@ -2142,7 +2142,7 @@ NewLines("Imports System \n Module C \n Sub Test() \n If TypeOf B() Is String Th
         End Sub
 
         <WorkItem(643, "https://github.com/dotnet/roslyn/issues/643")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodConfigureAwaitFalse()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Async Sub Main(args As String()) \n Dim x As Boolean = Await [|Foo|]().ConfigureAwait(False) \n End Sub \n End Module"),
@@ -2150,7 +2150,7 @@ NewLines("Imports System\nImports System.Collections.Generic\nImports System.Lin
         End Sub
 
         <WorkItem(643, "https://github.com/dotnet/roslyn/issues/643")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyConfigureAwaitFalse()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Async Sub Main(args As String()) \n Dim x As Boolean = Await [|Foo|]().ConfigureAwait(False) \n End Sub \n End Module"),
@@ -2159,7 +2159,7 @@ index:=1)
         End Sub
 
         <WorkItem(643, "https://github.com/dotnet/roslyn/issues/643")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodWithMethodChaining()
             Test(
 NewLines("Imports System \n Imports System.Linq \n Module M \n Async Sub T() \n Dim x As Boolean = Await [|F|]().ContinueWith(Function(a) True).ContinueWith(Function(a) False) \n End Sub \n End Module"),
@@ -2167,7 +2167,7 @@ NewLines("Imports System\nImports System.Linq\nImports System.Threading.Tasks\n\
         End Sub
 
         <WorkItem(643, "https://github.com/dotnet/roslyn/issues/643")>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodWithMethodChaining2()
             Test(
 NewLines("Imports System \n Imports System.Linq \n Module M \n Async Sub T() \n Dim x As Boolean = Await [|F|]().ContinueWith(Function(a) True).ContinueWith(Function(a) False) \n End Sub \n End Module"),
@@ -2176,7 +2176,7 @@ index:=1)
         End Sub
 
         <WorkItem(1130960)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGenerateMethodInTypeOfIsNot()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub M() \n If TypeOf [|Prop|] IsNot TypeOfIsNotDerived Then \n End If \n End Sub \n End Module"),
@@ -2184,7 +2184,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(529480)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInCollectionInitializers1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Module Program \n Sub M() \n Dim x = New List ( Of Integer ) From { [|T|]() } \n End Sub \n End Module"),
@@ -2192,7 +2192,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Module Program
         End Sub
 
         <WorkItem(529480)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestInCollectionInitializers2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Module Program \n Sub M() \n Dim x = New Dictionary ( Of Integer , Boolean ) From { { 1, [|T|]() } } \n End Sub \n End Module"),
@@ -2207,7 +2207,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Module Program
             End Function
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateExplicitConversionGenericClass()
                 Test(
     <text>Class Program
@@ -2236,7 +2236,7 @@ End Class
             End Sub
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateExplicitConversionClass()
                 Test(
     <text>Class Program
@@ -2265,7 +2265,7 @@ End Class
             End Sub
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateExplicitConversionAwaitExpression()
                 Test(
     <text>Imports System
@@ -2300,7 +2300,7 @@ End Class
             End Sub
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateImplicitConversionTargetTypeNotInSource()
                 Test(
     <text>Imports System
@@ -2346,7 +2346,7 @@ End Class
             End Sub
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateImplicitConversionGenericClass()
                 Test(
     <text>Class Program
@@ -2375,7 +2375,7 @@ End Class
             End Sub
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateImplicitConversionClass()
                 Test(
     <text>Class Program
@@ -2404,7 +2404,7 @@ End Class
             End Sub
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateImplicitConversionAwaitExpression()
                 Test(
     <text>Imports System
@@ -2439,7 +2439,7 @@ End Class
             End Sub
 
             <WorkItem(774321)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
             Public Sub TestGenerateExplicitConversionTargetTypeNotInSource()
                 Test(
     <text>Imports System

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
             Return FlattenActions(actions)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeParameterFromArgumentInferT()
             Test(
 NewLines("Module Program \n Sub Main() \n Dim f As [|Foo(Of Integer)|] \n End Sub \n End Module"),
@@ -31,7 +31,7 @@ NewLines("Module Program \n Sub Main() \n Dim f As Foo(Of Integer) \n End Sub \n
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassFromTypeParameter()
             Test(
 NewLines("Class C \n Dim emp As List(Of [|Employee|]) \n End Class"),
@@ -39,7 +39,7 @@ NewLines("Class C \n Dim emp As List(Of Employee) \n Private Class Employee \n E
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassFromFieldDeclarationIntoSameType()
             Test(
 NewLines("Class C \n dim f as [|Foo|] \n End Class"),
@@ -47,7 +47,7 @@ NewLines("Class C \n dim f as Foo \n Private Class Foo \n End Class \n End Class
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassFromFieldDeclarationIntoSameNamespace()
             Test(
 NewLines("Class C \n dim f as [|Foo|] \n End Class"),
@@ -62,7 +62,7 @@ NewLines("Class C \n dim f as [|foo|] \n End Class"))
         End Sub
 
         <WorkItem(539716)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassFromFullyQualifiedFieldIntoSameNamespace()
             Test(
 NewLines("Namespace NS \n Class Foo \n Private x As New NS.[|Bar|] \n End Class \n End Namespace"),
@@ -71,7 +71,7 @@ index:=1,
 parseOptions:=Nothing) ' Namespaces not supported in script
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassWithCtorFromObjectCreation()
             Test(
 NewLines("Class C \n Dim f As Foo = New [|Foo|]() \n End Class"),
@@ -79,7 +79,7 @@ NewLines("Class C \n Dim f As Foo = New Foo() \n Private Class Foo \n Public Sub
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestCreateException()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Throw New [|Foo|]() \n End Sub \n End Module"),
@@ -87,7 +87,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestCreateFieldDelegatingConstructor()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Call New [|Foo|](1, ""blah"") \n End Sub \n End Module"),
@@ -95,7 +95,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestCreateBaseDelegatingConstructor()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim d As B = New [|D|](4) \n End Sub \n End Module \n Class B \n Protected Sub New(value As Integer) \n End Sub \n End Class"),
@@ -103,7 +103,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateIntoNamespace()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Namespace Outer \n Module Program \n Sub Main(args As String()) \n Call New [|Blah|]() \n End Sub \n End Module \n End Namespace"),
@@ -111,7 +111,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateAssignmentToBaseField()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(i As Integer) \n Dim d As B = New [|D|](i) \n End Sub \n End Module \n Class B \n Protected i As Integer \n End Class"),
@@ -119,7 +119,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateGenericType()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Outer(Of M) \n Sub Main(i As Integer) \n Call New [|Foo(Of M)|] \n End Sub \n End Class"),
@@ -127,7 +127,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateIntoClass()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Outer(Of M) \n Sub Main(i As Integer) \n Call New [|Foo(Of M)|] \n End Sub \n End Class"),
@@ -135,7 +135,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateIntoClassFromFullyQualifiedInvocation()
             Test(
 NewLines("Class Program \n Sub Test() \n Dim d = New [|Program.Foo|]() \n End Sub \n End Class"),
@@ -143,7 +143,7 @@ NewLines("Class Program \n Sub Test() \n Dim d = New Program.Foo() \n End Sub \n
         End Sub
 
         <WorkItem(5776, "DevDiv_Projects/Roslyn")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateIntoNamespaceFromFullyQualifiedInvocation()
             Test(
 NewLines("Namespace Foo \n Class Program \n Sub Test() \n Dim d = New [|Foo.Bar|]() \n End Sub \n End Class \n End Namespace"),
@@ -152,7 +152,7 @@ index:=1,
 parseOptions:=Nothing) ' Namespaces not supported in script
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestInSecondConstraintClause()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class Program(Of T As {Foo, [|IBar|]}) \n End Class"),
@@ -178,7 +178,7 @@ expectedContainers:=Array.Empty(Of String)(),
 expectedDocumentName:="Foo.vb").ConfigureAwait(True)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeThatImplementsInterface1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim d As [|IFoo|] = New Foo() \n End Sub \n End Module"),
@@ -186,7 +186,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeThatImplementsInterface2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim d As IFoo = New [|Foo|]() \n End Sub \n End Module \n Friend Interface IFoo \n End Interface"),
@@ -194,7 +194,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeWithNamedArguments()
             Test(
 NewLines("Class Program \n Sub Test() \n Dim x = New [|Bar|](value:=7) \n End Sub \n End Class"),
@@ -203,14 +203,14 @@ index:=1)
         End Sub
 
         <WorkItem(539730)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNotIntoType()
             TestActionCount(
 NewLines("Class Program \n Inherits [|Temp|] \n Sub Test() \n End Sub \n End Class"),
 count:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassFromReturnType()
             Test(
 NewLines("Class Foo \n Function F() As [|Bar|] \n End Function \n End Class"),
@@ -218,7 +218,7 @@ NewLines("Class Foo \n Function F() As Bar \n End Function \n End Class \n Publi
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateClassWhereKeywordBecomesTypeName()
             Test(
 NewLines("Class Foo \n Dim x As New [|[Class]|] \n End Class"),
@@ -226,7 +226,7 @@ NewLines("Class Foo \n Dim x As New [Class] \n End Class \n Friend Class [Class]
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub NegativeTestGenerateClassFromEscapedType()
             Test(
 NewLines("Class Foo \n Dim x as New [|[Bar]|] \n End Class"),
@@ -235,7 +235,7 @@ index:=1)
         End Sub
 
         <WorkItem(539716)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeIntoContainingNamespace()
             Test(
 NewLines("Namespace NS \n Class Foo \n Dim x As New NS.[|Bar|] \n End Class \n End Namespace"),
@@ -245,7 +245,7 @@ parseOptions:=Nothing) ' Namespaces not supported in script
         End Sub
 
         <WorkItem(539736)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeIntoContainingModule()
             Test(
 NewLines("Module M \n Dim x As [|C|] \n End Module"),
@@ -254,7 +254,7 @@ index:=2)
         End Sub
 
         <WorkItem(539737)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateInterfaceInImplementsStatement()
             Test(
 NewLines("Class C \n Implements [|D|] \n End Class"),
@@ -262,7 +262,7 @@ NewLines("Class C \n Implements D \n End Class \n Friend Interface D \n End Inte
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAbsenceOfGenerateIntoInvokingTypeForConstraintList()
             TestActionCount(
 NewLines("Class EmployeeList(Of T As [|Employee|]) \n End Class"),
@@ -270,7 +270,7 @@ count:=3,
 parseOptions:=TestOptions.Regular)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestMissingOnImportsDirective()
             TestMissing(
 NewLines("Imports [|System|]"))
@@ -285,33 +285,33 @@ expectedContainers:=Array.Empty(Of String)(),
 expectedDocumentName:="Derived.vb").ConfigureAwait(True)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNotOfferedInsideBinaryExpressions()
             TestMissing(
 NewLines("Class Base \n Sub Main \n Dim a = 1 + [|Foo|] \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNotOfferedIfLeftSideOfDotIsNotAName()
             TestMissing(
 NewLines("Module Program \n Sub Main(args As String()) \n Call 1.[|T|] \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNotOfferedIfLeftFromDotIsNotAName()
             TestMissing(
 NewLines("Class C1 \n Sub Foo \n Me.[|Foo|] = 3 \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(539786)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestMissingOnAssignedVariable()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n [|B|] = 10 \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(539757)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestArrayInference1()
             Test(
 NewLines("Class Base \n Sub Main \n Dim p() As Base = New [|Derived|](10) {} \n End Sub \n End Class"),
@@ -320,7 +320,7 @@ index:=1)
         End Sub
 
         <WorkItem(539757)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestArrayInference2()
             Test(
 NewLines("Class Base \n Sub Main \n Dim p As Base() = New [|Derived|](10) {} \n End Sub \n End Class"),
@@ -329,7 +329,7 @@ index:=1)
         End Sub
 
         <WorkItem(539757)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestArrayInference3()
             Test(
 NewLines("Class Base \n Sub Main \n Dim p As Base = New [|Derived|](10) {} \n End Sub \n End Class"),
@@ -338,7 +338,7 @@ index:=1)
         End Sub
 
         <WorkItem(539749)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestMatchWithDifferentArity()
             Test(
 NewLines("Class Program \n Private Sub Main() \n Dim f As [|Foo(Of Integer)|] \n End Sub \n End Class \n Class Foo \n End Class"),
@@ -347,7 +347,7 @@ index:=1)
         End Sub
 
         <WorkItem(540504)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNoUnavailableTypeParameters1()
             Test(
 NewLines("Class C(Of T1, T2) \n Sub M(x As T1, y As T2) \n Dim a As Test = New [|Test|](x, y) \n End Sub \n End Class"),
@@ -356,7 +356,7 @@ index:=1)
         End Sub
 
         <WorkItem(540534)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestMultipleTypeParamsInConstructor1()
             Test(
 NewLines("Class C(Of T1, T2) \n Sub M(x As T1, y As T2) \n Dim a As Test(Of T1, T2) = New [|Test(Of T1, T2)|](x, y) \n End Sub \n End Class"),
@@ -365,7 +365,7 @@ index:=1)
         End Sub
 
         <WorkItem(540644)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateWithVoidArg()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As C = New [|C|](M()) \n End Sub \n Sub M() \n End Sub \n End Module"),
@@ -374,7 +374,7 @@ index:=1)
         End Sub
 
         <WorkItem(539735)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestInAsClause()
             Test(
 NewLines("Class D \n Sub M() \n Dim x As New [|C|](4) \n End Sub \n End Class"),
@@ -382,14 +382,14 @@ NewLines("Class D \n Sub M() \n Dim x As New C(4) \n End Sub \n End Class \n Fri
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNotOnConstructorToActualType()
             TestMissing(
 NewLines("Class C \n Sub Test() \n Dim x As Integer = 1 \n Dim obj As New [|C|](x) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(540986)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateAttribute1()
             Test(
 NewLines("<[|AttClass|]()> \n Class C \n End Class"),
@@ -398,7 +398,7 @@ index:=1)
         End Sub
 
         <WorkItem(540986)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateAttribute2()
             Test(
 NewLines("Imports System \n <[|AttClass|]()> \n Class C \n End Class"),
@@ -407,14 +407,14 @@ index:=1)
         End Sub
 
         <WorkItem(541607)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNotOnDictionaryAccess()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections \n Imports System.Collections.Generic \n Public Class A \n Public Sub Foo() \n Dim Table As Hashtable = New Hashtable() \n Table![|Orange|] = ""A fruit"" \n Table(""Broccoli"") = ""A vegetable"" \n Console.WriteLine(Table!Orange) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(542392)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityConstraint1()
             Test(
 NewLines("Imports System.Runtime.CompilerServices \n Module StringExtensions \n <Extension()> \n Public Sub Print(ByVal aString As String, x As [|C|]) \n Console.WriteLine(aString) \n End Sub \n End Module"),
@@ -423,7 +423,7 @@ index:=2)
         End Sub
 
         <WorkItem(542836)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNewLineAfterNestedType()
             Test(
 <Text>Class A
@@ -446,7 +446,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(543290)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNestedType()
             Test(
 NewLines("Option Explicit Off \n Module Program \n Sub Main(args As String()) \n Dim i = 2 \n Dim r As New i.[|Extension|] \n End Sub \n Public Class i \n End Class \n End Module"),
@@ -454,14 +454,14 @@ NewLines("Option Explicit Off \n Module Program \n Sub Main(args As String()) \n
         End Sub
 
         <WorkItem(543397)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestNewModule()
             TestMissing(
 NewLines("Module Program \n Sub Main \n Dim f As New [|Program|] \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(545363)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestInHiddenNamespace1()
             TestExactActionSetOffered(
 <text>
@@ -477,7 +477,7 @@ End Class
         End Sub
 
         <WorkItem(545363)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestInHiddenNamespace2()
             TestExactActionSetOffered(
 <text>
@@ -498,7 +498,7 @@ String.Format(FeaturesResources.Generate_nested_0_1, "class", "Foo"), FeaturesRe
         End Sub
 
         <WorkItem(545363)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestInHiddenNamespace3()
             Test(
 <text>
@@ -534,7 +534,7 @@ index:=1)
         End Sub
 
         <WorkItem(546852)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAnonymousMethodArgument()
             Test(
 NewLines("Module Program \n Sub Main() \n Dim c = New [|C|](Function() x) \n End Sub \n End Module"),
@@ -543,7 +543,7 @@ index:=1)
         End Sub
 
         <WorkItem(546851)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestOmittedArguments()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n Dim x = New [|C|](,) \n End Sub \n End Module"),
@@ -552,7 +552,7 @@ index:=1)
         End Sub
 
         <WorkItem(1003618)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub GenerateTypeThatBindsToNamespace()
             Test(
 NewLines("Imports System \n [|<System>|] \n Module Program \n Sub Main() \n End Sub \n End Module"),
@@ -561,7 +561,7 @@ index:=1)
         End Sub
 
         <WorkItem(821277)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestTooFewTypeArgument()
             Test(
 <text>
@@ -592,7 +592,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(821277)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestTooMoreTypeArgument()
             Test(
 <text>
@@ -623,7 +623,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub GenerateTypeWithPreferIntrinsicPredefinedKeywordFalse()
             Test(
 <text>
@@ -654,7 +654,7 @@ options:=New Dictionary(Of OptionKey, Object) From {{New OptionKey(Simplificatio
         End Sub
 
         <WorkItem(869506)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeOutsideCurrentProject()
             Dim initial = <Workspace>
                               <Project Language="Visual Basic" AssemblyName="Assembly1" CommonReferences="true">
@@ -690,7 +690,7 @@ End Namespace</Text>.NormalizedValue
         End Sub
 
         <WorkItem(940003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestWithProperties1()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n  Dim c As New [|Customer|](x:=1, y:=""Hello"") With {.Name = ""John"", .Age = Date.Today} \n End Sub \n End Module"),
@@ -699,7 +699,7 @@ index:=1)
         End Sub
 
         <WorkItem(940003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestWithProperties2()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n  Dim c As New [|Customer|](x:=1, y:=""Hello"") With {.Name = Nothing, .Age = Date.Today} \n End Sub \n End Module"),
@@ -708,7 +708,7 @@ index:=1)
         End Sub
 
         <WorkItem(940003)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestWithProperties3()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n  Dim c As New [|Customer|](x:=1, y:=""Hello"") With {.Name = Foo, .Age = Date.Today} \n End Sub \n End Module"),
@@ -717,7 +717,7 @@ index:=1)
         End Sub
 
         <WorkItem(1082031)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestWithProperties4()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n  Dim c As New [|Customer|] With {.Name = ""John"", .Age = Date.Today} \n End Sub \n End Module"),
@@ -726,7 +726,7 @@ index:=1)
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestWithNameOf()
             Test(
 NewLines("Imports System \n Module Program \n Sub Main() \n  Dim x = nameof([|Z|]) \n End Sub \n End Module"),
@@ -735,7 +735,7 @@ index:=1)
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestWithNameOf2()
             Test(
 NewLines("Imports System \n Class Program \n Sub Main() \n  Dim x = nameof([|Z|]) \n End Sub \n End Class"),
@@ -744,7 +744,7 @@ index:=2)
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestWithNameOf3()
             Test(
 NewLines("Imports System \n Class Program \n Sub Main() \n  Dim x = nameof([|Program.Z|]) \n End Sub \n End Class"),
@@ -753,7 +753,7 @@ index:=0)
         End Sub
 
         <WorkItem(1065647)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForNestedType()
             Test(
 NewLines("Public Interface I \n  Sub Foo(a As [|X.Y.Z|]) \n End Interface \n Public Class X \n End Class"),
@@ -762,7 +762,7 @@ index:=0)
         End Sub
 
         <WorkItem(1130905)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeInImports()
             Test(
 NewLines("Imports [|Fizz|]"),
@@ -770,7 +770,7 @@ NewLines("Friend Class Fizz\nEnd Class\n"))
         End Sub
 
         <WorkItem(1130905)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestGenerateTypeInImports2()
             Test(
 NewLines("Imports [|Fizz|]"),
@@ -779,7 +779,7 @@ index:=1)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields()
             Test(
 NewLines("Public Class A \n Public B As New [|B|]() \n End Class"),
@@ -788,7 +788,7 @@ index:=0)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields2()
             Test(
 NewLines("Public Class A \n Public B As New [|B|]() \n End Class"),
@@ -797,7 +797,7 @@ index:=1)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields3()
             Test(
 NewLines("Public Class A \n Public B As New [|B|]() \n End Class"),
@@ -806,7 +806,7 @@ index:=2)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields4()
             Test(
 NewLines("Public Class A \n Public B As New [|B|] \n End Class"),
@@ -815,7 +815,7 @@ index:=0)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields5()
             Test(
 NewLines("Public Class A \n Public B As New [|B|] \n End Class"),
@@ -824,7 +824,7 @@ index:=1)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields6()
             Test(
 NewLines("Public Class A \n Public B As New [|B|] \n End Class"),
@@ -833,7 +833,7 @@ index:=2)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields7()
             Test(
 NewLines("Public Class A \n Public B As New [|B(Of Integer)|] \n End Class"),
@@ -842,7 +842,7 @@ index:=0)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields8()
             Test(
 NewLines("Public Class A \n Public B As New [|B(Of Integer)|] \n End Class"),
@@ -851,7 +851,7 @@ index:=1)
         End Sub
 
         <WorkItem(1107929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)>
         Public Sub TestAccessibilityForPublicFields9()
             Test(
 NewLines("Public Class A \n Public B As New [|B(Of Integer)|] \n End Class"),
@@ -873,7 +873,7 @@ index:=2)
             End Function
 
             <WorkItem(829970)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
                 Test(
 NewLines("Module Program \n <[|Extension|]> \n End Module"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -13,14 +13,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New GenerateVariableCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateSimpleProperty()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Bar|]) \n End Sub \n End Module"),
 NewLines("Module Program \n Public Property Bar As Object \n Sub Main(args As String()) \n Foo(Bar) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateSimpleField()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Bar|]) \n End Sub \n End Module"),
@@ -28,7 +28,7 @@ NewLines("Module Program \n Private Bar As Object \n Sub Main(args As String()) 
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateReadOnlyField()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|Bar|]) \n End Sub \n End Module"),
@@ -37,7 +37,7 @@ index:=2)
         End Sub
 
         <WorkItem(539692)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFromAssignment()
             Test(
 NewLines("Class C \n Shared Sub M \n [|Foo|] = 3 \n End Sub \n End Class"),
@@ -46,7 +46,7 @@ index:=1)
         End Sub
 
         <WorkItem(539694)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateReadOnlyProperty()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim i As IFoo \n Main(i.[|Blah|]) \n End Sub \n End Module \n Interface IFoo \n End Interface"),
@@ -55,7 +55,7 @@ index:=1)
         End Sub
 
         <WorkItem(539695)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateProtectedSharedFieldIntoBase()
             Test(
 NewLines("Class Base \n End Class \n Class Derived \n Inherits Base \n Shared Sub Main \n Dim a = Base.[|Foo|] \n End Sub \n End Class"),
@@ -63,13 +63,13 @@ NewLines("Class Base \n Protected Shared Foo As Object \n End Class \n Class Der
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestNotOfferedForSharedAccessOffInterface()
             TestMissing(
 NewLines("Interface IFoo \n End Interface \n Class Program \n Sub Main \n IFoo.[|Bar|] = 3 \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFriendAccessibilityForField()
             Test(
 NewLines("Class A \n End Class \n Class B \n Sub Main \n Dim x = A.[|Foo|] \n End Sub \n End Class"),
@@ -77,7 +77,7 @@ NewLines("Class A \n Friend Shared Foo As Object \n End Class \n Class B \n Sub 
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyOnInterface()
             Test(
 NewLines("Interface IFoo \n End Interface \n Class C \n Sub Main \n Dim foo As IFoo \n Dim b = foo.[|Bar|] \n End Sub \n End Class"),
@@ -85,7 +85,7 @@ NewLines("Interface IFoo \n Property Bar As Object \n End Interface \n Class C \
         End Sub
 
         <WorkItem(539796)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyIntoModule()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n End Sub \n End Module \n Class C \n Sub M() \n Program.[|P|] = 10 \n End Sub \n End Class"),
@@ -93,7 +93,7 @@ NewLines("Module Program \n Public Property P As Integer \n Sub Main(args As Str
         End Sub
 
         <WorkItem(539796)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestFieldPropertyIntoModule()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n End Sub \n End Module \n Class C \n Sub M() \n [|Program.P|] = 10 \n End Sub \n End Class"),
@@ -102,7 +102,7 @@ index:=1)
         End Sub
 
         <WorkItem(539848)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestOnLeftOfMemberAccess()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|HERE|].ToString() \n End Sub \n End Module"),
@@ -111,21 +111,21 @@ index:=1)
         End Sub
 
         <WorkItem(539725)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestMissingWhenInterfacePropertyAlreadyExists()
             TestMissing(
 NewLines("Interface IFoo \n Property Blah As String() \n End Interface \n Module Program \n Sub Main(args As String()) \n Dim foo As IFoo \n Main(foo.[|Blah|]) \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(540013)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestMissingInAddressOf()
             TestMissing(
 NewLines("Delegate Sub D(x As Integer) \n Class C \n Public Sub Foo() \n Dim x As D = New D(AddressOf [|Method|]) \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(540578)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInferProperReturnType()
             Test(
 NewLines("Module Program \n Function Fun() As Integer \n Return [|P|] \n End Function \n End Module"),
@@ -133,77 +133,77 @@ NewLines("Module Program \n Public Property P As Integer \n Function Fun() As In
         End Sub
 
         <WorkItem(540576)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestAssignment()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As Integer \n x = [|P|] \n End Sub \n End Module"),
 NewLines("Module Program \n Public Property P As Integer \n Sub Main(args As String()) \n Dim x As Integer \n x = P \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFromSharedMethod()
             Test(
 NewLines("Class GenPropTest \n Public Shared Sub Main() \n [|genStaticUnqualified|] = """" \n End Sub \n End Class"),
 NewLines("Class GenPropTest \n Private Shared genStaticUnqualified As String \n Public Shared Sub Main() \n genStaticUnqualified = """" \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateSharedField()
             Test(
 NewLines("Class GenPropTest \n Public Sub Main() \n GenPropTest.[|genStaticUnqualified|] = """" \n End Sub \n End Class"),
 NewLines("Class GenPropTest \n Private Shared genStaticUnqualified As String \n Public Sub Main() \n GenPropTest.genStaticUnqualified = """" \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateInstanceFieldOffMe()
             Test(
 NewLines("Class GenPropTest \n Public Sub Main() \n Me.[|field|] = """" \n End Sub \n End Class"),
 NewLines("Class GenPropTest \n Private field As String \n Public Sub Main() \n Me.field = """" \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestSimpleInstanceField()
             Test(
 NewLines("Class GenPropTest \n Public Sub Main() \n [|field|] = """" \n End Sub \n End Class"),
 NewLines("Class GenPropTest \n Private field As String \n Public Sub Main() \n field = """" \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestFieldOnByRefParam()
             Test(
 NewLines("Class A \n End Class \n Class B \n Public Sub Foo(ByRef d As Integer) \n End Sub \n Public Sub Bar() \n Dim s As New A() \n Foo(s.[|field|]) \n End Sub \n End Class"),
 NewLines("Class A \n Friend field As Integer \n End Class \n Class B \n Public Sub Foo(ByRef d As Integer) \n End Sub \n Public Sub Bar() \n Dim s As New A() \n Foo(s.field) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestOnlyGenerateFieldInByRefProperty()
             TestExactActionSetOffered(
 NewLines("Class A \n End Class \n Class B \n Public Sub Foo(ByRef d As Integer) \n End Sub \n Public Sub Bar() \n Dim s As New A() \n Foo(s.[|field|]) \n End Sub \n End Class"),
 {String.Format(FeaturesResources.GenerateFieldIn, "field", "A")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldIsFirstWithLowerCase()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|field|] = 5 \n End Sub \n End Module"),
 NewLines("Module Program \n Private field As Integer \n Sub Main(args As String()) \n field = 5 \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyIsFirstWithUpperCase()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|Field|] = 5 \n End Sub \n End Module"),
 NewLines("Module Program \n Public Property Field As Integer \n Sub Main(args As String()) \n Field = 5 \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestNestedTypesAndInference()
             Test(
 NewLines("Imports System.Collections.Generic \n Class A \n Sub Main() \n Dim field As List(Of C) = B.[|C|] \n End Sub \n End Class \n Class B \n End Class \n Class C \n End Class"),
 NewLines("Imports System.Collections.Generic \n Class A \n Sub Main() \n Dim field As List(Of C) = B.C \n End Sub \n End Class \n Class B \n Public Shared Property C As List(Of C) \n End Class \n Class C \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestTypeInferenceWithGenerics1()
             Test(
 NewLines("Class A \n Sub Main() \n [|field|] = New C(Of B) \n End Sub \n End Class \n Class B \n End Class \n Class C(Of T) \n End Class"),
@@ -211,35 +211,35 @@ NewLines("Class A \n Private field As C(Of B) \n Sub Main() \n field = New C(Of 
         End Sub
 
         <WorkItem(540693)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestErrorType()
             Test(
 NewLines("Class A \n Sub Main() \n Dim field As List(Of C) = B.[|C|] \n End Sub \n End Class \n Class B \n End Class \n Class C(Of B) \n End Class"),
 NewLines("Class A \n Sub Main() \n Dim field As List(Of C) = B.C \n End Sub \n End Class \n Class B \n Public Shared Property C As List \n End Class \n Class C(Of B) \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestTypeParameter()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Sub Foo(Of T) \n [|z|] = GetType(T) \n End Sub \n End Class"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Private z As Type \n Sub Foo(Of T) \n z = GetType(T) \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInterfaceProperty()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Public Property X As Integer Implements [|IFoo.X|] \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n End Interface"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Public Property X As Integer Implements IFoo.X \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n Property X As Integer \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateEscapedKeywords()
             Test(
 NewLines("Class [Class] \n Private Sub Method(i As Integer) \n [|[Enum]|] = 5 \n End Sub \n End Class"),
 NewLines("Class [Class] \n Public Property [Enum] As Integer \n Private Sub Method(i As Integer) \n [Enum] = 5 \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateEscapedKeywords2()
             Test(
 NewLines("Class [Class] \n Private Sub Method(i As Integer) \n [|[Enum]|] = 5 \n End Sub \n End Class"),
@@ -248,28 +248,28 @@ index:=1)
         End Sub
 
         <WorkItem(528229)>
-        <WpfFact(Skip:="528229"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(Skip:="528229"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestRefLambda()
             Test(
 NewLines("Class [Class] \n Private Sub Method() \n [|test|] = Function(ByRef x As Integer) InlineAssignHelper(x, 10) \n End Sub \n Private Shared Function InlineAssignHelper(Of T)(ByRef target As T, value As T) As T \n target = value \n Return value \n End Function \n End Class"),
 NewLines("Class [Class] \n Private test As Object \n Private Sub Method() \n test = Function(ByRef x As Integer) InlineAssignHelper(x, 10) \n End Sub \n Private Shared Function InlineAssignHelper(Of T)(ByRef target As T, value As T) As T \n target = value \n Return value \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestPropertyParameters1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Public Property Item1(i As Integer) As String Implements [|IFoo.Item1|] \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As String) \n Throw New NotImplementedException() \n End Set \n End Property \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n ' Default Property Item(i As Integer) As String \n End Interface"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Public Property Item1(i As Integer) As String Implements IFoo.Item1 \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As String) \n Throw New NotImplementedException() \n End Set \n End Property \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n Property Item1(i As Integer) As String \n ' Default Property Item(i As Integer) As String \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestPropertyParameters2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Public Property Item1(i As Integer) As String Implements [|IFoo.Item1|] \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As String) \n Throw New NotImplementedException() \n End Set \n End Property \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n ' Default Property Item(i As Integer) As String \n End Interface"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Public Property Item1(i As Integer) As String Implements IFoo.Item1 \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As String) \n Throw New NotImplementedException() \n End Set \n End Property \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n Property Item1(i As Integer) As String \n ' Default Property Item(i As Integer) As String \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestDefaultProperty1()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Default Public Property Item(i As Integer) As String Implements [|IFoo.Item|] \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As String) \n Throw New NotImplementedException() \n End Set \n End Property \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n ' Default Property Item(i As Integer) As String \n End Interface"),
@@ -277,7 +277,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(540703)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestDefaultProperty2()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Class A \n Implements IFoo \n Default Public Property Item(i As Integer) As String Implements [|IFoo.Item|] \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As String) \n Throw New NotImplementedException() \n End Set \n End Property \n Sub Bar() \n End Sub \n End Class \n Interface IFoo \n ' Default Property Item(i As Integer) As String \n End Interface"),
@@ -285,7 +285,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(540737)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestErrorInGenericType()
             Test(
 NewLines("Imports System.Collections.Generic \n Class A \n Sub Main() \n Dim field As List(Of C) = B.[|C|] \n End Sub \n End Class \n Class B \n End Class \n Class C(Of T) \n End Class"),
@@ -293,7 +293,7 @@ NewLines("Imports System.Collections.Generic \n Class A \n Sub Main() \n Dim fie
         End Sub
 
         <WorkItem(542241)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestFieldWithAnonymousTypeType()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n [|a|] = New With {.a =., .b = 1} \n End Sub \n End Module"),
@@ -301,7 +301,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
         End Sub
 
         <WorkItem(542395)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestUnqualifiedModuleMethod1()
             Test(
 NewLines("Imports System.Runtime.CompilerServices \n Module StringExtensions \n Public Sub Print(ByVal aString As String) \n Console.WriteLine(aString) \n End Sub \n End Module \n Module M \n Sub Main() \n Print([|s|]) \n End Sub \n End Module"),
@@ -310,7 +310,7 @@ parseOptions:=Nothing) ' TODO (tomat): Modules nested in Script class not suppor
         End Sub
 
         <WorkItem(542395)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestUnqualifiedModuleMethod2()
             Test(
 NewLines("Imports System.Runtime.CompilerServices \n Module StringExtensions \n <Extension()> \n Public Sub Print(ByVal aString As String) \n Console.WriteLine(aString) \n End Sub \n End Module \n Module M \n Sub Main() \n Print([|s|]) \n End Sub \n End Module"),
@@ -319,7 +319,7 @@ parseOptions:=Nothing) ' TODO (tomat): Modules nested in Script class not suppor
         End Sub
 
         <WorkItem(542942)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInsideLambda()
             Test(
 NewLines("Module P \n Sub M() \n Dim t As System.Action = Sub() \n [|P.Foo|] = 5 \n End Sub \n End Sub \n End Module"),
@@ -327,7 +327,7 @@ NewLines("Module P \n Public Property Foo As Integer \n Sub M() \n Dim t As Syst
         End Sub
 
         <WorkItem(544632)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestMissingOnForEachExpression()
             TestMissing(
 <Text>
@@ -358,21 +358,21 @@ End Module
 </Text>.Value)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestLeftOfBinaryExpression()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Main([|a|] + b) \n End Sub \n End Module"),
 NewLines("Module Program \n Private a As Integer \n Sub Main(args As String()) \n Main(a + b) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestRightOfBinaryExpression()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Main(a + [|b|]) \n End Sub \n End Module"),
 NewLines("Module Program \n Private b As Integer \n Sub Main(args As String()) \n Main(a + b) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateLocal()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Foo([|bar|]) \n End Sub \n End Module"),
@@ -380,7 +380,7 @@ NewLines("Module Program \n Private bar As Object \n Sub Main(args As String()) 
         End Sub
 
         <WorkItem(809542)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateLocalBeforeComment()
             Test(
 "Imports System
@@ -407,7 +407,7 @@ End Module", index:=1)
         End Sub
 
         <WorkItem(809542)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateLocalAfterComment()
             Test(
 "Imports System
@@ -435,7 +435,7 @@ End Module", index:=1)
         End Sub
 
         <WorkItem(545218)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestTypeForLocal()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n foo([|xyz|]) \n End Sub \n Sub foo(x As Integer) \n End Sub \n End Module"),
@@ -443,7 +443,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim xyz As Integer = N
 index:=3)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInSelect()
             Test(
 NewLines("Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim q = From a In args \n Select [|v|] \n End Sub \n End Module"),
@@ -451,7 +451,7 @@ NewLines("Imports System.Linq \n Module Program \n Private v As Object \n Sub Ma
         End Sub
 
         <WorkItem(545400)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateLocalInIfPart()
             Test(
 NewLines("Module Program \n Sub Main() \n If ([|a|] Mod b <> 0) Then \n End If \n End Sub \n End Module"),
@@ -460,14 +460,14 @@ index:=3)
         End Sub
 
         <WorkItem(545672)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestCrashOnAggregateSelect()
             TestMissing(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim q2 = From j In {1} Select j Aggregate i In {1} \n Select [|i|] Into Count(), Sum(i) Select Count, Sum, j \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(546753)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestAddressOf()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n [|d|] = AddressOf test \n End Sub \n Public Function test() As String \n Return ""hello"" \n End Function \n End Module"),
@@ -475,27 +475,27 @@ NewLines("Imports System \n Module Program \n Private d As Func(Of String) \n Su
         End Sub
 
         <WorkItem(530756)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestMissingOnDictionaryAccess1()
             TestMissing(
 NewLines("Imports System.Collections \n  \n Module Program \n Sub Foo() \n Dim x = New Hashtable![|Foo|]!Bar \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(530756)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestMissingOnDictionaryAccess2()
             TestMissing(
 NewLines("Imports System.Collections \n  \n Module Program \n Sub Foo() \n Dim x = New Hashtable!Foo![|Bar|] \n End Sub \n End Module"))
         End Sub
 
         <WorkItem(530756)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestMissingOnDictionaryAccess3()
             TestMissing(
 NewLines("Imports System.Collections \n  \n Module Program \n Sub Foo() \n Dim x = New Hashtable![|Foo!Bar|] \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestFormattingInGenerateVariable()
             Test(
 <Text>Module Program
@@ -517,7 +517,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(666189)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyInScript()
             Test(
 <Text>Dim x As Integer
@@ -529,7 +529,7 @@ parseOptions:=New VisualBasicParseOptions(kind:=SourceCodeKind.Script),
 compareTokens:=False)
         End Sub
         <WorkItem(666189)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInScript()
             Test(
 <Text>Dim x As Integer
@@ -543,7 +543,7 @@ index:=1)
         End Sub
 
         <WorkItem(977580)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestWithThrow()
             Test(
 NewLines("Imports System \n Public Class A \n Public Sub B() \n Throw [|MyExp|] \n End Sub \n End Class"),
@@ -551,7 +551,7 @@ NewLines("Imports System \n Public Class A \n Private MyExp As Exception \n Publ
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInsideNameOfProperty()
             Test(
 NewLines("Imports System \n Class C \n Sub M() \n Dim x = NameOf ([|Z|]) \n End Sub \n End Class"),
@@ -559,7 +559,7 @@ NewLines("Imports System \n Class C \n Public Property Z As Object \n Sub M() \n
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInsideNameOfField()
             Test(
 NewLines("Imports System \n Class C \n Sub M() \n Dim x = NameOf ([|Z|]) \n End Sub \n End Class"),
@@ -567,7 +567,7 @@ NewLines("Imports System \n Class C \n Private Z As Object \n Sub M() \n Dim x =
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInsideNameOfReadonlyField()
             Test(
 NewLines("Imports System \n Class C \n Sub M() \n Dim x = NameOf ([|Z|]) \n End Sub \n End Class"),
@@ -575,7 +575,7 @@ NewLines("Imports System \n Class C \n Private ReadOnly Z As Object \n Sub M() \
         End Sub
 
         <WorkItem(1032176)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInsideNameOfLocal()
             Test(
 NewLines("Imports System \n Class C \n Sub M() \n Dim x = NameOf ([|Z|]) \n End Sub \n End Class"),
@@ -583,7 +583,7 @@ NewLines("Imports System \n Class C \n Sub M() \n Dim Z As Object = Nothing \n D
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessProperty()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B|] \n End Sub \n End Class"),
@@ -591,7 +591,7 @@ NewLines("Public Class C \n Public Property B As C \n Sub Main(a As C) \n Dim x 
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessProperty2()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B|] \n End Sub \n End Class"),
@@ -599,7 +599,7 @@ NewLines("Public Class C \n Public Property B As Object \n Sub Main(a As C) \n D
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessProperty3()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B|] \n End Sub \n End Class"),
@@ -607,7 +607,7 @@ NewLines("Public Class C \n Public Property B As Integer \n Sub Main(a As C) \n 
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessProperty4()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C? = a?[|.B|] \n End Sub \n End Class"),
@@ -615,7 +615,7 @@ NewLines("Public Class C \n Public Property B As C \n Sub Main(a As C) \n Dim x 
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessField()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B|] \n End Sub \n End Class"),
@@ -624,7 +624,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessField2()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B|] \n End Sub \n End Class"),
@@ -633,7 +633,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessField3()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B|] \n End Sub \n End Class"),
@@ -642,7 +642,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessField4()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C? = a?[|.B|] \n End Sub \n End Class"),
@@ -651,7 +651,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyField()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B|] \n End Sub \n End Class"),
@@ -660,7 +660,7 @@ index:=2)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyField2()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B|] \n End Sub \n End Class"),
@@ -669,7 +669,7 @@ index:=2)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyField3()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B|] \n End Sub \n End Class"),
@@ -678,7 +678,7 @@ index:=2)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyField4()
             Test(
 NewLines("Public Class C \n Sub Main(a As C) \n Dim x As C? = a?[|.B|] \n End Sub \n End Class"),
@@ -687,7 +687,7 @@ index:=2)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessPropertyInsideReferencedClass()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -695,7 +695,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessPropertyInsideReferencedClass2()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -703,7 +703,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integ
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessPropertyInsideReferencedClass3()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -711,7 +711,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integ
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessPropertyInsideReferencedClass4()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -719,7 +719,7 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?.B.Z
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessFieldInsideReferencedClass()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -728,7 +728,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessFieldInsideReferencedClass2()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -737,7 +737,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessFieldInsideReferencedClass3()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -746,7 +746,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessFieldInsideReferencedClass4()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -755,7 +755,7 @@ index:=1)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyFieldInsideReferencedClass()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As C = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -764,7 +764,7 @@ index:=2)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyFieldInsideReferencedClass2()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -773,7 +773,7 @@ index:=2)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyFieldInsideReferencedClass3()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x As Integer? = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -782,7 +782,7 @@ index:=2)
         End Sub
 
         <WorkItem(1064815)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestConditionalAccessReadOnlyFieldInsideReferencedClass4()
             Test(
 NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?[|.B.Z|] \n End Sub \n Private Function B() As D \n Throw New NotImplementedException() \n End Function \n Private Class D \n End Class \n End Class"),
@@ -790,14 +790,14 @@ NewLines("Imports System \n Public Class C \n Sub Main(a As C) \n Dim x = a?.B.Z
 index:=2)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyInPropertyInitializer()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Property a As Integer = [|y|] \n End Module"),
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Private y As Integer \n Property a As Integer = y \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInPropertyInitializer()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Property a As Integer = [|y|] \n End Module"),
@@ -805,7 +805,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateReadonlyFieldInPropertyInitializer()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Property a As Integer = [|y|] \n End Module"),
@@ -813,21 +813,21 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=2)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyInObjectInitializer1()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.[|Name|] = ""blah""} \n End Sub \n End Module \n Friend Class Customer \n End Class"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.Name = ""blah""} \n End Sub \n End Module \n Friend Class Customer \n Public Property Name As String \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyInObjectInitializer2()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.Name = ""blah"", .[|Age|] = blah} \n End Sub \n End Module \n Friend Class Customer \n Public Property Name As String \n End Class"),
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.Name = ""blah"", .Age = blah} \n End Sub \n End Module \n Friend Class Customer \n Public Property Age As Object \n Public Property Name As String \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyInObjectInitializer3()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.Name = [|name|]} \n End Sub \n End Module \n Friend Class Customer \n End Class"),
@@ -835,7 +835,7 @@ NewLines("Module Program \n Public Property name As Object \n Sub Main(args As S
 index:=2)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInObjectInitializer1()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.[|Name|] = ""blah""} \n End Sub \n End Module \n Friend Class Customer \n End Class"),
@@ -843,7 +843,7 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer 
 index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInObjectInitializer2()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.[|Name|] = name} \n End Sub \n End Module \n Friend Class Customer \n End Class"),
@@ -851,27 +851,27 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer 
 index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInObjectInitializer3()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.Name = [|name|]} \n End Sub \n End Module \n Friend Class Customer \n End Class"),
 NewLines("Module Program \n Private name As Object \n Sub Main(args As String()) \n Dim x As New Customer With {.Name = name} \n End Sub \n End Module \n Friend Class Customer \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestInvalidObjectInitializer()
             TestMissing(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With { [|Name|] = ""blkah""} \n End Sub \n End Module \n Friend Class Customer \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestOnlyPropertyAndFieldOfferedForObjectInitializer()
             TestActionCount(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.[|Name|] = ""blah""} \n End Sub \n End Module \n Friend Class Customer \n End Class"),
 2)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateLocalInObjectInitializerValue()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n Dim x As New Customer With {.Name = [|blah|]} \n End Sub \n End Module \n Friend Class Customer \n End Class"),
@@ -879,14 +879,14 @@ NewLines("Module Program \n Sub Main(args As String()) \n Dim blah As Object = N
 index:=3)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGeneratePropertyInTypeOf()
             Test(
 NewLines("Module C \n Sub Test() \n If TypeOf [|B|] Is String Then \n End If \n End Sub \n End Module"),
 NewLines("Module C \n Public Property B As String \n Sub Test() \n If TypeOf B Is String Then \n End If \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInTypeOf()
             Test(
 NewLines("Module C \n Sub Test() \n If TypeOf [|B|] Is String Then \n End If \n End Sub \n End Module"),
@@ -894,7 +894,7 @@ NewLines("Module C \n Private B As String \n Sub Test() \n If TypeOf B Is String
 index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateReadOnlyFieldInTypeOf()
             Test(
 NewLines("Module C \n Sub Test() \n If TypeOf [|B|] Is String Then \n End If \n End Sub \n End Module"),
@@ -902,7 +902,7 @@ NewLines("Module C \n Private ReadOnly B As String \n Sub Test() \n If TypeOf B 
 index:=2)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateLocalInTypeOf()
             Test(
 NewLines("Module C \n Sub Test() \n If TypeOf [|B|] Is String Then \n End If \n End Sub \n End Module"),
@@ -911,7 +911,7 @@ index:=3)
         End Sub
 
         <WorkItem(1130960)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
         Public Sub TestGeneratePropertyInTypeOfIsNot()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub M() \n If TypeOf [|Prop|] IsNot TypeOfIsNotDerived Then \n End If \n End Sub \n End Module"),
@@ -920,7 +920,7 @@ index:=0)
         End Sub
 
         <WorkItem(1130960)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateFieldInTypeOfIsNot()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub M() \n If TypeOf [|Prop|] IsNot TypeOfIsNotDerived Then \n End If \n End Sub \n End Module"),
@@ -929,7 +929,7 @@ index:=1)
         End Sub
 
         <WorkItem(1130960)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateReadOnlyFieldInTypeOfIsNot()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub M() \n If TypeOf [|Prop|] IsNot TypeOfIsNotDerived Then \n End If \n End Sub \n End Module"),
@@ -938,7 +938,7 @@ index:=2)
         End Sub
 
         <WorkItem(1130960)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateLocalInTypeOfIsNot()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub M() \n If TypeOf [|Prop|] IsNot TypeOfIsNotDerived Then \n End If \n End Sub \n End Module"),
@@ -946,7 +946,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=3)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateVariableFromLambda()
             Test(
 NewLines("Class [Class] \n Private Sub Method(i As Integer) \n [|foo|] = Function() \n Return 2 \n End Function \n End Sub \n End Class"),
@@ -954,7 +954,7 @@ NewLines("Imports System\n\nClass [Class]\n    Private foo As Func(Of Integer)\n
 index:=0)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateVariableFromLambda2()
             Test(
 NewLines("Class [Class] \n Private Sub Method(i As Integer) \n [|foo|] = Function() \n Return 2 \n End Function \n End Sub \n End Class"),
@@ -962,7 +962,7 @@ NewLines("Imports System\n\nClass [Class]\n    Public Property foo As Func(Of In
 index:=1)
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
         Public Sub TestGenerateVariableFromLambda3()
             Test(
 NewLines("Class [Class] \n Private Sub Method(i As Integer) \n [|foo|] = Function() \n Return 2 \n End Function \n End Sub \n End Class"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests.vb
@@ -14,105 +14,105 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Implem
                 Nothing, New ImplementAbstractClassCodeFixProvider)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestSimpleCases()
             Test(
                 NewLines("Public MustInherit Class Foo \n Public MustOverride Sub Foo(i As Integer) \n Protected MustOverride Function Bar(s As String, ByRef d As Double) As Boolean \n End Class \n Public Class [|Bar|] \n Inherits Foo \n End Class"),
                 NewLines("Imports System \n Public MustInherit Class Foo \n Public MustOverride Sub Foo(i As Integer) \n Protected MustOverride Function Bar(s As String, ByRef d As Double) As Boolean \n End Class \n Public Class Bar \n Inherits Foo \n Public Overrides Sub Foo(i As Integer) \n Throw New NotImplementedException() \n End Sub \n Protected Overrides Function Bar(s As String, ByRef d As Double) As Boolean \n Throw New NotImplementedException() \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalIntParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Integer = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Integer = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Integer = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalTrueParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Boolean = True) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Boolean = True) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Boolean = True) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalFalseParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Boolean = False) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Boolean = False) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Boolean = False) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalStringParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As String = ""a"") \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As String = ""a"") \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As String = ""a"") \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalCharParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Char = ""c""c) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Char = ""c""c) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Char = ""c""c) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalLongParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Long = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Long = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Long = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalShortParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Short = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Short = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Short = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalUShortParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As UShort = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As UShort = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As UShort = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalNegativeIntParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Integer = -3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Integer = -3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Integer = -3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalUIntParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As UInteger = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As UInteger = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As UInteger = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalULongParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As ULong = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As ULong = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As ULong = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalDecimalParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Decimal = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Decimal = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Decimal = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalDoubleParameter()
             Test(
                 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Double = 3) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
                 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Double = 3) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Double = 3) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalStructParameter()
             Test(
                 NewLines("Structure S \n End Structure \n MustInherit Class b \n Public MustOverride Sub g(Optional x As S = Nothing) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
@@ -120,7 +120,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Implem
         End Sub
 
         <WorkItem(916114)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalNullableStructParameter()
             Test(
 NewLines("Structure S \n End Structure \n MustInherit Class b \n Public MustOverride Sub g(Optional x As S? = Nothing) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
@@ -128,14 +128,14 @@ NewLines("Imports System \n Structure S \n End Structure \n MustInherit Class b 
         End Sub
 
         <WorkItem(916114)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalNullableIntParameter()
             Test(
 NewLines("MustInherit Class b \n Public MustOverride Sub g(Optional x As Integer? = Nothing, Optional y As Integer? = 5) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
 NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Optional x As Integer? = Nothing, Optional y As Integer? = 5) \n End Class \n Class c \n Inherits b \n Public Overrides Sub g(Optional x As Integer? = Nothing, Optional y As Integer? = 5) \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestOptionalClassParameter()
             Test(
                 NewLines("Class S \n End Class \n MustInherit Class b \n Public MustOverride Sub g(Optional x As S = Nothing) \n End Class \n Class [|c|] \n Inherits b \n End Class"),
@@ -143,7 +143,7 @@ NewLines("Imports System \n MustInherit Class b \n Public MustOverride Sub g(Opt
         End Sub
 
         <WorkItem(544641)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestClassStatementTerminators1()
             Test(
 NewLines("Imports System \n MustInherit Class D \n MustOverride Sub Foo() \n End Class \n Class [|C|] : Inherits D : End Class"),
@@ -151,7 +151,7 @@ NewLines("Imports System \n MustInherit Class D \n MustOverride Sub Foo() \n End
         End Sub
 
         <WorkItem(544641)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestClassStatementTerminators2()
             Test(
 NewLines("Imports System \n MustInherit Class D \n MustOverride Sub Foo() \n End Class \n Class [|C|] : Inherits D : Implements IDisposable : End Class"),
@@ -159,14 +159,14 @@ NewLines("Imports System \n MustInherit Class D \n MustOverride Sub Foo() \n End
         End Sub
 
         <WorkItem(530737)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestRenameTypeParameters()
             Test(
 NewLines("MustInherit Class A(Of T) \n MustOverride Sub Foo(Of S As T)() \n End Class \n Class [|C(Of S)|] \n Inherits A(Of S) \n End Class"),
 NewLines("Imports System \n MustInherit Class A(Of T) \n MustOverride Sub Foo(Of S As T)() \n End Class \n Class C(Of S) \n Inherits A(Of S) \n Public Overrides Sub Foo(Of S1 As S)() \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         Public Sub TestFormattingInImplementAbstractClass()
             Test(
 <Text>Imports System

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementAbstractClass/ImplementAbstractClassTests_FixAllTests.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Implem
     Partial Public Class ImplementAbstractClassTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInDocument()
@@ -122,7 +122,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionId)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInProject()
@@ -245,7 +245,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionId)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution()
@@ -376,7 +376,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionId)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution_DifferentAssemblyWithSameTypeName()

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
@@ -14,21 +14,21 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Implem
         End Function
 
         <WorkItem(540085)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSimpleMethod()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class C \n Implements [|I|] \n End Class"),
 NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class C \n Implements I \n Public Sub M() Implements I.M \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMethodConflict1()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class C \n Implements [|I|] \n Function M() As Integer \n End Function \n End Class"),
 NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class C \n Implements I \n Private Sub I_M() Implements I.M \n Throw New NotImplementedException() \n End Sub \n Function M() As Integer \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMethodConflict2()
             Test(
 NewLines("Interface IFoo \n Sub Bar() \n End Interface \n Class C \n Implements [|IFoo|] \n Public Sub Bar() \n End Sub \n End Class"),
@@ -36,7 +36,7 @@ NewLines("Imports System \n Interface IFoo \n Sub Bar() \n End Interface \n Clas
         End Sub
 
         <WorkItem(542012)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMethodConflictWithField()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class C \n Implements [|I|] \n Private m As Integer \n End Class"),
@@ -44,7 +44,7 @@ NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class C \
         End Sub
 
         <WorkItem(542015)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestAutoPropertyConflict()
             Test(
 NewLines("Interface I \n Property M As Integer \n End Interface \n Class C \n Implements [|I|] \n Public Property M As Integer \n End Class"),
@@ -52,7 +52,7 @@ NewLines("Imports System \n Interface I \n Property M As Integer \n End Interfac
         End Sub
 
         <WorkItem(542015)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestFullPropertyConflict()
             Test(
 NewLines("Interface I \n Property M As Integer \n End Interface \n Class C \n Implements [|I|] \n Private Property M As Integer \n Get \n Return 5 \n End Get \n Set(value As Integer) \n End Set \n End Property \n End Class"),
@@ -60,7 +60,7 @@ NewLines("Imports System \n Interface I \n Property M As Integer \n End Interfac
         End Sub
 
         <WorkItem(542019)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestConflictFromBaseClass1()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class B \n Public Sub M() \n End Sub \n End Class \n Class C \n Inherits B \n Implements [|I|] \n End Class"),
@@ -68,7 +68,7 @@ NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class B \
         End Sub
 
         <WorkItem(542019)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestConflictFromBaseClass2()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class B \n Protected M As Integer \n End Class \n Class C \n Inherits B \n Implements [|I|] \n End Class"),
@@ -76,14 +76,14 @@ NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class B \
         End Sub
 
         <WorkItem(542019)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestConflictFromBaseClass3()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class B \n Public Property M As Integer \n End Class \n Class C \n Inherits B \n Implements [|I|] \n End Class"),
 NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class B \n Public Property M As Integer \n End Class \n Class C \n Inherits B \n Implements I \n Private Sub I_M() Implements I.M \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementAbstractly1()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n MustInherit Class C \n Implements [|I|] \n End Class"),
@@ -91,42 +91,42 @@ NewLines("Interface I \n Sub M() \n End Interface \n MustInherit Class C \n Impl
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementGenericType()
             Test(
 NewLines("Interface IInterface1(Of T) \n Sub Method1(t As T) \n End Interface \n Class [Class] \n Implements [|IInterface1(Of Integer)|] \n End Class "),
 NewLines("Imports System \n Interface IInterface1(Of T) \n Sub Method1(t As T) \n End Interface \n Class [Class] \n Implements IInterface1(Of Integer) \n Public Sub Method1(t As Integer) Implements IInterface1(Of Integer).Method1 \n Throw New NotImplementedException() \n End Sub \n End Class "))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementGenericTypeWithGenericMethod()
             Test(
 NewLines("Interface IInterface1(Of T) \n Sub Method1(Of U)(arg As T, arg1 As U) \n End Interface \n Class [Class] \n Implements [|IInterface1(Of Integer)|] \n End Class "),
 NewLines("Imports System \n Interface IInterface1(Of T) \n Sub Method1(Of U)(arg As T, arg1 As U) \n End Interface \n Class [Class] \n Implements IInterface1(Of Integer) \n Public Sub Method1(Of U)(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1 \n Throw New NotImplementedException() \n End Sub \n End Class "))
         End Sub
 
-        <WpfFact, WorkItem(6623, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, WorkItem(6623, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementGenericTypeWithGenericMethodWithNaturalConstraint()
             Test(
 NewLines("Imports System.Collections.Generic \n Interface IInterface1(Of T) \n Sub Method1(Of U As IList(Of T))(arg As T, arg1 As U) \n End Interface \n Class [Class] \n Implements [|IInterface1(Of Integer)|] \n End Class "),
 NewLines("Imports System \n Imports System.Collections.Generic \n Interface IInterface1(Of T) \n Sub Method1(Of U As IList(Of T))(arg As T, arg1 As U) \n End Interface \n Class [Class] \n Implements IInterface1(Of Integer) \n Public Sub Method1(Of U As IList(Of Integer))(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1 \n Throw New NotImplementedException() \n End Sub \n End Class "))
         End Sub
 
-        <WpfFact, WorkItem(6623, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, WorkItem(6623, "DevDiv_Projects/Roslyn"), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementGenericTypeWithGenericMethodWithUnexpressibleConstraint()
             Test(
 NewLines("Interface IInterface1(Of T) \n Sub Method1(Of U As T)(arg As T, arg1 As U) \n End Interface \n Class [Class] \n Implements [|IInterface1(Of Integer)|] \n End Class "),
 NewLines("Imports System \n Interface IInterface1(Of T) \n Sub Method1(Of U As T)(arg As T, arg1 As U) \n End Interface \n Class [Class] \n Implements IInterface1(Of Integer) \n Public Sub Method1(Of U As Integer)(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1 \n Throw New NotImplementedException() \n End Sub \n End Class "))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementThroughFieldMember()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class C \n Implements [|I|] \n Private x As I \n End Class"),
 NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class C \n Implements I \n Private x As I \n Public Sub M() Implements I.M \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementThroughFieldMember1()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class C \n Implements [|I|] \n Private x As I \n End Class"),
@@ -135,7 +135,7 @@ index:=1)
         End Sub
 
         <WorkItem(472, "https://github.com/dotnet/roslyn/issues/472")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementThroughFieldMemberRemoveUnnecessaryCast()
             Test(
 "Imports System.Collections
@@ -156,7 +156,7 @@ index:=1)
         End Sub
 
         <WorkItem(472, "https://github.com/dotnet/roslyn/issues/472")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementThroughFieldMemberRemoveUnnecessaryCastAndMe()
             Test(
 "Imports System.Collections
@@ -176,7 +176,7 @@ End Class",
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementThroughFieldMemberInterfaceWithNonStandardProperties()
             Dim source =
 <File>
@@ -226,14 +226,14 @@ End Class
 
 
         <WorkItem(540355)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMissingOnImplementationWithDifferentName()
             TestMissing(
 NewLines("Interface I1(Of T) \n Function Foo() As Double \n End Interface \n Class M \n Implements [|I1(Of Double)|] \n Public Function I_Foo() As Double Implements I1(Of Double).Foo \n Return 2 \n End Function \n End Class"))
         End Sub
 
         <WorkItem(540366)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestWithMissingEndBlock()
             Test(
 NewLines("Imports System \n Class M \n Implements [|IServiceProvider|]"),
@@ -241,35 +241,35 @@ NewLines("Imports System \n Class M \n Implements IServiceProvider \n Public Fun
         End Sub
 
         <WorkItem(540367)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSimpleProperty()
             Test(
 NewLines("Interface I1 \n Property Foo() As Integer \n End Interface \n Class M \n Implements [|I1|] \n End Class"),
 NewLines("Imports System \n Interface I1 \n Property Foo() As Integer \n End Interface \n Class M \n Implements I1 \n Public Property Foo As Integer Implements I1.Foo \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As Integer) \n Throw New NotImplementedException() \n End Set \n End Property \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestArrayType()
             Test(
 NewLines("Interface I \n Function M() As String() \n End Interface \n Class C \n Implements [|I|] \n End Class"),
 NewLines("Imports System \n Interface I \n Function M() As String() \n End Interface \n Class C \n Implements I \n Public Function M() As String() Implements I.M \n Throw New NotImplementedException() \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceWithByRefParameters()
             Test(
 NewLines("Class C \n Implements [|I|] \n Private foo As I \n End Class \n Interface I \n Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) \n Function Method2() As Integer \n End Interface"),
 NewLines("Imports System \n Class C \n Implements I \n Private foo As I \n Public Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) Implements I.Method1 \n Throw New NotImplementedException() \n End Sub \n Public Function Method2() As Integer Implements I.Method2 \n Throw New NotImplementedException() \n End Function \n End Class \n Interface I \n Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) \n Function Method2() As Integer \n End Interface"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceWithTypeCharacter()
             Test(
 NewLines("Interface I1 \n Function Method1$() \n End Interface \n Class C \n Implements [|I1|] \n End Class"),
 NewLines("Imports System \n Interface I1 \n Function Method1$() \n End Interface \n Class C \n Implements I1 \n Public Function Method1() As String Implements I1.Method1 \n Throw New NotImplementedException() \n End Function \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceWithParametersTypeSpecifiedAsTypeCharacter()
             Test(
 NewLines("Interface I1 \n Sub Method1(ByRef arg#) \n End Interface \n Class C \n Implements [|I1|] \n End Class"),
@@ -277,14 +277,14 @@ NewLines("Imports System \n Interface I1 \n Sub Method1(ByRef arg#) \n End Inter
         End Sub
 
         <WorkItem(540403)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMissingOnInterfaceWithJustADelegate()
             TestMissing(
 NewLines("Interface I1 \n Delegate Sub Del() \n End Interface \n Class C \n Implements [|I1|] \n End Class"))
         End Sub
 
         <WorkItem(540381)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestOrdering1()
             Test(
 NewLines("Class C \n Implements [|I|] \n Private foo As I \n End Class \n Interface I \n Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) \n Function Method2() As Integer \n End Interface"),
@@ -292,14 +292,14 @@ NewLines("Imports System \n Class C \n Implements I \n Private foo As I \n Publi
         End Sub
 
         <WorkItem(540415)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDefaultProperty1()
             Test(
 NewLines("Interface I1 \n Default Property Foo(ByVal arg As Integer) \n End Interface \n Class C \n Implements [|I1|] \n End Class"),
 NewLines("Imports System \n Interface I1 \n Default Property Foo(ByVal arg As Integer) \n End Interface \n Class C \n Implements I1 \n Default Public Property Foo(arg As Integer) As Object Implements I1.Foo \n Get \n Throw New NotImplementedException() \n End Get \n Set(value As Object) \n Throw New NotImplementedException() \n End Set \n End Property \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementNestedInterface()
             Test(
 NewLines("Interface I1 \n Sub Foo() \n Delegate Sub Del(ByVal arg As Integer) \n Interface I2 \n Sub Foo(ByVal arg As Del) \n End Interface \n End Interface \n Class C \n Implements [|I1.I2|] \n End Class"),
@@ -307,7 +307,7 @@ NewLines("Imports System \n Interface I1 \n Sub Foo() \n Delegate Sub Del(ByVal 
         End Sub
 
         <WorkItem(540402)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestArrayRankSpecifiers()
             Test(
 NewLines("Interface I1 \n Sub Method1(ByVal arg() As Integer) \n End Interface \n Class C \n Implements [|I1|] \n End Class"),
@@ -315,7 +315,7 @@ NewLines("Imports System \n Interface I1 \n Sub Method1(ByVal arg() As Integer) 
         End Sub
 
         <WorkItem(540398)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSimplifyImplementsClause()
             Test(
 NewLines("Namespace ConsoleApplication \n Interface I1 \n Sub Method1() \n End Interface \n Class C \n Implements [|I1|] \n End Class \n End Namespace"),
@@ -324,7 +324,7 @@ parseOptions:=Nothing) ' Namespaces not supported in script
         End Sub
 
         <WorkItem(541078)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestParamArray()
             Test(
 NewLines("Interface I2 \n Function G(ParamArray args As Double()) As Integer \n End Interface \n Class A \n Implements [|I2|] \n End Class"),
@@ -332,7 +332,7 @@ NewLines("Imports System \n Interface I2 \n Function G(ParamArray args As Double
         End Sub
 
         <WorkItem(541092)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestShowForNonImplementedPrivateInterfaceMethod()
             Test(
 NewLines("Interface I1 \n Private Sub Foo() \n End Interface \n Class A \n Implements [|I1|] \n End Class"),
@@ -340,14 +340,14 @@ NewLines("Imports System \n Interface I1 \n Private Sub Foo() \n End Interface \
         End Sub
 
         <WorkItem(541092)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDoNotShowForImplementedPrivateInterfaceMethod()
             TestMissing(
 NewLines("Interface I1 \n Private Sub Foo() \n End Interface \n Class A \n Implements [|I1|] \n Public Sub Foo() Implements I1.Foo \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
         <WorkItem(542010)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNoImplementThroughSynthesizedFields()
             TestActionCount(
 NewLines("Interface I \n Sub M() \n End Interface \n Class C \n Implements [|I|] \n Public Property X As I \n End Class"),
@@ -364,7 +364,7 @@ index:=1)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIReadOnlyListThroughField()
             Test(
 NewLines("Imports System.Collections.Generic \n Class A \n Implements [|IReadOnlyList(Of Integer)|] \n Private field As Integer() \n End Class"),
@@ -378,7 +378,7 @@ index:=1)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIReadOnlyListThroughProperty()
             Test(
 NewLines("Imports System.Collections.Generic \n Class A \n Implements [|IReadOnlyList(Of Integer)|] \n Private Property field As Integer() \n End Class"),
@@ -392,7 +392,7 @@ index:=1)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceThroughField()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class A \n Implements I \n Public Sub M() Implements I.M \n End Sub \n End Class \n
@@ -403,7 +403,7 @@ index:=1)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceThroughField_FieldImplementsMultipleInterfaces()
             TestActionCount(
 NewLines("Interface I \n Sub M() \n End Interface \n Interface I2 \n Sub M2() \n End Interface \n Class A \n Implements I, I2 \n Public Sub M() Implements I.M, I2.M2 \n End Sub \n End Class \n
@@ -432,7 +432,7 @@ index:=1)
 
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceThroughField_MultipleFieldsCanImplementInterface()
             TestActionCount(
 NewLines("Interface I \n Sub M() \n End Interface \n Class A \n Implements I \n Public Sub M() Implements I.M \n End Sub \n End Class \n
@@ -455,7 +455,7 @@ index:=2)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceThroughField_MultipleFieldsForMultipleInterfaces()
             TestActionCount(
 NewLines("Interface I \n Sub M() \n End Interface \n Interface I2 \n Sub M2() \n End Interface \n Class A \n Implements I \n Public Sub M() Implements I.M \n End Sub \n End Class \n
@@ -489,7 +489,7 @@ index:=1)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNoImplementThroughDefaultProperty()
             TestActionCount(
 NewLines("Interface I \n Sub M() \n End Interface \n Class A \n Implements I \n Public Sub M() Implements I.M \n End Sub \n End Class \n
@@ -498,7 +498,7 @@ count:=1)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNoImplementThroughParameterizedProperty()
             TestActionCount(
 NewLines("Interface I \n Sub M() \n End Interface \n Class A \n Implements I \n Public Sub M() Implements I.M \n End Sub \n End Class \n
@@ -507,7 +507,7 @@ count:=1)
         End Sub
 
         <WorkItem(768799)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNoImplementThroughWriteOnlyProperty()
             TestActionCount(
 NewLines("Interface I \n Sub M() \n End Interface \n Class A \n Implements I \n Public Sub M() Implements I.M \n End Sub \n End Class \n
@@ -516,7 +516,7 @@ count:=1)
         End Sub
 
         <WorkItem(540469)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub InsertBlankLineAfterImplementsAndInherits()
             Test(
 <Text>Interface I1
@@ -543,7 +543,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(542290)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMethodShadowsProperty()
             Test(
 NewLines("Interface I \n Sub M() \n End Interface \n Class B \n 'Protected m As Integer \n Public Property M As Integer \n End Class \n Class C \n Inherits B \n Implements [|I|] \n End Class"),
@@ -551,7 +551,7 @@ NewLines("Imports System \n Interface I \n Sub M() \n End Interface \n Class B \
         End Sub
 
         <WorkItem(542606)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestRemMethod()
             Test(
 NewLines("Interface I \n Sub [Rem] \n End Interface \n Class C \n Implements [|I|] ' Implement interface \n End Class"),
@@ -559,14 +559,14 @@ NewLines("Imports System \n Interface I \n Sub [Rem] \n End Interface \n Class C
         End Sub
 
         <WorkItem(543425)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMissingIfEventAlreadyImplemented()
             TestMissing(
 NewLines("Imports System.ComponentModel \n Class C \n Implements [|INotifyPropertyChanged|] \n Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged \n End Class"))
         End Sub
 
         <WorkItem(543506)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestAddEvent1()
             Test(
 NewLines("Imports System.ComponentModel \n Class C \n Implements [|INotifyPropertyChanged|] \n End Class"),
@@ -574,7 +574,7 @@ NewLines("Imports System.ComponentModel \n Class C \n Implements INotifyProperty
         End Sub
 
         <WorkItem(543588)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNameSimplifyGenericType()
             Test(
 NewLines("Interface I(Of In T, Out R) \n Sub Foo() \n End Interface \n Class C(Of T, R) \n Implements [|I(Of T, R)|] \n End Class"),
@@ -582,7 +582,7 @@ NewLines("Imports System \n Interface I(Of In T, Out R) \n Sub Foo() \n End Inte
         End Sub
 
         <WorkItem(544156)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestInterfacePropertyRedefinition()
             Test(
 NewLines("Interface I1 \n Property Bar As Integer \n End Interface \n Interface I2 \n Inherits I1 \n Property Bar As Integer \n End Interface \n Class C \n Implements [|I2|] \n End Class"),
@@ -590,14 +590,14 @@ NewLines("Imports System \n Interface I1 \n Property Bar As Integer \n End Inter
         End Sub
 
         <WorkItem(544208)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMissingOnWrongArity()
             TestMissing(
 NewLines("Interface I1(Of T) \n  ReadOnly Property Bar As Integer \n End Interface \n Class C \n Implements [|I1|] \n End Class"))
         End Sub
 
         <WorkItem(529328)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestPropertyShadowing()
             Test(
 NewLines("Interface I1 \n Property Bar As Integer \n Sub Foo() \n End Interface \n Class B \n Public Property Bar As Integer \n End Class \n Class C \n Inherits B \n Implements [|I1|] \n End Class"),
@@ -605,14 +605,14 @@ NewLines("Imports System \n Interface I1 \n Property Bar As Integer \n Sub Foo()
         End Sub
 
         <WorkItem(544206)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestEventWithImplicitDelegateCreation()
             Test(
 NewLines("Interface I1 \n Event E(x As String) \n End Interface \n Class C \n Implements [|I1|] \n End Class"),
 NewLines("Interface I1 \n Event E(x As String) \n End Interface \n Class C \n Implements I1 \n Public Event E(x As String) Implements I1.E \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestStringLiteral()
             Test(
 NewLines("Interface IFoo \n Sub Foo(Optional s As String = """""""") \n End Interface \n Class Bar \n Implements [|IFoo|] \n End Class"),
@@ -620,14 +620,14 @@ NewLines("Imports System \n Interface IFoo \n Sub Foo(Optional s As String = """
         End Sub
 
         <WorkItem(545643), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestVBConstantValue1()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub VBNullChar(Optional x As String = Constants.vbNullChar) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub VBNullChar(Optional x As String = Constants.vbNullChar) \n End Interface \n  \n Class C \n Implements I \n Public Sub VBNullChar(Optional x As String = Constants.vbNullChar) Implements I.VBNullChar \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestVBConstantValue2()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub VBNullChar(Optional x As String = Constants.vbNullChar) \n End Interface \n  \n Namespace N \n Class Microsoft \n Implements [|I|] \n End Class \n End Namespace"),
@@ -636,7 +636,7 @@ parseOptions:=Nothing)
         End Sub
 
         <WorkItem(545679), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestVBConstantValue3()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub ChrW(Optional x As String = Strings.ChrW(1)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -644,7 +644,7 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(545674)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDateTimeLiteral1()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As Date = #6/29/2012#) \n End Interface \n Class C \n Implements [|I|] \n End Class"),
@@ -652,7 +652,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Date = #6/29/20
         End Sub
 
         <WorkItem(545675), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestEnumConstant1()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As DayOfWeek = DayOfWeek.Friday) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -660,7 +660,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545644)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMultiDimensionalArray1()
             Test(
 NewLines("Interface I \n Sub Foo(x As Integer()()) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -668,7 +668,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(x As Integer()()) \n End Inte
         End Sub
 
         <WorkItem(545640), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestUnicodeQuote()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As String = ChrW(8220)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -676,14 +676,14 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(545563)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestLongMinValue()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As Long = Long.MinValue) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
 NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Long = Long.MinValue) \n End Interface \n  \n Class C \n Implements I \n Public Sub Foo(Optional x As Long = Long.MinValue) Implements I.Foo \n Throw New NotImplementedException() \n End Sub \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMinMaxValues()
             Test(
 <Text>Interface I
@@ -775,7 +775,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf),
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestFloatConstants()
             Test(
 <Text>Interface I
@@ -868,7 +868,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestEnumParameters()
             Test(
 <Text><![CDATA[Imports System
@@ -925,7 +925,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestEnumParameters2()
             Test(
 <Text><![CDATA[
@@ -986,7 +986,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(545691)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestMultiDimArray1()
             Test(
 NewLines("Interface I \n Sub Foo(x As Integer(,)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -994,7 +994,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(x As Integer(,)) \n End Inter
         End Sub
 
         <WorkItem(545640), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestQuoteEscaping1()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As Char = ChrW(8220)) \n End Interface \n Class C \n Implements [|I|] \n End Class"),
@@ -1002,7 +1002,7 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(545866)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestQuoteEscaping2()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As Object = ""‟"") \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1010,7 +1010,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Object = ""‟"
         End Sub
 
         <WorkItem(545689)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDecimalLiteral1()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As Decimal = Decimal.MaxValue) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1018,7 +1018,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545687), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestRemoveParenthesesAroundTypeReference1()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As DayOfWeek = DayOfWeek.Monday) \n End Interface \n  \n Class C \n Implements [|I|] \n  \n Property DayOfWeek As DayOfWeek \n End Class"),
@@ -1026,7 +1026,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545694), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNullableDefaultValue1()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As DayOfWeek? = DayOfWeek.Friday) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1034,7 +1034,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545688)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestHighPrecisionDouble()
             Test(
 NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Double = 2.8025969286496341E-45) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1042,7 +1042,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Double = 2.8025
         End Sub
 
         <WorkItem(545729), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestCharSurrogates()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As Char = ChrW(55401)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1050,7 +1050,7 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(545733), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestReservedChar()
             Test(
 NewLines("Option Strict On \n Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As Char = Chr(13)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1058,7 +1058,7 @@ NewLines("Option Strict On \n Imports System \n Imports Microsoft.VisualBasic \n
         End Sub
 
         <WorkItem(545685)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestCastEnumValue()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As ConsoleColor = CType(-1, ConsoleColor)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1066,7 +1066,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545756)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestArrayOfNullables()
             Test(
 NewLines("Interface I \n Sub Foo(x As Integer?()) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1074,7 +1074,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(x As Integer?()) \n End Inter
         End Sub
 
         <WorkItem(545753)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestOptionalArrayParameterWithDefault()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As Integer() = Nothing) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1082,7 +1082,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Integer() = Not
         End Sub
 
         <WorkItem(545742), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestRemFieldEnum()
             Test(
 NewLines("Option Strict On \n Imports System \n Enum E \n [Rem] \n End Enum \n  \n Interface I \n Sub Foo(Optional x As E = E.[Rem]) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1090,7 +1090,7 @@ NewLines("Option Strict On \n Imports System \n Enum E \n [Rem] \n End Enum \n  
         End Sub
 
         <WorkItem(545790)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestByteParameter()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As Byte = 1) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1098,7 +1098,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Byte = 1) \n En
         End Sub
 
         <WorkItem(545789)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDefaultParameterSuffix1()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As Object = 1L) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1106,7 +1106,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Object = 1L) \n
         End Sub
 
         <WorkItem(545809)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestZeroValuedEnum()
             Test(
 NewLines("Enum E \n A = 1 \n End Enum \n  \n Interface I \n Sub Foo(Optional x As E = 0) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1114,7 +1114,7 @@ NewLines("Imports System \n Enum E \n A = 1 \n End Enum \n  \n Interface I \n Su
         End Sub
 
         <WorkItem(545824)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestByteCast()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As Object = CByte(1)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1122,7 +1122,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Object = CByte(
         End Sub
 
         <WorkItem(545825)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDecimalValues()
             Test(
 <Text>Option Strict On
@@ -1183,7 +1183,7 @@ End Class
         End Sub
 
         <WorkItem(545693)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSmallDecimal()
             Test(
 NewLines("Option Strict On \n  \n Interface I \n Sub Foo(Optional x As Decimal = Long.MinValue) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1191,7 +1191,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545771)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestEventConflict()
             Test(
 NewLines("Interface IA \n Event E As EventHandler \n End Interface \n Interface IB \n Inherits IA \n Shadows Event E As Action \n End Interface \n Class C \n Implements [|IB|] \n End Class"),
@@ -1199,7 +1199,7 @@ NewLines("Interface IA \n Event E As EventHandler \n End Interface \n Interface 
         End Sub
 
         <WorkItem(545826)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDecimalField()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As Object = 1D) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1207,7 +1207,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545827)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDoubleInObjectContext()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As Object = 1.0) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1215,7 +1215,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545860)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestLargeDecimal()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As Decimal = 10000000000000000000D) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1223,7 +1223,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545870)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSurrogatePair1()
             Test(
 NewLines("Interface I \n Sub Foo(Optional x As String = ""𪛖"") \n End Interface \n Class C \n Implements [|I|] \n End Class"),
@@ -1231,7 +1231,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As String = ""𪛖
         End Sub
 
         <WorkItem(545893), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestVBTab()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As String = vbTab) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1239,7 +1239,7 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(545912)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestEscapeTypeParameter()
             Test(
 NewLines("Interface I \n Sub Foo(Of [TO], TP, TQ)() \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1247,7 +1247,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Of [TO], TP, TQ)() \n End Int
         End Sub
 
         <WorkItem(545892)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestLargeUnsignedLong()
             Test(
 NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional x As ULong = 10000000000000000000UL) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1255,7 +1255,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(545865)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSmallDecimalValues()
             Dim markup =
 <File>
@@ -1406,7 +1406,7 @@ End Class
         End Sub
 
         <WorkItem(544641)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestClassStatementTerminators1()
             Test(
 NewLines("Imports System \n Class C : Implements [|IServiceProvider|] : End Class"),
@@ -1414,7 +1414,7 @@ NewLines("Imports System \n Class C : Implements IServiceProvider \n Public Func
         End Sub
 
         <WorkItem(544641)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestClassStatementTerminators2()
             Test(
 NewLines("Imports System \n MustInherit Class D \n MustOverride Sub Foo() \n End Class \n Class C : Inherits D : Implements [|IServiceProvider|] : End Class"),
@@ -1422,7 +1422,7 @@ NewLines("Imports System \n MustInherit Class D \n MustOverride Sub Foo() \n End
         End Sub
 
         <WorkItem(544652), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestConvertNonprintableCharToString()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As Object = CStr(Chr(1))) \n End Interface \n  \n Class C \n Implements [|I|] ' Implement \n End Class"),
@@ -1430,7 +1430,7 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(545684), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSimplifyModuleNameWhenPossible1()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As String = ChrW(1)) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1438,7 +1438,7 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(545684), WorkItem(715013)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestSimplifyModuleNameWhenPossible2()
             Test(
 NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub Foo(Optional x As String = ChrW(1)) \n End Interface \n  \n Class C \n Implements [|I|] \n Public Sub ChrW(x As Integer) \n End Sub \n End Class"),
@@ -1446,7 +1446,7 @@ NewLines("Imports System \n Imports Microsoft.VisualBasic \n Interface I \n Sub 
         End Sub
 
         <WorkItem(544676)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDoubleWideREM()
             Test(
 NewLines("Interface I \n Sub ［ＲＥＭ］() \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1454,7 +1454,7 @@ NewLines("Imports System \n Interface I \n Sub ［ＲＥＭ］() \n End Interfac
         End Sub
 
         <WorkItem(545917)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDoubleWideREM2()
             Test(
 NewLines("Interface I \n Sub Foo(Of ［ＲＥＭ］)() \n End Interface \n Class C \n Implements [|I|] \n End Class"),
@@ -1462,7 +1462,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Of ［ＲＥＭ］)() \n End 
         End Sub
 
         <WorkItem(545953)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestGenericEnumWithRenamedTypeParameters1()
             Test(
 NewLines("Option Strict On \n Class C(Of T) \n Enum E \n X \n End Enum \n End Class \n Interface I \n Sub Foo(Of M)(Optional x As C(Of M()).E = C(Of M()).E.X) \n End Interface \n Class C \n Implements [|I|] ' Implement \n End Class"),
@@ -1470,7 +1470,7 @@ NewLines("Option Strict On \n Imports System \n Class C(Of T) \n Enum E \n X \n 
         End Sub
 
         <WorkItem(545953)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestGenericEnumWithRenamedTypeParameters2()
             Test(
 NewLines("Option Strict On \n Class C(Of T) \n Enum E \n X \n End Enum \n End Class \n Interface I \n Sub Foo(Of T)(Optional x As C(Of T()).E = C(Of T()).E.X) \n End Interface \n Class C \n Implements [|I|] \n End Class"),
@@ -1478,7 +1478,7 @@ NewLines("Option Strict On \n Imports System \n Class C(Of T) \n Enum E \n X \n 
         End Sub
 
         <WorkItem(546197)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDoubleQuoteChar()
             Test(
 NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Object = """"""""c) \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1486,7 +1486,7 @@ NewLines("Imports System \n Interface I \n Sub Foo(Optional x As Object = """"""
         End Sub
 
         <WorkItem(530165)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestGenerateIntoAppropriatePartial()
             Test(
 NewLines("Interface I \n  \n Sub M() \n  \n End Interface \n  \n Class C \n  \n End Class \n  \n Partial Class C \n Implements [|I|] \n End Class"),
@@ -1494,7 +1494,7 @@ NewLines("Imports System \n Interface I \n  \n Sub M() \n  \n End Interface \n  
         End Sub
 
         <WorkItem(546325)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestAttributes()
             Test(
 NewLines("Imports System.Runtime.InteropServices \n  \n Interface I \n Function Foo(<MarshalAs(UnmanagedType.U1)> x As Boolean) As <MarshalAs(UnmanagedType.U1)> Boolean \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1502,7 +1502,7 @@ NewLines("Imports System \n Imports System.Runtime.InteropServices \n  \n Interf
         End Sub
 
         <WorkItem(530564)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestShortenedDecimal()
             Test(
 NewLines("Option Strict On \n Interface I \n Sub Foo(Optional x As Decimal = 1000000000000000000D) \n End Interface \n Class C \n Implements [|I|] ' Implement \n End Class"),
@@ -1510,7 +1510,7 @@ NewLines("Option Strict On \n Imports System \n Interface I \n Sub Foo(Optional 
         End Sub
 
         <WorkItem(530713)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementAbstractly2()
             Test(
 NewLines("Interface I \n Property Foo() As Integer \n End Interface \n  \n MustInherit Class C \n Implements [|I|] ' Implement interface abstractly \n End Class"),
@@ -1518,7 +1518,7 @@ NewLines("Imports System \n Interface I \n Property Foo() As Integer \n End Inte
         End Sub
 
         <WorkItem(916114)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestOptionalNullableStructParameter()
             Test(
 NewLines("Interface I \n ReadOnly Property g(Optional x As S? = Nothing) \n End Interface \n Class c \n Implements [|I|] \n End Class \n Structure S \n End Structure"),
@@ -1526,7 +1526,7 @@ NewLines("Imports System \n Interface I \n ReadOnly Property g(Optional x As S? 
         End Sub
 
         <WorkItem(916114)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestOptionalNullableLongParameter()
             Test(
 NewLines("Interface I \n ReadOnly Property g(Optional x As Long? = Nothing, Optional y As Long? = 5) \n End Interface \n Class c \n Implements [|I|] \n End Class"),
@@ -1534,7 +1534,7 @@ NewLines("Imports System \n Interface I \n ReadOnly Property g(Optional x As Lon
         End Sub
 
         <WorkItem(530345)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestAttributeFormattingInNonStatementContext()
             Test(
 <Text>Imports System.Runtime.InteropServices
@@ -1566,7 +1566,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(546779)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestPropertyReturnTypeAttributes()
             Test(
 NewLines("Imports System.Runtime.InteropServices \n  \n Interface I \n Property P(<MarshalAs(UnmanagedType.I4)> x As Integer) As <MarshalAs(UnmanagedType.I4)> Integer \n End Interface \n  \n Class C \n Implements [|I|] \n End Class"),
@@ -1574,7 +1574,7 @@ NewLines("Imports System \n Imports System.Runtime.InteropServices \n  \n Interf
         End Sub
 
         <WorkItem(847464)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceForPartialType()
             Test(
 NewLines("Public Interface I \n Sub Foo() \n End Interface \n Partial Class C \n End Class \n Partial Class C \n Implements [|I|] \n End Class"),
@@ -1582,7 +1582,7 @@ NewLines("Imports System \n Public Interface I \n Sub Foo() \n End Interface \n 
         End Sub
 
         <WorkItem(617698)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub Bugfix_617698_RecursiveSimplificationOfQualifiedName()
             Test(
 <Text>Interface A(Of B)
@@ -1620,7 +1620,7 @@ End Interface
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceForIDisposable()
             Test(
 <Text>Imports System
@@ -1640,7 +1640,7 @@ index:=1,
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceForIDisposableNonApplicable1()
             Test(
 <Text>Imports System
@@ -1665,7 +1665,7 @@ End Class
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceForIDisposableNonApplicable2()
             Test(
 <Text>Imports System
@@ -1691,7 +1691,7 @@ End Class
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementInterfaceForIDisposableWithSealedClass()
             Test(
 <Text>Imports System
@@ -1712,7 +1712,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(939123)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNoComAliasNameAttributeOnMethodParameters()
             Test(
 NewLines("Imports System.Runtime.InteropServices \n
@@ -1725,7 +1725,7 @@ Public Function F(p As Long) As Integer Implements I.F \n Throw New NotImplement
         End Sub
 
         <WorkItem(939123)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNoComAliasNameAttributeOnMethodReturnType()
             Test(
 NewLines("Imports System.Runtime.InteropServices \n
@@ -1738,7 +1738,7 @@ Public Function F(p As Long) As Integer Implements I.F \n Throw New NotImplement
         End Sub
 
         <WorkItem(939123)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNoComAliasNameAttributeOnPropertyParameters()
             Test(
 NewLines("Imports System.Runtime.InteropServices \n
@@ -1754,7 +1754,7 @@ End Property \n End Class"))
         End Sub
 
         <WorkItem(529920)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestNewLineBeforeDirective()
             Test(
 "Imports System
@@ -1773,7 +1773,7 @@ End Class
         End Sub
 
         <WorkItem(529947)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestCommentAfterInterfaceList1()
             Test(
 "Imports System
@@ -1791,7 +1791,7 @@ End Class
         End Sub
 
         <WorkItem(529947)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestCommentAfterInterfaceList2()
             Test(
 "Imports System
@@ -1811,7 +1811,7 @@ REM Comment", compareTokens:=False)
 
         <WorkItem(994456)>
         <WorkItem(958699)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposable_NoDisposePattern()
             Test(
 "Imports System
@@ -1828,7 +1828,7 @@ End Class
 
         <WorkItem(994456)>
         <WorkItem(958699)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposable1_DisposePattern()
             Test(
 "Imports System
@@ -1842,7 +1842,7 @@ End Class
 
         <WorkItem(994456)>
         <WorkItem(958699)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposableAbstractly_NoDisposePattern()
             Test(
 "Imports System
@@ -1857,7 +1857,7 @@ End Class
 
         <WorkItem(994456)>
         <WorkItem(958699)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposableThroughMember_NoDisposePattern()
             Test(
 "Imports System
@@ -1875,7 +1875,7 @@ End Class", index:=2, compareTokens:=False)
         End Sub
 
         <WorkItem(941469)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposable2()
             Test(
 "Imports System
@@ -1892,7 +1892,7 @@ End Class", index:=1, compareTokens:=False)
         End Sub
 
         <WorkItem(958699)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposable_NoNamespaceImportForSystem()
             Test(
 "Class C : Implements [|System.IDisposable|]
@@ -1904,7 +1904,7 @@ End Class
         End Sub
 
         <WorkItem(951968)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposableViaBaseInterface_NoDisposePattern()
             Test(
 "Imports System
@@ -1930,7 +1930,7 @@ End Class", index:=0, compareTokens:=False)
         End Sub
 
         <WorkItem(951968)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestImplementIDisposableViaBaseInterface()
             Test(
 "Imports System
@@ -1953,7 +1953,7 @@ End Class", index:=1, compareTokens:=False)
         End Sub
 
         <WorkItem(951968)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDontImplementDisposePatternForLocallyDefinedIDisposable()
             Test(
 "Namespace System
@@ -1977,7 +1977,7 @@ End Namespace",
 End Namespace", compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDontImplementDisposePatternForStructures()
             Test(
 "Imports System
@@ -1993,7 +1993,7 @@ End Structure
         End Sub
 
         <WorkItem(994328)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDisposePatternWhenAdditionalImportsAreIntroduced1()
             Test(
 "Interface I(Of T, U As T) : Inherits System.IDisposable, System.IEquatable(Of Integer)
@@ -2041,7 +2041,7 @@ End Class", index:=1, compareTokens:=False)
         End Sub
 
         <WorkItem(994328)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestDisposePatternWhenAdditionalImportsAreIntroduced2()
             Test(
 "Class C
@@ -2129,7 +2129,7 @@ End Interface", index:=1, compareTokens:=False)
         End Function
 
         <WorkItem(1132014)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Sub TestInaccessibleAttributes()
             Test(
 "Imports System

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests_FixAllTests.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Implem
     Partial Public Class ImplementInterfaceTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInDocument()
@@ -122,7 +122,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionEquivalenceKey)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInProject()
@@ -245,7 +245,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionEquivalenceKey)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution()
@@ -376,7 +376,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionEquivalenceKey)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution_DifferentAssemblyWithSameTypeName()

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/InsertMissingCast/InsertMissingCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/InsertMissingCast/InsertMissingCastTests.vb
@@ -13,82 +13,82 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Insert
                 Nothing, New InsertMissingCastCodeFixProvider)
         End Function
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestPredefinedAssignment()
             Test(
 NewLines("Option Strict On \n Module M1 \n Sub Main() \n Dim b As Byte = 1 \n Dim c As Byte = 2 \n b = [|b & c|] \n End Sub \n End Module"),
 NewLines("Option Strict On \n Module M1 \n Sub Main() \n Dim b As Byte = 1 \n Dim c As Byte = 2 \n b = CByte(b & c) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestAssignment()
             Test(
 NewLines("Option Strict On \n Class Base \n End Class \n Class Derived \n Inherits Base \n End Class \n Module M1 \n Sub Main() \n Dim d As Derived = Nothing \n Dim b As Base = Nothing \n d = [|b|] \n End Sub \n End Module"),
 NewLines("Option Strict On \n Class Base \n End Class \n Class Derived \n Inherits Base \n End Class \n Module M1 \n Sub Main() \n Dim d As Derived = Nothing \n Dim b As Base = Nothing \n d = CType(b, Derived) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestMethodCall()
             Test(
 NewLines("Option Strict On \n Class Base \n End Class \n Class Derived \n Inherits Base \n End Class \n Module M1 \n Sub foo(d As Derived) \n End Sub \n Sub Main() \n Dim b As Base = Nothing \n foo([|b|]) \n End Sub \n End Module"),
 NewLines("Option Strict On \n Class Base \n End Class \n Class Derived \n Inherits Base \n End Class \n Module M1 \n Sub foo(d As Derived) \n End Sub \n Sub Main() \n Dim b As Base = Nothing \n foo(CType(b, Derived)) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestMethodCallPredefined()
             Test(
 NewLines("Option Strict On \n Module M1 \n Sub foo(d As Integer) \n End Sub \n Sub Main() \n foo([|""10""|]) \n End Sub \n End Module"),
 NewLines("Option Strict On \n Module M1 \n Sub foo(d As Integer) \n End Sub \n Sub Main() \n foo(CInt(""10"")) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestConditional()
             Test(
 NewLines("Option Strict On \n Module M1 \n Sub Main() \n Dim i As Integer = 10 \n Dim b = If([|i|], True, False) \n End Sub \n End Module"),
 NewLines("Option Strict On \n Module M1 \n Sub Main() \n Dim i As Integer = 10 \n Dim b = If(CBool(i), True, False) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestReturn()
             Test(
 NewLines("Option Strict On \n Module M1 \n Function foo() As Integer \n Return [|""10""|] \n End Function \n End Module"),
 NewLines("Option Strict On \n Module M1 \n Function foo() As Integer \n Return CInt(""10"") \n End Function \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestLambda()
             Test(
 NewLines("Option Strict On \n Class Base \n End Class \n Class Derived \n Inherits Base \n End Class \n Module M1 \n Sub Main() \n Dim l = Function() As Derived \n Return [|New Base()|] \n End Function \n End Sub \n End Module"),
 NewLines("Option Strict On \n Class Base \n End Class \n Class Derived \n Inherits Base \n End Class \n Module M1 \n Sub Main() \n Dim l = Function() As Derived \n Return CType(New Base(), Derived) \n End Function \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestAttribute()
             Test(
 NewLines("Option Strict On \n Module Program \n <System.Obsolete(""as"", [|10|])> \n Sub Main(args As String()) \n End Sub \n End Module"),
 NewLines("Option Strict On \n Module Program \n <System.Obsolete(""as"", CBool(10))> \n Sub Main(args As String()) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestMultiline()
             Test(
 NewLines("Option Strict On \n Module Program \n Sub Main(args As String()) \n Dim x As Integer = [|10.0 + \n 11.0 + \n 10|] ' asas \n End Sub \n End Module"),
 NewLines("Option Strict On \n Module Program \n Sub Main(args As String()) \n Dim x As Integer = CInt(10.0 + \n 11.0 + \n 10) ' asas \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestWidening()
             TestMissing(
 NewLines("Option Strict On \n Module Program \n Sub Main(args As String()) \n Dim x As Double = 10[||] \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestInvalidCast()
             TestMissing(
 NewLines("Option Strict On \n Class A \n End Class \n Class B \n End Class \n Module Program[||] \n Sub Main(args As String()) \n Dim x As A = New B() \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInsertMissingCast)>
         Public Sub TestOptionStrictOn()
             Test(
 NewLines("Option Strict On \n Module Module1 \n Sub Main() \n Dim red = ColorF.FromArgb(255, 255, 0, 0) \n Dim c As Color = [|red|] \n End Sub \n End Module \n Public Structure ColorF \n Public A, R, G, B As Single \n Public Shared Function FromArgb(a As Double, r As Double, g As Double, b As Double) As ColorF \n Return New ColorF With {.A = CSng(a), .R = CSng(r), .G = CSng(g), .B = CSng(b)} \n End Function \n Public Shared Widening Operator CType(x As Color) As ColorF \n Return ColorF.FromArgb(x.A / 255, x.R / 255, x.G / 255, x.B / 255) \n End Operator \n Public Shared Narrowing Operator CType(x As ColorF) As Color \n Return Color.FromArgb(CByte(x.A * 255), CByte(x.R * 255), CByte(x.G * 255), CByte(x.B * 255)) \n End Operator \n End Structure \n Public Structure Color \n Public A, R, G, B As Byte \n Public Shared Function FromArgb(a As Byte, r As Byte, g As Byte, b As Byte) As Color \n Return New Color With {.A = a, .R = r, .G = g, .B = b} \n End Function \n End Structure"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Iterator/IteratorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Iterator/IteratorTests.vb
@@ -13,39 +13,39 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.I
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New VisualBasicConvertToIteratorCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
         Public Sub TestConvertToIteratorFunction()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Module1 \n Function M() As IEnumerable(Of Integer) \n [|Yield|] 1 \n End Function \n End Module"),
 NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Module1 \n Iterator Function M() As IEnumerable(Of Integer) \n Yield 1 \n End Function \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
         Public Sub TestConvertToIteratorSub()
             TestMissing(
 NewLines("Module Module1 \n Sub M() As \n [|Yield|] 1 \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
         Public Sub TestConvertToIteratorFunctionLambda()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Module1 \n Sub M() \n Dim a As Func(Of IEnumerable(Of Integer)) = Function() \n [|Yield|] 0 \n End Function \n End Sub \n End Module"),
 NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Module1 \n Sub M() \n Dim a As Func(Of IEnumerable(Of Integer)) = Iterator Function() \n Yield 0 \n End Function \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
         Public Sub TestConvertToIteratorSubLambda()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Module1 \n Sub M() \n Dim a As Func(Of IEnumerable(Of Integer)) = Sub() \n [|Yield|] 0 \n End Sub \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
         Public Sub TestConvertToIteratorSingleLineFunctionLambda()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Module1 \n Sub M() \n Dim a As Func(Of IEnumerable(Of Integer)) = Function() [|Yield|] 0 \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToIterator)>
         Public Sub TestConvertToIteratorSingleLineSubLambda()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Module1 \n Sub M() \n Dim a As Func(Of IEnumerable(Of Integer)) = Sub() [|Yield|] 0 \n End Sub \n End Module"))
@@ -59,40 +59,40 @@ NewLines("Imports System \n Imports System.Collections.Generic \n \n Module Modu
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New VisualBasicChangeToYieldCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
         Public Sub TestChangeToYieldCodeFixProviderFunction()
             Test(
 NewLines("Module Module1 \n Iterator Function M() As IEnumerable(Of Integer) \n [|Return|] 1 \n End Function \n End Module"),
 NewLines("Module Module1 \n Iterator Function M() As IEnumerable(Of Integer) \n Yield 1 \n End Function \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
         Public Sub TestChangeToYieldCodeFixProviderSub()
             Test(
 NewLines("Module Module1 \n Iterator Sub M() \n [|Return|] 1 \n End Sub \n End Module"),
 NewLines("Module Module1 \n Iterator Sub M() \n Yield 1 \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
         Public Sub TestChangeToYieldCodeFixProviderFunctionLambda()
             Test(
 NewLines("Module Module1 \n Sub M() \n Dim a = Iterator Function() \n [|Return|] 0 \n End Function \n End Sub \n End Module"),
 NewLines("Module Module1 \n Sub M() \n Dim a = Iterator Function() \n Yield 0 \n End Function \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
         Public Sub TestChangeToYieldCodeFixProviderSubLambda()
             Test(
 NewLines("Module Module1 \n Sub M() \n Dim a = Iterator Sub() \n [|Return|] 0 \n End Sub \n End Sub \n End Module"),
 NewLines("Module Module1 \n Sub M() \n Dim a = Iterator Sub() \n Yield 0 \n End Sub \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
         Public Sub TestChangeToYieldCodeFixProviderSingleLineFunctionLambda()
             TestMissing(NewLines("Module Module1 \n Sub M() \n Dim a = Iterator Function() [|Return|] 0 \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsChangeToYield)>
         Public Sub TestChangeToYieldCodeFixProviderSingleLineSubLambda()
             Test(
 NewLines("Module Module1 \n Sub M() \n Dim a = Iterator Sub() [|Return|] 0 \n End Sub \n End Module"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
@@ -14,27 +14,27 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.MoveTo
 
 #Region "Imports Tests"
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub TestImportsMissing()
             TestMissing(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n [|Imports Microsoft|] \n Module Program \n Sub Main(args As String()) \n  \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub ImportsInsideDeclaration()
             Test(
 NewLines("Module Program \n [|Imports System|] \n Sub Main(args As String()) \n End Sub \n End Module"),
 NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub ImportsAfterDeclarations()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n End Sub \n End Module \n [|Imports System|]"),
 NewLines("Imports System Module Program \n Sub Main(args As String()) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub ImportsMovedNextToOtherImports()
             Dim text = <File>
 Imports Microsoft
@@ -59,7 +59,7 @@ End Module</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub ImportsMovedAfterOptions()
             Dim text = <File>
 Option Explicit Off
@@ -84,7 +84,7 @@ End Module</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub ImportsWithTriviaMovedNextToOtherImports()
             Dim text = <File>
 Imports Microsoft
@@ -109,7 +109,7 @@ End Module</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub ImportsWithTriviaMovedNextToOtherImportsWithTrivia()
             Dim text = <File>
 Imports Microsoft 'C1
@@ -135,7 +135,7 @@ End Module</File>
         End Sub
 
         <WorkItem(601222)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub OnlyMoveOptions()
             Dim text = <File>
 Imports Sys = System
@@ -147,27 +147,27 @@ Option Infer Off
 #End Region
 
 #Region "Option Tests"
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub TestOptionsMissing()
             TestMissing(
 NewLines("[|Option Explicit Off|] \n Module Program \n Sub Main(args As String()) \n  \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub OptionsInsideDeclaration()
             Test(
 NewLines("Module Program \n [|Option Explicit Off|] \n Sub Main(args As String()) \n End Sub \n End Module"),
 NewLines("Option Explicit Off \n Module Program \n Sub Main(args As String()) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub OptionsAfterDeclarations()
             Test(
 NewLines("Module Program \n Sub Main(args As String()) \n End Sub \n End Module \n [|Option Explicit Off|]"),
 NewLines("Option Explicit Off \n Module Program \n Sub Main(args As String()) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub OptionsMovedNextToOtherOptions()
             Dim text = <File>
 Option Explicit Off
@@ -192,7 +192,7 @@ End Module</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub OptionsWithTriviaMovedNextToOtherOptions()
             Dim text = <File>
 Imports Microsoft
@@ -217,7 +217,7 @@ End Module</File>
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub OptionsWithTriviaMovedNextToOtherOptionsWithTrivia()
             Dim text = <File>
 Option Explicit Off'C1
@@ -244,7 +244,7 @@ End Module</File>
 #End Region
 
 #Region "Attribute Tests"
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub AttributeNoAction1()
             Dim text = <File>
 [|&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;|]
@@ -259,7 +259,7 @@ End Module</File>
             TestMissing(text.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub AttributeNoAction2()
             Dim text = <File>
 [|&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;|]
@@ -273,7 +273,7 @@ End Module</File>
             TestMissing(text.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub AttributeAfterDeclaration()
             Dim text = <File>
 Module Program
@@ -295,7 +295,7 @@ End Module
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub AttributeInsideDeclaration()
             Dim text = <File>
 Module Program
@@ -316,7 +316,7 @@ End Module
             Test(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Sub
 
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub AttributePreserveTrivia()
             Dim text = <File>
 &lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Comment
@@ -340,7 +340,7 @@ End Module
         End Sub
 
         <WorkItem(600949)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub RemoveAttribute()
             Dim text = <File>
 Class C
@@ -356,7 +356,7 @@ End Class
         End Sub
 
         <WorkItem(606857)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub MoveImportBeforeAttribute()
             Dim text = <File>
 &lt;Assembly:CLSCompliant(True)&gt;
@@ -369,7 +369,7 @@ End Class
         End Sub
 
         <WorkItem(606877)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub NewLineWhenMovingFromEOF()
             Dim text = <File>Imports System
 &lt;Assembly:CLSCompliant(True)&gt;
@@ -383,7 +383,7 @@ Imports System
         End Sub
 
         <WorkItem(606851)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
         Public Sub DoNotMoveLeadingWhitespace()
             Dim text = <File>Imports System
  
@@ -399,7 +399,7 @@ Imports System
 #End Region
 
         <WorkItem(632305)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Sub TestHiddenRegion()
             Dim code =
 <File>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Remove
         End Function
 
         <WorkItem(545979)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToErrorType()
             Dim markup =
 <File>
@@ -29,7 +29,7 @@ End Module
         End Sub
 
         <WorkItem(545148)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub ParenthesizeToKeepParseTheSame1()
             Dim markup =
 <File>
@@ -59,7 +59,7 @@ End Module
         End Sub
 
         <WorkItem(530762)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub ParenthesizeToKeepParseTheSame2()
             Dim markup =
 <File>
@@ -83,7 +83,7 @@ End Module
         End Sub
 
         <WorkItem(530762)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub ParenthesizeToKeepParseTheSame3()
             Dim markup =
 <File>
@@ -107,7 +107,7 @@ End Module
         End Sub
 
         <WorkItem(545149)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub InsertCallKeywordIfNecessary1()
             Dim markup =
 <File>
@@ -131,7 +131,7 @@ End Module
         End Sub
 
         <WorkItem(545150)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub InsertCallKeywordIfNecessary2()
             Dim markup =
 <File>
@@ -159,7 +159,7 @@ End Module
         End Sub
 
         <WorkItem(545229)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
         Public Sub InsertCallKeywordIfNecessary3()
             Dim code =
 <File>
@@ -190,7 +190,7 @@ End Class
 
         <WorkItem(545528)>
         <WorkItem(16488, "DevDiv_Projects/Roslyn")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub AddExplicitArgumentListIfNecessary1()
             Dim markup =
 <File>
@@ -218,7 +218,7 @@ End Module
         End Sub
 
         <WorkItem(545134)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveConversionFromNullableLongToIComparable()
             Dim markup =
 <File>
@@ -235,7 +235,7 @@ End Class
         End Sub
 
         <WorkItem(545151)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveArrayLiteralConversion()
             Dim markup =
 <File>
@@ -251,7 +251,7 @@ End Module
         End Sub
 
         <WorkItem(545152)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveAddressOfCastToDelegate()
             Dim markup =
 <File>
@@ -268,7 +268,7 @@ End Module
         End Sub
 
         <WorkItem(545311)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInLambda1()
             Dim markup =
 <File>
@@ -292,7 +292,7 @@ End Module
         End Sub
 
         <WorkItem(545311)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInLambda2()
             Dim markup =
 <File>
@@ -320,7 +320,7 @@ End Module
         End Sub
 
         <WorkItem(545311)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInLambda3()
             Dim markup =
 <File>
@@ -353,7 +353,7 @@ End Module
         End Sub
 
         <WorkItem(545311)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInFunctionStatement()
             Dim markup =
 <File>
@@ -377,7 +377,7 @@ End Module
         End Sub
 
         <WorkItem(545311)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInFunctionVariableAssignment()
             Dim markup =
 <File>
@@ -401,7 +401,7 @@ End Module
         End Sub
 
         <WorkItem(545312)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInBinaryExpression()
             Dim markup =
 <File>
@@ -429,7 +429,7 @@ End Module
         End Sub
 
         <WorkItem(545423)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInsideCaseLabel()
             Dim markup =
 <File>
@@ -457,7 +457,7 @@ End Module
         End Sub
 
         <WorkItem(545421)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInOptionalParameterValue()
             Dim markup =
 <File>
@@ -481,7 +481,7 @@ End Module
         End Sub
 
         <WorkItem(545579)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInRangeCaseClause1()
             Dim markup =
 <File>
@@ -511,7 +511,7 @@ End Module
         End Sub
 
         <WorkItem(545579)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastInRangeCaseClause2()
             Dim markup =
 <File>
@@ -541,7 +541,7 @@ End Module
         End Sub
 
         <WorkItem(545580)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastForLoop1()
             Dim markup =
 <File>
@@ -567,7 +567,7 @@ End Module
         End Sub
 
         <WorkItem(545580)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastForLoop2()
             Dim markup =
 <File>
@@ -593,7 +593,7 @@ End Module
         End Sub
 
         <WorkItem(545580)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnneededCastForLoop3()
             Dim markup =
 <File>
@@ -619,7 +619,7 @@ End Module
         End Sub
 
         <WorkItem(545599)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNeededCastWithUserDefinedConversionsAndOptionStrictOff()
             Dim markup =
 <File>
@@ -642,7 +642,7 @@ End Class
         End Sub
 
         <WorkItem(529535)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNeededCastWhenResultIsAmbiguous()
             Dim markup =
 <File>
@@ -690,7 +690,7 @@ End Module
         End Sub
 
         <WorkItem(545261)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastToNothingInArrayInitializer()
             Dim markup =
 <File>
@@ -714,7 +714,7 @@ End Module
         End Sub
 
         <WorkItem(545526)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastThatResultsInDifferentStringRepresentations()
             Dim markup =
 <File>
@@ -735,7 +735,7 @@ End Module
         End Sub
 
         <WorkItem(545631)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastThatChangesArrayLiteralTypeAndBreaksOverloadResolution()
             Dim markup =
 <File>
@@ -754,7 +754,7 @@ End Module
         End Sub
 
         <WorkItem(545456)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastInAttribute()
             Dim markup =
 <File>
@@ -792,7 +792,7 @@ End Class
         End Sub
 
         <WorkItem(545701)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub AddParenthesesIfCopyBackAffected1()
             Dim markup =
 <File>
@@ -826,7 +826,7 @@ End Module
         End Sub
 
         <WorkItem(545701)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub AddParenthesesIfCopyBackAffected2()
             Dim markup =
 <File>
@@ -860,7 +860,7 @@ End Module
         End Sub
 
         <WorkItem(545701)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub AddParenthesesIfCopyBackAffected3()
             Dim markup =
 <File>
@@ -894,7 +894,7 @@ End Module
         End Sub
 
         <WorkItem(545971)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastPassedToParamArray1()
             Dim markup =
 <File>
@@ -912,7 +912,7 @@ End Module
         End Sub
 
         <WorkItem(545971)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastPassedToParamArray2()
             Dim markup =
 <File>
@@ -930,7 +930,7 @@ End Module
         End Sub
 
         <WorkItem(545971)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastPassedToParamArray1()
             Dim markup =
 <File>
@@ -960,7 +960,7 @@ End Module
         End Sub
 
         <WorkItem(545971)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastPassedToParamArray2()
             Dim markup =
 <File>
@@ -990,7 +990,7 @@ End Module
         End Sub
 
         <WorkItem(545971)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastPassedToParamArray3()
             Dim markup =
 <File>
@@ -1022,7 +1022,7 @@ End Module
         End Sub
 
         <WorkItem(545971)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastPassedToParamArray4()
             Dim markup =
 <File>
@@ -1054,7 +1054,7 @@ End Module
         End Sub
 
         <WorkItem(545971)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastPassedToParamArray5()
             Dim markup =
 <File>
@@ -1085,7 +1085,7 @@ End Module
             Test(markup, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastToArrayLiteral1()
             Dim markup =
 <File>
@@ -1108,7 +1108,7 @@ End Module
             Test(markup, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastToArrayLiteral2()
             Dim markup =
 <File>
@@ -1126,7 +1126,7 @@ End Module
             TestMissing(markup)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastToArrayLiteral()
             Dim markup =
 <File>
@@ -1141,7 +1141,7 @@ End Module
         End Sub
 
         <WorkItem(545972)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastInBinaryIf1()
             Dim markup =
 <File>
@@ -1165,7 +1165,7 @@ End Class
         End Sub
 
         <WorkItem(545972)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastInBinaryIf2()
             Dim markup =
 <File>
@@ -1189,7 +1189,7 @@ End Class
         End Sub
 
         <WorkItem(545974)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastInObjectCreationExpression()
             Dim markup =
 <File>
@@ -1215,7 +1215,7 @@ End Module
         End Sub
 
         <WorkItem(545973)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastInSelectCase()
             Dim markup =
 <File>
@@ -1247,7 +1247,7 @@ End Module
         End Sub
 
         <WorkItem(545526)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToDoubleInOptionStrictOff()
             Dim markup =
 <File>
@@ -1268,7 +1268,7 @@ End Module
         End Sub
 
         <WorkItem(545828)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCStrInCharToStringToObjectChain()
             Dim markup =
 <File>
@@ -1285,7 +1285,7 @@ End Module
         End Sub
 
         <WorkItem(545808)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastWithMultipleUserDefinedConversionsAndOptionStrictOff()
             Dim markup =
 <File>
@@ -1311,7 +1311,7 @@ End Class
         End Sub
 
         <WorkItem(545998)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastWhichWouldChangeAttributeOverloadResolution()
             Dim markup =
 <File>
@@ -1332,7 +1332,7 @@ End Class
             TestMissing(markup)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontMoveTrailingComment()
             Dim markup =
 <File>
@@ -1359,7 +1359,7 @@ End Module
             Test(markup, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastInFieldInitializer()
             Dim markup =
 <File>
@@ -1388,7 +1388,7 @@ End Class
             Test(markup, expected, compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontDuplicateTrivia()
             Dim markup =
 <File>
@@ -1420,7 +1420,7 @@ End Module
         End Sub
 
         <WorkItem(531479)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub EscapeNextStatementIfNeeded()
             Dim markup =
 <File>
@@ -1456,7 +1456,7 @@ End Module
         End Sub
 
         <WorkItem(607749)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub Bugfix_607749()
             Dim markup =
 <File>
@@ -1488,7 +1488,7 @@ End Class
         End Sub
 
         <WorkItem(609477)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub Bugfix_609477()
             Dim markup =
 <File>
@@ -1515,7 +1515,7 @@ End Module
         End Sub
 
         <WorkItem(552813)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastWhileNarrowingWithOptionOn()
             Dim markup =
 <File>
@@ -1532,7 +1532,7 @@ End Module
         End Sub
 
         <WorkItem(577929)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastWhileDefaultingNullables()
             Dim markup =
 <File>
@@ -1547,7 +1547,7 @@ End Module
             TestMissing(markup)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastAroundAction()
             Dim markup =
 <File>
@@ -1576,7 +1576,7 @@ End Module
         End Sub
 
         <WorkItem(578016)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCStr()
             Dim markup =
 <File>Option Strict On
@@ -1594,7 +1594,7 @@ End Module
         End Sub
 
         <WorkItem(530105)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNumericCast()
             Dim markup =
 <File>
@@ -1606,7 +1606,7 @@ End Interface
         End Sub
 
         <WorkItem(530104)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCTypeFromNumberToEnum()
             Dim markup =
 <File>
@@ -1620,7 +1620,7 @@ End Interface
         End Sub
 
         <WorkItem(530077)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastForLambdaToDelegateConversionWithOptionStrictOn()
             Dim markup =
  <File>
@@ -1639,7 +1639,7 @@ End Module
         End Sub
 
         <WorkItem(529966)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveForNarrowingConversionFromObjectWithOptionStrictOnInsideQueryExpression()
             Dim markup =
 <File>
@@ -1658,7 +1658,7 @@ End Module
         End Sub
 
         <WorkItem(530650)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastFromLambdaToDelegateParenthesizeLambda()
             Dim markup =
 <File>
@@ -1685,7 +1685,7 @@ End Module
         End Sub
 
         <WorkItem(707189)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastFromInvocationStatement()
             Dim markup =
 <File>
@@ -1718,7 +1718,7 @@ End Module
         End Sub
 
         <WorkItem(707189)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastFromInvocationStatement2()
             Dim markup =
 <File>
@@ -1755,7 +1755,7 @@ End Class
         End Sub
 
         <WorkItem(768895)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveUnnecessaryCastInTernary()
             Dim markup =
 <File>
@@ -1780,7 +1780,7 @@ End Class
         End Sub
 
         <WorkItem(770187)>
-        <WpfFact(Skip:="770187"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(Skip:="770187"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastInSelectCaseExpression()
             ' Cast removal invokes a different user defined operator, hence the cast is necessary.
 
@@ -1825,7 +1825,7 @@ End Namespace]]>
         End Sub
 
         <WorkItem(770187)>
-        <WpfFact(Skip:="770187"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(Skip:="770187"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastInSelectCaseExpression2()
             ' Cast removal invokes a different user defined operator, hence the cast is necessary.
 
@@ -1870,7 +1870,7 @@ End Namespace]]>
         End Sub
 
         <WorkItem(770187)>
-        <WpfFact(Skip:="770187"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact(Skip:="770187"), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveNecessaryCastInSelectCaseExpression3()
             ' Cast removal invokes a different user defined operator, hence the cast is necessary.
 
@@ -1917,7 +1917,7 @@ End Namespace]]>
 #Region "Interface Casts"
 
         <WorkItem(545889)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToInterfaceForUnsealedType()
             Dim markup =
 <File>
@@ -1947,7 +1947,7 @@ End Class
         End Sub
 
         <WorkItem(545890)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToInterfaceForSealedType1()
             ' Note: The cast below can be removed because C is sealed and the
             ' unspecified optional parameters of I.Foo() and C.Foo() have the
@@ -1996,7 +1996,7 @@ End Class
         End Sub
 
         <WorkItem(545890)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToInterfaceForSealedType2()
             ' Note: The cast below can be removed because C is sealed and the
             ' interface member has no parameters.
@@ -2048,7 +2048,7 @@ End Class
         End Sub
 
         <WorkItem(545890)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToInterfaceForSealedType3()
             ' Note: The cast below can be removed because C is sealed and the
             ' interface member has no parameters.
@@ -2112,7 +2112,7 @@ End Class
         End Sub
 
         <WorkItem(545890)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToInterfaceForSealedType4()
             ' Note: The cast below can't be removed (even though C is sealed)
             ' because the unspecified optional parameter default values differ.
@@ -2141,7 +2141,7 @@ End Class
         End Sub
 
         <WorkItem(545890)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToInterfaceForSealedType5()
             ' Note: The cast below cannot be removed (even though C is sealed)
             ' because default values differ for optional parameters and
@@ -2171,7 +2171,7 @@ End Class
         End Sub
 
         <WorkItem(545888)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToInterfaceForSealedType6()
             ' Note: The cast below can't be removed (even though C is sealed)
             ' because the specified named arguments refer to parameters that
@@ -2201,7 +2201,7 @@ End Class
         End Sub
 
         <WorkItem(545888)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToInterfaceForSealedType7()
             ' Note: The cast below can be removed as C is sealed and
             ' because the specified named arguments refer to parameters that
@@ -2250,7 +2250,7 @@ End Class
         End Sub
 
         <WorkItem(545888)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToInterfaceForSealedType9()
             ' Note: The cast below can't be removed (even though C is sealed)
             ' because it would result in binding to a Dispose method that doesn't
@@ -2278,7 +2278,7 @@ End Class
         End Sub
 
         <WorkItem(545887)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToInterfaceForStruct1()
             ' Note: The cast below can't be removed because the cast boxes 's' and
             ' unboxing would change program behavior.
@@ -2319,7 +2319,7 @@ End Structure
         End Sub
 
         <WorkItem(545834), WorkItem(530073)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToInterfaceForStruct2()
             ' Note: The cast below can be removed because we are sure to have
             ' a fresh copy of the struct from the GetEnumerator() method.
@@ -2361,7 +2361,7 @@ End Class
         End Sub
 
         <WorkItem(544655)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToICloneableForDelegate()
             ' Note: The cast below can be removed because delegates are implicitly sealed.
 
@@ -2394,7 +2394,7 @@ End Class
         End Sub
 
         <WorkItem(545926)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToICloneableForArray()
             ' Note: The cast below can be removed because arrays are implicitly sealed.
 
@@ -2425,7 +2425,7 @@ End Class
         End Sub
 
         <WorkItem(529937)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToICloneableForArray2()
             ' Note: The cast below can be removed because arrays are implicitly sealed.
 
@@ -2454,7 +2454,7 @@ End Module
         End Sub
 
         <WorkItem(529897)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastToIConvertibleForEnum()
             ' Note: The cast below can be removed because enums are implicitly sealed.
 
@@ -2487,7 +2487,7 @@ End Class
 
         <WorkItem(844482)>
         <WorkItem(1031406)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DoNotRemoveCastFromDerivedToBaseWithImplicitReference()
             ' Cast removal changes the runtime behavior of the program.
             Dim markup =
@@ -2510,7 +2510,7 @@ End Class
         End Sub
 
         <WorkItem(995908)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveCastIntroducesDuplicateAnnotations()
             Dim markup =
 <File>
@@ -2577,7 +2577,7 @@ End Module
 #End Region
 
         <WorkItem(739, "#739")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveAroundArrayLiteralInInterpolation1()
             Dim markup =
 <File>
@@ -2597,7 +2597,7 @@ End Module
         End Sub
 
         <WorkItem(739, "#739")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveAroundArrayLiteralInInterpolation2()
             Dim markup =
 <File>
@@ -2617,7 +2617,7 @@ End Module
         End Sub
 
         <WorkItem(739, "#739")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub RemoveAroundArrayLiteralInInterpolation3()
             Dim markup =
 <File>
@@ -2637,7 +2637,7 @@ End Module
         End Sub
 
         <WorkItem(2761, "https://github.com/dotnet/roslyn/issues/2761")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastFromBaseToDerivedWithNarrowingReference()
             Dim markup =
 <File>
@@ -2660,7 +2660,7 @@ End Class
         End Sub
 
         <WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToTypeParameterWithExceptionConstraint()
             Dim markup =
 <File>
@@ -2678,7 +2678,7 @@ End Class
         End Sub
 
         <WorkItem(3254, "https://github.com/dotnet/roslyn/issues/3254")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DontRemoveCastToTypeParameterWithExceptionSubTypeConstraint()
             Dim markup =
 <File>
@@ -2696,7 +2696,7 @@ End Class
         End Sub
 
         <WorkItem(3163, "https://github.com/dotnet/roslyn/issues/3163")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DoNotRemoveCastInUserDefinedNarrowingConversionStrictOn()
             Dim markup =
 <File>
@@ -2735,7 +2735,7 @@ End Structure
         End Sub
 
         <WorkItem(3163, "https://github.com/dotnet/roslyn/issues/3163")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Sub DoNotRemoveCastInUserDefinedNarrowingConversionStrictOff()
             Dim markup =
 <File>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests_FixAllTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Remove
     Partial Public Class RemoveUnnecessaryCastTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInDocument()
@@ -170,7 +170,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=Nothing)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInProject()
@@ -307,7 +307,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=Nothing)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution()

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Remove
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(New VisualBasicRemoveUnnecessaryImportsDiagnosticAnalyzer(), New RemoveUnnecessaryImportsCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestProjectLevelMemberImport1()
             Test(
 NewLines("[|Imports System \n Module Program \n Sub Main(args As DateTime()) \n End Sub \n End Module|]"),
@@ -25,69 +25,69 @@ parseOptions:=TestOptions.Regular,
 compilationOptions:=TestOptions.ReleaseExe.WithGlobalImports({GlobalImport.Parse("System")}))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestProjectLevelMemberImport2()
             TestMissing(
 NewLines("[|Imports System \n Module Program \n Sub Main(args As DateTime()) \n End Sub \n End Module|]"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestNoImports()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n End Sub \n End Module|]"),
 NewLines("Module Program \n Sub Main(args As String()) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestSimpleTypeName()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim s As DateTime \n End Sub \n End Module|]"),
 NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Dim s As DateTime \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestGenericTypeName()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim s As List(Of Integer) \n End Sub \n End Module|]"),
 NewLines("Imports System.Collections.Generic \n Module Program \n Sub Main(args As String()) \n Dim s As List(Of Integer) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestNamespaceName()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n Dim s As Collections.Generic.List(Of Integer) \n End Sub \n End Module|]"),
 NewLines("Imports System \n Module Program \n Sub Main(args As String()) \n Dim s As Collections.Generic.List(Of Integer) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestAliasName()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Imports G = System.Collections.Generic \n Module Program \n Sub Main(args As String()) \n Dim s As G.List(Of Integer) \n End Sub \n End Module|]"),
 NewLines("Imports G = System.Collections.Generic \n Module Program \n Sub Main(args As String()) \n Dim s As G.List(Of Integer) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestExtensionMethod()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As String()) \n args.Where(Function(a) a.Length > 21) \n End Sub \n End Module|]"),
 NewLines("Imports System.Linq \n Module Program \n Sub Main(args As String()) \n args.Where(Function(a) a.Length > 21) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestModuleMember()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Imports Foo \n Namespace Foo \n Public Module M \n Public Sub Bar(i As Integer) \n End Sub \n End Module \n End Namespace \n Module Program \n Sub Main(args As String()) \n Bar(0) \n End Sub \n End Module|]"),
 NewLines("Imports Foo \n Namespace Foo \n Public Module M \n Public Sub Bar(i As Integer) \n End Sub \n End Module \n End Namespace \n Module Program \n Sub Main(args As String()) \n Bar(0) \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestInvalidCodeRemovesImports()
             Test(
 NewLines("[|Imports System \n Imports System.Collections.Generic \n Module Program \n Sub Main() \n gibberish Dim lst As List(Of String) \n Console.WriteLine(""TEST"") \n End Sub \n End Module|]"),
 NewLines("Imports System \n Module Program \n Sub Main() \n gibberish Dim lst As List(Of String) \n Console.WriteLine(""TEST"") \n End Sub \n End Module"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestExcludedCodeIsIgnored()
             Test(
 NewLines("[|Imports System \n Module Program \n Sub Main() \n #If False Then \n Console.WriteLine(""TEST"") \n #End If \n End Sub \n End Module|]"),
@@ -95,7 +95,7 @@ NewLines("Module Program \n Sub Main() \n #If False Then \n Console.WriteLine(""
         End Sub
 
         <WorkItem(541744)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestCommentsAroundImportsStatement()
             Test(
 <Text>'c1
@@ -121,20 +121,20 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(541747)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestAttribute()
             TestMissing(
 NewLines("[|Imports SomeNamespace \n <SomeAttr> \n Class Foo \n End Class \n Namespace SomeNamespace \n Public Class SomeAttrAttribute \n Inherits Attribute \n End Class \n End Namespace|]"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestAttributeArgument()
             TestMissing(
 NewLines("[|Imports System \n Imports SomeNamespace \n <SomeAttribute(Foo.C)> \n Module Program \n Sub Main(args As String()) \n End Sub \n End Module \n Namespace SomeNamespace \n Public Enum Foo \n A \n B \n C \n End Enum \n End Namespace \n Public Class SomeAttribute \n Inherits Attribute \n Public Sub New(x As SomeNamespace.Foo) \n End Sub \n End Class|]"))
         End Sub
 
         <WorkItem(541757)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImportsSurroundedByDirectives()
             Test(
 NewLines("#If True Then \n [|Imports System.Collections.Generic \n #End If \n Module Program \n End Module|]"),
@@ -142,7 +142,7 @@ NewLines("#If True Then \n #End If \n Module Program \n End Module"))
         End Sub
 
         <WorkItem(541758)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemovingUnbindableImports()
             Test(
 NewLines("[|Imports gibberish \n Module Program \n End Module|]"),
@@ -150,7 +150,7 @@ NewLines("Module Program \n End Module"))
         End Sub
 
         <WorkItem(541744)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestPreservePrecedingComments()
             Test(
 <Text>' c1
@@ -168,7 +168,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(541757)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestDirective1()
             Test(
 <Text>#If True Then
@@ -186,7 +186,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(541757)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestDirective2()
             Test(
 <Text>#If True Then
@@ -208,7 +208,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(541932)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImportsClauseRemoval1()
             Test(
 NewLines("[|Imports System, foo, System.Collections.Generic \n Module Program \n Sub Main(args As String()) \n Console.WriteLine(""TEST"") \n Dim q As List(Of Integer) \n End Sub \n End Module \n Namespace foo \n Class bar \n End Class \n End Namespace|]"),
@@ -216,7 +216,7 @@ NewLines("Imports System, System.Collections.Generic \n Module Program \n Sub Ma
         End Sub
 
         <WorkItem(541932)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImportsClauseRemoval2()
             Test(
 NewLines("[|Imports System, System.Collections.Generic, foo \n Module Program \n Sub Main(args As String()) \n Console.WriteLine(""TEST"") \n Dim q As List(Of Integer) \n End Sub \n End Module \n Namespace foo \n Class bar \n End Class \n End Namespace|]"),
@@ -224,7 +224,7 @@ NewLines("Imports System, System.Collections.Generic \n Module Program \n Sub Ma
         End Sub
 
         <WorkItem(541932)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImportsClauseRemoval3()
             Test(
 NewLines("[|Imports foo, System, System.Collections.Generic \n Module Program \n Sub Main(args As String()) \n Console.WriteLine(""TEST"") \n Dim q As List(Of Integer) \n End Sub \n End Module \n Namespace foo \n Class bar \n End Class \n End Namespace|]"),
@@ -232,7 +232,7 @@ NewLines("Imports System, System.Collections.Generic \n Module Program \n Sub Ma
         End Sub
 
         <WorkItem(541758)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestUnbindableNamespace()
             Test(
 NewLines("[|Imports gibberish \n Module Program \n End Module|]"),
@@ -240,7 +240,7 @@ NewLines("Module Program \n End Module"))
         End Sub
 
         <WorkItem(541780)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemoveClause()
             Test(
 NewLines("[|Imports System, foo, System.Collections.Generic \n Module Program \n Sub Main(args As String()) \n Console.WriteLine(""TEST"") \n Dim q As List(Of Integer) \n End Sub \n End Module \n Namespace foo \n Class bar \n End Class \n End Namespace|]"),
@@ -248,14 +248,14 @@ NewLines("Imports System, System.Collections.Generic \n Module Program \n Sub Ma
         End Sub
 
         <WorkItem(528603)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemoveClauseWithExplicitLC1()
             Test(
 NewLines("[|Imports A _ \n , B \n Module Program \n Sub Main(args As String()) \n Dim q As CA \n End Sub \n End Module \n Namespace A \n Public Class CA \n End Class \n End Namespace \n Namespace B \n Public Class CB \n End Class \n End Namespace|]"),
 NewLines("Imports A \n Module Program \n Sub Main(args As String()) \n Dim q As CA \n End Sub \n End Module \n Namespace A \n Public Class CA \n End Class \n End Namespace \n Namespace B \n Public Class CB \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemoveClauseWithExplicitLC2()
             Test(
 NewLines("[|Imports B _ \n , A \n Module Program \n Sub Main(args As String()) \n Dim q As CA \n End Sub \n End Module \n Namespace A \n Public Class CA \n End Class \n End Namespace \n Namespace B \n Public Class CB \n End Class \n End Namespace|]"),
@@ -263,7 +263,7 @@ NewLines("Imports A \n Module Program \n Sub Main(args As String()) \n Dim q As 
         End Sub
 
         <WorkItem(528603)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemoveClauseWithExplicitLC3()
             Test(
 <Text>[|Imports A _
@@ -317,7 +317,7 @@ End Namespace</Text>.NormalizedValue,
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestTypeImports()
             Test(
 <Text>[|Imports Foo
@@ -344,7 +344,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(528603)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestTypeImports_DoesNotRemove()
             TestMissing(
 <Text>[|Imports Foo
@@ -363,7 +363,7 @@ End Class|]</Text>.NormalizedValue, parseOptions:=Nothing)
             ' TODO: Enable testing in script when it comes online
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestAlias()
             Test(
 <Text>[|Imports F = SomeNS
@@ -389,7 +389,7 @@ End Namespace</Text>.NormalizedValue,
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestAlias_DoesNotRemove()
             TestMissing(
 <Text>[|Imports F = SomeNS
@@ -408,7 +408,7 @@ End Namespace|]</Text>.NormalizedValue)
 
         <WorkItem(541809)>
         <WorkItem(16488, "DevDiv_Projects/Roslyn")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImportsOnSameLine1()
             Test(
 <Text>[|Imports A : Imports B
@@ -448,7 +448,7 @@ End Namespace</Text>.NormalizedValue,
 compareTokens:=False)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImportsOnSameLine2()
             Test(
 <Text>[|Imports A : Imports B
@@ -503,21 +503,21 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(541808)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestTypeImport1()
             TestMissing(
 NewLines("[|Imports Foo \n Module Program \n Sub Main() \n Bar() \n End Sub \n End Module \n Public Class Foo \n Shared Sub Bar() \n End Sub \n End Class|]"),
 parseOptions:=Nothing) 'TODO (tomat): modules not yet supported in script
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestTypeImport2()
             TestMissing(
 NewLines("[|Imports Foo \n Module Program \n Sub Main() \n Dim q As Integer = Bar \n End Sub \n End Module \n Public Class Foo \n Public Shared Bar As Integer \n End Sub \n End Class|]"),
 parseOptions:=Nothing) 'TODO (tomat): modules not yet supported in script
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestUnusedTypeImportIsRemoved()
             Test(
 <Text>[|Imports SomeNS.Foo
@@ -544,7 +544,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(528643)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestExtensionMethodLinq()
             ' TODO: Enable script context testing.
 
@@ -575,7 +575,7 @@ End Namespace|]</Text>.NormalizedValue, parseOptions:=TestOptions.Regular)
         End Sub
 
         <WorkItem(543217)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestExtensionMethodLinq2()
             TestMissing(
 <Text>[|Imports System.Collections.Generic
@@ -597,7 +597,7 @@ End Module
         End Sub
 
         <WorkItem(542135)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImportedTypeUsedAsGenericTypeArgument()
             TestMissing(
 <Text>[|Imports GenericThingie
@@ -620,7 +620,7 @@ End Class|]</Text>.NormalizedValue)
         End Sub
 
         <WorkItem(542132)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemoveSuperfluousNewLines1()
             Test(
 <Text>[|Imports System
@@ -641,7 +641,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(542132)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemoveSuperfluousNewLines2()
             Test(
 <Text><![CDATA[[|Imports System
@@ -669,7 +669,7 @@ compareTokens:=False)
         End Sub
 
         <WorkItem(542895)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub RegressionFor10326()
             Test(
 NewLines("[|Imports System.ComponentModel \n <Foo(GetType(Category))> \n Class Category \n End Class|]"),
@@ -677,7 +677,7 @@ NewLines("<Foo(GetType(Category))> \n Class Category \n End Class"))
         End Sub
 
         <WorkItem(712656)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemovalSpan1()
             TestSpans(
 <text>    [|Imports System
@@ -692,7 +692,7 @@ End Namespace</text>.NormalizedValue)
 
         <WorkItem(545434)>
         <WorkItem(712656)>
-        <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemovalSpan2()
             TestSpans(
 <text>
@@ -708,7 +708,7 @@ Imports System.Runtime.InteropServices|]</text>.NormalizedValue,
         End Sub
 
         <WorkItem(712656)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestRemovalSpan3()
             Test(
 <text>
@@ -725,7 +725,7 @@ Class C : Dim x As Action : End Class</text>.NormalizedValue)
         End Sub
 
         <WorkItem(545831)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestImplicitElementAtOrDefault()
             Test(
 <Text><![CDATA[[|Option Strict On
@@ -796,7 +796,7 @@ End Namespace]]></Text>.NormalizedValue)
         End Sub
 
         <WorkItem(545964)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryImports)>
         Public Sub TestMissingOnSynthesizedEventType()
             TestMissing(
 NewLines("[|Class C \n Event E() \n End Class|]"))

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests_FixAllTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Remove
     Partial Public Class RemoveUnnecessaryImportsTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInDocument()
@@ -80,7 +80,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=Nothing)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInProject()
@@ -145,7 +145,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=Nothing)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution()

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Simpli
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(New VisualBasicSimplifyTypeNamesDiagnosticAnalyzer(), New SimplifyTypeNamesCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestGenericNames()
             Dim source =
         <Code>
@@ -53,7 +53,7 @@ End Class
             Test(source.Value, expected.Value)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestArgument()
             Test(
 NewLines("Imports System \n Imports System.Collections.Generic \n Imports System.Linq \n Module Program \n Sub Main(args As [|System.String|]()) \n End Sub \n End Module"),
@@ -61,7 +61,7 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Imports System
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestAliasWithMemberAccess()
             Test(
 NewLines("Imports Foo = System.Int32 \n Module Program \n Sub Main(args As String()) \n Dim x = [|System.Int32|].MaxValue \n End Sub \n End Module"),
@@ -69,7 +69,7 @@ NewLines("Imports Foo = System.Int32 \n Module Program \n Sub Main(args As Strin
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestWithCursorAtBeginning()
             Test(
 NewLines("Imports System.IO \n Module Program \n Sub Main(args As String()) \n Dim x As [|System.IO.File|] \n End Sub \n End Module"),
@@ -77,7 +77,7 @@ NewLines("Imports System.IO \n Module Program \n Sub Main(args As String()) \n D
 index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMinimalSimplifyOnNestedNamespaces()
             Dim source =
 NewLines("Imports Outer \n Namespace Outer \n Namespace Inner \n Class Foo \n End Class \n End Namespace \n End Namespace \n Module Program \n Sub Main(args As String()) \n Dim x As [|Outer.Inner.Foo|] \n End Sub \n End Module")
@@ -89,7 +89,7 @@ index:=0)
         End Sub
 
         <WorkItem(540567)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMinimalSimplifyOnNestedNamespacesFromMetadataAlias()
             Test(
 NewLines("Imports A1 = System.IO.File \n Class Foo \n Dim x As [|System.IO.File|] \n End Class"),
@@ -98,7 +98,7 @@ index:=0)
         End Sub
 
         <WorkItem(540567)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMinimalSimplifyOnNestedNamespacesFromMetadata()
             Test(
 NewLines("Imports System \n Class Foo \n Dim x As [|System.IO.File|] \n End Class"),
@@ -107,7 +107,7 @@ index:=0)
         End Sub
 
         <WorkItem(540569)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestFixAllOccurrences()
             Dim actionId = SimplifyTypeNamesCodeFixProvider.GetCodeActionId(IDEDiagnosticIds.SimplifyNamesDiagnosticId, "NS1.SomeClass")
             Test(
@@ -117,7 +117,7 @@ fixAllActionEquivalenceKey:=actionId)
         End Sub
 
         <WorkItem(578686)>
-        <WpfFact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllOccurrencesForAliases()
             Test(
@@ -126,7 +126,7 @@ NewLines("Imports System \n Imports foo = C.D \n Imports bar = A.B \n Namespace 
 index:=1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyFromReference()
             Test(
         NewLines("Imports System.Threading \n Class Class1 \n Dim v As [|System.Threading.Thread|] \n End Class"),
@@ -134,7 +134,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestGenericClassDefinitionAsClause()
             Test(
         NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class Base \n End Class \n End Namespace \n Class SomeClass(Of x As [|SomeNamespace.Base|]) \n End Class"),
@@ -142,7 +142,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestGenericClassInstantiationOfClause()
             Test(
         NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class GenericClass(Of T) \n End Class \n Class Foo \n Sub Method1() \n Dim q As GenericClass(Of [|SomeNamespace.SomeClass|]) \n End Sub \n End Class"),
@@ -150,7 +150,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestGenericMethodDefinitionAsClause()
             Test(
         NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T As [|SomeNamespace.SomeClass|]) \n End Sub \n End Class"),
@@ -158,7 +158,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestGenericMethodInvocationOfClause()
             Test(
         NewLines("Imports SomeNamespace \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace \n Class Foo \n Sub Method1(Of T) \n End Sub \n Sub Method2() \n Method1(Of [|SomeNamespace.SomeClass|]) \n End Sub \n End Class"),
@@ -167,7 +167,7 @@ index:=1)
         End Sub
 
         <WorkItem(6872, "DevDiv_Projects/Roslyn")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestAttributeApplication()
             Test(
         NewLines("Imports SomeNamespace \n <[|SomeNamespace.Something|]()> \n Class Foo \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"),
@@ -176,7 +176,7 @@ index:=1)
         End Sub
 
         <WorkItem(6872, "DevDiv_Projects/Roslyn")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMultipleAttributeApplicationBelow()
 
             'IMPLEMENT NOT ESCAPE ATTRIBUTE DEPENDENT ON CONTEXT
@@ -188,7 +188,7 @@ index:=1)
         End Sub
 
         <WorkItem(6872, "DevDiv_Projects/Roslyn")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMultipleAttributeApplicationAbove()
             Test(
         NewLines("Imports System \n Imports SomeNamespace \n <[|SomeNamespace.Something|]()> \n <Existing()> \n Class Foo \n End Class \n Class ExistingAttribute \n Inherits System.Attribute \n End Class \n Namespace SomeNamespace \n Class SomethingAttribute \n Inherits System.Attribute \n End Class \n End Namespace"),
@@ -196,7 +196,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifiedLeftmostQualifierIsEscapedWhenMatchesKeyword()
             Test(
         NewLines("Imports Outer \n Class SomeClass \n Dim x As [|Outer.Namespace.Something|] \n End Class \n Namespace Outer \n Namespace [Namespace] \n Class Something \n End Class \n End Namespace \n End Namespace"),
@@ -204,7 +204,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestTypeNameIsEscapedWhenMatchingKeyword()
             Test(
         NewLines("Imports Outer \n Class SomeClass \n Dim x As [|Outer.Class|] \n End Class \n Namespace Outer \n Class [Class] \n End Class \n End Namespace"),
@@ -212,25 +212,25 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyNotSuggestedInImportsStatement()
             TestMissing(
         NewLines("[|Imports SomeNamespace \n Imports SomeNamespace.InnerNamespace \n Namespace SomeNamespace \n Namespace InnerNamespace \n Class SomeClass \n End Class \n End Namespace \n End Namespace|]"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNoSimplifyInGenericAsClauseIfConflictsWithTypeParameterName()
             TestMissing(
         NewLines("[|Imports SomeNamespace \n Class Class1 \n Sub Foo(Of SomeClass)(x As SomeNamespace.SomeClass) \n End Sub \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace|]"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyNotOfferedIfSimplifyingWouldCauseAmbiguity()
             TestMissing(
         NewLines("[|Imports SomeNamespace \n Class SomeClass \n End Class \n Class Class1 \n Dim x As SomeNamespace.SomeClass \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace|]"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyInGenericAsClauseIfNoConflictWithTypeParameterName()
             Test(
         NewLines("Imports SomeNamespace \n Class Class1 \n Sub Foo(Of T)(x As [|SomeNamespace.SomeClass|]) \n End Sub \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"),
@@ -238,7 +238,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestCaseInsensitivity()
             Test(
         NewLines("Imports SomeNamespace \n Class Foo \n Dim x As [|SomeNamespace.someclass|] \n End Class \n Namespace SomeNamespace \n Class SomeClass \n End Class \n End Namespace"),
@@ -246,7 +246,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyGenericTypeWithArguments()
             Dim source =
         NewLines("Imports System.Collections.Generic \n Class Foo \n Function F() As [|System.Collections.Generic.List(Of Integer)|] \n End Function \n End Class")
@@ -257,7 +257,7 @@ index:=1)
             TestActionCount(source, 1)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestParameterType()
             Test(
         NewLines("Imports System.IO \n Module Program \n Sub Main(args As String(), f As [|System.IO.FileMode|]) \n End Sub \n End Module"),
@@ -266,7 +266,7 @@ index:=1)
         End Sub
 
         <WorkItem(540565)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestLocation1()
             Test(
         NewLines("Imports Foo \n Namespace Foo \n Class FooClass \n End Class \n End Namespace \n Module Program \n Sub Main(args As String()) \n Dim x As [|Foo.FooClass|] \n End Sub \n End Module"),
@@ -274,7 +274,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllFixesUnrelatedTypes()
             Test(
@@ -282,7 +282,7 @@ index:=1)
         NewLines("Imports A \n Imports B \n Imports C \n Module Program \n Sub Method1(a As FooA, b As FooB, c As FooC) \n Dim qa As FooA \n Dim qb As FooB \n Dim qc As FooC \n End Sub \n End Module \n Namespace A \n Class FooA \n End Class \n End Namespace \n Namespace B \n Class FooB \n End Class \n End Namespace \n Namespace C \n Class FooC \n End Class \n End Namespace"))
         End Sub
 
-        <WpfFact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestSimplifyFixesAllNestedTypeNames()
             Dim source =
@@ -295,7 +295,7 @@ index:=1)
         End Sub
 
         <WorkItem(551040)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyNestedType()
             Dim source =
         NewLines("Class Preserve \n Public Class X \n Public Shared Y \n End Class \n End Class \n Class Z(Of T) \n Inherits Preserve \n End Class \n Class M \n Public Shared Sub Main() \n Redim [|Z(Of Integer).X|].Y(1) \n End Function \n End Class")
@@ -307,7 +307,7 @@ index:=1)
         End Sub
 
         <WorkItem(551040)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyStaticMemberAccess()
             Dim source =
         NewLines("Class Preserve \n Public Shared Y \n End Class \n Class Z(Of T) \n Inherits Preserve \n End Class \n Class M \n Public Shared Sub Main() \n Redim [|Z(Of Integer).Y(1)|] \n End Function \n End Class")
@@ -319,7 +319,7 @@ index:=1)
         End Sub
 
         <WorkItem(540398)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestImplementsClause()
             Test(
         NewLines("Imports System \n Class Foo \n Implements IComparable(Of String) \n Public Function CompareTo(other As String) As Integer Implements [|System.IComparable(Of String).CompareTo|] \n Return Nothing \n End Function \n End Class"),
@@ -327,7 +327,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimpleArray()
             Test(
         NewLines("Imports System.Collections.Generic \n Namespace N1 \n Class Test \n Private a As [|System.Collections.Generic.List(Of System.String())|] \n End Class \n End Namespace"),
@@ -335,7 +335,7 @@ index:=1)
         index:=0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimpleMultiDimArray()
             Test(
         NewLines("Imports System.Collections.Generic \n Namespace N1 \n Class Test \n Private a As [|System.Collections.Generic.List(Of System.String()(,)(,,,)) |]  \n End Class \n End Namespace"),
@@ -344,13 +344,13 @@ index:=1)
         End Sub
 
         <WorkItem(542093)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNoSimplificationOfParenthesizedPredefinedTypes()
             TestMissing(
         NewLines("[|Module M \n Sub Main() \n Dim x = (System.String).Equals("", "") \n End Sub \n End Module|]"))
         End Sub
 
-        <WpfFact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact(Skip:="1033012"), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestConflicts()
             Test(
@@ -491,7 +491,7 @@ End Namespace
         End Sub
 
         <WorkItem(542138)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyModuleWithReservedName()
             Test(
         NewLines("Namespace X \n Module [String] \n Sub Main() \n [|X.String.Main|] \n End Sub \n End Module \n End Namespace"),
@@ -500,7 +500,7 @@ End Namespace
         End Sub
 
         <WorkItem(542348)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestPreserve1()
             Test(
         NewLines("Module M \n Dim preserve() \n Sub Main() \n ReDim [|M.preserve|](1) \n End Sub \n End Module"),
@@ -510,7 +510,7 @@ End Namespace
 
         <WorkItem(551040)>
         <WorkItem(542348)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestPreserve3()
             Test(
         NewLines("Class Preserve \n Class X \n Public Shared Dim Y \n End Class \n End Class \n Class Z(Of T) \n Inherits Preserve \n End Class \n Module M \n Sub Main() \n ReDim [|Z(Of Integer).X.Y|](1) ' Simplify Z(Of Integer).X \n End Sub \n End Module"),
@@ -518,21 +518,21 @@ End Namespace
         End Sub
 
         <WorkItem(545603)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableInImports1()
             TestMissing(
         NewLines("Imports [|System.Nullable(Of Integer)|]"))
         End Sub
 
         <WorkItem(545603)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableInImports2()
             TestMissing(
         NewLines("Imports [|System.Nullable(Of Integer)|]"))
         End Sub
 
         <WorkItem(545795)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestColorColor1()
             Test(
         NewLines("Namespace N \n Class Color \n Shared Sub Foo() \n End Class \n  \n Class Program \n Shared Property Color As Color \n  \n Shared Sub Main() \n Dim c = [|N.Color.Foo|]() \n End Sub \n End Class \n End Namespace"),
@@ -540,7 +540,7 @@ End Namespace
         End Sub
 
         <WorkItem(545795)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestColorColor2()
             Test(
         NewLines("Namespace N \n Class Color \n Shared Sub Foo() \n End Class \n  \n Class Program \n Shared Property Color As Color \n  \n Shared Sub Main() \n Dim c = [|N.Color.Foo|]() \n End Sub \n End Class \n End Namespace"),
@@ -548,7 +548,7 @@ End Namespace
         End Sub
 
         <WorkItem(545795)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestColorColor3()
             Test(
         NewLines("Namespace N \n Class Color \n Shared Sub Foo() \n End Class \n  \n Class Program \n Shared Property Color As Color \n  \n Shared Sub Main() \n Dim c = [|N.Color.Foo|]() \n End Sub \n End Class \n End Namespace"),
@@ -556,7 +556,7 @@ End Namespace
         End Sub
 
         <WorkItem(546829)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestKeyword1()
             Test(
         NewLines("Module m \n Sub main() \n Dim x = [|m.Equals|](1, 1) \n End Sub \n End Module"),
@@ -564,7 +564,7 @@ End Namespace
         End Sub
 
         <WorkItem(546844)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestKeyword2()
             Test(
         NewLines("Module M \n Sub main() \n Dim x = [|M.Class|] \n End Sub \n Dim [Class] \n End Module"),
@@ -572,14 +572,14 @@ End Namespace
         End Sub
 
         <WorkItem(546907)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestDoNotSimplifyNullableInMemberAccessExpression()
             TestMissing(
         NewLines("Imports System \n Module Program \n Dim x = [|Nullable(Of Guid).op_Implicit|](Nothing) \n End Module"))
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMissingNullableSimplificationInsideCref()
             TestMissing(
 "Imports System
@@ -591,7 +591,7 @@ End Class")
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMissingNullableSimplificationInsideCref2()
             TestMissing(
 "''' <summary>
@@ -602,7 +602,7 @@ End Class")
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMissingNullableSimplificationInsideCref3()
             TestMissing(
 "''' <summary>
@@ -613,7 +613,7 @@ End Class")
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestMissingNullableSimplificationInsideCref4()
             TestMissing(
 "Imports System
@@ -627,7 +627,7 @@ End Class")
         <WorkItem(2196, "https://github.com/dotnet/roslyn/issues/2196")>
         <WorkItem(2197, "https://github.com/dotnet/roslyn/issues/2197")>
         <WorkItem(29, "https: //github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableSimplificationInsideCref()
             ' NOTE: This will probably stop working if issues 2196 / 2197 related to VB compiler and semantic model are fixed.
             ' It is unclear whether Nullable(Of Integer) is legal in the below case. Currently the VB compiler allows this while
@@ -652,7 +652,7 @@ End Class")
         <WorkItem(2189, "https://github.com/dotnet/roslyn/issues/2189")>
         <WorkItem(2196, "https://github.com/dotnet/roslyn/issues/2196")>
         <WorkItem(2197, "https://github.com/dotnet/roslyn/issues/2197")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableSimplificationInsideCref2()
             ' NOTE: This will probably stop working if issues 2196 / 2197 related to VB compiler and semantic model are fixed.
             ' It is unclear whether Nullable(Of Integer) is legal in the below case. Currently the VB compiler allows this while
@@ -678,7 +678,7 @@ End Class")
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableSimplificationInsideCref3()
             Test(
 "Imports System
@@ -700,7 +700,7 @@ End Structure")
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableSimplificationInsideCref4()
             Test(
 "Imports System
@@ -724,7 +724,7 @@ End Structure")
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableSimplificationInsideCref5()
             Test(
 "Imports System
@@ -748,7 +748,7 @@ End Structure")
         End Sub
 
         <WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestNullableSimplificationInsideCref6()
             Test(
 "Imports System
@@ -772,34 +772,34 @@ End Structure")
         End Sub
 
         <WorkItem(529930)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestReservedNameInAttribute1()
             TestMissing(
         NewLines("<[|Global.Assembly|]> ' Simplify \n Class Assembly \n Inherits Attribute \n End Class"))
         End Sub
 
         <WorkItem(529930)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestReservedNameInAttribute2()
             TestMissing(
         NewLines("<[|Global.Assembly|]> ' Simplify \n Class Assembly \n Inherits Attribute \n End Class"))
         End Sub
 
         <WorkItem(529930)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestReservedNameInAttribute3()
             TestMissing(
         NewLines("<[|Global.Module|]> ' Simplify \n Class Module \n Inherits Attribute \n End Class"))
         End Sub
 
         <WorkItem(529930)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestReservedNameInAttribute4()
             TestMissing(
         NewLines("<[|Global.Module|]> ' Simplify \n Class Module \n Inherits Attribute \n End Class"))
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestAliasedType()
             Dim source =
         NewLines("Class Program \n Sub Foo() \n Dim x As New [|Global.Program|] \n End Sub \n End Class")
@@ -810,7 +810,7 @@ End Structure")
         End Sub
 
         <WorkItem(674789)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub CheckForAssemblyNameInFullWidthIdentifier()
             Dim source =
         <Code>
@@ -839,7 +839,7 @@ End Namespace
         End Sub
 
         <WorkItem(568043)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DontSimplifyNamesWhenThereAreParseErrors()
             Dim source =
         <Code>
@@ -858,7 +858,7 @@ End Module
             TestMissing(source.Value)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub ShowModuleNameAsUnnecessaryMemberAccess()
             Dim source =
         <Code>
@@ -902,7 +902,7 @@ End Namespace
             Test(source.Value, expected.Value)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub ShowModuleNameAsUnnecessaryQualifiedName()
             Dim source =
         <Code>
@@ -952,7 +952,7 @@ End Namespace
         End Sub
 
         <WorkItem(608200)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub Bugfix_608200()
             Dim source =
         <Code>
@@ -992,7 +992,7 @@ End Module
         End Sub
 
         <WorkItem(578686)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DontUseAlias()
             Dim source =
         <Code>
@@ -1038,7 +1038,7 @@ End Namespace
         End Sub
 
         <WorkItem(547246)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub CreateCodeIssueWithProperIssueSpan()
             Dim source =
         <Code>
@@ -1072,7 +1072,7 @@ End Module
         End Sub
 
         <WorkItem(629572)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DoNotIncludeAliasNameIfLastTargetNameIsTheSame_1()
             Dim source =
         <Code>
@@ -1120,7 +1120,7 @@ End Namespace
         End Sub
 
         <WorkItem(629572)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DoNotIncludeAliasNameIfLastTargetNameIsTheSame_2()
             Dim source =
         <Code>
@@ -1154,7 +1154,7 @@ End Module
         End Sub
 
         <WorkItem(686306)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DontSimplifyNameSyntaxToTypeSyntaxInVBCref()
             Dim source =
         <Code>
@@ -1168,7 +1168,7 @@ End Module
         End Sub
 
         <WorkItem(721817)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DontSimplifyNameSyntaxToPredefinedTypeSyntaxInVBCref()
             Dim source =
         <Code>
@@ -1189,7 +1189,7 @@ Public Class Test
         End Sub
 
         <WorkItem(721694)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub EnableReducersInsideVBCref()
             Dim source =
         <Code>
@@ -1216,7 +1216,7 @@ Public Class Test_Dev11
         End Sub
 
         <WorkItem(736377)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DontSimplifyTypeNameBrokenCode()
             Dim source =
         <Code>
@@ -1236,7 +1236,7 @@ End Class
         End Sub
 
         <WorkItem(860565)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub SimplifyGenericTypeName_Bug860565()
             Dim source =
         <Code>
@@ -1256,7 +1256,7 @@ End Interface
         End Sub
 
         <WorkItem(813385)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub DontSimplifyAliases()
             Dim source =
         <Code>
@@ -1273,7 +1273,7 @@ End Class
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInLocalDeclarationDefaultValue_1()
             Dim source =
         <Code>
@@ -1297,7 +1297,7 @@ End Module
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInLocalDeclarationDefaultValue_2()
             Dim source =
         <Code>
@@ -1322,7 +1322,7 @@ End Module
 
         <WorkItem(942568)>
         <WorkItem(954536)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInCref1()
             Dim source =
         <Code>
@@ -1344,7 +1344,7 @@ End Module
 
         <WorkItem(942568)>
         <WorkItem(954536)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInCref2()
             Dim source =
         <Code>
@@ -1364,7 +1364,7 @@ End Module
 
         <WorkItem(1012713)>
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInCref3()
             Dim source =
         <Code>
@@ -1377,7 +1377,7 @@ End Module
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInLocalDeclarationNonDefaultValue_1()
             Dim source =
         <Code>
@@ -1392,7 +1392,7 @@ End Class
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInLocalDeclarationNonDefaultValue_2()
             Dim source =
         <Code>
@@ -1407,7 +1407,7 @@ End Class
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInLocalDeclarationNonDefaultValue_3()
             Dim source =
         <Code>
@@ -1422,7 +1422,7 @@ End Class
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInMemberAccess_Default_1()
             Dim source =
         <Code>
@@ -1448,7 +1448,7 @@ End Module
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInMemberAccess_Default_2()
             Dim source =
         <Code>
@@ -1470,7 +1470,7 @@ End Module
         End Sub
 
         <WorkItem(956667)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInMemberAccess_Default_3()
             Dim source =
         <Code>
@@ -1491,7 +1491,7 @@ End Class
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInMemberAccess_NonDefault_1()
             Dim source =
         <Code>
@@ -1505,7 +1505,7 @@ End Module
         End Sub
 
         <WorkItem(942568)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInMemberAccess_NonDefault_2()
             Dim source =
         <Code>
@@ -1520,7 +1520,7 @@ End Module
         End Sub
 
         <WorkItem(954536)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInCref_NonDefault_1()
             Dim source =
         <Code>
@@ -1533,7 +1533,7 @@ End Module
         End Sub
 
         <WorkItem(954536)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInCref_NonDefault_2()
             Dim source =
         <Code>
@@ -1553,7 +1553,7 @@ End Module
         End Sub
 
         <WorkItem(954536)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInCref_NonDefault_3()
             Dim source =
         <Code>
@@ -1566,7 +1566,7 @@ End Module
         End Sub
 
         <WorkItem(954536)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestIntrinsicTypesInCref_NonDefault_4()
             Dim source =
         <Code>
@@ -1586,7 +1586,7 @@ End Module
         End Sub
 
         <WorkItem(965208)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub TestSimplifyDiagnosticId()
             Dim source =
         <Code>
@@ -1636,7 +1636,7 @@ End Module
         End Sub
 
         <WorkItem(995168)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub SimplifyToPredefinedTypeNameShouldNotBeOfferedInsideNameOf1()
             TestMissing("Imports System
 Module Program
@@ -1647,7 +1647,7 @@ End Module")
         End Sub
 
         <WorkItem(995168)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub SimplifyToPredefinedTypeNameShouldNotBeOfferedInsideNameOf2()
             TestMissing("
 Module Program
@@ -1658,7 +1658,7 @@ End Module")
         End Sub
 
         <WorkItem(995168)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub SimplifyToPredefinedTypeNameShouldNotBeOfferedInsideNameOf3()
             TestMissing("Imports System
 Module Program
@@ -1669,7 +1669,7 @@ End Module")
         End Sub
 
         <WorkItem(995168)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Sub SimplifyTypeNameInsideNameOf()
             Test("Imports System
 Module Program

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests_FixAllTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Simpli
     Public Class SimplifyTypeNamesTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInDocument()
@@ -100,7 +100,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionId)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInProject()
@@ -191,7 +191,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionId)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution()
@@ -282,7 +282,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionId)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution_RemoveMe()
@@ -489,7 +489,7 @@ End Class]]>
             Test(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=fixAllActionId)
         End Sub
 
-        <WpfFact>
+        <Fact>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
         Public Sub TestFixAllInSolution_SimplifyMemberAccess()

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Spellc
             Return Tuple.Create(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New SpellcheckCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub NoSpellcheckForIfOnly2Characters()
             Dim text = <File>Class Foo
     Sub Bar()
@@ -24,7 +24,7 @@ End Class</File>
             TestMissing(text)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub AfterNewExpression()
             Dim text = <File>Class Foo
     Sub Bar()
@@ -34,7 +34,7 @@ End Class</File>
             TestExactActionSetOffered(text.NormalizedValue, {String.Format(FeaturesResources.ChangeTo, "Fooa", "Foo")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub InAsClause()
             Dim text = <File>Class Foo
     Sub Bar()
@@ -45,7 +45,7 @@ End Class</File>
                 {String.Format(FeaturesResources.ChangeTo, "Foa", "Foo")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub InSimpleAsClause()
             Dim text = <File>Class Foo
     Sub Bar()
@@ -56,7 +56,7 @@ End Class</File>
                 {String.Format(FeaturesResources.ChangeTo, "Foa", "Foo")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub InFunc()
             Dim text = <File>Class Foo
     Sub Bar(a as Func(Of [|Foa|]))
@@ -66,7 +66,7 @@ End Class</File>
                 {String.Format(FeaturesResources.ChangeTo, "Foa", "Foo")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub CorrectIdentifier()
             Dim text = <File>Module Program
     Sub Main(args As String())
@@ -77,7 +77,7 @@ End Module</File>
             TestExactActionSetOffered(text.NormalizedValue, {String.Format(FeaturesResources.ChangeTo, "zza", "zzz")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         <WorkItem(1065708)>
         Public Sub InTypeOfIsExpression()
             Dim text = <File>Imports System
@@ -90,7 +90,7 @@ End Class</File>
             TestExactActionSetOffered(text.NormalizedValue, {String.Format(FeaturesResources.ChangeTo, "Boolea", "Boolean")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         <WorkItem(1065708)>
         Public Sub InTypeOfIsNotExpression()
             Dim text = <File>Imports System
@@ -103,7 +103,7 @@ End Class</File>
             TestExactActionSetOffered(text.NormalizedValue, {String.Format(FeaturesResources.ChangeTo, "Boolea", "Boolean")})
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub InvokeCorrectIdentifier()
             Dim text = <File>Module Program
     Sub Main(args As String())
@@ -122,7 +122,7 @@ End Module</File>
             Test(text, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub AfterDot()
             Dim text = <File>Module Program
     Sub Main(args As String())
@@ -139,7 +139,7 @@ End Module</File>
             Test(text, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub NotInaccessibleProperty()
             Dim text = <File>Module Program
     Sub Main(args As String())
@@ -158,7 +158,7 @@ End Class</File>
             TestMissing(text)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub GenericName1()
             Dim text = <File>Class Foo(Of T)
     Dim x As [|Foo2(Of T)|]
@@ -171,7 +171,7 @@ End Class</File>
             Test(text, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub GenericName2()
             Dim text = <File>Class Foo(Of T)
     Dim x As [|Foo2|]
@@ -184,7 +184,7 @@ End Class</File>
             Test(text, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub QualifiedName1()
             Dim text = <File>Module Program
     Dim x As New [|Foo2.Bar|]
@@ -209,7 +209,7 @@ End Class</File>
             Test(text, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub QualifiedName2()
             Dim text = <File>Module Program
     Dim x As New [|Foo.Ba2|]
@@ -234,7 +234,7 @@ End Class</File>
             Test(text, expected)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub MiddleOfDottedExpression()
             Dim text = <File>Module Program
     Sub Main(args As String())
@@ -268,7 +268,7 @@ End Class</File>
         End Sub
 
         <WorkItem(547161)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub NotForOverloadResolutionFailure()
             Dim text = <File>Module Program
     Sub Main(args As String())
@@ -287,7 +287,7 @@ End Module</File>
         End Sub
 
         <WorkItem(547169)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub HandlePredefinedTypeKeywordCorrectly()
             Dim text = <File>
 Imports System
@@ -316,7 +316,7 @@ End Module</File>
         End Sub
 
         <WorkItem(547166)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub KeepEscapedIdentifiersEscaped()
             Dim text = <File>
 Module Program
@@ -344,7 +344,7 @@ End Module</File>
         End Sub
 
         <WorkItem(547166)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub NoDuplicateCorrections()
             Dim text = <File>
 Module Program
@@ -372,7 +372,7 @@ End Module</File>
             Test(text, expected)
         End Sub
 
-        <ConditionalWpfFact(GetType(x86))>
+        <ConditionalFact(GetType(x86))>
         <Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         <WorkItem(5391, "https://github.com/dotnet/roslyn/issues/5391")>
         Public Sub SuggestEscapedPredefinedTypes()
@@ -424,7 +424,7 @@ End Module</File>
         End Sub
 
         <WorkItem(775448)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)>
         Public Sub ShouldTriggerOnBC32045()
             ' BC32045: 'A' has no type parameters and so cannot have type arguments.
 
@@ -459,7 +459,7 @@ End Class</File>
         End Sub
 
         <WorkItem(908322)>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestObjectConstruction()
             Test(
 NewLines("Class AwesomeClass \n Sub M() \n Dim foo = New [|AwesomeClas()|] \n End Sub \n End Class"),
@@ -468,7 +468,7 @@ index:=0)
         End Sub
 
         <WorkItem(6338, "https://github.com/dotnet/roslyn/issues/6338")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Sub TestMissingName()
             TestMissing(
 NewLines("<Assembly: Microsoft.CodeAnalysis.[||]>"))
@@ -480,11 +480,11 @@ NewLines("<Assembly: Microsoft.CodeAnalysis.[||]>"))
             Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, CodeFixProvider)
                 Return Tuple.Create(Of DiagnosticAnalyzer, CodeFixProvider)(
                     New VisualBasicUnboundIdentifiersDiagnosticAnalyzer(),
-                    New SpellcheckCodeFixProvider())
+                    New SpellCheckCodeFixProvider())
             End Function
 
             <WorkItem(829970)>
-            <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+            <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
             Public Sub TestIncompleteStatement()
                 Test(
 NewLines("Class AwesomeClass \n Inherits System.Attribute \n End Class \n Module Program \n <[|AwesomeClas|]> \n End Module"),

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionAllCodeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionAllCodeTests.vb
@@ -19,12 +19,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Suppre
             Return New Tuple(Of Analyzer, ISuppressionFixProvider)(New Analyzer(), New VisualBasicSuppressionCodeFixProvider())
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
         Public Sub TestPragmaWarningOnEveryNodes()
             TestPragma(TestResource.AllInOneVisualBasicCode, VisualBasicParseOptions.Default, verifier:=Function(t) t.IndexOf("#Disable Warning", StringComparison.Ordinal) >= 0)
         End Sub
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
         Public Sub TestSuppressionWithAttributeOnEveryNodes()
             Dim facts = New VisualBasicSyntaxFactsService()
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Suppre
                 End Function
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirective()
                     Dim source = <![CDATA[
 Imports System
@@ -96,7 +96,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestMultilineStatementPragmaWarningDirective1()
                     Dim source = <![CDATA[
 Imports System
@@ -135,7 +135,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestMultilineStatementPragmaWarningDirective2()
                     Dim source = <![CDATA[
 Imports System
@@ -180,7 +180,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestMultilineStatementPragmaWarningDirective3()
                     Dim source = <![CDATA[
 Imports System
@@ -225,7 +225,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestMultilineStatementPragmaWarningDirective4()
                     Dim source = <![CDATA[
 Imports System
@@ -264,7 +264,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestMultilineStatementPragmaWarningDirective5()
                     Dim source = <![CDATA[
 Imports System
@@ -303,7 +303,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestMultilineStatementPragmaWarningDirective6()
                     Dim source = <![CDATA[
 Imports System
@@ -345,7 +345,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestMultilineStatementPragmaWarningDirective7()
                     Dim source = <![CDATA[
 Imports System
@@ -387,7 +387,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirectiveWithExistingTrivia()
                     Dim source = <![CDATA[
 Imports System
@@ -429,7 +429,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(970129)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionAroundSingleToken()
                     Dim source = <![CDATA[
 Imports System
@@ -477,7 +477,7 @@ End Module]]>
                 End Sub
 
                 <WorkItem(1066576)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirectiveAroundTrivia1()
                     Dim source = <![CDATA[
 Class C
@@ -523,7 +523,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(1066576)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirectiveAroundTrivia2()
                     Dim source = <![CDATA['''[|<summary></summary>|]]]>
                     Dim expected = <![CDATA[#Disable Warning BC42312
@@ -534,7 +534,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(1066576)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirectiveAroundTrivia3()
                     Dim source = <![CDATA[   '''[|<summary></summary>|]   ]]>
                     Dim expected = <![CDATA[#Disable Warning BC42312
@@ -545,7 +545,7 @@ End Class]]>
                 End Sub
 
                 <WorkItem(1066576)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirectiveAroundTrivia4()
                     Dim source = <![CDATA[
 
@@ -566,7 +566,7 @@ Class C : End Class
                 End Sub
 
                 <WorkItem(1066576)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirectiveAroundTrivia5()
                     Dim source = <![CDATA[class C1 : End Class
 '''<summary><see [|cref="abc"|]/></summary>
@@ -583,7 +583,7 @@ Class C3 : End Class]]>
                 End Sub
 
                 <WorkItem(1066576)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestPragmaWarningDirectiveAroundTrivia6()
                     Dim source = <![CDATA[class C1 : End Class
 Class C2 : End Class [|'''|]
@@ -605,7 +605,7 @@ Class C3 : End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, ISuppressionFixProvider)(New VisualBasicSimplifyTypeNamesDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestHiddenDiagnosticCannotBeSuppressed()
                     Dim source = <![CDATA[
 Imports System
@@ -648,9 +648,9 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, ISuppressionFixProvider)(New UserDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                
+
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestInfoDiagnosticSuppressed()
 
                     Dim source = <![CDATA[
@@ -722,9 +722,9 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, ISuppressionFixProvider)(New UserDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                
+
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestDiagnosticWithBadIdSuppressed()
 
                     ' Diagnostics with bad/invalid ID are not reported.
@@ -768,7 +768,7 @@ End Class]]>
                 End Function
 
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestWarningDiagnosticWithNameMatchingKeywordSuppressed()
                     Dim source = <![CDATA[
 Imports System
@@ -831,7 +831,7 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, ISuppressionFixProvider)(New UserDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestErrorDiagnosticCanBeSuppressed()
                     Dim source = <![CDATA[
 Imports System
@@ -886,9 +886,9 @@ End Class]]>
                     Return Tuple.Create(Of DiagnosticAnalyzer, ISuppressionFixProvider)(Nothing, New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                
+
                 <WorkItem(730770)>
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestCompilerDiagnosticsCannotBeSuppressed()
 
                     Dim source = <![CDATA[
@@ -908,7 +908,7 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, ISuppressionFixProvider)(New VisualBasicSimplifyTypeNamesDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestHiddenDiagnosticsCannotBeSuppressed()
                     Dim source = <![CDATA[
 Imports System
@@ -978,7 +978,7 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, ISuppressionFixProvider)(New UserDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnSimpleType()
                     Dim source = <![CDATA[
 Imports System
@@ -1013,7 +1013,7 @@ End Class"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnNamespace()
                     Dim source = <![CDATA[
 Imports System
@@ -1053,7 +1053,7 @@ End Namespace"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnTypeInsideNamespace()
                     Dim source = <![CDATA[
 Imports System
@@ -1097,7 +1097,7 @@ End Namespace"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnNestedType()
                     Dim source = <![CDATA[
 Imports System
@@ -1141,7 +1141,7 @@ End Namespace"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnMethod()
                     Dim source = <![CDATA[
 Imports System
@@ -1185,7 +1185,7 @@ End Namespace"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnOverloadedMethod()
                     Dim source = <![CDATA[
 Imports System
@@ -1237,7 +1237,7 @@ End Namespace"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnGenericMethod()
                     Dim source = <![CDATA[
 Imports System
@@ -1289,7 +1289,7 @@ End Namespace"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnProperty()
                     Dim source = <![CDATA[
 Imports System
@@ -1337,7 +1337,7 @@ End Namespace"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnField()
                     Dim source = <![CDATA[
 Imports System
@@ -1369,7 +1369,7 @@ End Class"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionOnEvent()
                     Dim source = <![CDATA[
 Imports System
@@ -1449,7 +1449,7 @@ End Class"
                     TestMissing(fixedSource)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionWithExistingGlobalSuppressionsDocument()
                     Dim source =
                     <Workspace>
@@ -1488,7 +1488,7 @@ End Class]]>
                     Test(source.ToString(), expected)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionWithExistingGlobalSuppressionsDocument2()
                     ' Own custom file named GlobalSuppressions.cs
                     Dim source =
@@ -1524,7 +1524,7 @@ End Class
                     Test(source.ToString(), expected)
                 End Sub
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Sub TestSuppressionWithExistingGlobalSuppressionsDocument3()
                     ' Own custom file named GlobalSuppressions.vb + existing GlobalSuppressions2.vb with global suppressions
                     Dim source =


### PR DESCRIPTION
Removing WpfFact from Analyzer and Codefix tests as they don't use any editor apis.

1281 WpfFact tests removed, 21152 to go.