### PR TITLE
Fix hardcoded help prefix in InteractiveWindow

### DIFF
--- a/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
+++ b/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
         {
             string format = "{0,-" + _maxCommandNameLength + "}  {1}";
             return _commands.GroupBy(entry => entry.Value).
-                Select(group => string.Format(format, string.Join(_commandSeparator, group.Key.Names.Select(s => "#" + s)), group.Key.Description)).
+                Select(group => string.Format(format, string.Join(_commandSeparator, group.Key.Names.Select(s => CommandPrefix + s)), group.Key.Description)).
                 OrderBy(line => line);
         }
 

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -50,6 +50,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             {
                 var mock = new Mock<IInteractiveWindowCommand>();
                 mock.Setup(m => m.Names).Returns(new[] { name });
+                mock.Setup(m => m.Description).Returns(string.Format("Description of {0} command.", name));
                 yield return mock.Object;
             }
         }
@@ -179,6 +180,16 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Assert.Equal(2, commands.Where(n => n.Names.Last() == "clear").Count());
             Assert.NotNull(commands.Where(n => n.Names.First() == "help").SingleOrDefault());
             Assert.NotNull(commands.Where(n => n.Names.First() == "reset").SingleOrDefault());
+        }
+
+        [WorkItem(6625, "https://github.com/dotnet/roslyn/issues/6625")]
+        [WpfFact]
+        public void InteractiveWindow_DisplayCommandsHelp()
+        {            
+            var commandList = MockCommands("foo").ToArray();
+            var commands = new Commands.Commands(null, "&", commandList);
+
+            Assert.Equal(new string[] { "&foo  Description of foo command."}, commands.Help().ToArray());
         }
 
         [WorkItem(3970, "https://github.com/dotnet/roslyn/issues/3970")]


### PR DESCRIPTION
```
Python interactive window. Type $help for a list of commands.
>>> $help
Keyboard shortcuts:
  Enter                If the current submission appears to be complete, evaluate it.  Otherwise, insert a new line.
  Ctrl-Enter           Within the current submission, evaluate the current submission.
                       Within the current submission, evaluate the current submission.
  Shift-Enter          Insert a new line.
  Escape               Clear the current submission.
  Alt-UpArrow          Replace the current submission with a previous submission.
  Alt-DownArrow        Replace the current submission with a subsequent submission (after having previously navigated backwards).
  Ctrl-Alt-UpArrow     Replace the current submission with a previous submission beginning with the same text.
  Ctrl-Alt-DownArrow   Replace the current submission with a subsequent submission beginning with the same text (after having previously navigated backwards).
  UpArrow              At the end of the current submission, replace the current submission with a previous submission.
                       Elsewhere, move the cursor up one line.
  DownArrow            At the end of the current submission, replace the current submission with a subsequent submission (after having previously navigated backwards).
                       Elsewhere, move the cursor down one line.
  Ctrl-K, Ctrl-Enter   Paste the selection at the end of interactive buffer, leave caret at the end of input.
  Ctrl-E, Ctrl-Enter   Paste and execute the selection before any pending input in the interactive buffer.
  Ctrl-A               First press, select the submission containing the cursor.  Second press, select all text in the window.
REPL commands:
  $$            A comment marker
  $attach       Attaches the Visual Studio debugger to the REPL window process to enable debugging
  $cls, $clear  Clears the contents of the editor window, leaving history and execution context intact.
  $help         Display help on specified command, or all available commands and key bindings if none specified.
  $load         Loads commands from file and executes until complete
  $mod          Switches the current scope to the specified module name.
  $reset        Reset the execution environment to the initial state, keep history.
  $wait         Wait for at least the specified number of milliseconds
>>> $$
>>> 
```
Fix #6625

@dotnet/roslyn-interactive @zooba