### PR TITLE
.editorconfig: Don't set indent_size for all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,10 +4,13 @@ http://EditorConfig.org
 # top-most EditorConfig file
 root = true
 
-# Default settings:
-# Use 4 spaces as indentation
+# Don't use tabs for indentation.
 [*]
 indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Code files
+[*.cs,*.csx,*.vb,*.vbx]
 indent_size = 4
 
 # Xml project files
@@ -16,4 +19,8 @@ indent_size = 2
 
 # Xml config files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
 indent_size = 2


### PR DESCRIPTION
Roslyn has many different kinds of files in it, so it would be a lot of
work to try to assign appropriate indent_size values to all of them, and
would tend to get out of date; consequently, it's not a very good idea
to include indent_size in the [*] section.

One example that was wrong here is .json; .xml and .xsd were also
similarly afflicted. (And .xsd most certainly does not need any more
afflictions beyond those that were "designed" into it.)