### PR TITLE
create a dump for a failing test

### DIFF
--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -658,7 +660,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
             return workspace.CurrentSolution;
         }
 
-        private void StopObservingAndWaitForReferenceToGo(ObjectReference observed, int delay = 0)
+        [DllImport("dbghelp.dll")]
+        private static extern bool MiniDumpWriteDump(IntPtr hProcess, int ProcessId, IntPtr hFile, int DumpType, IntPtr ExceptionParam, IntPtr UserStreamParam, IntPtr CallbackParam);
+
+        private static void DumpProcess(string dumpFileName)
+        {
+            using (var fs = File.Create(dumpFileName))
+            {
+                var proc = System.Diagnostics.Process.GetCurrentProcess();
+                MiniDumpWriteDump(proc.Handle, proc.Id, fs.SafeFileHandle.DangerousGetHandle(), /*MiniDumpWithFullMemory*/2, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            }
+        }
+
+        private void StopObservingAndWaitForReferenceToGo(ObjectReference observed, int delay = 0, string dumpFileName = null)
         {
             // stop observing it and let GC reclaim it
             observed.Strong = null;
@@ -674,8 +688,20 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             const int TimerPrecision = 30;
             var actualTimePassed = DateTime.UtcNow - start + TimeSpan.FromMilliseconds(TimerPrecision);
+            var isTargetCollected = observed.Weak.Target == null;
 
-            Assert.True(observed.Weak.Target == null,
+            if (!isTargetCollected && !string.IsNullOrEmpty(dumpFileName))
+            {
+                if (string.Compare(Path.GetExtension(dumpFileName), ".dmp", StringComparison.OrdinalIgnoreCase) != 0)
+                {
+                    dumpFileName += ".dmp";
+                }
+
+                DumpProcess(dumpFileName);
+                Assert.True(false, $"Target object not collected.  Process dump saved to '{dumpFileName}'");
+            }
+
+            Assert.True(isTargetCollected,
                 string.Format("Target object ({0}) was not collected after {1} ms", observed.Weak.Target, actualTimePassed));
         }
 
@@ -1016,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/6409"), Trait(Traits.Feature, Traits.Features.Workspace)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestRecoverableSyntaxTreeVisualBasic()
         {
             var pid = ProjectId.CreateNewId();
@@ -1044,11 +1070,11 @@ End Class";
             TestRecoverableSyntaxTree(sol, did);
         }
 
-        private void TestRecoverableSyntaxTree(Solution sol, DocumentId did)
+        private void TestRecoverableSyntaxTree(Solution sol, DocumentId did, [CallerMemberName] string callingTest = null)
         {
             // get it async and wait for it to get GC'd
             var observed = GetObservedSyntaxTreeRootAsync(sol, did);
-            StopObservingAndWaitForReferenceToGo(observed);
+            StopObservingAndWaitForReferenceToGo(observed, dumpFileName: callingTest);
 
             var doc = sol.GetDocument(did);
 
@@ -1067,7 +1093,7 @@ End Class";
 
             // get it async and wait for it to get GC'd
             var observed2 = GetObservedSyntaxTreeRootAsync(doc2.Project.Solution, did);
-            StopObservingAndWaitForReferenceToGo(observed2);
+            StopObservingAndWaitForReferenceToGo(observed2, dumpFileName: callingTest);
 
             // access the tree & root again (recover it)
             var tree2 = doc2.GetSyntaxTreeAsync().Result;


### PR DESCRIPTION
A flaky test was disabled for #6409 because an object wasn't gathered by the GC, but manual investigation hasn't yielded anything useful.  This PR will now cause the test to create a memory dump if the object wasn't gathered which can then be investigated after-the-fact (due to artifact archiving in Jenkins).

This code is meant to be temporary and removed once the bug has been fixed or an actionable dump has been collected.

FYI @dotnet/roslyn-infrastructure 