### PR TITLE
Parameter to Restore.cmd to allow to restore different solution

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,5 +1,13 @@
 @echo off
+@setlocal
+
 set NuGetExe="%~dp0NuGet.exe"
+
+REM If someone passed in a different Roslyn solution, use that.
+REM We make use of this when Roslyn is an sub-module for some 
+REM internal repositories.
+set RoslynSolution=%1
+if "%RoslynSolution%" == "" set RoslynSolution=%~dp0Roslyn.sln
 
 echo Restoring packages: Toolsets
 call %NugetExe% restore -verbosity quiet "%~dp0build\ToolsetPackages\project.json" -configfile "%~dp0nuget.config"
@@ -8,4 +16,4 @@ echo Restoring packages: Samples
 call %NugetExe% restore -verbosity quiet "%~dp0src\Samples\Samples.sln" -configfile "%~dp0nuget.config"
 
 echo Restoring packages: Roslyn (this may take some time)
-call %NugetExe% restore -verbosity quiet "%~dp0Roslyn.sln" -configfile "%~dp0nuget.config"
+call %NugetExe% restore -verbosity quiet "%RoslynSolution%Roslyn.sln" -configfile "%~dp0nuget.config"


### PR DESCRIPTION
We need a hook, so that the internal Restore can bypass 
restoring Roslyn's roslyn.sln and instead use it's own
solution. 