### PR TITLE
Exit on assert failure in bootstrap build

### DIFF
--- a/build/scripts/VBCSCompiler.exe.config
+++ b/build/scripts/VBCSCompiler.exe.config
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false"/>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="1.1.0.0-1.1.65535.65535" newVersion="1.1.37.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="1.0.0.0-1.0.65535.65535" newVersion="1.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.diagnostics>
+    <trace autoflush="true">
+      <listeners>
+        <clear/>
+        <add name="exitingTraceListener" type="Microsoft.CodeAnalysis.CommandLine.ExitingTraceListener,VBCSCompiler" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
+</configuration>

--- a/build/scripts/csc.exe.config
+++ b/build/scripts/csc.exe.config
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false"/>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="1.1.0.0-1.1.65535.65535" newVersion="1.1.37.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="1.0.0.0-1.0.65535.65535" newVersion="1.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.diagnostics>
+    <trace autoflush="true">
+      <listeners>
+        <clear/>
+        <add name="exitingTraceListener" type="Microsoft.CodeAnalysis.CommandLine.ExitingTraceListener,csc" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
+</configuration>

--- a/build/scripts/vbc.exe.config
+++ b/build/scripts/vbc.exe.config
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false"/>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="1.1.0.0-1.1.65535.65535" newVersion="1.1.37.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="1.0.0.0-1.0.65535.65535" newVersion="1.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.diagnostics>
+    <trace autoflush="true">
+      <listeners>
+        <clear/>
+        <add name="exitingTraceListener" type="Microsoft.CodeAnalysis.CommandLine.ExitingTraceListener,vbc" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
+</configuration>

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -138,10 +138,13 @@ compile_toolset()
 # Save the toolset binaries from Binaries/BUILD_CONFIGURATION to Binaries/Bootstrap
 save_toolset()
 {
-    mkdir -p Binaries/Bootstrap/csccore
-    mkdir -p Binaries/Bootstrap/vbccore
-    cp Binaries/$BUILD_CONFIGURATION/csccore/* Binaries/Bootstrap/csccore
-    cp Binaries/$BUILD_CONFIGURATION/vbccore/* Binaries/Bootstrap/vbccore
+    local vbcTarget=Binaries/Bootstrap/vbccore
+    local cscTarget=Binaries/Bootstrap/csccore
+
+    mkdir -p $vbcTarget
+    mkdir -p $cscTarget
+    cp Binaries/$BUILD_CONFIGURATION/csccore/* $cscTarget
+    cp Binaries/$BUILD_CONFIGURATION/vbccore/* $vbcTarget
 }
 
 # Clean out all existing binaries.  This ensures the bootstrap phase forces

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -44,6 +44,9 @@
     <Compile Include="..\..\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\ExitingTraceListener.cs">
+      <Link>ExitingTraceListener.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\SimpleAnalyzerAssemblyLoader.cs">
       <Link>SimpleAnalyzerAssemblyLoader.cs</Link>
     </Compile>

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -51,6 +51,9 @@
     <Compile Include="..\..\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\ExitingTraceListener.cs">
+      <Link>ExitingTraceListener.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\ShadowCopyAnalyzerAssemblyLoader.cs">
       <Link>ShadowCopyAnalyzerAssemblyLoader.cs</Link>
     </Compile>

--- a/src/Compilers/Shared/ExitingTraceListener.cs
+++ b/src/Compilers/Shared/ExitingTraceListener.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.CommandLine
+{
+    /// <summary>
+    /// This trace listener is useful in environments where we don't want a dialog but instead want
+    /// to exit with a reliable stack trace of the failure.  For example during a bootstrap build where
+    /// the assert dialog would otherwise cause a Jenkins build to timeout. 
+    /// </summary>
+    internal sealed class ExitingTraceListener : TraceListener
+    {
+        public override void Write(string message)
+        {
+            Exit(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            Exit(message);
+        }
+
+        private static void Exit(string originalMessage)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine($"Debug.Assert failed with message: {originalMessage}");
+            builder.AppendLine("Stack Trace");
+            var stackTrace = new StackTrace();
+            builder.AppendLine(stackTrace.ToString());
+
+            var message = builder.ToString();
+            var logFullName = GetLogFileFullName();
+            File.WriteAllText(logFullName, message);
+
+            Console.WriteLine(message);
+            Console.WriteLine($"Log at: {logFullName}");
+
+            Environment.Exit(1);
+        }
+
+        private static string GetLogFileFullName()
+        {
+            var assembly = typeof(ExitingTraceListener).Assembly;
+            var name = $"{Path.GetFileName(assembly.Location)}.tracelog";
+            var path = Path.GetDirectoryName(assembly.Location);
+            return Path.Combine(path, name);
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -63,6 +63,9 @@
     <Compile Include="..\..\Shared\AbstractAnalyzerAssemblyLoader.cs">
       <Link>AbstractAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\ExitingTraceListener.cs">
+      <Link>ExitingTraceListener.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\SimpleAnalyzerAssemblyLoader.cs">
       <Link>SimpleAnalyzerAssemblyLoader.cs</Link>
     </Compile>


### PR DESCRIPTION
This changes the compilers and server to exit the process when a Debug.Assert
call fails in a bootstrap build.  The current behavior of throwing up a dialog
blocks the Jenkins build until a timeout occurs and leaves no data.  Now a full
stack trace will be printed, the process exits with a non-zero exit code and the
entire run will fail promptly.