### PR TITLE
If analyzer assembly referenced by a project is non-existent (e.g. pe…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_IAnalyzerHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_IAnalyzerHost.cs
@@ -48,8 +48,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 GetAnalyzerDependencyCheckingService().CheckForConflictsAsync();
             }
 
-            GetAnalyzerFileWatcherService().AddPath(analyzerAssemblyFullPath);
-            GetAnalyzerFileWatcherService().ErrorIfAnalyzerAlreadyLoaded(_id, analyzerAssemblyFullPath);
+            if (File.Exists(analyzerAssemblyFullPath))
+            {
+                GetAnalyzerFileWatcherService().AddPath(analyzerAssemblyFullPath);
+                GetAnalyzerFileWatcherService().ErrorIfAnalyzerAlreadyLoaded(_id, analyzerAssemblyFullPath);
+            }
+            else
+            {
+                analyzer.UpdatedOnDisk += OnAnalyzerChanged;
+            }
         }
 
         public void RemoveAnalyzerAssembly(string analyzerAssemblyFullPath)


### PR DESCRIPTION
…nding nuget restore), hook up analyzer's UpdatedOnDisk to remove/add an analyzer. This ensures that that when the analyzer assembly shows up on the disk, say via nuget restore, we don't issue the analyzer changed on disk diagnostic but attempt to load and execute the analyzer.

Verified that this fixes VSO [#164967](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems#_a=edit&id=164967)