### PR TITLE
Don't add nested code actions *and* their parent to the smart tag list.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -220,6 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         }
 
                         newActions.AddRange(childActionSets[0].Actions);
+                        continue;
                     }
 
                     newActions.Add(action);

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -331,9 +331,9 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 return Task.FromResult<Document>(null);
             }
 
-            private static string ComputeEquivalenceKey(IEnumerable<CodeAction> nestedActions)
+            private static string ComputeEquivalenceKey(ImmutableArray<CodeAction> nestedActions)
             {
-                if (nestedActions == null)
+                if (nestedActions.IsDefault)
                 {
                     return null;
                 }
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 {
                     foreach (var action in nestedActions)
                     {
-                        equivalenceKey.Append(action.EquivalenceKey ?? action.GetHashCode().ToString() + ";");
+                        equivalenceKey.Append((action.EquivalenceKey ?? action.GetHashCode().ToString()) + ";");
                     }
 
                     return equivalenceKey.Length > 0 ? equivalenceKey.ToString() : null;


### PR DESCRIPTION
Fixes https://github.com/dotnet/Roslyn/issues/6753

Tagging @dotnet/roslyn-ide 