### PR TITLE
Refactor the code to use the equals expressions that evaluate the method call to Kind consistently (Issue #6005)

### DIFF
--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // cases:
             //   [ |
-            if (token.Kind() == SyntaxKind.OpenBracketToken &&
+            if (token.IsKind(SyntaxKind.OpenBracketToken) &&
                 token.Parent.IsKind(SyntaxKind.AttributeList))
             {
                 return true;
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // cases:
             //   [Foo(1), |
-            if (token.Kind() == SyntaxKind.CommaToken &&
+            if (token.IsKind(SyntaxKind.CommaToken) &&
                 token.Parent.IsKind(SyntaxKind.AttributeList))
             {
                 return true;
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // cases:
             //   [specifier: |
-            if (token.Kind() == SyntaxKind.ColonToken &&
+            if (token.IsKind(SyntaxKind.ColonToken) &&
                 token.Parent.IsKind(SyntaxKind.AttributeTargetSpecifier))
             {
                 return true;
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // previous token.
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenBraceToken)
+            if (token.IsKind(SyntaxKind.OpenBraceToken))
             {
                 if (token.Parent is BaseTypeDeclarationSyntax)
                 {
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // class C {
             //   int i;
             //   |
-            if (token.Kind() == SyntaxKind.SemicolonToken)
+            if (token.IsKind(SyntaxKind.SemicolonToken))
             {
                 if (token.Parent is MemberDeclarationSyntax &&
                     token.Parent.GetParent() is BaseTypeDeclarationSyntax)
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //    void Foo() {
             //    }
             //    |
-            if (token.Kind() == SyntaxKind.CloseBraceToken)
+            if (token.IsKind(SyntaxKind.CloseBraceToken))
             {
                 if (token.Parent is BaseTypeDeclarationSyntax &&
                     token.Parent.GetParent() is BaseTypeDeclarationSyntax)
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //   [Bar]
             //   |
 
-            if (token.Kind() == SyntaxKind.CloseBracketToken &&
+            if (token.IsKind(SyntaxKind.CloseBracketToken) &&
                 token.Parent.IsKind(SyntaxKind.AttributeList))
             {
                 // attributes belong to a member which itself is in a
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // root: |
-            if (token.Kind() == SyntaxKind.None)
+            if (token.IsKind(SyntaxKind.None))
             {
                 // root namespace
 
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.OpenBraceToken)
+            if (token.IsKind(SyntaxKind.OpenBraceToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration))
                 {
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // class C {
             //   int i;
             //   |
-            if (token.Kind() == SyntaxKind.SemicolonToken)
+            if (token.IsKind(SyntaxKind.SemicolonToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.ExternAliasDirective, SyntaxKind.UsingDirective))
                 {
@@ -408,7 +408,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //    void Foo() {
             //    }
             //    |
-            if (token.Kind() == SyntaxKind.CloseBraceToken)
+            if (token.IsKind(SyntaxKind.CloseBraceToken))
             {
                 if (token.Parent is BaseTypeDeclarationSyntax)
                 {
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //   [Bar]
             //   |
 
-            if (token.Kind() == SyntaxKind.CloseBracketToken &&
+            if (token.IsKind(SyntaxKind.CloseBracketToken) &&
                 token.Parent.IsKind(SyntaxKind.AttributeList))
             {
                 // assembly attributes belong to the containing compilation unit
@@ -566,8 +566,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                                   .GetPreviousTokenIfTouchingWord(position);
 
             // global::
-            if (token.Kind() == SyntaxKind.ColonColonToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.GlobalKeyword)
+            if (token.IsKind(SyntaxKind.ColonColonToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.GlobalKeyword))
             {
                 return true;
             }
@@ -579,7 +579,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // Note: we take care of the using alias case in the IsTypeContext
             // call below.
 
-            if (token.Kind() == SyntaxKind.UsingKeyword)
+            if (token.IsKind(SyntaxKind.UsingKeyword))
             {
                 var usingDirective = token.GetAncestor<UsingDirectiveSyntax>();
                 if (usingDirective != null)
@@ -665,8 +665,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.ColonToken ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.ColonToken) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.BaseList))
                 {
@@ -684,7 +684,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.EqualsToken &&
+            if (token.IsKind(SyntaxKind.EqualsToken) &&
                 token.GetAncestor<UsingDirectiveSyntax>() != null)
             {
                 return true;
@@ -713,13 +713,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.WhereKeyword &&
+            if (token.IsKind(SyntaxKind.WhereKeyword) &&
                 token.Parent.IsKind(SyntaxKind.TypeParameterConstraintClause))
             {
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.IdentifierToken &&
+            if (token.IsKind(SyntaxKind.IdentifierToken) &&
                 token.HasMatchingText(SyntaxKind.WhereKeyword) &&
                 token.Parent.IsKind(SyntaxKind.IdentifierName) &&
                 token.Parent.IsParentKind(SyntaxKind.SimpleBaseType) &&
@@ -740,9 +740,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.ColonToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.IdentifierToken &&
-                token.GetPreviousToken(includeSkipped: true).GetPreviousToken().Kind() == SyntaxKind.WhereKeyword)
+            if (token.IsKind(SyntaxKind.ColonToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.IdentifierToken) &&
+                token.GetPreviousToken(includeSkipped: true).GetPreviousToken().IsKind(SyntaxKind.WhereKeyword))
             {
                 return true;
             }
@@ -766,7 +766,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //    where T : class, |
             //    where T : struct, |
             //    where T : Foo, |
-            if (token.Kind() == SyntaxKind.CommaToken &&
+            if (token.IsKind(SyntaxKind.CommaToken) &&
                 token.Parent.IsKind(SyntaxKind.TypeParameterConstraintClause))
             {
                 var constraintClause = token.Parent as TypeParameterConstraintClauseSyntax;
@@ -787,7 +787,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             var token = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken && token.Parent.IsKind(SyntaxKind.TypeOfExpression))
+            if (token.IsKind(SyntaxKind.OpenParenToken) && token.Parent.IsKind(SyntaxKind.TypeOfExpression))
             {
                 return true;
             }
@@ -799,7 +799,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             var token = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken && token.Parent.IsKind(SyntaxKind.DefaultExpression))
+            if (token.IsKind(SyntaxKind.OpenParenToken) && token.Parent.IsKind(SyntaxKind.DefaultExpression))
             {
                 return true;
             }
@@ -812,7 +812,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             var token = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken && token.Parent.IsKind(SyntaxKind.SizeOfExpression))
+            if (token.IsKind(SyntaxKind.OpenParenToken) && token.Parent.IsKind(SyntaxKind.SizeOfExpression))
             {
                 return true;
             }
@@ -906,7 +906,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
                 token.Parent.IsDelegateOrConstructorOrMethodParameterList())
             {
                 if (allowableIndex.HasValue)
@@ -920,7 +920,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.CommaToken &&
+            if (token.IsKind(SyntaxKind.CommaToken) &&
                 token.Parent.IsDelegateOrConstructorOrMethodParameterList())
             {
                 if (allowableIndex.HasValue)
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.CloseBracketToken &&
+            if (token.IsKind(SyntaxKind.CloseBracketToken) &&
                 token.Parent.IsKind(SyntaxKind.AttributeList) &&
                 token.Parent.IsParentKind(SyntaxKind.Parameter) &&
                 token.Parent.GetParent().GetParent().IsDelegateOrConstructorOrMethodParameterList())
@@ -966,7 +966,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.DelegateKeyword &&
+            if (token.IsKind(SyntaxKind.DelegateKeyword) &&
                 token.Parent.IsKind(SyntaxKind.DelegateDeclaration))
             {
                 return true;
@@ -981,10 +981,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OperatorKeyword)
+            if (token.IsKind(SyntaxKind.OperatorKeyword))
             {
-                if (token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.ImplicitKeyword ||
-                    token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.ExplicitKeyword)
+                if (token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.ImplicitKeyword) ||
+                    token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.ExplicitKeyword))
                 {
                     return true;
                 }
@@ -997,10 +997,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             var token = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.RefKeyword ||
-                token.Kind() == SyntaxKind.OutKeyword ||
-                token.Kind() == SyntaxKind.ParamsKeyword ||
-                token.Kind() == SyntaxKind.ThisKeyword)
+            if (token.IsKind(SyntaxKind.RefKeyword) ||
+                token.IsKind(SyntaxKind.OutKeyword) ||
+                token.IsKind(SyntaxKind.ParamsKeyword) ||
+                token.IsKind(SyntaxKind.ThisKeyword))
             {
                 position = token.SpanStart;
                 tokenOnLeftOfPosition = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
@@ -1013,9 +1013,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // int this[ |
             // int this[int i, |
-            if (token.Kind() == SyntaxKind.OpenParenToken ||
-                token.Kind() == SyntaxKind.OpenBracketToken ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OpenParenToken) ||
+                token.IsKind(SyntaxKind.OpenBracketToken) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.ParameterList, SyntaxKind.BracketedParameterList))
                 {
@@ -1032,8 +1032,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OpenParenToken) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.ParameterList) &&
                     token.Parent.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression))
@@ -1060,8 +1060,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OpenParenToken) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.ParameterList) &&
                     token.Parent.IsParentKind(SyntaxKind.AnonymousMethodExpression))
@@ -1079,8 +1079,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.RefKeyword ||
-                token.Kind() == SyntaxKind.OutKeyword)
+            if (token.IsKind(SyntaxKind.RefKeyword) ||
+                token.IsKind(SyntaxKind.OutKeyword))
             {
                 position = token.SpanStart;
                 tokenOnLeftOfPosition = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
@@ -1192,18 +1192,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.ConstKeyword &&
+            if (token.IsKind(SyntaxKind.ConstKeyword) &&
                 token.Parent.IsKind(SyntaxKind.LocalDeclarationStatement))
             {
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.OpenParenToken)
+            if (token.IsKind(SyntaxKind.OpenParenToken))
             {
                 var previous = token.GetPreviousToken(includeSkipped: true);
-                if (previous.Kind() == SyntaxKind.ForKeyword ||
-                    previous.Kind() == SyntaxKind.ForEachKeyword ||
-                    previous.Kind() == SyntaxKind.UsingKeyword)
+                if (previous.IsKind(SyntaxKind.ForKeyword) ||
+                    previous.IsKind(SyntaxKind.ForEachKeyword) ||
+                    previous.IsKind(SyntaxKind.UsingKeyword))
                 {
                     return true;
                 }
@@ -1234,8 +1234,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.FixedKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.FixedKeyword))
             {
                 return true;
             }
@@ -1251,8 +1251,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.CatchKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.CatchKeyword))
             {
                 return true;
             }
@@ -1265,8 +1265,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.IsKeyword ||
-                token.Kind() == SyntaxKind.AsKeyword)
+            if (token.IsKind(SyntaxKind.IsKeyword) ||
+                token.IsKind(SyntaxKind.AsKeyword))
             {
                 return true;
             }
@@ -1279,7 +1279,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             var token = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.NewKeyword)
+            if (token.IsKind(SyntaxKind.NewKeyword))
             {
                 // we can follow a 'new' if it's the 'new' for an expression.
                 var start = token.SpanStart;
@@ -1347,7 +1347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = preProcessorTokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.HashToken)
+            if (token.IsKind(SyntaxKind.HashToken))
             {
                 return true;
             }
@@ -1390,7 +1390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken)
                                   .GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.None)
+            if (token.IsKind(SyntaxKind.None))
             {
                 // global statements can't come before usings/externs
                 var compilationUnit = syntaxTree.GetRoot(cancellationToken) as CompilationUnitSyntax;
@@ -1483,7 +1483,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
                 token.Parent.IsKind(SyntaxKind.CastExpression))
             {
                 return true;
@@ -1497,20 +1497,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
             // case |
-            if (token.Kind() == SyntaxKind.CaseKeyword &&
+            if (token.IsKind(SyntaxKind.CaseKeyword) &&
                 token.Parent.IsKind(SyntaxKind.CaseSwitchLabel))
             {
                 return true;
             }
 
             // goto case |
-            if (token.Kind() == SyntaxKind.CaseKeyword &&
+            if (token.IsKind(SyntaxKind.CaseKeyword) &&
                 token.Parent.IsKind(SyntaxKind.GotoCaseStatement))
             {
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.EqualsToken &&
+            if (token.IsKind(SyntaxKind.EqualsToken) &&
                 token.Parent.IsKind(SyntaxKind.EqualsValueClause))
             {
                 var equalsValue = (EqualsValueClauseSyntax)token.Parent;
@@ -1549,14 +1549,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // [Foo( |
             // [Foo(x, |
             if (token.Parent.IsKind(SyntaxKind.AttributeArgumentList) &&
-               (token.Kind() == SyntaxKind.CommaToken ||
-                token.Kind() == SyntaxKind.OpenParenToken))
+               (token.IsKind(SyntaxKind.CommaToken) ||
+                token.IsKind(SyntaxKind.OpenParenToken)))
             {
                 return true;
             }
 
             // [Foo(x: |
-            if (token.Kind() == SyntaxKind.ColonToken &&
+            if (token.IsKind(SyntaxKind.ColonToken) &&
                 token.Parent.IsKind(SyntaxKind.NameColon) &&
                 token.Parent.IsParentKind(SyntaxKind.AttributeArgument))
             {
@@ -1564,7 +1564,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // [Foo(X = |
-            if (token.Kind() == SyntaxKind.EqualsToken &&
+            if (token.IsKind(SyntaxKind.EqualsToken) &&
                 token.Parent.IsKind(SyntaxKind.NameEquals) &&
                 token.Parent.IsParentKind(SyntaxKind.AttributeArgument))
             {
@@ -1635,16 +1635,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // no expressions after .   ::   ->
-            if (token.Kind() == SyntaxKind.DotToken ||
-                token.Kind() == SyntaxKind.ColonColonToken ||
-                token.Kind() == SyntaxKind.MinusGreaterThanToken)
+            if (token.IsKind(SyntaxKind.DotToken) ||
+                token.IsKind(SyntaxKind.ColonColonToken) ||
+                token.IsKind(SyntaxKind.MinusGreaterThanToken))
             {
                 return false;
             }
 
             // Normally you can have any sort of expression after an equals. However, this does not
             // apply to a "using Foo = ..." situation.
-            if (token.Kind() == SyntaxKind.EqualsToken)
+            if (token.IsKind(SyntaxKind.EqualsToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.NameEquals) &&
                     token.Parent.IsParentKind(SyntaxKind.UsingDirective))
@@ -1664,24 +1664,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // q |= |
             // q <<= |
             // q >>= |
-            if (token.Kind() == SyntaxKind.EqualsToken ||
-                token.Kind() == SyntaxKind.MinusEqualsToken ||
-                token.Kind() == SyntaxKind.AsteriskEqualsToken ||
-                token.Kind() == SyntaxKind.PlusEqualsToken ||
-                token.Kind() == SyntaxKind.SlashEqualsToken ||
-                token.Kind() == SyntaxKind.ExclamationEqualsToken ||
-                token.Kind() == SyntaxKind.CaretEqualsToken ||
-                token.Kind() == SyntaxKind.AmpersandEqualsToken ||
-                token.Kind() == SyntaxKind.BarEqualsToken ||
-                token.Kind() == SyntaxKind.PercentEqualsToken ||
-                token.Kind() == SyntaxKind.LessThanLessThanEqualsToken ||
-                token.Kind() == SyntaxKind.GreaterThanGreaterThanEqualsToken)
+            if (token.IsKind(SyntaxKind.EqualsToken) ||
+                token.IsKind(SyntaxKind.MinusEqualsToken) ||
+                token.IsKind(SyntaxKind.AsteriskEqualsToken) ||
+                token.IsKind(SyntaxKind.PlusEqualsToken) ||
+                token.IsKind(SyntaxKind.SlashEqualsToken) ||
+                token.IsKind(SyntaxKind.ExclamationEqualsToken) ||
+                token.IsKind(SyntaxKind.CaretEqualsToken) ||
+                token.IsKind(SyntaxKind.AmpersandEqualsToken) ||
+                token.IsKind(SyntaxKind.BarEqualsToken) ||
+                token.IsKind(SyntaxKind.PercentEqualsToken) ||
+                token.IsKind(SyntaxKind.LessThanLessThanEqualsToken) ||
+                token.IsKind(SyntaxKind.GreaterThanGreaterThanEqualsToken))
             {
                 return true;
             }
 
             // ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
                 token.Parent.IsKind(SyntaxKind.ParenthesizedExpression))
             {
                 return true;
@@ -1747,7 +1747,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     // If this is a multiplication expression and a semantic model was passed in,
                     // check to see if the expression to the left is a type name. If it is, treat
                     // this as a pointer type.
-                    if (token.Kind() == SyntaxKind.AsteriskToken && semanticModelOpt != null)
+                    if (token.IsKind(SyntaxKind.AsteriskToken) && semanticModelOpt != null)
                     {
                         var type = binary.Left as TypeSyntax;
                         if (type != null && type.IsPotentialTypeName(semanticModelOpt, cancellationToken))
@@ -1765,11 +1765,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //    Foo ? bar
             // This parses as a local decl called bar of type Foo* or Foo?
             if (tokenOnLeftOfPosition.IntersectsWith(position) &&
-                tokenOnLeftOfPosition.Kind() == SyntaxKind.IdentifierToken)
+                tokenOnLeftOfPosition.IsKind(SyntaxKind.IdentifierToken))
             {
                 var previousToken = tokenOnLeftOfPosition.GetPreviousToken(includeSkipped: true);
-                if (previousToken.Kind() == SyntaxKind.AsteriskToken ||
-                    previousToken.Kind() == SyntaxKind.QuestionToken)
+                if (previousToken.IsKind(SyntaxKind.AsteriskToken) ||
+                    previousToken.IsKind(SyntaxKind.QuestionToken))
                 {
                     if (previousToken.Parent.IsKind(SyntaxKind.PointerType) ||
                         previousToken.Parent.IsKind(SyntaxKind.NullableType))
@@ -1797,8 +1797,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // new int[|
             // new int[expr, |
-            if (token.Kind() == SyntaxKind.OpenBracketToken ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OpenBracketToken) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.ArrayRankSpecifier))
                 {
@@ -1807,7 +1807,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // foo ? |
-            if (token.Kind() == SyntaxKind.QuestionToken &&
+            if (token.IsKind(SyntaxKind.QuestionToken) &&
                 token.Parent.IsKind(SyntaxKind.ConditionalExpression))
             {
                 // If the condition is simply a TypeSyntax that binds to a type, treat this as a nullable type.
@@ -1819,7 +1819,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // foo ? bar : |
-            if (token.Kind() == SyntaxKind.ColonToken &&
+            if (token.IsKind(SyntaxKind.ColonToken) &&
                 token.Parent.IsKind(SyntaxKind.ConditionalExpression))
             {
                 return true;
@@ -1828,7 +1828,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // typeof(|
             // default(|
             // sizeof(|
-            if (token.Kind() == SyntaxKind.OpenParenToken)
+            if (token.IsKind(SyntaxKind.OpenParenToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.TypeOfExpression, SyntaxKind.DefaultExpression, SyntaxKind.SizeOfExpression))
                 {
@@ -1839,9 +1839,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // Foo(|
             // Foo(expr, |
             // this[|
-            if (token.Kind() == SyntaxKind.OpenParenToken ||
-                token.Kind() == SyntaxKind.OpenBracketToken ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OpenParenToken) ||
+                token.IsKind(SyntaxKind.OpenBracketToken) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.ArgumentList, SyntaxKind.BracketedArgumentList))
                 {
@@ -1853,8 +1853,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // [Foo(expr, |
             if (attributes)
             {
-                if (token.Kind() == SyntaxKind.OpenParenToken ||
-                    token.Kind() == SyntaxKind.CommaToken)
+                if (token.IsKind(SyntaxKind.OpenParenToken) ||
+                    token.IsKind(SyntaxKind.CommaToken))
                 {
                     if (token.Parent.IsKind(SyntaxKind.AttributeArgumentList))
                     {
@@ -1865,8 +1865,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // Foo(ref |
             // Foo(bar |
-            if (token.Kind() == SyntaxKind.RefKeyword ||
-                token.Kind() == SyntaxKind.OutKeyword)
+            if (token.IsKind(SyntaxKind.RefKeyword) ||
+                token.IsKind(SyntaxKind.OutKeyword))
             {
                 if (token.Parent.IsKind(SyntaxKind.Argument))
                 {
@@ -1875,7 +1875,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // Foo(bar: |
-            if (token.Kind() == SyntaxKind.ColonToken &&
+            if (token.IsKind(SyntaxKind.ColonToken) &&
                 token.Parent.IsKind(SyntaxKind.NameColon) &&
                 token.Parent.IsParentKind(SyntaxKind.Argument))
             {
@@ -1883,24 +1883,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // a => |
-            if (token.Kind() == SyntaxKind.EqualsGreaterThanToken)
+            if (token.IsKind(SyntaxKind.EqualsGreaterThanToken))
             {
                 return true;
             }
 
             // new List<int> { |
             // new List<int> { expr, |
-            if (token.Kind() == SyntaxKind.OpenBraceToken ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OpenBraceToken) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent is InitializerExpressionSyntax)
                 {
                     // The compiler treats the ambiguous case as an object initializer, so we'll say
                     // expressions are legal here
-                    if (token.Parent.Kind() == SyntaxKind.ObjectInitializerExpression && token.Kind() == SyntaxKind.OpenBraceToken)
+                    if (token.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) && token.IsKind(SyntaxKind.OpenBraceToken))
                     {
                         // In this position { a$$ =, the user is trying to type an object initializer.
-                        if (!token.IntersectsWith(position) && token.GetNextToken().GetNextToken().Kind() == SyntaxKind.EqualsToken)
+                        if (!token.IntersectsWith(position) && token.GetNextToken().GetNextToken().IsKind(SyntaxKind.EqualsToken))
                         {
                             return false;
                         }
@@ -1929,7 +1929,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // for (; |
             // for (; ; |
-            if (token.Kind() == SyntaxKind.SemicolonToken &&
+            if (token.IsKind(SyntaxKind.SemicolonToken) &&
                 token.Parent.IsKind(SyntaxKind.ForStatement))
             {
                 var forStatement = (ForStatementSyntax)token.Parent;
@@ -1941,7 +1941,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // for ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
                 token.Parent.IsKind(SyntaxKind.ForStatement))
             {
                 var forStatement = (ForStatementSyntax)token.Parent;
@@ -1953,7 +1953,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // for (; ; Foo(), | 
             // for ( Foo(), |
-            if (token.Kind() == SyntaxKind.CommaToken &&
+            if (token.IsKind(SyntaxKind.CommaToken) &&
                 token.Parent.IsKind(SyntaxKind.ForStatement))
             {
                 return true;
@@ -1962,7 +1962,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // foreach (var v in |
             // from a in |
             // join b in |
-            if (token.Kind() == SyntaxKind.InKeyword)
+            if (token.IsKind(SyntaxKind.InKeyword))
             {
                 if (token.Parent.IsKind(SyntaxKind.ForEachStatement, SyntaxKind.FromClause, SyntaxKind.JoinClause))
                 {
@@ -1972,8 +1972,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // join x in y on |
             // join x in y on a equals |
-            if (token.Kind() == SyntaxKind.OnKeyword ||
-                token.Kind() == SyntaxKind.EqualsKeyword)
+            if (token.IsKind(SyntaxKind.OnKeyword) ||
+                token.IsKind(SyntaxKind.EqualsKeyword))
             {
                 if (token.Parent.IsKind(SyntaxKind.JoinClause))
                 {
@@ -1982,7 +1982,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // where |
-            if (token.Kind() == SyntaxKind.WhereKeyword &&
+            if (token.IsKind(SyntaxKind.WhereKeyword) &&
                 token.Parent.IsKind(SyntaxKind.WhereClause))
             {
                 return true;
@@ -1990,8 +1990,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // orderby |
             // orderby a, |
-            if (token.Kind() == SyntaxKind.OrderByKeyword ||
-                token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OrderByKeyword) ||
+                token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.OrderByClause))
                 {
@@ -2000,7 +2000,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // select |
-            if (token.Kind() == SyntaxKind.SelectKeyword &&
+            if (token.IsKind(SyntaxKind.SelectKeyword) &&
                 token.Parent.IsKind(SyntaxKind.SelectClause))
             {
                 return true;
@@ -2008,8 +2008,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // group |
             // group expr by |
-            if (token.Kind() == SyntaxKind.GroupKeyword ||
-                token.Kind() == SyntaxKind.ByKeyword)
+            if (token.IsKind(SyntaxKind.GroupKeyword) ||
+                token.IsKind(SyntaxKind.ByKeyword))
             {
                 if (token.Parent.IsKind(SyntaxKind.GroupClause))
                 {
@@ -2020,7 +2020,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // return |
             // yield return |
             // but not: [return |
-            if (token.Kind() == SyntaxKind.ReturnKeyword)
+            if (token.IsKind(SyntaxKind.ReturnKeyword))
             {
                 if (token.GetPreviousToken(includeSkipped: true).Kind() != SyntaxKind.OpenBracketToken)
                 {
@@ -2029,14 +2029,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // throw |
-            if (token.Kind() == SyntaxKind.ThrowKeyword)
+            if (token.IsKind(SyntaxKind.ThrowKeyword))
             {
                 return true;
             }
 
             // while ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.WhileKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.WhileKeyword))
             {
                 return true;
             }
@@ -2044,50 +2044,50 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // todo: handle 'for' cases.
 
             // using ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.UsingKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UsingKeyword))
             {
                 return true;
             }
 
             // lock ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.LockKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.LockKeyword))
             {
                 return true;
             }
 
             // lock ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.IfKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.IfKeyword))
             {
                 return true;
             }
 
             // switch ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.SwitchKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.SwitchKeyword))
             {
                 return true;
             }
 
             // checked ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.CheckedKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.CheckedKeyword))
             {
                 return true;
             }
 
             // unchecked ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.UncheckedKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UncheckedKeyword))
             {
                 return true;
             }
 
             // when ( |
-            if (token.Kind() == SyntaxKind.OpenParenToken &&
-                token.GetPreviousToken(includeSkipped: true).Kind() == SyntaxKind.WhenKeyword)
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.WhenKeyword))
             {
                 return true;
             }
@@ -2104,7 +2104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // can dot into a member afterward. For example:
             //
             // var a = new { new C().Foo };
-            if (token.Kind() == SyntaxKind.OpenBraceToken || token.Kind() == SyntaxKind.CommaToken)
+            if (token.IsKind(SyntaxKind.OpenBraceToken) || token.IsKind(SyntaxKind.CommaToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.AnonymousObjectCreationExpression))
                 {
@@ -2116,7 +2116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // $@"{ |
             // $"{x} { |
             // $@"{x} { |
-            if (token.Kind() == SyntaxKind.OpenBraceToken)
+            if (token.IsKind(SyntaxKind.OpenBraceToken))
             {
                 return token.Parent.IsKind(SyntaxKind.Interpolation)
                     && ((InterpolationSyntax)token.Parent).OpenBraceToken == token;
@@ -2319,7 +2319,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (token.Kind() == SyntaxKind.CloseBraceToken)
+            if (token.IsKind(SyntaxKind.CloseBraceToken))
             {
                 var block = token.GetAncestor<BlockSyntax>();
 
@@ -2371,7 +2371,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //  enum E : i|
 
             return
-                token.Kind() == SyntaxKind.ColonToken &&
+                token.IsKind(SyntaxKind.ColonToken) &&
                 token.Parent.IsKind(SyntaxKind.BaseList) &&
                 token.Parent.IsParentKind(SyntaxKind.EnumDeclaration);
         }


### PR DESCRIPTION
This commit refers to the issue #6005. Refactor Roslyn class SyntaxTreeExtensions.cs to change "Kind() == SyntaxKind" to "IsKind(SyntaxKind)". 