### PR TITLE
Always "fail fast" in EE unit tests...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -28,6 +28,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         internal static readonly ImmutableArray<Alias> NoAliases = ImmutableArray<Alias>.Empty;
 
+        protected ExpressionCompilerTestBase()
+        {
+            // We never want to swallow Exceptions (generate a non-fatal Watson) when running tests.
+            ExpressionEvaluatorFatalError.IsFailFastEnabled = true;
+        }
+
         public override void Dispose()
         {
             base.Dispose();

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         private const string RegistryKey = @"Software\Microsoft\ExpressionEvaluator";
         private const string RegistryValue = "EnableFailFast";
-        private static readonly bool s_isFailFastEnabled;
+        internal static bool IsFailFastEnabled;
 
         static ExpressionEvaluatorFatalError()
         {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                                     var value = getValueMethod.Invoke(eeKey, new object[] { RegistryValue });
                                     if ((value != null) && (value is int))
                                     {
-                                        s_isFailFastEnabled = ((int)value == 1);
+                                        IsFailFastEnabled = ((int)value == 1);
                                     }
                                 }
                             }
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal static bool CrashIfFailFastEnabled(Exception exception)
         {
-            if (!s_isFailFastEnabled)
+            if (!IsFailFastEnabled)
             {
                 return false;
             }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                             }
                             onSuccess(method);
                         }
-                        catch (Exception e) when (ExpressionEvaluatorFatalError.ReportNonFatalException(e, DkmComponentManager.ReportCurrentNonFatalException))
+                        catch (Exception e)
                         {
                             onFailure(e);
                         }
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                             builder?.Free();
                             completionRoutine(new DkmGetFrameNameAsyncResult(frameName));
                         }
-                        catch (Exception e) when (ExpressionEvaluatorFatalError.ReportNonFatalException(e, DkmComponentManager.ReportCurrentNonFatalException))
+                        catch (Exception e)
                         {
                             completionRoutine(DkmGetFrameNameAsyncResult.CreateErrorResult(e));
                         }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     {
                         onCompleted(result);
                     }
-                    catch (Exception e) when (ExpressionEvaluatorFatalError.ReportNonFatalException(e, DkmComponentManager.ReportCurrentNonFatalException))
+                    catch (Exception e)
                     {
                         onException(e);
                     }
@@ -901,7 +901,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     {
                         completionRoutine();
                     }
-                    catch (Exception e) when (ExpressionEvaluatorFatalError.ReportNonFatalException(e, DkmComponentManager.ReportCurrentNonFatalException))
+                    catch (Exception e)
                     {
                         _onException(e);
                     }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -23,11 +23,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal readonly DkmInspectionContext DefaultInspectionContext;
 
-        internal ResultProviderTestBase(ResultProvider resultProvider, DkmInspectionContext defaultInspectionContext)
+        protected ResultProviderTestBase(ResultProvider resultProvider, DkmInspectionContext defaultInspectionContext)
         {
             _formatter = resultProvider.Formatter;
             _resultProvider = resultProvider;
             this.DefaultInspectionContext = defaultInspectionContext;
+
+            // We never want to swallow Exceptions (generate a non-fatal Watson) when running tests.
+            ExpressionEvaluatorFatalError.IsFailFastEnabled = true;
         }
 
         internal DkmClrValue CreateDkmClrValue(

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -29,6 +29,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         Friend Shared ReadOnly NoAliases As ImmutableArray(Of [Alias]) = ImmutableArray(Of [Alias]).Empty
 
+        Protected Sub New()
+            ' We never want to swallow Exceptions (generate a non-fatal Watson) when running tests.
+            ExpressionEvaluatorFatalError.IsFailFastEnabled = True
+        End Sub
+
         Public Overrides Sub Dispose()
             MyBase.Dispose()
 


### PR DESCRIPTION
We always want to "fail fast" if there is an Exception in the EE unit
tests (we never want to go down the "generate a non-fatal Watson" code
path).  Also, there were several places where we were generating
non-fatal Watsons for cases that were not truly "exceptional" (the
Exception was being handled reasonably and returned as an "error" result).

We should only have a filter to generate a non-fatal Watson in places
where it would also make sense to throw an unhandled Exception.

(fixes #6051)