### PR TITLE
Clarify overflow checks

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -100,8 +100,21 @@
   </PropertyGroup>
 
   <Target Name="VerifyBuildFlags">
-    <Error Condition="('$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real') AND '$(BuildVersion)' == '42.42.42.42'"
-           Text="Must specify a build version in order to real sign a build." />
+    <Error 
+        Condition="('$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real') AND '$(BuildVersion)' == '42.42.42.42'"
+        Text="Must specify a build version in order to real sign a build." />
+
+    <Error 
+        Condition="'$(CheckForOverflowUnderflow)' != '' OR '$(RemoveIntegerChecks)' != ''"
+        Text="The following properties cannot be set by individual projects: CheckForOverflowUnderflow and RemoveIntegerChecks" />
+    
+    <PropertyGroup Condition="'$(ProjectLanguage)' == 'CSharp'">
+        <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(ProjectLanguage)' == 'VB'">
+        <RemoveIntegerChecks>true</RemoveIntegerChecks>
+    </PropertyGroup>
   </Target>
 
   <!-- ====================================================================================

--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -235,7 +235,6 @@
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
         <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
       </PropertyGroup>
       <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <DebugType>pdbonly</DebugType>

--- a/src/Compilers/CSharp/CscCore/CscCore.csproj
+++ b/src/Compilers/CSharp/CscCore/CscCore.csproj
@@ -39,7 +39,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <NoWarn>1591</NoWarn>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>

--- a/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/CSharpCommandLineTest.csproj
@@ -53,7 +53,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <NoWarn>1591</NoWarn>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -83,6 +82,7 @@
       <DependentUpon>CommandLineTestResources.resx</DependentUpon>
     </Compile>
     <Compile Include="ErrorLoggerTests.cs" />
+    <Compile Include="MiscTests.cs" />
     <Compile Include="TouchedFileLoggingTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/CSharp/Test/CommandLine/MiscTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/MiscTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
+{
+    public class MiscTests
+    {
+        /// <summary>
+        /// Sanity check to help ensure our code base was compiled without overflow checking.
+        /// </summary>
+        [Fact]
+        public void OverflowCheck()
+        {
+            int max = int.MaxValue;
+            int x = max + max;
+            Assert.Equal(-2, x);
+            int y = 0 - int.MaxValue;
+            Assert.Equal(-2147483647, y);
+        }
+    }
+}

--- a/src/Compilers/Server/PortableServer/PortableServer.csproj
+++ b/src/Compilers/Server/PortableServer/PortableServer.csproj
@@ -43,7 +43,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <NoWarn>1591</NoWarn>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>

--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -45,7 +45,6 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
     <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.xml</DocumentationFile>

--- a/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/CommandLine/BasicCommandLineTest.vbproj
@@ -80,6 +80,7 @@
     <Compile Include="CommandLineBreakingChanges.vb" />
     <Compile Include="CommandLineTests.vb" />
     <Compile Include="ErrorLoggerTests.vb" />
+    <Compile Include="MiscTests.vb" />
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>
       <DependentUpon>Application.myapp</DependentUpon>

--- a/src/Compilers/VisualBasic/Test/CommandLine/MiscTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/MiscTests.vb
@@ -1,0 +1,19 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Xunit
+
+Public Class MiscTests
+
+    ''' <summary>
+    ''' Sanity check to help ensure our code base was compiled without overflow checking.
+    ''' </summary>
+    <Fact>
+    Public Sub OverflowCheck()
+        Dim max = Integer.MaxValue
+        Dim x = max + max
+        Assert.Equal(-2, x)
+        Dim y = 0 - max
+        Assert.Equal(-2147483647, y)
+    End Sub
+
+End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -1353,18 +1353,19 @@ End Class
         Private Function CheckedConvert(value As Object, type As TypeSymbol) As Object
             type = type.GetEnumUnderlyingTypeOrSelf()
 
+            Dim c = CType(value, IConvertible)
             Select Case type.SpecialType
-                Case System_Byte : Return CByte(value)
-                Case System_SByte : Return CSByte(value)
-                Case System_Int16 : Return CShort(value)
-                Case System_UInt16 : Return CUShort(value)
-                Case System_Int32 : Return CInt(value)
-                Case System_UInt32 : Return CUInt(value)
-                Case System_Int64 : Return CLng(value)
-                Case System_UInt64 : Return CULng(value)
-                Case System_Single : Return CSng(value)
-                Case System_Double : Return CDbl(value)
-                Case System_Decimal : Return CDec(value)
+                Case System_Byte : Return c.ToByte(Nothing)
+                Case System_SByte : Return c.ToSByte(Nothing)
+                Case System_Int16 : Return c.ToInt16(Nothing)
+                Case System_UInt16 : Return c.ToUInt16(Nothing)
+                Case System_Int32 : Return c.ToInt32(Nothing)
+                Case System_UInt32 : Return c.ToUInt32(Nothing)
+                Case System_Int64 : Return c.ToInt64(Nothing)
+                Case System_UInt64 : Return c.ToUInt64(Nothing)
+                Case System_Single : Return c.ToSingle(Nothing)
+                Case System_Double : Return c.ToDouble(Nothing)
+                Case System_Decimal : Return c.ToDecimal(Nothing)
                 Case Else
                     Throw New NotSupportedException()
             End Select

--- a/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
+++ b/src/Compilers/VisualBasic/VbcCore/VbcCore.csproj
@@ -39,7 +39,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <NoWarn>1591</NoWarn>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
@@ -18,7 +18,6 @@
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider</AssemblyName>
     <VBSyntaxGeneratorToolPath>$(OutDir)..\VBSyntaxGenerator.exe</VBSyntaxGeneratorToolPath>
     <UseCommonOutputDirectory>True</UseCommonOutputDirectory>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
     <RestorePackages>true</RestorePackages>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
   </PropertyGroup>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
@@ -18,7 +18,6 @@
     <ProjectTypeGuids>{14182A97-F7F0-4C62-8B27-98AA8AE2109A};{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</ProjectTypeGuids>
     <VBSyntaxGeneratorToolPath>$(OutDir)VBSyntaxGenerator.exe</VBSyntaxGeneratorToolPath>
     <UseCommonOutputDirectory>True</UseCommonOutputDirectory>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/BasicResultProviderTest.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/BasicResultProviderTest.vbproj
@@ -13,7 +13,6 @@
     </RootNamespace>
     <AssemblyName>Roslyn.ExpressionEvaluator.VisualBasic.ResultProvider.UnitTests</AssemblyName>
     <UseCommonOutputDirectory>True</UseCommonOutputDirectory>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <VBRuntime>
     </VBRuntime>

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -44,14 +44,12 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
     <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.Features.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DefineTrace>true</DefineTrace>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.Features.xml</DocumentationFile>

--- a/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
+++ b/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
@@ -35,13 +35,11 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DefineTrace>true</DefineTrace>
-    <RemoveIntegerChecks>true</RemoveIntegerChecks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
The intent of the code base was to be run with overflow checking disabled.  However the actual settings were quite a bit different:

- CSharp: checking enabled in debug, disabled in release
- VB: checking disabled in all modes

For both languages individual projects could, and often did, override this setting.  Typically it specified the global default but not always.

This is confusing and makes it difficult to reason about our source code.  Furthermore much of our testing occurs in debug mode and it's not logical for our code to behave substantially different in Debug than it would in Release.

This change clarifies our overflow checking behavior.  It's disabled in all modes now.  The change goes further to prevent individual projects from overriding this setting and adds unit tests to make sure it was applied correctly.

Note: this PR is not intended to state whether it's better for overflow checking to be enabled or disabled.  It is intended to enforce the decision the code base was designed around.