### PR TITLE
Fix `InteractivePasteCommandHandler` to handle line-copy and box-copy

### DIFF
--- a/src/EditorFeatures/Core/CommandHandlers/InteractivePasteCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/InteractivePasteCommandHandler.cs
@@ -4,11 +4,15 @@ extern alias InteractiveWindow;
 
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
@@ -27,6 +31,20 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         private const string InteractiveContentTypeName = "Interactive Content";
         // Duplicated string, originally defined at `Microsoft.VisualStudio.InteractiveWindow.InteractiveWindow`
         private const string InteractiveClipboardFormat = "89344A36-9821-495A-8255-99A63969F87D";
+
+        // The following two field definitions have to stay in sync with VS editor implementation
+
+        /// <summary>
+        /// A data format used to tag the contents of the clipboard so that it's clear
+        /// the data has been put in the clipboard by our editor
+        /// </summary>
+        internal const string ClipboardLineBasedCutCopyTag = "VisualStudioEditorOperationsLineCutCopyClipboardTag";
+
+        /// <summary>
+        /// A data format used to tag the contents of the clipboard as a box selection.
+        /// This is the same string that was used in VS9 and previous versions.
+        /// </summary>
+        internal const string BoxSelectionCutCopyTag = "MSDEVColumnSelect";
 
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
         private readonly ITextUndoHistoryRegistry _textUndoHistoryRegistry;
@@ -64,23 +82,85 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         [MethodImpl(MethodImplOptions.NoInlining)]  // Avoid loading InteractiveWindow unless necessary
         private void PasteInteractiveFormat(ITextView textView)
         {
-            var editorOperation = _editorOperationsFactoryService.GetEditorOperations(textView);
+            var editorOperations = _editorOperationsFactoryService.GetEditorOperations(textView);
+
+            var data = RoslynClipboard.GetDataObject();
+            Debug.Assert(data != null);
+
+            bool dataHasLineCutCopyTag = false;
+            bool dataHasBoxCutCopyTag = false;
+
+            dataHasLineCutCopyTag = data.GetDataPresent(ClipboardLineBasedCutCopyTag);
+            dataHasBoxCutCopyTag = data.GetDataPresent(BoxSelectionCutCopyTag);
+            Debug.Assert(!(dataHasLineCutCopyTag && dataHasBoxCutCopyTag));
+
             var blocks = InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.BufferBlock.Deserialize((string)RoslynClipboard.GetData(InteractiveClipboardFormat));
+
+            var sb = PooledStringBuilder.GetInstance();
+            foreach (var block in blocks)
+            {
+                switch (block.Kind)
+                {
+                    // the actual linebreak was converted to regular Input when copied
+                    // This LineBreak block was created by coping box selection and is used as line separater when pasted
+                    case InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.ReplSpanKind.LineBreak:
+                        Debug.Assert(dataHasBoxCutCopyTag);
+                        sb.Builder.Append(block.Content);
+                        break;
+                    case InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.ReplSpanKind.Input:
+                    case InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.ReplSpanKind.Output:
+                    case InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.ReplSpanKind.StandardInput:
+                        sb.Builder.Append(block.Content);
+                        break;
+                }
+            }
+            var text = sb.ToStringAndFree();
+
             using (var transaction = _textUndoHistoryRegistry.GetHistory(textView.TextBuffer).CreateTransaction(EditorFeaturesResources.Paste))
             {
-                foreach (var block in blocks)
+                editorOperations.AddBeforeTextBufferChangePrimitive();
+                if (dataHasLineCutCopyTag && textView.Selection.IsEmpty)
                 {
-                    switch (block.Kind)
+                    editorOperations.MoveToStartOfLine(extendSelection: false);
+                    editorOperations.InsertText(text);
+                }
+                else if (dataHasBoxCutCopyTag)
+                {                    
+                    // If the caret is on a blank line, treat this like a normal stream insertion
+                    if (textView.Selection.IsEmpty && !HasNonWhiteSpaceCharacter(textView.Caret.Position.BufferPosition.GetContainingLine()))
                     {
-                        case InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.ReplSpanKind.Input:
-                        case InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.ReplSpanKind.Output:
-                        case InteractiveWindow::Microsoft.VisualStudio.InteractiveWindow.ReplSpanKind.StandardInput:
-                            editorOperation.InsertText(block.Content);
-                            break;
+                        // trim the last newline before paste
+                        var trimmed = text.Remove(text.LastIndexOf(textView.Options.GetNewLineCharacter()));
+                        editorOperations.InsertText(trimmed);
+                    }
+                    else
+                    {
+                        VirtualSnapshotPoint unusedStart, unusedEnd;
+                        editorOperations.InsertTextAsBox(text, out unusedStart, out unusedEnd);
                     }
                 }
+                else
+                {
+                    editorOperations.InsertText(text);
+                }
+                editorOperations.AddAfterTextBufferChangePrimitive();
                 transaction.Complete();
             }
+        }
+
+        private static bool HasNonWhiteSpaceCharacter(ITextSnapshotLine line)
+        {
+            var snapshot = line.Snapshot;
+            int start = line.Start.Position;
+            int count = line.Length;
+            for (int i = 0; i < count; i++)
+            {
+                if (!char.IsWhiteSpace(snapshot[start + i]))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         // The mock clipboard used in tests will implement this interface 
@@ -88,6 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         {
             bool ContainsData(string format);
             object GetData(string format);
+            IDataObject GetDataObject();
         }
 
         // In product code, we use this simple wrapper around system clipboard.
@@ -102,6 +183,11 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             public object GetData(string format)
             {
                 return Clipboard.GetData(format);
+            }
+
+            public IDataObject GetDataObject()
+            {
+                return Clipboard.GetDataObject();
             }
         }
     }

--- a/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
@@ -2,18 +2,11 @@
 
 Imports System.Text
 Imports System.Windows
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor.Commands
-Imports Microsoft.CodeAnalysis.Editor.Host
-Imports Microsoft.CodeAnalysis.Editor.Implementation.Interactive
-Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
-Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
-Imports Microsoft.VisualStudio.Text
-Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.InteractiveWindow
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
-Imports Microsoft.VisualStudio.InteractiveWindow
+Imports Microsoft.CodeAnalysis.Editor.Commands
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
     Public Class InteractivePasteCommandhandlerTests
@@ -41,17 +34,17 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
 
                 Dim blocks = New BufferBlock() _
                 {
-                    New BufferBlock(ReplSpanKind.Output, "a" & vbCr & vbLf & "bc"),
+                    New BufferBlock(ReplSpanKind.Output, "a" & vbCrLf & "bc"),
                     New BufferBlock(ReplSpanKind.Prompt, "> "),
                     New BufferBlock(ReplSpanKind.Prompt, "< "),
                     New BufferBlock(ReplSpanKind.Input, "12"),
                     New BufferBlock(ReplSpanKind.StandardInput, "3")
                 }
-                CopyToClipboard(clipboard, blocks, includeRepl:=True)
+                CopyToClipboard(clipboard, blocks, includeRepl:=True, isLineCopy:=False, isBoxCopy:=False)
 
                 handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
 
-                Assert.Equal("a" & vbCr & vbLf & "bc123", textView.TextBuffer.CurrentSnapshot.GetText())
+                Assert.Equal("a" & vbCrLf & "bc123", textView.TextBuffer.CurrentSnapshot.GetText())
             End Using
         End Function
 
@@ -73,13 +66,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
 
                 Dim blocks = New BufferBlock() _
                 {
-                    New BufferBlock(ReplSpanKind.Output, "a" & vbCr & vbLf & "bc"),
+                    New BufferBlock(ReplSpanKind.Output, "a" & vbCrLf & "bc"),
                     New BufferBlock(ReplSpanKind.Prompt, "> "),
                     New BufferBlock(ReplSpanKind.Prompt, "< "),
                     New BufferBlock(ReplSpanKind.Input, "12"),
                     New BufferBlock(ReplSpanKind.StandardInput, "3")
                 }
-                CopyToClipboard(clipboard, blocks, includeRepl:=False)
+                CopyToClipboard(clipboard, blocks, includeRepl:=False, isLineCopy:=False, isBoxCopy:=False)
 
                 handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() editorOperations.InsertText("p"))
 
@@ -87,7 +80,126 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
             End Using
         End Function
 
-        Private Sub CopyToClipboard(clipboard As MockClipboard, blocks As BufferBlock(), includeRepl As Boolean)
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Interactive)>
+        Public Async Function PasteCommandWithInteractiveFormatAsLineCopy() As System.Threading.Tasks.Task
+            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document/>
+                        </Project>
+                    </Workspace>)
+
+                Dim textView = workspace.Documents.Single().GetTextView()
+                Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
+
+                editorOperations.InsertText("line1")
+                editorOperations.InsertNewLine()
+                editorOperations.InsertText("line2")
+
+                Assert.Equal("line1" & vbCrLf & "    line2", textView.TextBuffer.CurrentSnapshot.GetText())
+
+                Dim handler = CreateCommandHandler(workspace)
+                Dim clipboard = DirectCast(handler.RoslynClipboard, MockClipboard)
+
+                Dim blocks = New BufferBlock() _
+                {
+                    New BufferBlock(ReplSpanKind.Prompt, "> "),
+                    New BufferBlock(ReplSpanKind.Input, "InsertedLine"),
+                    New BufferBlock(ReplSpanKind.Output, vbCrLf)
+                }
+                CopyToClipboard(clipboard, blocks, includeRepl:=True, isLineCopy:=True, isBoxCopy:=False)
+
+                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+
+                Assert.Equal("line1" & vbCrLf & "InsertedLine" & vbCrLf & "    line2", textView.TextBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Interactive)>
+        Public Async Function PasteCommandWithInteractiveFormatAsBoxCopy() As System.Threading.Tasks.Task
+            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document/>
+                        </Project>
+                    </Workspace>)
+
+                Dim textView = workspace.Documents.Single().GetTextView()
+                Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
+
+                editorOperations.InsertText("line1")
+                editorOperations.InsertNewLine()
+                editorOperations.InsertText("line2")
+                editorOperations.MoveLineUp(False)
+                editorOperations.MoveToPreviousCharacter(False)
+
+                Assert.Equal("line1" & vbCrLf & "    line2", textView.TextBuffer.CurrentSnapshot.GetText())
+
+                Dim handler = CreateCommandHandler(workspace)
+                Dim clipboard = DirectCast(handler.RoslynClipboard, MockClipboard)
+
+                Dim blocks = New BufferBlock() _
+                {
+                    New BufferBlock(ReplSpanKind.Prompt, "> "),
+                    New BufferBlock(ReplSpanKind.Input, "BoxLine1"),
+                    New BufferBlock(ReplSpanKind.LineBreak, vbCrLf),
+                    New BufferBlock(ReplSpanKind.Prompt, "> "),
+                    New BufferBlock(ReplSpanKind.Input, "BoxLine2"),
+                    New BufferBlock(ReplSpanKind.LineBreak, vbCrLf)
+                }
+                CopyToClipboard(clipboard, blocks, includeRepl:=True, isLineCopy:=False, isBoxCopy:=True)
+
+                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+
+                Assert.Equal("lineBoxLine11" & vbCrLf & "    BoxLine2line2", textView.TextBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Interactive)>
+        Public Async Function PasteCommandWithInteractiveFormatAsBoxCopyOnBlankLine() As System.Threading.Tasks.Task
+            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document/>
+                        </Project>
+                    </Workspace>)
+
+                Dim textView = workspace.Documents.Single().GetTextView()
+                Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
+
+                editorOperations.InsertNewLine()
+                editorOperations.InsertText("line1")
+                editorOperations.InsertNewLine()
+                editorOperations.InsertText("line2")
+                editorOperations.MoveLineUp(False)
+                editorOperations.MoveLineUp(False)
+
+                Assert.Equal(vbCrLf & "line1" & vbCrLf & "    line2", textView.TextBuffer.CurrentSnapshot.GetText())
+
+                Dim handler = CreateCommandHandler(workspace)
+                Dim clipboard = DirectCast(handler.RoslynClipboard, MockClipboard)
+
+                Dim blocks = New BufferBlock() _
+                {
+                    New BufferBlock(ReplSpanKind.Prompt, "> "),
+                    New BufferBlock(ReplSpanKind.Input, "BoxLine1"),
+                    New BufferBlock(ReplSpanKind.LineBreak, vbCrLf),
+                    New BufferBlock(ReplSpanKind.Prompt, "> "),
+                    New BufferBlock(ReplSpanKind.Input, "BoxLine2"),
+                    New BufferBlock(ReplSpanKind.LineBreak, vbCrLf)
+                }
+                CopyToClipboard(clipboard, blocks, includeRepl:=True, isLineCopy:=False, isBoxCopy:=True)
+
+                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+
+                Assert.Equal("BoxLine1" & vbCrLf & "BoxLine2" & vbCrLf & "line1" & vbCrLf & "    line2", textView.TextBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Function
+
+        Private Sub CopyToClipboard(clipboard As MockClipboard, blocks As BufferBlock(), includeRepl As Boolean, isLineCopy As Boolean, isBoxCopy As Boolean)
             clipboard.Clear()
             Dim data = New DataObject()
             Dim builder = New StringBuilder()
@@ -100,7 +212,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
             If includeRepl Then
                 data.SetData(InteractiveWindow.ClipboardFormat, BufferBlock.Serialize(blocks))
             End If
-            clipboard.SetDataObject(data)
+            If isLineCopy Then
+                data.SetData(InteractiveWindow.ClipboardLineBasedCutCopyTag, True)
+            End If
+            If isBoxCopy Then
+                data.SetData(InteractiveWindow.BoxSelectionCutCopyTag, True)
+            End If
+                clipboard.SetDataObject(data)
         End Sub
 
         Private Class MockClipboard
@@ -126,6 +244,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
                 Else
                     Return _data.GetData(format)
                 End If
+            End Function
+
+            Public Function GetDataObject() As IDataObject Implements InteractivePasteCommandHandler.IRoslynClipboard.GetDataObject
+                Return _data
             End Function
         End Class
     End Class


### PR DESCRIPTION
The paste of line-copied and box-copied content from Interactive Window was broken in VS editor.

For line-copied content, if we hit CTRL + C in interactive window as follows (| indicate caret position):
```cs
Microsoft (R) Roslyn C# Compiler version 42.42.42.42
Loading context from 'CSharpInteractive.rsp'.
Type "#help" for more information.
> int |x = 10;
> 
```

And hit CTRL + V in a VS editor for any Roslyn type (e.g. a csx file):
```cs
int y = 10;
int z| = 10;
```

We will get this today:
```cs
int y = 10;
int zint x = 10;
 = 10;
```

This is after the fix:
```cs
int y = 10;
int x = 10;
int z = 10;
```

For box-copied content, if we hit CTRL + C in interactive window as follows (| indicates selection):
```cs
Microsoft (R) Roslyn C# Compiler version 42.42.42.42
Loading context from 'CSharpInteractive.rsp'.
Type "#help" for more information.
> int |x = 10|;
> int |w = 10|; 
```

And hit CTRL + V in a VS editor for any Roslyn type (e.g. a csx file):
```cs
int y| = 10;
int z| = 10;
```

We will get this today:
```cs
int yx = 10w = 10 = 10;
int zx = 10w = 10 = 10;
```

This is after the fix:
```cs
int yx = 10 = 10;
int zw = 10 = 10;
```

@dotnet/roslyn-interactive 