### PR TITLE
Scanner and parser fixes for real literals

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5282,6 +5282,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid real literal.
+        /// </summary>
+        internal static string ERR_InvalidReal {
+            get {
+                return ResourceManager.GetString("ERR_InvalidReal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid signature public key specified in AssemblySignatureKeyAttribute..
         /// </summary>
         internal static string ERR_InvalidSignaturePublicKey {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5282,7 +5282,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid real literal.
+        ///   Looks up a localized string similar to Invalid real literal..
         /// </summary>
         internal static string ERR_InvalidReal {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4666,4 +4666,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_PublicSignButNoKey" xml:space="preserve">
     <value>Public signing was specified and requires a public key, but no public key was specified.</value>
   </data>
+  <data name="ERR_InvalidReal" xml:space="preserve">
+    <value>Invalid real literal</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4667,6 +4667,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Public signing was specified and requires a public key, but no public key was specified.</value>
   </data>
   <data name="ERR_InvalidReal" xml:space="preserve">
-    <value>Invalid real literal</value>
+    <value>Invalid real literal.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -404,6 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidAttributeArgument = 591,
         ERR_AttributeOnBadSymbolType = 592,
         ERR_FloatOverflow = 594,
+        ERR_InvalidReal = 595,
         ERR_ComImportWithoutUuidAttribute = 596,
         ERR_InvalidNamedArgument = 599,
         ERR_DllImportOnInvalidMethod = 601,

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -1029,10 +1029,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         TextWindow.AdvanceChar();
                     }
 
-                    while ((ch = TextWindow.PeekChar()) >= '0' && ch <= '9')
+                    if (!((ch = TextWindow.PeekChar()) >= '0' && ch <= '9'))
                     {
-                        _builder.Append(ch);
-                        TextWindow.AdvanceChar();
+                        // use this for now (CS0595), cant use CS0594 as we dont know 'type'
+                        this.AddError(MakeError(ErrorCode.ERR_InvalidReal));
+                        // add dummy exponent, so parser does not blow up
+                        _builder.Append('0');
+                    }
+                    else
+                    {
+                        while ((ch = TextWindow.PeekChar()) >= '0' && ch <= '9')
+                        {
+                            _builder.Append(ch);
+                            TextWindow.AdvanceChar();
+                        }
                     }
                 }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
@@ -44,6 +44,38 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_FloatOverflow, "3e100m").WithArguments("decimal"));
         }
 
+        [Fact]
+        public void CS0595ERR_InvalidReal()
+        {
+            var test =
+@"public class C
+{
+    double d1 = 0e;
+    double d2 = .0e;
+    double d3 = 0.0e;
+    double d4 = 0e+;
+    double d5 = 0e-;
+}";
+
+            ParserErrorMessageTests.ParseAndValidate(test,
+                  // (3,17): error CS0595: Invalid real literal
+                  //     double d1 = 0e;
+                  Diagnostic(ErrorCode.ERR_InvalidReal, "").WithLocation(3, 17),
+                  // (4,17): error CS0595: Invalid real literal
+                  //     double d2 = .0e;
+                  Diagnostic(ErrorCode.ERR_InvalidReal, "").WithLocation(4, 17),
+                  // (5,17): error CS0595: Invalid real literal
+                  //     double d3 = 0.0e;
+                  Diagnostic(ErrorCode.ERR_InvalidReal, "").WithLocation(5, 17),
+                  // (6,17): error CS0595: Invalid real literal
+                  //     double d4 = 0e+;
+                  Diagnostic(ErrorCode.ERR_InvalidReal, "").WithLocation(6, 17),
+                  // (7,17): error CS0595: Invalid real literal
+                  //     double d5 = 0e-;
+                  Diagnostic(ErrorCode.ERR_InvalidReal, "").WithLocation(7, 17)
+                );
+        }
+
         [WorkItem(6079, "https://github.com/dotnet/roslyn/issues/6079")]
         [Fact]
         public void FloatLexicalError()
@@ -55,18 +87,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 }";
             // The precise errors don't matter so much as the fact that the compiler should not crash.
             ParserErrorMessageTests.ParseAndValidate(test,
-                // (3,23): error CS0594: Floating-point constant is outside the range of type 'double'
-                //     const double d1 = 0endOfDirective.Span;
-                Diagnostic(ErrorCode.ERR_FloatOverflow, "").WithArguments("double").WithLocation(3, 23),
-                // (3,25): error CS1002: ; expected
-                //     const double d1 = 0endOfDirective.Span;
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "ndOfDirective").WithLocation(3, 25),
-                // (3,43): error CS1519: Invalid token ';' in class, struct, or interface member declaration
-                //     const double d1 = 0endOfDirective.Span;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(3, 43),
-                // (3,43): error CS1519: Invalid token ';' in class, struct, or interface member declaration
-                //     const double d1 = 0endOfDirective.Span;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(3, 43)
+                  // (3,23): error CS0595: Invalid real literal
+                  //     const double d1 = 0endOfDirective.Span;
+                  Diagnostic(ErrorCode.ERR_InvalidReal, "").WithLocation(3, 23),
+                  // (3,25): error CS1002: ; expected
+                  //     const double d1 = 0endOfDirective.Span;
+                  Diagnostic(ErrorCode.ERR_SemicolonExpected, "ndOfDirective").WithLocation(3, 25),
+                  // (3,43): error CS1519: Invalid token ';' in class, struct, or interface member declaration
+                  //     const double d1 = 0endOfDirective.Span;
+                  Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(3, 43),
+                  // (3,43): error CS1519: Invalid token ';' in class, struct, or interface member declaration
+                  //     const double d1 = 0endOfDirective.Span;
+                  Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(3, 43)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -1416,7 +1416,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
-            Assert.Equal((int)ErrorCode.ERR_FloatOverflow, errors[0].Code);
+            Assert.Equal((int)ErrorCode.ERR_InvalidReal, errors[0].Code);
             Assert.Equal(text, token.Text);
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/RealParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/RealParserTests.cs
@@ -367,6 +367,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 "40497058210285131854513962138377228261454376934125320985913276672363" +
                 "28125001e-324",
                 0x0000000000000001);
+
+            CheckOneDouble("1.0e-99999999999999999999", 0.0);
+            CheckOneDouble("0e-99999999999999999999", 0.0);
+            CheckOneDouble("0e99999999999999999999", 0.0);
         }
 
         static void TestRoundTripDouble(ulong bits)
@@ -548,10 +552,6 @@ Error for double input ""{s}""
             // 0.11111111111111111111111011
             //                          ^
             CheckOneFloat("0.99999992549419403076171875", 0x3f7fffff);
-
-            CheckOneDouble("1.0e-99999999999999999999", 0.0);
-            CheckOneDouble("0e-99999999999999999999", 0.0);
-            CheckOneDouble("0e99999999999999999999", 0.0);
         }
 
 

--- a/src/Compilers/Core/CodeAnalysisTest/RealParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/RealParserTests.cs
@@ -548,6 +548,10 @@ Error for double input ""{s}""
             // 0.11111111111111111111111011
             //                          ^
             CheckOneFloat("0.99999992549419403076171875", 0x3f7fffff);
+
+            CheckOneDouble("1.0e-99999999999999999999", 0.0);
+            CheckOneDouble("0e-99999999999999999999", 0.0);
+            CheckOneDouble("0e99999999999999999999", 0.0);
         }
 
 

--- a/src/Compilers/Core/Portable/RealParser.cs
+++ b/src/Compilers/Core/Portable/RealParser.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="s">The decimal floating-point constant's string</param>
         /// <param name="d">The nearest double value, if conversion succeeds</param>
-        /// <returns>True of the input was converted; false if there was an overflow</returns>
+        /// <returns>True if the input was converted; false if there was an overflow</returns>
         public static bool TryParseDouble(string s, out double d)
         {
             var str = DecimalFloatingPointString.FromSource(s);
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="s">The float floating-point constant's string</param>
         /// <param name="f">The nearest float value, if conversion succeeds</param>
-        /// <returns>True of the input was converted; false if there was an overflow</returns>
+        /// <returns>True if the input was converted; false if there was an overflow</returns>
         public static bool TryParseFloat(string s, out float f)
         {
             var str = DecimalFloatingPointString.FromSource(s);

--- a/src/Compilers/Core/Portable/RealParser.cs
+++ b/src/Compilers/Core/Portable/RealParser.cs
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis
                 result.Mantissa = mantissaBuilder.ToString();
                 if (i < source.Length && (source[i] == 'e' || source[i] == 'E'))
                 {
-                    const int MAX_EXP_QUAD = (1 << 14); // IEEE quad, without sign
+                    const int MAX_EXP = (1 << 30); // even playing ground
                     char exponentSign = '\0';
                     i++;
                     if (i < source.Length && (source[i] == '-' || source[i] == '+'))
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis
                     int exponentMagnitude = 0;
 
                     if (int.TryParse(source.Substring(firstExponent, lastExponent - firstExponent), out exponentMagnitude) &&
-                        exponentMagnitude <= MAX_EXP_QUAD)
+                        exponentMagnitude <= MAX_EXP)
                     {
                         if (exponentSign == '-')
                         {
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis
                     }
                     else
                     {
-                        exponent = exponentSign == '-' ? -MAX_EXP_QUAD : MAX_EXP_QUAD;
+                        exponent = exponentSign == '-' ? -MAX_EXP : MAX_EXP;
                     }
                 }
                 result.Exponent = exponent;


### PR DESCRIPTION
Fixes #6817, #6109 and #6079 (correctly this time).

As a temporary measure I have added CS0595 (adjacent to CS0594 and not used from what I can see) to indicate an invalid real literal. For now the only case I can see is for missing exponent digits, so the error could possibly be made more specific.

/cc @gafter 