### PR TITLE
Fix TypeChar handler in Interactive Window

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
@@ -479,6 +479,17 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             {
                 using (var transaction = UndoHistory?.CreateTransaction(InteractiveWindowResources.TypeChar))
                 {
+                    if (transaction != null)
+                    {
+                        var mergeDirections = TextTransactionMergeDirections.Forward | TextTransactionMergeDirections.Backward;
+                        // replacing selected text should be an atomic undo operation).
+                        if ((!TextView.Selection.IsEmpty && !IsEmptyBoxSelection()))
+                        {
+                            mergeDirections = TextTransactionMergeDirections.Forward;
+                        }
+                        transaction.MergePolicy = new TextTransactionMergePolicy(mergeDirections);
+                    }
+
                     if (InsertText(typedChar.ToString()))
                     {
                         transaction?.Complete();

--- a/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
@@ -475,9 +475,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             }
 
             /// <summary>Implements <see cref="IInteractiveWindowOperations2.TypeChar"/>.</summary>
-            internal void TypeChar(char typedChar)
+            public void TypeChar(char typedChar)
             {
-                InsertText(typedChar.ToString());
+                using (var transaction = UndoHistory?.CreateTransaction(InteractiveWindowResources.TypeChar))
+                {
+                    if (InsertText(typedChar.ToString()))
+                    {
+                        transaction?.Complete();
+                    }
+                }
             }
 
             /// <summary>Implements <see cref="IInteractiveWindow.InsertCode"/>.</summary>
@@ -498,44 +504,39 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
             }
 
-            private void InsertText(string text)
+            private bool InsertText(string text)
             {
-                using (var transaction = UndoHistory?.CreateTransaction(InteractiveWindowResources.TypeChar))
+                var selection = TextView.Selection;
+                var caretPosition = TextView.Caret.Position.BufferPosition;
+                if (!TextView.Selection.IsEmpty)
                 {
-                    var selection = TextView.Selection;
-                    var caretPosition = TextView.Caret.Position.BufferPosition;
-                    if (!TextView.Selection.IsEmpty)
+                    if (!IsSelectionInsideCurrentSubmission())
                     {
-                        if (!IsSelectionInsideCurrentSubmission())
-                        {
-                            return;
-                        }
-
-                        DeleteSelection();
-
-                        if (selection.Mode == TextSelectionMode.Box)
-                        {
-                            ReduceBoxSelectionToEditableBox(isDelete: true);
-                        }
-                        else
-                        {
-                            selection.Clear();
-                            MoveCaretToClosestEditableBuffer();
-                        }
+                        return false;
                     }
-                    else if (IsInActivePrompt(caretPosition))
+
+                    DeleteSelection();
+
+                    if (selection.Mode == TextSelectionMode.Box)
                     {
+                        ReduceBoxSelectionToEditableBox(isDelete: true);
+                    }
+                    else
+                    {
+                        selection.Clear();
                         MoveCaretToClosestEditableBuffer();
                     }
-                    else if (MapToEditableBuffer(caretPosition) == null)
-                    {
-                        return;
-                    }
-
-                    EditorOperations.InsertText(text);
-
-                    transaction?.Complete();
                 }
+                else if (IsInActivePrompt(caretPosition))
+                {
+                    MoveCaretToClosestEditableBuffer();
+                }
+                else if (MapToEditableBuffer(caretPosition) == null)
+                {
+                    return false;
+                }
+
+                return EditorOperations.InsertText(text);
             }
 
             /// <summary>Implements the core of <see cref="IInteractiveWindow.SubmitAsync"/>.</summary>

--- a/src/InteractiveWindow/Editor/InteractiveWindow.csproj
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.csproj
@@ -124,6 +124,7 @@
     <Compile Include="SmartIndent\InteractiveSmartIndenterProvider.cs" />
     <Compile Include="SmartUpDownOption.cs" />
     <Compile Include="SubmissionBufferAddedEventArgs.cs" />
+    <Compile Include="TextTransactionMergePolicy.cs" />
     <Compile Include="Utils\Contract.cs" />
     <Compile Include="Utils\EditorExtensions.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs">

--- a/src/InteractiveWindow/Editor/InteractiveWindow.csproj
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Roslyn.InteractiveWindow.UnitTests" />
-    <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests2"/>
+    <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests2" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.InteractiveServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.VsInteractiveWindow" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures" />
@@ -137,6 +137,7 @@
     <EmbeddedResource Include="InteractiveWindowResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>InteractiveWindowResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/src/InteractiveWindow/Editor/InteractiveWindowResources.Designer.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindowResources.Designer.cs
@@ -10,9 +10,8 @@
 
 namespace Microsoft.VisualStudio.InteractiveWindow {
     using System;
-    using System.Reflection;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.InteractiveWindow.InteractiveWindowResources", typeof(InteractiveWindowResources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.InteractiveWindow.InteractiveWindowResources", typeof(InteractiveWindowResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/InteractiveWindow/Editor/TextTransactionMergePolicy.cs
+++ b/src/InteractiveWindow/Editor/TextTransactionMergePolicy.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text.Operations;
+
+namespace Microsoft.VisualStudio.InteractiveWindow
+{
+    // The code here is copied from `Microsoft.VisualStudio.Text.Operations.Implementation` 
+    // with minor modification to provide ability for merging undo transactions in InteractiveWindow .
+
+    [Flags]
+    internal enum TextTransactionMergeDirections
+    {
+        Forward = 0x0001,
+        Backward = 0x0002
+    }
+
+    /// <summary>
+    /// This is the merge policy used for determining whether text's undo transactions can be merged.
+    /// </summary>
+    internal class TextTransactionMergePolicy : IMergeTextUndoTransactionPolicy
+    {
+        TextTransactionMergeDirections _allowableMergeDirections;
+
+        public TextTransactionMergePolicy() : this(TextTransactionMergeDirections.Forward | TextTransactionMergeDirections.Backward)
+        {
+        }
+
+        public TextTransactionMergePolicy(TextTransactionMergeDirections allowableMergeDirections)
+        {
+            _allowableMergeDirections = allowableMergeDirections;
+        }
+
+        public bool CanMerge(ITextUndoTransaction newTransaction, ITextUndoTransaction oldTransaction)
+        {
+            // Validate
+            if (newTransaction == null)
+            {
+                throw new ArgumentNullException("newTransaction");
+            }
+
+            if (oldTransaction == null)
+            {
+                throw new ArgumentNullException("oldTransaction");
+            }
+
+            TextTransactionMergePolicy oldPolicy = oldTransaction.MergePolicy as TextTransactionMergePolicy;
+            TextTransactionMergePolicy newPolicy = newTransaction.MergePolicy as TextTransactionMergePolicy;
+            if (oldPolicy == null || newPolicy == null)
+            {
+                throw new InvalidOperationException("The MergePolicy for both transactions should be a TextTransactionMergePolicy.");
+            }
+
+            // Make sure the merge policy directions permit merging these two transactions.
+            if ((oldPolicy._allowableMergeDirections & TextTransactionMergeDirections.Forward) == 0 ||
+                (newPolicy._allowableMergeDirections & TextTransactionMergeDirections.Backward) == 0)
+            {
+                return false;
+            }
+
+            // Only merge text transactions that have the same description
+            if (newTransaction.Description != oldTransaction.Description)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public void PerformTransactionMerge(ITextUndoTransaction existingTransaction, ITextUndoTransaction newTransaction)
+        {
+            if (existingTransaction == null)
+                throw new ArgumentNullException("existingTransaction");
+            if (newTransaction == null)
+                throw new ArgumentNullException("newTransaction");
+
+            // Remove trailing AfterTextBufferChangeUndoPrimitive from previous transaction and skip copying
+            // initial BeforeTextBufferChangeUndoPrimitive from newTransaction, as they are unnecessary.
+            int copyStartIndex = 0;
+
+            // Copy items from newTransaction into existingTransaction.
+            for (int i = copyStartIndex; i < newTransaction.UndoPrimitives.Count; i++)
+            {
+                existingTransaction.UndoPrimitives.Add(newTransaction.UndoPrimitives[i]);
+            }
+        }
+
+        public bool TestCompatiblePolicy(IMergeTextUndoTransactionPolicy other)
+        {
+            if (other == null)
+            {
+                throw new ArgumentNullException("other");
+            }
+
+            // Only merge transaction if they are both a text transaction
+            return this.GetType() == other.GetType();
+        }
+    }
+}

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -491,8 +491,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             AssertCaretVirtualPosition(2, promptWidth + 1);
         }
 
-
-
         private void AssertCaretVirtualPosition(int expectedLine, int expectedColumn)
         {
             ITextSnapshotLine actualLine;

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -491,6 +491,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             AssertCaretVirtualPosition(2, promptWidth + 1);
         }
 
+
+
         private void AssertCaretVirtualPosition(int expectedLine, int expectedColumn)
         {
             ITextSnapshotLine actualLine;
@@ -1048,6 +1050,46 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             AssertEx.Equal(submissions, actualSubmissions);
         }
 
+        [WorkItem(6397, "https://github.com/dotnet/roslyn/issues/6397")]
+        [WpfFact]
+        public void TypeCharWithUndoRedo()
+        {
+            Window.Operations.TypeChar('a');
+            Window.Operations.TypeChar('b');
+            Window.Operations.TypeChar('c');
+            Assert.Equal("> abc", GetTextFromCurrentSnapshot());
+
+            // undo/redo for consecutive TypeChar's shold be a single action
+
+            ((InteractiveWindow)Window).Undo_TestOnly(1);
+            Assert.Equal("> ", GetTextFromCurrentSnapshot());
+
+            ((InteractiveWindow)Window).Redo_TestOnly(1);
+            Assert.Equal("> abc", GetTextFromCurrentSnapshot());
+
+            // make a stream selection as follows:
+            // > |aaa|
+            Window.Operations.SelectAll();
+            Window.Operations.TypeChar('1');
+            Window.Operations.TypeChar('2');
+            Window.Operations.TypeChar('3');
+
+            Assert.Equal("> 123", GetTextFromCurrentSnapshot());
+
+            ((InteractiveWindow)Window).Undo_TestOnly(1);
+            Assert.Equal("> abc", GetTextFromCurrentSnapshot());
+
+            ((InteractiveWindow)Window).Undo_TestOnly(1);
+            Assert.Equal("> ", GetTextFromCurrentSnapshot());
+
+            // type in active prompt
+            MoveCaretToPreviousPosition(2);
+            Window.Operations.TypeChar('x');
+            Window.Operations.TypeChar('y');
+            Window.Operations.TypeChar('z');
+            Assert.Equal("> xyz", GetTextFromCurrentSnapshot());
+        }
+
         private string GetTextFromCurrentSnapshot()
         {
             return Window.TextView.TextBuffer.CurrentSnapshot.GetText();
@@ -1109,6 +1151,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         internal static void CutLine(this IInteractiveWindowOperations operations)
         {
             ((IInteractiveWindowOperations2)operations).CutLine();
+        }
+
+        internal static void TypeChar(this IInteractiveWindowOperations operations, char typedChar)
+        {
+            ((IInteractiveWindowOperations2)operations).TypeChar(typedChar);
         }
     }
 }

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -216,8 +216,20 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                 switch ((VSConstants.VSStd2KCmdID)nCmdID)
                 {
                     case VSConstants.VSStd2KCmdID.TYPECHAR:
-                        // No-op since character was inserted in pre-language service filter below
-                        return VSConstants.S_OK;
+                        {
+                            var operations = _window.Operations as IInteractiveWindowOperations2;
+                            if (operations != null)
+                            {
+                                char typedChar = (char)(ushort)System.Runtime.InteropServices.Marshal.GetObjectForNativeVariant(pvaIn);
+                                operations.TypeChar(typedChar);
+                                return VSConstants.S_OK;
+                            }
+                            else
+                            {
+                                _window.Operations.Delete();
+                            }
+                            break;
+                        }
 
                     case VSConstants.VSStd2KCmdID.RETURN:
                         if (_window.Operations.Return())
@@ -420,21 +432,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
             {
                 switch ((VSConstants.VSStd2KCmdID)nCmdID)
                 {
-                    case VSConstants.VSStd2KCmdID.TYPECHAR:
-                        {
-                            var operations = _window.Operations as IInteractiveWindowOperations2;
-                            if (operations != null)
-                            {
-                                char typedChar = (char)(ushort)System.Runtime.InteropServices.Marshal.GetObjectForNativeVariant(pvaIn);
-                                operations.TypeChar(typedChar);
-                            }
-                            else
-                            {
-                                _window.Operations.Delete();
-                            }
-                            break;
-                        }
-
                     case VSConstants.VSStd2KCmdID.RETURN:
                         if (_window.Operations.TrySubmitStandardInput())
                         {

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -215,6 +215,10 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
             {
                 switch ((VSConstants.VSStd2KCmdID)nCmdID)
                 {
+                    case VSConstants.VSStd2KCmdID.TYPECHAR:
+                        // No-op since character was inserted in pre-language service filter below
+                        return VSConstants.S_OK;
+
                     case VSConstants.VSStd2KCmdID.RETURN:
                         if (_window.Operations.Return())
                         {
@@ -423,9 +427,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                             {
                                 char typedChar = (char)(ushort)System.Runtime.InteropServices.Marshal.GetObjectForNativeVariant(pvaIn);
                                 operations.TypeChar(typedChar);
-                                return VSConstants.S_OK;
                             }
-                            _window.Operations.Delete();
+                            else
+                            {
+                                _window.Operations.Delete();
+                            }
                             break;
                         }
 


### PR DESCRIPTION
Previous change on `TypeChar` handling (#6914) incorrectly shortcut all subsequent handlers in pre-language service filter , the result is missing functionalities like auto-completion...  This fixes the issue by handling typed char in pre-language service filter, then let the execution flow to other language service handlers, and finally stop the execution in pre-editor filter.

Also add support for merging consecutive TypeChar operations in Interactive Window, which fixes #6397

@dotnet/roslyn-interactive 