### PR TITLE
Set Experimental flag for our VSIXes

### DIFF
--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -98,6 +98,14 @@
     <OverwriteReadOnlyFiles Condition="'$(OverwriteReadOnlyFiles)' == ''">true</OverwriteReadOnlyFiles>
   </PropertyGroup>
 
+  <!-- Don't validate our .vsixmanifests for correct schemas. Right now our build machines are on Visual Studio 2015 RTM, but we want to set a property
+       (Experimental) that was added in Update 1. Since the schema is pulled from the box, you can't build with RTM unless we either disable schema
+       validation or otherwise copy the schemas in and then point the target to those. Since schema changes happen fairly rarely, I'll just disable
+       schema validation and turn it on as soon as we're on update 1 only. -->
+  <PropertyGroup>
+    <BypassVsixValidation>true</BypassVsixValidation>
+  </PropertyGroup>
+
   <!-- Project language -->
   <PropertyGroup Condition="'$(ProjectLanguage)' == ''">
     <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#'">CSharp</ProjectLanguage>

--- a/src/Compilers/Extension/source.extension.vsixmanifest
+++ b/src/Compilers/Extension/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>Roslyn Compilers</DisplayName>
     <Description xml:space="preserve">Package of the Roslyn compilers that enables them for Visual Studio builds.</Description>
   </Metadata>
-  <Installation>
+  <Installation Experimental="true">
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Pro" />
   </Installation>
   <Dependencies>

--- a/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
+++ b/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>Roslyn Expression Evaluators</DisplayName>
     <Description xml:space="preserve">Roslyn Expression Evaluators</Description>
   </Metadata>
-  <Installation>
+  <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />

--- a/src/InteractiveWindow/VisualStudio/source.extension.vsixmanifest
+++ b/src/InteractiveWindow/VisualStudio/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>VisualStudio Interactive Components</DisplayName>
     <Description>Interactive components for Visual Studio.</Description>
   </Metadata>
-  <Installation>
+  <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />

--- a/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
@@ -28,7 +28,7 @@ governing permissions and limitations under the License.
     <DisplayName>Make Const for C#</DisplayName>
     <Description>This is a sample code issue extension for the Microsoft Roslyn CTP.</Description>
   </Metadata>
-  <Installation InstalledByMsi="false">
+  <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="14.0" />
   </Installation>
   <Dependencies>

--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>Roslyn Language Services</DisplayName>
     <Description>C# and VB.NET language services for Visual Studio.</Description>
   </Metadata>
-  <Installation>
+  <Installation Experimental="true">
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Pro" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />

--- a/src/VisualStudio/SetupInteractive/source.extension.vsixmanifest
+++ b/src/VisualStudio/SetupInteractive/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>Roslyn Interactive Language Services</DisplayName>
     <Description>Roslyn interactive language services.</Description>
   </Metadata>
-  <Installation InstalledByMsi="false">
+  <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>Roslyn Diagnostics</DisplayName>
     <Description xml:space="preserve">Roslyn Diagnostics Window</Description>
   </Metadata>
-  <Installation InstalledByMsi="false">
+  <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />

--- a/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>Roslyn Interactive Components</DisplayName>
     <Description>Interactive Roslyn components for Visual Studio.</Description>
   </Metadata>
-  <Installation>
+  <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />


### PR DESCRIPTION
Set the Experimental flag for all our VSIXes, so you can double-click install the VSIXes that you build as well. This flag is stripped by internal tooling and replaced with InstalledByMsi="true" when we build our MSI.