### PR TITLE
Port fix for flaky test TestAnalyzerLoading from future to master

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -193,11 +193,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var dir = Temp.CreateDirectory();
             var test = dir.CopyFile(typeof(FromFileLoader).Assembly.Location);
             var analyzerFile = TestHelpers.CreateCSharpAnalyzerAssemblyWithTestAnalyzer(dir, "MyAnalyzer");
-            var loadDomain = AppDomain.CreateDomain("AnalyzerTestDomain", null, dir.Path, dir.Path, false);
-            var remoteTest = (RemoteAnalyzerFileReferenceTest)loadDomain.CreateInstanceAndUnwrap(typeof(RemoteAnalyzerFileReferenceTest).Assembly.FullName, typeof(RemoteAnalyzerFileReferenceTest).FullName);
-            remoteTest.SetAssert(RemoteAssert.Instance);
-            remoteTest.TestSuccess(analyzerFile.Path);
-            AppDomain.Unload(loadDomain);
+            var loadDomain = AppDomainUtils.Create("AnalyzerTestDomain", basePath: dir.Path);
+            try
+            {
+                var remoteTest = (RemoteAnalyzerFileReferenceTest)loadDomain.CreateInstanceAndUnwrap(typeof(RemoteAnalyzerFileReferenceTest).Assembly.FullName, typeof(RemoteAnalyzerFileReferenceTest).FullName);
+                remoteTest.SetAssert(RemoteAssert.Instance);
+                remoteTest.TestSuccess(analyzerFile.Path);
+            }
+            finally
+            {
+                AppDomain.Unload(loadDomain);
+            }
         }
 
         [ConditionalFact(typeof(x86))]


### PR DESCRIPTION
The test is failing intermittently with an InvalidCastException 'Unable to cast transparent proxy to type 'Microsoft.CodeAnalysis.UnitTests.RemoteAnalyzerFileReferenceTest' over [here](http://source.roslyn.io/#Roslyn.Compilers.UnitTests/AnalyzerFileReferenceTests.cs,197). This test creates a separate appdomain, invokes CreateInstanceAndUnwrap on it and then casts the created object to type RemoteAnalyzerFileReferenceTest defined in the same assembly. This indicates that the CLR ended up loading a separate instance of the assembly from a different path in the appdomain, causing the cast failure.

Fix is to use the [AppDomainUtils.Create](http://source.roslyn.io/Roslyn.Test.Utilities.Desktop/R/32b4516c21702320.html) method for creating the appdomain. This helper method has a special assembly resolve handler hooked up to the created appdomain that first attempts to resolve the assembly from current xunit directory. This helper is already being used by a similar remote analyzer loading test [TestAnalyzerLoading_Error](http://source.roslyn.io/#Roslyn.Compilers.UnitTests/AnalyzerFileReferenceTests.cs,b04fd584904390af).

Fixes #6665