### PR TITLE
add imports for System.Console in response file - fixes #6768

### DIFF
--- a/src/Interactive/CsiCore/csi.rsp
+++ b/src/Interactive/CsiCore/csi.rsp
@@ -27,6 +27,7 @@
 /u:System
 /u:System.IO
 /u:System.Collections.Generic
+/u:System.Console
 /u:System.Diagnostics
 /u:System.Dynamic
 /u:System.Linq

--- a/src/Interactive/csi/csi.rsp
+++ b/src/Interactive/csi/csi.rsp
@@ -4,6 +4,7 @@
 /u:System
 /u:System.IO
 /u:System.Collections.Generic
+/u:System.Console
 /u:System.Diagnostics
 /u:System.Dynamic
 /u:System.Linq

--- a/src/VisualStudio/CSharp/Repl/CSharpInteractive.rsp
+++ b/src/VisualStudio/CSharp/Repl/CSharpInteractive.rsp
@@ -4,6 +4,7 @@
 /u:System
 /u:System.IO
 /u:System.Collections.Generic
+/u:System.Console
 /u:System.Diagnostics
 /u:System.Dynamic
 /u:System.Linq

--- a/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractive.rsp
+++ b/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractive.rsp
@@ -11,6 +11,7 @@
 /Imports:System
 /Imports:System.Collections
 /Imports:System.Collections.Generic
+/Imports:System.Console
 /Imports:System.Data
 /Imports:System.Diagnostics
 /Imports:System.Linq


### PR DESCRIPTION
I still need to add unit test for this but apparently we first need to figure out how to hook up a real evaluator to a test first.

#6768 