### PR TITLE
Allow the 'replace method with property' refactoring to work with get/set methods, not just Get/Set methods.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -411,5 +411,14 @@ index: 0);
 @"partial class C { int Foo { get { } set { } } } partial class C { }",
 index: 1);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public void TestUpdateGetSetCaseInsensitive()
+        {
+            Test(
+@"using System; class C { int [||]getFoo() { } void setFoo(int i) { } }",
+@"using System; class C { int Foo { get { } set { } } }",
+index: 1);
+        }
     }
 }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -95,14 +95,20 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
 
         private static bool HasGetPrefix(string text)
         {
-            return text.StartsWith(GetPrefix) && text.Length > GetPrefix.Length && !char.IsLower(text[GetPrefix.Length]);
+            return HasPrefix(text, GetPrefix);
+        }
+        private static bool HasPrefix(string text, string prefix)
+        {
+            return text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && text.Length > prefix.Length && !char.IsLower(text[prefix.Length]);
         }
 
         private IMethodSymbol FindSetMethod(IMethodSymbol getMethod)
         {
             var containingType = getMethod.ContainingType;
-            var setMethod = containingType.GetMembers("Set" + getMethod.Name.Substring(GetPrefix.Length))
+            var setMethodName = "Set" + getMethod.Name.Substring(GetPrefix.Length);
+            var setMethod = containingType.GetMembers()
                                           .OfType<IMethodSymbol>()
+                                          .Where(m => setMethodName.Equals(m.Name, StringComparison.OrdinalIgnoreCase))
                                           .Where(m => IsValidSetMethod(m, getMethod))
                                           .FirstOrDefault();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/Roslyn/issues/6718

Tagging @dotnet/roslyn-ide 