### PR TITLE
Local constant declarations can specify const multiple times

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7995,10 +7995,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     mod = this.AddError(mod, ErrorCode.ERR_BadMemberFlag, mod.Text);
                 }
-
-                // check for duplicates, can only be const
                 else if (list.Any(mod.Kind))
                 {
+                    // check for duplicates, can only be const
                     mod = this.AddError(mod, ErrorCode.ERR_TypeExpected, mod.Text);
                 }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7997,7 +7997,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 }
 
                 // check for duplicates, can only be const
-                if (list.Any(mod.Kind))
+                else if (list.Any(mod.Kind))
                 {
                     mod = this.AddError(mod, ErrorCode.ERR_TypeExpected, mod.Text);
                 }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7996,6 +7996,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     mod = this.AddError(mod, ErrorCode.ERR_BadMemberFlag, mod.Text);
                 }
 
+                // check for duplicates, can only be const
+                if (list.Any(mod.Kind))
+                {
+                    mod = this.AddError(mod, ErrorCode.ERR_TypeExpected, mod.Text);
+                }
+
                 list.Add(mod);
             }
         }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
@@ -144,6 +144,33 @@ namespace x
             ParserErrorMessageTests.ParseAndValidate(test, Diagnostic(ErrorCode.ERR_TooManyCharsInConst, ""));
         }
 
+        [Fact]
+        public void CS1015ERR_TypeExpected()
+        {
+            var test = @"
+public class C
+{
+    public static void Main()
+    {
+        const int i = 0;
+        const const double d = 0;
+        const const const long l = 0;
+    }    
+}
+";
+            ParserErrorMessageTests.ParseAndValidate(test,
+                // (7,15): error CS1031: Type expected
+                //         const const double d = 0;
+                Diagnostic(ErrorCode.ERR_TypeExpected, "const").WithArguments("const").WithLocation(7, 15),
+                // (8,15): error CS1031: Type expected
+                //         const const const long l = 0;
+                Diagnostic(ErrorCode.ERR_TypeExpected, "const").WithArguments("const").WithLocation(8, 15),
+                // (8,21): error CS1031: Type expected
+                //         const const const long l = 0;
+                Diagnostic(ErrorCode.ERR_TypeExpected, "const").WithArguments("const").WithLocation(8, 21)
+            );
+        }
+
         [WorkItem(553293, "DevDiv")]
         [Fact]
         public void CS1021ERR_IntOverflow()

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
@@ -155,6 +155,7 @@ public class C
         const int i = 0;
         const const double d = 0;
         const const const long l = 0;
+        const readonly readonly readonly const double r = 0;
     }    
 }
 ";
@@ -167,7 +168,19 @@ public class C
                 Diagnostic(ErrorCode.ERR_TypeExpected, "const").WithArguments("const").WithLocation(8, 15),
                 // (8,21): error CS1031: Type expected
                 //         const const const long l = 0;
-                Diagnostic(ErrorCode.ERR_TypeExpected, "const").WithArguments("const").WithLocation(8, 21)
+                Diagnostic(ErrorCode.ERR_TypeExpected, "const").WithArguments("const").WithLocation(8, 21),
+                // (9,15): error CS0106: The modifier 'readonly' is not valid for this item
+                //         const readonly readonly readonly const double r = 0;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "readonly").WithArguments("readonly").WithLocation(9, 15),
+                // (9,24): error CS0106: The modifier 'readonly' is not valid for this item
+                //         const readonly readonly readonly const double r = 0;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "readonly").WithArguments("readonly").WithLocation(9, 24),
+                // (9,33): error CS0106: The modifier 'readonly' is not valid for this item
+                //         const readonly readonly readonly const double r = 0;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "readonly").WithArguments("readonly").WithLocation(9, 33),
+                // (9,42): error CS1031: Type expected
+                //         const readonly readonly readonly const double r = 0;
+                Diagnostic(ErrorCode.ERR_TypeExpected, "const").WithArguments("const").WithLocation(9, 42)
             );
         }
 


### PR DESCRIPTION
Fixes #6761.
Matches behavior for const field declarations.

Side note: There should be a `ParseAndValidate` that ignores additional errors. Sometimes the extra errors make a test needlessly complex.