### PR TITLE
Do not offer to generate a new constructor if the actual error is due…

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -762,9 +762,69 @@ class Derived : Base
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public async Task TestGenerateWithIncorrectConstructorArguments_Crash()
         {
+            await TestMissingAsync(
+@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; abstract class Y { class X : Y { void M ( ) { new X ( new [|string|] ( ) ) ; } } } ");
+        }
+
+        [WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task PreferOutConstructorToInnerInThePresenceOfError()
+        {
             await TestAsync(
-@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; abstract class Y { class X : Y { void M ( ) { new X ( new [|string|] ( ) ) ; } } } ",
-@"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; abstract class Y { class X : Y { private string v ; public X ( string v ) { this . v = v ; } void M ( ) { new X ( new string ( ) ) ; } } } ");
+@"class X { private int v ; public X ( ) { } public X ( int v ) { this . v = v ; } X ( string x ) { new X ( [|new X ( 1 )|] ) ; } } ",
+@"class X { private int v ; private X x ; public X ( ) { } public X ( X x ) { this . x = x ; } public X ( int v ) { this . v = v ; } X ( string x ) { new X ( new X ( 1 ) ) ; } } ");
+        }
+
+        [WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task PreferOutConstructorToInnerInThePresenceOfError_2()
+        {
+            await TestAsync(
+@"class X { private int v ; public X ( ) { } X ( string x ) { new X ( new X ( [|i|] : 1 ) ) ; } } ",
+@"class X { private int i ; private int v ; public X ( ) { } public X ( int i ) { this . i = i ; } X ( string x ) { new X ( new X ( i : 1 ) ) ; } } ");
+        }
+
+        [WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task PreferOutConstructorToInnerInThePresenceOfError_3()
+        {
+            await TestAsync(
+@"class X { private int v ; public X ( ) { } X ( string x ) { new X ( new X ( [|1|] ) ) ; } } ",
+@"class X { private int v ; public X ( ) { } public X ( int v ) { this . v = v ; } X ( string x ) { new X ( new X ( 1 ) ) ; } } ");
+        }
+
+        [WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task PreferOutConstructorToInnerInThePresenceOfError_4()
+        {
+            await TestAsync(
+@"class X { X ( string x ) { new X ( new [|X|] ( ) ) ; } } ",
+@"class X { public X ( ) { } X ( string x ) { new X ( new X ( ) ) ; } } ");
+        }
+
+        [WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task PreferOutConstructorToInnerInThePresenceOfError_5()
+        {
+            await TestAsync(
+@"class X { X ( string x ) { new X ( X : new [|X|] ( ) ) ; } } ",
+@"class X { public X ( ) { } X ( string x ) { new X ( X : new X ( ) ) ; } } ");
+        }
+
+        [WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task PreferOutConstructorToInnerInThePresenceOfError_6()
+        {
+            await TestMissingAsync(
+@"class X { X ( string x ) { new X ( new str [||] ing ( ) ) ; } } ");
+        }
+
+        [WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task PreferOutConstructorToInnerInThePresenceOfError_7()
+        {
+            await TestMissingAsync(
+@"abstract class Y { class X : Y { async Task M ( ) { new X ( new [|string|] ( ) ) ; } } } ");
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -580,5 +580,68 @@ Public Class [|;;|]Derived
 
 End Class")
         End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError() As Task
+            Await TestMissingAsync(
+NewLines("Class X \n Sub New(s As String) \n New X(New [|String|]) \n End Sub \n End Class"))
+        End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError_2() As Task
+            Await TestAsync(
+NewLines("MustInherit Class Y \n Class X \n Inherits Y \n Sub M() \n Dim a = New X([|New String|]) \n End Sub \n End Class \n End Class"),
+NewLines("MustInherit Class Y \n Class X \n Inherits Y \n Private v As String \n Public Sub New(v As String) \n Me.v = v \n End Sub \n Sub M() \n Dim a = New X(New String) \n End Sub \n End Class \n End Class"))
+        End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError_3() As Task
+            Await TestAsync(
+NewLines("Class X \n Sub New(s As String) \n Dim a = New X(New [|X|]()) \n End Sub \n End Class"),
+NewLines("Class X \n Public Sub New() \n End Sub \n Sub New(s As String) \n Dim a = New X(New X()) \n End Sub \n End Class"))
+        End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError_4() As Task
+            Await TestAsync(
+NewLines("Class X \n Public Sub New() \n End Sub \n Sub New(s As String) \n Dim a = New X([|New X()|]) \n End Sub \n End Class"),
+NewLines("Class X \n Private x As X \n Public Sub New() \n End Sub \n Public Sub New(x As X) \n Me.x = x \n End Sub \n Sub New(s As String) \n Dim a = New X(New X()) \n End Sub \n End Class"))
+        End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError_5() As Task
+            Await TestAsync(
+NewLines("Class X \n Sub New(s As String) \n Dim a = New X(New Y([|1|])) \n End Sub \n End Class \n Friend Class Y \n End Class"),
+NewLines("Class X \n Sub New(s As String) \n Dim a = New X(New Y(1)) \n End Sub \n End Class \n Friend Class Y \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
+        End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError_6() As Task
+            Await TestAsync(
+NewLines("Class X \n Sub New(s As String) \n Dim a = New X([|New Y(1)|]) \n End Sub \n End Class \n Friend Class Y \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"),
+NewLines("Class X \n Private y As Y \n Public Sub New(y As Y) \n Me.y = y \n End Sub \n Sub New(s As String) \n Dim a = New X(New Y(1)) \n End Sub \n End Class \n Friend Class Y \n Private v As Integer \n Public Sub New(v As Integer) \n Me.v = v \n End Sub \n End Class"))
+        End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError_7() As Task
+            Await TestAsync(
+NewLines("Class X \n Private x As X \n Public Sub New() \n End Sub \n Public Sub New(x As X) \n Me.x = x \n End Sub \n Sub New(s As String) \n Dim a = New X(New [|X|](m:=1)) \n End Sub \n End Class"),
+NewLines("Class X \n Private m As Integer \n Private x As X \n Public Sub New() \n End Sub \n Public Sub New(m As Integer) \n Me.m = m \n End Sub \n Public Sub New(x As X) \n Me.x = x \n End Sub \n Sub New(s As String) \n Dim a = New X(New X(m:=1)) \n End Sub \n End Class"))
+        End Function
+
+        <WorkItem(4600, "https://github.com/dotnet/roslyn/issues/4600")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function PreferOutConstructorToInnerInThePresenceOfError_8() As Task
+            Await TestAsync(
+NewLines("Class X \n Private m As Integer \n Public Sub New() \n End Sub \n Public Sub New(m As Integer) \n Me.m = m \n End Sub \n Sub New(s As String) \n Dim a = New [|X|](z:=New X(m:=1)) \n End Sub \n End Class"),
+NewLines("Class X \n Private m As Integer \n Private z As X \n Public Sub New() \n End Sub \n Public Sub New(z As X) \n Me.z = z \n End Sub \n Public Sub New(m As Integer) \n Me.m = m \n End Sub \n Sub New(s As String) \n Dim a = New X(z:=New X(m:=1)) \n End Sub \n End Class"))
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
@@ -18,15 +18,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateConstructor
         Friend Const BC30057 As String = "BC30057" ' error BC30057: Too many arguments to 'Public Sub New()'.
         Friend Const BC30272 As String = "BC30272" ' error BC30272: 'p' is not a parameter of 'Public Sub New()'.
         Friend Const BC30274 As String = "BC30274" ' error BC30274: Parameter 'prop' of 'Public Sub New(prop As String)' already has a matching argument.
+        Friend Const BC30311 As String = "BC30311" ' error BC30311: Value of type 'X' cannot be converted to 'Y'.
         Friend Const BC30389 As String = "BC30389" ' error BC30389: 'x' is not accessible in this context
         Friend Const BC30455 As String = "BC30455" ' error BC30455: Argument not specified for parameter 'x' of 'Public Sub New(x As Integer)'.
         Friend Const BC30512 As String = "BC30512" ' error BC30512: Option Strict On disallows implicit conversions from 'Object' to 'Integer'.
+        Friend Const BC30518 As String = "BC30518" ' error BC30518: Overload resolution failure.
         Friend Const BC32006 As String = "BC32006" ' error BC32006: 'Char' values cannot be converted to 'Integer'. 
         Friend Const BC30387 As String = "BC30387" ' error BC32006: Class 'Derived' must declare a 'Sub New' because its base class 'Base' does not have an accessible 'Sub New' that can be called with no arguments. 
 
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30057, BC30272, BC30274, BC30389, BC30455, BC32006, BC30512, BC30387)
+                Return ImmutableArray.Create(BC30057, BC30272, BC30274, BC30311, BC30389, BC30455, BC32006, BC30512, BC30518, BC30387)
             End Get
         End Property
 
@@ -55,8 +57,46 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateConstructor
         End Function
 
         Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
-            If TypeOf node Is SimpleNameSyntax OrElse TypeOf node Is InvocationExpressionSyntax OrElse TypeOf node Is ObjectCreationExpressionSyntax OrElse TypeOf node Is AttributeSyntax Then
+            If TypeOf node Is SimpleNameSyntax OrElse
+               TypeOf node Is InvocationExpressionSyntax OrElse
+               TypeOf node Is AttributeSyntax Then
                 Return True
+            ElseIf TypeOf node Is ObjectCreationExpressionSyntax Then
+                If diagnostic.Id = BC30057 OrElse diagnostic.Id = BC30518 Then
+                    ' "Too manny arguments" and "Overload resolution failure" place the 
+                    ' diagnostic on the constructor instead of its arguments so we do 
+                    ' Not need any special handling.
+                    Return True
+                ElseIf diagnostic.Id = BC32006 OrElse diagnostic.Id = BC30311 Then
+                    ' Conversion errors set the span for the diagnostic around the argument
+                    ' itself We need to only return true if one of the arguments in our constructor
+                    ' exactly matches the span of the diagnostic.
+                    ' example:
+                    '       New X(New Y()) : Error cannot convert from 'Y' to 'T'
+                    Dim arguments = CType(node, ObjectCreationExpressionSyntax).ArgumentList.Arguments
+                    If arguments.Count > 0 Then
+                        Return arguments.Any(Function(x) x.Span = diagnostic.Location.SourceSpan)
+                    Else
+                        ' There are no arguments, but we do not want to return true if the diagnostic
+                        ' has the same span because we want to run this check again on an ancestor node.
+                        Return node.Span <> diagnostic.Location.SourceSpan
+                    End If
+                Else
+                    ' Verify that we are Not returning an outer constructor node, we should only offer to
+                    ' generate a constructor for the inner most constructor that does Not exist.
+                    ' example:
+                    '      New X(New Y())
+                    '  If X already exists And accepts Y, but Y "does not contain a constructor that takes n arguments" we should only 
+                    '  offer to generate Y, since Y Is the only constructor with an error.
+                    Dim arguments = CType(node, ObjectCreationExpressionSyntax).ArgumentList.Arguments
+                    If arguments.Count > 0 Then
+                        Return Not arguments.Any(
+                            Function(x) TypeOf x.GetExpression() Is ObjectCreationExpressionSyntax AndAlso x.Span.Contains(diagnostic.Location.SourceSpan))
+                    Else
+                        ' No arguments to examine so we assume that current node is the best choice for generating a constructor.
+                        Return True
+                    End If
+                End If
             End If
 
             Return diagnostic.Id = BC30387 AndAlso TypeOf node Is ClassBlockSyntax


### PR DESCRIPTION
… to inner constructor being passed as argument

This change attempts to pick the best possible constructor to try and generate.  in a situation like
``` C#
new X(new string())
```
We cannot generate the constructor for `string` so, with this change, we do not offer to generate anything.

In the case below:
```C#
new X(new T(i: 1))
```
if `T(i: 1)` doesn't exist, we offer to generate it before we offer to generate `X(T)`

Fixes https://github.com/dotnet/roslyn/issues/4600