### PR TITLE
Audit usages of Compilation.References

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Security;
 using System.Threading;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.CSharp.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -27,40 +28,45 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.QuickInfo
         {
             using (var workspace = CSharpWorkspaceFactory.CreateWorkspaceFromFile(markup, options))
             {
-                var position = workspace.Documents.Single().CursorPosition.Value;
-
-                var noListeners = SpecializedCollections.EmptyEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>>();
-
-                var provider = new SemanticQuickInfoProvider(
-                    workspace.GetService<ITextBufferFactoryService>(),
-                    workspace.GetService<IContentTypeRegistryService>(),
-                    workspace.GetService<IProjectionBufferFactoryService>(),
-                    workspace.GetService<IEditorOptionsFactoryService>(),
-                    workspace.GetService<ITextEditorFactoryService>(),
-                    workspace.GetService<IGlyphService>(),
-                    workspace.GetService<ClassificationTypeMap>());
-
-                TestWithOptions(workspace, provider, position, expectedResults);
-
-                // speculative semantic model
-                var document = workspace.CurrentSolution.Projects.First().Documents.First();
-                if (CanUseSpeculativeSemanticModel(document, position))
-                {
-                    var buffer = workspace.Documents.Single().TextBuffer;
-                    using (var edit = buffer.CreateEdit())
-                    {
-                        edit.Replace(0, buffer.CurrentSnapshot.Length, buffer.CurrentSnapshot.GetText());
-                        edit.Apply();
-                    }
-
-                    TestWithOptions(workspace, provider, position, expectedResults);
-                }
+                TestWithOptions(workspace, expectedResults);
             }
         }
 
-        private void TestWithOptions(TestWorkspace workspace, SemanticQuickInfoProvider provider, int position, Action<object>[] expectedResults)
+        private void TestWithOptions(TestWorkspace workspace, params Action<object>[] expectedResults)
         {
-            var document = workspace.CurrentSolution.Projects.First().Documents.First();
+            var testDocument = workspace.DocumentWithCursor;
+            var position = testDocument.CursorPosition.GetValueOrDefault();
+            var documentId = workspace.GetDocumentId(testDocument);
+            var document = workspace.CurrentSolution.GetDocument(documentId);
+
+            var provider = new SemanticQuickInfoProvider(
+                workspace.GetService<ITextBufferFactoryService>(),
+                workspace.GetService<IContentTypeRegistryService>(),
+                workspace.GetService<IProjectionBufferFactoryService>(),
+                workspace.GetService<IEditorOptionsFactoryService>(),
+                workspace.GetService<ITextEditorFactoryService>(),
+                workspace.GetService<IGlyphService>(),
+                workspace.GetService<ClassificationTypeMap>());
+
+            TestWithOptions(document, provider, position, expectedResults);
+
+            // speculative semantic model
+            if (CanUseSpeculativeSemanticModel(document, position))
+            {
+                var buffer = testDocument.TextBuffer;
+                using (var edit = buffer.CreateEdit())
+                {
+                    var currentSnapshot = buffer.CurrentSnapshot;
+                    edit.Replace(0, currentSnapshot.Length, currentSnapshot.GetText());
+                    edit.Apply();
+                }
+
+                TestWithOptions(document, provider, position, expectedResults);
+            }
+        }
+
+        private void TestWithOptions(Document document, SemanticQuickInfoProvider provider, int position, Action<object>[] expectedResults)
+        {
             var state = provider.GetItemAsync(document, position, cancellationToken: CancellationToken.None).Result;
             if (state != null)
             {
@@ -4205,6 +4211,26 @@ class C
 }
 ",
                 Documentation(@"string http://microsoft.com null cat"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(6657, "https://github.com/dotnet/roslyn/issues/6657")]
+        public void OptionalParameterFromPreviousSubmission()
+        {
+            const string workspaceDefinition = @"
+<Workspace>
+    <Submission Language=""C#"" CommonReferences=""true"">
+        void M(int x = 1) { }
+    </Submission>
+    <Submission Language=""C#"" CommonReferences=""true"">
+        M(x$$: 2)
+    </Submission>
+</Workspace>
+";
+            using (var workspace = TestWorkspaceFactory.CreateWorkspace(XElement.Parse(workspaceDefinition), workspaceKind: WorkspaceKind.Interactive))
+            {
+                TestWithOptions(workspace, MainDescription("(parameter) int x = 1"));
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -131,12 +131,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 }
 
                 // it is from one of its p2p references
-                foreach (var reference in model.Compilation.References.OfType<CompilationReference>())
+                foreach (var referencedCompilation in model.Compilation.GetReferencedCompilations())
                 {
                     // find the reference that contains the given tree
-                    if (reference.Compilation.ContainsSyntaxTree(tree))
+                    if (referencedCompilation.ContainsSyntaxTree(tree))
                     {
-                        return reference.Compilation.GetSemanticModel(tree);
+                        return referencedCompilation.GetSemanticModel(tree);
                     }
                 }
 

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
@@ -49,6 +49,11 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
         public static string GetAssemblyDisplay(Compilation compilation, IAssemblySymbol assemblySymbol)
         {
+            // This method is only used to generate a comment at the top of Metadata-as-Source documents and
+            // previous submissions are never viewed as metadata (i.e. we always have compilations) so there's no
+            // need to consume compilation.ScriptCompilationInfo.PreviousScriptCompilation.
+
+            // TODO (https://github.com/dotnet/roslyn/issues/6859): compilation.GetMetadataReference(assemblySymbol)?
             var assemblyReference = compilation.References.Where(r =>
             {
                 var referencedSymbol = compilation.GetAssemblyOrModuleSymbol(r) as IAssemblySymbol;
@@ -58,14 +63,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             })
             .FirstOrDefault();
 
-            if (assemblyReference != null && assemblyReference.Display != null)
-            {
-                return assemblyReference.Display;
-            }
-            else
-            {
-                return FeaturesResources.LocationUnknown;
-            }
+            return assemblyReference?.Display ?? FeaturesResources.LocationUnknown;
         }
 
         public static INamedTypeSymbol GetTopLevelContainingNamedType(ISymbol symbol)

--- a/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// </summary>
         private static void EmitReferences(Compilation compilation, HashSet<string> fullNameSet, List<ModuleData> dependencies, DiagnosticBag diagnostics)
         {
-            var previousSubmission = compilation.ScriptCompilationInfo?.PreviousScriptCompilation;
+            // NOTE: specifically don't need to consider previous submissions since they will always be compilations.
             foreach (var metadataReference in compilation.References)
             {
                 if (metadataReference is CompilationReference)

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
@@ -661,7 +661,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 return ImmutableArray<ObjectListItem>.Empty;
             }
 
-            var builder = ImmutableArray.CreateBuilder<ObjectListItem>();
+            var builder = ArrayBuilder<ObjectListItem>.GetInstance();
 
             foreach (var reference in compilation.References)
             {
@@ -673,7 +673,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 }
             }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableAndFree();
         }
 
         private ImmutableArray<INamedTypeSymbol> GetAccessibleTypes(INamespaceSymbol namespaceSymbol, Compilation compilation)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -404,13 +404,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             Contract.ThrowIfFalse(equivalentTypesWithDifferingAssemblies.All(kvp => kvp.Value.ContainingType == null));
 
             var referencedAssemblies = new MultiDictionary<string, IAssemblySymbol>();
-            foreach (var reference in compilation.References)
+            foreach (var assembly in compilation.GetReferencedAssemblySymbols())
             {
-                var referencedAssemblyOrModule = compilation.GetAssemblyOrModuleSymbol(reference);
-                if (referencedAssemblyOrModule.MatchesKind(SymbolKind.Assembly))
-                {
-                    referencedAssemblies.Add(referencedAssemblyOrModule.Name, (IAssemblySymbol)referencedAssemblyOrModule);
-                }
+                 referencedAssemblies.Add(assembly.Name, assembly);
             }
 
             int verifiedCount = 0;

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.AssemblySymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.AssemblySymbolKey.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -29,10 +30,10 @@ namespace Microsoft.CodeAnalysis
                     yield return compilation.Assembly;
                 }
 
-                foreach (var reference in compilation.References)
+                // Might need keys for symbols from previous script compilations.
+                foreach (var assembly in compilation.GetReferencedAssemblySymbols())
                 {
-                    var assembly = compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
-                    if (assembly != null && (ignoreAssemblyKey || assembly.Identity.Name == _assemblyName))
+                    if (ignoreAssemblyKey || assembly.Identity.Name == _assemblyName)
                     {
                         yield return assembly;
                     }

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
@@ -149,6 +149,42 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.True(vbResult.Count() > 0);
         }
 
+        [Fact, WorkItem(6616, "https://github.com/dotnet/roslyn/issues/6616")]
+        public static void FindDeclarationsAsync_PreviousSubmission()
+        {
+            var solution = CreateSolution();
+
+            var submission0Id = ProjectId.CreateNewId();
+            var submission0DocId = DocumentId.CreateNewId(submission0Id);
+            const string submission0Name = "Submission#0";
+            solution = solution
+                .AddProject(submission0Id, submission0Name, submission0Name, LanguageNames.CSharp)
+                .AddMetadataReference(submission0Id, MscorlibRef)
+                .AddDocument(submission0DocId, submission0Name, @"
+public class Outer
+{
+    public class Inner
+    {
+    }
+}
+");
+
+            var submission1Id = ProjectId.CreateNewId();
+            var submission1DocId = DocumentId.CreateNewId(submission1Id);
+            const string submission1Name = "Submission#1";
+            solution = solution
+                .AddProject(submission1Id, submission1Name, submission1Name, LanguageNames.CSharp)
+                .AddMetadataReference(submission1Id, MscorlibRef)
+                .AddProjectReference(submission1Id, new ProjectReference(submission0Id))
+                .AddDocument(submission1DocId, submission1Name, @"
+Inner i;
+");
+
+            var actualSymbol = SymbolFinder.FindDeclarationsAsync(solution.GetProject(submission1Id), "Inner", ignoreCase: false).Result.SingleOrDefault();
+            var expectedSymbol = solution.GetProject(submission0Id).GetCompilationAsync().Result.GlobalNamespace.GetMembers("Outer").SingleOrDefault().GetMembers("Inner").SingleOrDefault();
+            Assert.Equal(expectedSymbol, actualSymbol);
+        }
+
         #endregion
 
         #region FindSourceDeclarationsAsync_Project


### PR DESCRIPTION
Most callers are probably interested in
`Compilation.ScriptCompilationInfo.PreviousScriptCompilation` as well.
Behavioral changes expected in QuickInfo (fix crash) and SymbolFinder
(offer additional CodeFixes).

Fixes #6616 and #6657.