### PR TITLE
Keep property on a single line if the getter was on a single line.

### DIFF
--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -12,9 +12,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 {
-    // https://github.com/dotnet/roslyn/issues/5408
-    //[Export]
-    //[DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Export]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class UseAutoPropertyAnalyzer : AbstractUseAutoPropertyAnalyzer<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ExpressionSyntax>
     {
         protected override bool SupportsReadOnlyProperties(Compilation compilation)

--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -12,8 +12,9 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 {
-    [Export]
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    // https://github.com/dotnet/roslyn/issues/5408
+    //[Export]
+    //[DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class UseAutoPropertyAnalyzer : AbstractUseAutoPropertyAnalyzer<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ExpressionSyntax>
     {
         protected override bool SupportsReadOnlyProperties(Compilation compilation)

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -264,5 +264,57 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
         {
             TestMissing(@"class Class { public int [|P|] { get; set; } }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public void TestSingleLine1()
+        {
+            Test(
+@"class Class
+{
+    [|int i|];
+    int P { get { return i; } }
+}",
+@"class Class
+{
+    int P { get; }
+}", compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public void TestSingleLine2()
+        {
+            Test(
+@"class Class
+{
+    [|int i|];
+    int P
+    {
+        get { return i; }
+    }
+}",
+@"class Class
+{
+    int P { get; }
+}", compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public void TestSingleLine3()
+        {
+            Test(
+@"class Class
+{
+    [|int i|];
+    int P
+    {
+        get { return i; }
+        set { i = value; }
+    }
+}",
+@"class Class
+{
+    int P { get; set; }
+}", compareTokens: false);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyCodeFixProvider.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyCodeFixProvider.vb
@@ -5,6 +5,7 @@ Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Editing
+Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.UseAutoProperty
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -18,7 +19,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
             Return Utilities.GetNodeToRemove(identifier)
         End Function
 
-        Protected Overrides Async Function UpdatePropertyAsync(project As Project,
+        Protected Overrides Function GetFormattingRules(document As Document) As IEnumerable(Of IFormattingRule)
+            Return Nothing
+        End Function
+
+        Protected Overrides Async Function UpdatePropertyAsync(propertyDocument As Document,
                                                          compilation As Compilation,
                                                          fieldSymbol As IFieldSymbol,
                                                          propertySymbol As IPropertySymbol,
@@ -27,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
                                                          cancellationToken As CancellationToken) As Task(Of SyntaxNode)
             Dim statement = propertyDeclaration.PropertyStatement
             If Not isWrittenToOutsideOfConstructor AndAlso Not propertyDeclaration.Accessors.Any(SyntaxKind.SetAccessorBlock) Then
-                Dim generator = SyntaxGenerator.GetGenerator(project)
+                Dim generator = SyntaxGenerator.GetGenerator(propertyDocument.Project)
                 statement = DirectCast(generator.WithModifiers(statement, DeclarationModifiers.ReadOnly), PropertyStatementSyntax)
             End If
 

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -23,6 +25,8 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         where TConstructorDeclaration : SyntaxNode
         where TExpression : SyntaxNode
     {
+        protected static SyntaxAnnotation SpecializedFormattingAnnotation = new SyntaxAnnotation();
+
         public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
             AbstractUseAutoPropertyAnalyzer<TPropertyDeclaration, TFieldDeclaration, TVariableDeclarator, TExpression>.UseAutoProperty);
 
@@ -30,8 +34,10 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
         protected abstract SyntaxNode GetNodeToRemove(TVariableDeclarator declarator);
 
+        protected abstract IEnumerable<IFormattingRule> GetFormattingRules(Document document);
+
         protected abstract Task<SyntaxNode> UpdatePropertyAsync(
-            Project project, Compilation compilation, IFieldSymbol fieldSymbol, IPropertySymbol propertySymbol,
+            Document propertyDocument, Compilation compilation, IFieldSymbol fieldSymbol, IPropertySymbol propertySymbol,
             TPropertyDeclaration propertyDeclaration, bool isWrittenOutsideConstructor, CancellationToken cancellationToken);
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
@@ -76,7 +82,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
             // First, create the updated property we want to replace the old property with
             var isWrittenToOutsideOfConstructor = IsWrittenToOutsideOfConstructorOrProperty(fieldSymbol, fieldLocations, property, cancellationToken);
-            var updatedProperty = await UpdatePropertyAsync(project, compilation, fieldSymbol, propertySymbol, property,
+            var updatedProperty = await UpdatePropertyAsync(propertyDocument, compilation, fieldSymbol, propertySymbol, property,
                 isWrittenToOutsideOfConstructor, cancellationToken).ConfigureAwait(false);
 
             // Now, rename all usages of the field to point at the property.  Except don't actually 
@@ -106,6 +112,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             var nodeToRemove = GetNodeToRemove(declarator);
 
             const SyntaxRemoveOptions options = SyntaxRemoveOptions.KeepUnbalancedDirectives | SyntaxRemoveOptions.AddElasticMarker;
+
             if (fieldDocument == propertyDocument)
             {
                 // Same file.  Have to do this in a slightly complicated fashion.
@@ -115,8 +122,11 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 editor.RemoveNode(nodeToRemove, options);
                 editor.ReplaceNode(property, updatedProperty);
 
+                var newRoot = editor.GetChangedRoot();
+                newRoot = Format(newRoot, fieldDocument, cancellationToken);
+
                 return solution.WithDocumentSyntaxRoot(
-                    fieldDocument.Id, editor.GetChangedRoot());
+                    fieldDocument.Id, newRoot);
             }
             else
             {
@@ -127,11 +137,23 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 var newFieldTreeRoot = fieldTreeRoot.RemoveNode(nodeToRemove, options);
                 var newPropertyTreeRoot = propertyTreeRoot.ReplaceNode(property, updatedProperty);
 
+                newFieldTreeRoot = Format(newFieldTreeRoot, fieldDocument, cancellationToken);
+                newPropertyTreeRoot = Format(newPropertyTreeRoot, propertyDocument, cancellationToken);
+
                 updatedSolution = solution.WithDocumentSyntaxRoot(fieldDocument.Id, newFieldTreeRoot);
                 updatedSolution = updatedSolution.WithDocumentSyntaxRoot(propertyDocument.Id, newPropertyTreeRoot);
 
                 return updatedSolution;
             }
+        }
+
+        private SyntaxNode Format(SyntaxNode newRoot, Document document, CancellationToken cancellationToken)
+        {
+            var formattingRules = GetFormattingRules(document);
+
+            return formattingRules == null
+                ? newRoot
+                : Formatter.Format(newRoot, SpecializedFormattingAnnotation, document.Project.Solution.Workspace, options: null, rules: formattingRules, cancellationToken: cancellationToken);
         }
 
         private static bool IsWrittenToOutsideOfConstructorOrProperty(

--- a/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
@@ -294,10 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             var text = default(SourceText);
             if (tree != null && tree.TryGetText(out text))
             {
-                var line1 = text.Lines.IndexOf(token1.Span.End);
-                var line2 = text.Lines.IndexOf(token2.SpanStart);
-
-                return line1 == line2;
+                return text.AreOnSameLine(token1, token2);
             }
 
             return CommonFormattingHelpers.GetTextBetween(token1, token2).ContainsLineBreak();

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
@@ -185,5 +185,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             return caseSensitive ? normalizedLeft == right : normalizedLeft == CaseInsensitiveComparison.ToLower(right);
         }
+
+        public static bool AreOnSameLine(this SourceText text, SyntaxToken token1, SyntaxToken token2)
+        {
+            return token1.RawKind != 0 &&
+                token2.RawKind != 0 && 
+                text.Lines.IndexOf(token1.Span.End) == text.Lines.IndexOf(token2.SpanStart);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/Roslyn/issues/5335