### PR TITLE
fixed error list refresh issues

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
@@ -3,22 +3,53 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal partial class DiagnosticAnalyzerService : IDiagnosticUpdateSource
     {
-        public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
+        private const string DiagnosticsUpdatedEventName = "DiagnosticsUpdated";
+
+        // use eventMap and taskQueue to serialize events
+        private readonly EventMap _eventMap;
+        private readonly SimpleTaskQueue _eventQueue;
 
         private DiagnosticAnalyzerService(IDiagnosticUpdateSourceRegistrationService registrationService) : this()
         {
+            _eventMap = new EventMap();
+            _eventQueue = new SimpleTaskQueue(TaskScheduler.Default);
+
             registrationService.Register(this);
         }
 
-        internal void RaiseDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs state)
+        public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated
         {
-            this.DiagnosticsUpdated?.Invoke(sender, state);
+            add
+            {
+                _eventMap.AddEventHandler(DiagnosticsUpdatedEventName, value);
+            }
+
+            remove
+            {
+                _eventMap.RemoveEventHandler(DiagnosticsUpdatedEventName, value);
+            }
+        }
+
+        internal void RaiseDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs args)
+        {
+            // raise serialized events
+            var ev = _eventMap.GetEventHandlers<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName);
+            if (ev.HasHandlers)
+            {
+                var asyncToken = Listener.BeginAsyncOperation(nameof(RaiseDiagnosticsUpdated));
+                _eventQueue.ScheduleTask(() =>
+                {
+                    ev.RaiseEvent(handler => handler(sender, args));
+                }).CompletesAsyncOperation(asyncToken);
+            }
         }
 
         bool IDiagnosticUpdateSource.SupportGetDiagnostics { get { return true; } }


### PR DESCRIPTION
fixed 2 issues

1. when re-analysis is requested, we reset diagnostic states without raising events and then do re-analysis which will raise events. this works fine in normal situation but in build de-duplication situation where we put all diagnostics to "Document" bucket rather than "Syntax" or "Project" (since we can't figure that out from build output), the above causes issues where we reset state but actual re-analysis doesnt happen since state was put in wrong bucket from build de-duplication.

now, we will raise events when reset states for re-analysis.

2. noticed a potential race between diagnostic changed events raised by build de-duplication and solution crawler. the possibility is quite low since we pause solution crawler while building except high priority queue, but still it could mess things up especially since we do /1/ now. so, I made all diagnostic changed events to be serialized.