### PR TITLE
Clean up complexity around OfficialBuild flag that is breaking official builds

### DIFF
--- a/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
+++ b/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
@@ -99,14 +99,11 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
-    <DefineConstants>$(DefineConstants);OFFICIAL_BUILD</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\VisualStudio\Setup\ProvideRoslynBindingRedirection.cs">
       <Link>ProvideRoslynBindingRedirection.cs</Link>
     </Compile>
-    <Compile Include="AssemblyRedirects.cs" Condition="('$(AssemblyVersion)' == '42.42.42.42') or ('$(OfficialBuild)' == 'true')" />
+    <Compile Include="AssemblyRedirects.cs" />
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\VSL.Imports.targets" />

--- a/src/InteractiveWindow/VisualStudio/VisualStudioInteractiveWindow.csproj
+++ b/src/InteractiveWindow/VisualStudio/VisualStudioInteractiveWindow.csproj
@@ -118,14 +118,11 @@
     <Reference Include="System.XML" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
-    <DefineConstants>$(DefineConstants);OFFICIAL_BUILD</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\VisualStudio\Setup\ProvideRoslynBindingRedirection.cs">
       <Link>ProvideRoslynBindingRedirection.cs</Link>
     </Compile>
-    <Compile Include="AssemblyRedirects.cs" Condition="('$(AssemblyVersion)' == '42.42.42.42') or ('$(OfficialBuild)' == 'true')" />
+    <Compile Include="AssemblyRedirects.cs" />
     <Compile Include="CommandIds.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="VsInteractiveWindowEditorFactoryService.cs" />

--- a/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
+++ b/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
@@ -28,17 +28,6 @@ namespace Roslyn.VisualStudio.Setup
                 PublicKeyToken = "31BF3856AD364E35",
                 OldVersionLowerBound = "0.7.0.0",
                 OldVersionUpperBound = "1.2.0.0",
-
-#if OFFICIAL_BUILD
-                // If this is an official build we want to generate binding
-                // redirects from our old versions to the release version 
-                NewVersion = "1.2.0.0",
-#else
-                // Non-official builds get redirects to local 42.42.42.42,
-                // which will only be built locally
-                NewVersion = "42.42.42.42",
-#endif
-
                 GenerateCodeBase = GenerateCodeBase,
                 CodeBase = fileName,
             };

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -22,9 +22,6 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
-    <DefineConstants>$(DefineConstants);OFFICIAL_BUILD</DefineConstants>
-  </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
@@ -192,7 +189,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyRedirects.cs" Condition="('$(AssemblyVersion)' == '42.42.42.42') or ('$(OfficialBuild)' == 'true')" />
+    <Compile Include="AssemblyRedirects.cs" />
     <Compile Include="ProvideRoslynBindingRedirection.cs" />
   </ItemGroup>
   <ImportGroup Label="Targets">


### PR DESCRIPTION
Remove source code dependencies on our OfficialBuild flag 

The official build flag specifies which assembly version is baked into Roslyn. This was being used in various ways to either include or not include binding redirects, but we now always want binding redirects. Also, we were passing the flag along to the compiler to figure out which NewVersion to bake into the redirects, but setting nothing at all conveniently does exactly what we want.