### PR TITLE
Tidy syntax node

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Portable/project.lock.json
+++ b/src/Compilers/Core/MSBuildTask/Portable/project.lock.json
@@ -468,6 +468,24 @@
           "lib/net45/_._": {}
         }
       },
+      "System.Collections.Immutable/1.1.38-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        }
+      },
       "System.Console/4.0.0-beta-23428": {
         "dependencies": {
           "System.IO": "[4.0.0, )",
@@ -568,6 +586,20 @@
           "lib/net46/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23428": {
+        "dependencies": {
+          "System.Runtime": "[4.0.20, )"
+        },
+        "frameworkAssemblies": [
+          "mscorlib"
+        ],
+        "compile": {
+          "ref/net46/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/net46/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
       "System.IO.Pipes/4.0.0-beta-23428": {
         "dependencies": {
           "System.IO": "[4.0.0, )",
@@ -612,6 +644,30 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.1-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.1-beta-23428": {
@@ -668,6 +724,14 @@
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.1-beta-23428": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
         }
       },
       "System.Text.Encoding/4.0.11-beta-23428": {
@@ -794,6 +858,24 @@
           "lib/net45/_._": {}
         }
       },
+      "System.Collections.Immutable/1.1.38-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        }
+      },
       "System.Console/4.0.0-beta-23428": {
         "dependencies": {
           "System.IO": "[4.0.0, )",
@@ -894,6 +976,20 @@
           "lib/net46/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23428": {
+        "dependencies": {
+          "System.Runtime": "[4.0.20, )"
+        },
+        "frameworkAssemblies": [
+          "mscorlib"
+        ],
+        "compile": {
+          "ref/net46/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/net46/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
       "System.IO.Pipes/4.0.0-beta-23428": {
         "dependencies": {
           "System.IO": "[4.0.0, )",
@@ -938,6 +1034,30 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.1-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.1-beta-23428": {
@@ -994,6 +1114,14 @@
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.1-beta-23428": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
         }
       },
       "System.Text.Encoding/4.0.11-beta-23428": {
@@ -3157,6 +3285,43 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
+      "System.Collections.Concurrent/4.0.11-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.38-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        }
+      },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "[4.0.10, )",
@@ -3322,6 +3487,17 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23428": {
+        "dependencies": {
+          "System.Runtime": "[4.0.20, )"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
       "System.IO.Pipes/4.0.0-beta-23428": {
         "dependencies": {
           "System.IO": "[4.0.0, )",
@@ -3392,6 +3568,30 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.1-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.1-beta-23428": {
@@ -3570,6 +3770,17 @@
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
+      "System.Security.Principal/4.0.1-beta-23428": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.1/System.Security.Principal.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.11-beta-23428": {
         "dependencies": {
           "System.Runtime": "[4.0.0, )"
@@ -3591,6 +3802,22 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.11-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
       "System.Threading/4.0.11-beta-23428": {
@@ -3675,6 +3902,30 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
       "System.Xml.XDocument/4.0.11-beta-23428": {
@@ -4336,6 +4587,43 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
+      "System.Collections.Concurrent/4.0.11-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.38-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.1/System.Collections.Immutable.dll": {}
+        }
+      },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "[4.0.10, )",
@@ -4501,6 +4789,17 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23428": {
+        "dependencies": {
+          "System.Runtime": "[4.0.20, )"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
       "System.IO.Pipes/4.0.0-beta-23428": {
         "dependencies": {
           "System.IO": "[4.0.0, )",
@@ -4571,6 +4870,30 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.1-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.1-beta-23428": {
@@ -4749,6 +5072,17 @@
           "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
+      "System.Security.Principal/4.0.1-beta-23428": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.1/System.Security.Principal.dll": {}
+        }
+      },
       "System.Text.Encoding/4.0.11-beta-23428": {
         "dependencies": {
           "System.Runtime": "[4.0.0, )"
@@ -4770,6 +5104,22 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.11-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
       "System.Threading/4.0.11-beta-23428": {
@@ -4854,6 +5204,30 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23428": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
       "System.Xml.XDocument/4.0.11-beta-23428": {
@@ -5965,6 +6339,65 @@
         "System.Collections.Concurrent.nuspec"
       ]
     },
+    "System.Collections.Concurrent/4.0.11-beta-23428": {
+      "sha512": "Ew3bQggXrw9/2dWb9gbLDFUBf+tdcgf+BPsrCR+dAZm7srZJbMDJspteEMw6oBJW12T0uDWiL78dvzYn5WePtQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.4/System.Collections.Concurrent.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Collections.Concurrent.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/4d35187eef65432fad2e29fc07b8ab72.psmdcp",
+        "ref/dotnet5.2/de/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/es/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/fr/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/it/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/ja/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/ko/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/System.Collections.Concurrent.dll",
+        "ref/dotnet5.2/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/zh-hans/System.Collections.Concurrent.xml",
+        "ref/dotnet5.2/zh-hant/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/de/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/es/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/fr/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/it/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/ja/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/ko/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/System.Collections.Concurrent.dll",
+        "ref/dotnet5.4/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/zh-hans/System.Collections.Concurrent.xml",
+        "ref/dotnet5.4/zh-hant/System.Collections.Concurrent.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Collections.Concurrent.xml",
+        "ref/netcore50/es/System.Collections.Concurrent.xml",
+        "ref/netcore50/fr/System.Collections.Concurrent.xml",
+        "ref/netcore50/it/System.Collections.Concurrent.xml",
+        "ref/netcore50/ja/System.Collections.Concurrent.xml",
+        "ref/netcore50/ko/System.Collections.Concurrent.xml",
+        "ref/netcore50/ru/System.Collections.Concurrent.xml",
+        "ref/netcore50/System.Collections.Concurrent.dll",
+        "ref/netcore50/System.Collections.Concurrent.xml",
+        "ref/netcore50/zh-hans/System.Collections.Concurrent.xml",
+        "ref/netcore50/zh-hant/System.Collections.Concurrent.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.Concurrent.nuspec"
+      ]
+    },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
@@ -5976,6 +6409,20 @@
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
+        "System.Collections.Immutable.nuspec"
+      ]
+    },
+    "System.Collections.Immutable/1.1.38-beta-23428": {
+      "sha512": "hAx+RuY2GpV2W5NPPVBCgk4VQjTFZrWqC2iJNBsIxtkxzqGQvSrxGBq4/U6QawQx4AoqOYRtErOgexTLv8Q94w==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.1/System.Collections.Immutable.dll",
+        "lib/dotnet5.1/System.Collections.Immutable.xml",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "package/services/metadata/core-properties/13d8f69f0c9b423d96554a22cce41270.psmdcp",
         "System.Collections.Immutable.nuspec"
       ]
     },
@@ -6890,6 +7337,38 @@
         "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
+    "System.IO.FileSystem.Primitives/4.0.1-beta-23428": {
+      "sha512": "Y883fqYOCHSIy/NYAhYn36ZakBy51V4tR9zkO55BCQf6FHTVwOzzrzZEsqhs4Sv2TRDiiMKQ0WfazqRLb/YsYA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/a5c6176458e047c897d5fd5ad8ad5525.psmdcp",
+        "ref/dotnet5.1/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/es/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/fr/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/it/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/ja/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/ko/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet5.1/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/zh-hans/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.1/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.FileSystem.Primitives.nuspec"
+      ]
+    },
     "System.IO.Pipes/4.0.0-beta-23428": {
       "sha512": "QaaJYoGrKDcfuI5BSaIfG9fvYj3COMtoGlk8gKZBU+HBNJUGKccF9+GdIgq58f/EGjgaKHRkts20BzRxpGBQyA==",
       "type": "Package",
@@ -7330,6 +7809,20 @@
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "package/services/metadata/core-properties/644d6c945e3d43e2806bf6892201a6ef.psmdcp",
+        "System.Reflection.Metadata.nuspec"
+      ]
+    },
+    "System.Reflection.Metadata/1.1.1-beta-23428": {
+      "sha512": "aicq/+SVNVm6Ga0qWAFzo3NZxLMUyUDFAgXSsDPJDCpSSMUOVW1oNsFE5CjTHgJjQM7ni/N2QgN2Y0DGYYDgAg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.2/System.Reflection.Metadata.dll",
+        "lib/dotnet5.2/System.Reflection.Metadata.xml",
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/3b00ff8dfcf34fb8914839c7436cec7b.psmdcp",
         "System.Reflection.Metadata.nuspec"
       ]
     },
@@ -8162,6 +8655,48 @@
         "System.Security.Principal.nuspec"
       ]
     },
+    "System.Security.Principal/4.0.1-beta-23428": {
+      "sha512": "35UG9UlfEaI8Uu+u0u/GCPJJ2pB0Alt+19FKtvCLVfh2XCiy2+hXFDXP4VnIlno+v7a6nV6DVtLHn1DprTTyfw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.1/System.Security.Principal.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "package/services/metadata/core-properties/20664f2874e144c4a9e7deac9e733472.psmdcp",
+        "ref/dotnet5.1/de/System.Security.Principal.xml",
+        "ref/dotnet5.1/es/System.Security.Principal.xml",
+        "ref/dotnet5.1/fr/System.Security.Principal.xml",
+        "ref/dotnet5.1/it/System.Security.Principal.xml",
+        "ref/dotnet5.1/ja/System.Security.Principal.xml",
+        "ref/dotnet5.1/ko/System.Security.Principal.xml",
+        "ref/dotnet5.1/ru/System.Security.Principal.xml",
+        "ref/dotnet5.1/System.Security.Principal.dll",
+        "ref/dotnet5.1/System.Security.Principal.xml",
+        "ref/dotnet5.1/zh-hans/System.Security.Principal.xml",
+        "ref/dotnet5.1/zh-hant/System.Security.Principal.xml",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Security.Principal.xml",
+        "ref/netcore50/es/System.Security.Principal.xml",
+        "ref/netcore50/fr/System.Security.Principal.xml",
+        "ref/netcore50/it/System.Security.Principal.xml",
+        "ref/netcore50/ja/System.Security.Principal.xml",
+        "ref/netcore50/ko/System.Security.Principal.xml",
+        "ref/netcore50/ru/System.Security.Principal.xml",
+        "ref/netcore50/System.Security.Principal.dll",
+        "ref/netcore50/System.Security.Principal.xml",
+        "ref/netcore50/zh-hans/System.Security.Principal.xml",
+        "ref/netcore50/zh-hant/System.Security.Principal.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Security.Principal.nuspec"
+      ]
+    },
     "System.Text.Encoding/4.0.0": {
       "sha512": "AMxFNOXpA6Ab8swULbXuJmoT2K5w6TnV3ObF5wsmEcIHQUJghoZtDVfVHb08O2wW15mOSI1i9Wg0Dx0pY13o8g==",
       "type": "Package",
@@ -8479,6 +9014,67 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Text.RegularExpressions.nuspec"
+      ]
+    },
+    "System.Text.RegularExpressions/4.0.11-beta-23428": {
+      "sha512": "1wnqfRl70Z/+BGQs0eNsseyxtiNGoeo/hvn/G1z4H9paDYq3DCt7nsf9iyOkV7xjHe2Hp6LBH9CGY+x887BWbg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.4/System.Text.RegularExpressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Text.RegularExpressions.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/bfeed7eea3fc4260963870196c024cc4.psmdcp",
+        "ref/dotnet5.1/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/fr/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/it/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/ja/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/ko/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/System.Text.RegularExpressions.dll",
+        "ref/dotnet5.1/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/zh-hans/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.1/zh-hant/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/fr/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/it/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/ja/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/ko/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/System.Text.RegularExpressions.dll",
+        "ref/dotnet5.4/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/zh-hans/System.Text.RegularExpressions.xml",
+        "ref/dotnet5.4/zh-hant/System.Text.RegularExpressions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Text.RegularExpressions.xml",
+        "ref/netcore50/es/System.Text.RegularExpressions.xml",
+        "ref/netcore50/fr/System.Text.RegularExpressions.xml",
+        "ref/netcore50/it/System.Text.RegularExpressions.xml",
+        "ref/netcore50/ja/System.Text.RegularExpressions.xml",
+        "ref/netcore50/ko/System.Text.RegularExpressions.xml",
+        "ref/netcore50/ru/System.Text.RegularExpressions.xml",
+        "ref/netcore50/System.Text.RegularExpressions.dll",
+        "ref/netcore50/System.Text.RegularExpressions.xml",
+        "ref/netcore50/zh-hans/System.Text.RegularExpressions.xml",
+        "ref/netcore50/zh-hant/System.Text.RegularExpressions.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Text.RegularExpressions.nuspec"
@@ -9064,6 +9660,67 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Xml.ReaderWriter.nuspec"
+      ]
+    },
+    "System.Xml.ReaderWriter/4.0.11-beta-23428": {
+      "sha512": "oBoJgSYK1qMTYVfBN4CX/DcbVhOFMzsuHmuBewFvyZgLT07dprGOegbh8ifrLE+w+bLOHuy/OiESdNsSfg2tIw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.4/System.Xml.ReaderWriter.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Xml.ReaderWriter.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/87afa65432c7476daf6b93c3ba600faf.psmdcp",
+        "ref/dotnet5.1/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/fr/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/it/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/ja/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/ko/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/System.Xml.ReaderWriter.dll",
+        "ref/dotnet5.1/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/zh-hans/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.1/zh-hant/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/fr/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/it/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/ja/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/ko/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/System.Xml.ReaderWriter.dll",
+        "ref/dotnet5.4/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/zh-hans/System.Xml.ReaderWriter.xml",
+        "ref/dotnet5.4/zh-hant/System.Xml.ReaderWriter.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/es/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/fr/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/it/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/ja/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/ko/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/ru/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/System.Xml.ReaderWriter.dll",
+        "ref/netcore50/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/zh-hans/System.Xml.ReaderWriter.xml",
+        "ref/netcore50/zh-hant/System.Xml.ReaderWriter.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Xml.ReaderWriter.nuspec"

--- a/src/Compilers/VisualBasic/Portable/Syntax/ArgumentSyntax.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/ArgumentSyntax.vb
@@ -1,9 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
     Partial Public Class ArgumentSyntax
@@ -20,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         ''' <returns>True if this argument is an omitted argument; otherwise false.</returns>
         Public ReadOnly Property IsOmitted As Boolean
             Get
-                Return Kind = SyntaxKind.OmittedArgument
+                Return Kind() = SyntaxKind.OmittedArgument
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/DirectiveTriviaSyntax.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/DirectiveTriviaSyntax.vb
@@ -10,13 +10,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
         Public Function GetRelatedDirectives() As List(Of DirectiveTriviaSyntax)
             Dim list = New List(Of DirectiveTriviaSyntax)()
-            Me.GetRelatedDirectives(list)
+            GetRelatedDirectives(list)
             Return list
         End Function
 
         Private Sub GetRelatedDirectives(list As List(Of DirectiveTriviaSyntax))
             list.Clear()
-            Dim p = Me.GetPreviousRelatedDirective()
+            Dim p = GetPreviousRelatedDirective()
             While p IsNot Nothing
                 list.Add(p)
                 p = p.GetPreviousRelatedDirective()
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             list.Reverse()
             list.Add(Me)
-            Dim n = Me.GetNextRelatedDirective()
+            Dim n = GetNextRelatedDirective()
             While n IsNot Nothing
                 list.Add(n)
                 n = n.GetNextRelatedDirective()

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/ComplexIdentifierSyntax.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/ComplexIdentifierSyntax.vb
@@ -20,10 +20,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Friend Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), text As String, precedingTrivia As VisualBasicSyntaxNode, followingTrivia As VisualBasicSyntaxNode, possibleKeywordKind As SyntaxKind, isBracketed As Boolean, identifierText As String, typeCharacter As TypeCharacter)
             MyBase.New(kind, errors, annotations, text, precedingTrivia, followingTrivia)
 
-            Me._possibleKeywordKind = possibleKeywordKind
-            Me._isBracketed = isBracketed
-            Me._identifierText = identifierText
-            Me._typeCharacter = typeCharacter
+            _possibleKeywordKind = possibleKeywordKind
+            _isBracketed = isBracketed
+            _identifierText = identifierText
+            _typeCharacter = typeCharacter
 
         End Sub
 
@@ -52,13 +52,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend Overrides ReadOnly Property PossibleKeywordKind As SyntaxKind
             Get
-                Return Me._possibleKeywordKind
+                Return _possibleKeywordKind
             End Get
         End Property
 
         Public Overrides ReadOnly Property RawContextualKind As Integer
             Get
-                Return Me._possibleKeywordKind
+                Return _possibleKeywordKind
             End Get
         End Property
 
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend Overrides ReadOnly Property IsBracketed As Boolean
             Get
-                Return Me._isBracketed
+                Return _isBracketed
             End Get
         End Property
 
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend Overrides ReadOnly Property IdentifierText As String
             Get
-                Return Me._identifierText
+                Return _identifierText
             End Get
         End Property
 
@@ -87,7 +87,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend Overrides ReadOnly Property TypeCharacter As TypeCharacter
             Get
-                Return Me._typeCharacter
+                Return _typeCharacter
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SeparatedSyntaxList.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SeparatedSyntaxList.vb
@@ -17,30 +17,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private _list As SyntaxList(Of VisualBasicSyntaxNode)
 
         Friend Sub New(list As SyntaxList(Of VisualBasicSyntaxNode))
-            Me._list = list
+            _list = list
         End Sub
 
         Friend ReadOnly Property Node As VisualBasicSyntaxNode
             Get
-                Return Me._list.Node
+                Return _list.Node
             End Get
         End Property
 
         Public ReadOnly Property Count As Integer
             Get
-                Return (Me._list.Count + 1) >> 1
+                Return (_list.Count + 1) >> 1
             End Get
         End Property
 
         Public ReadOnly Property SeparatorCount As Integer
             Get
-                Return (Me._list.Count) >> 1
+                Return (_list.Count) >> 1
             End Get
         End Property
 
         Default Public ReadOnly Property Item(index As Integer) As TNode
             Get
-                Return DirectCast(Me._list(index << 1), TNode)
+                Return DirectCast(_list(index << 1), TNode)
             End Get
         End Property
 
@@ -49,16 +49,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         ''' <param name="index">The index.</param><returns></returns>
         Public Function GetSeparator(index As Integer) As SyntaxToken
-            Return DirectCast(Me._list((index << 1) + 1), SyntaxToken)
+            Return DirectCast(_list((index << 1) + 1), SyntaxToken)
         End Function
 
         Public Function Any() As Boolean
-            Return (Me.Count > 0)
+            Return (Count > 0)
         End Function
 
         Public Function Any(kind As SyntaxKind) As Boolean
-            For i = 0 To Me.Count - 1
-                Dim element = Me.Item(i)
+            For i = 0 To Count - 1
+                Dim element = Item(i)
                 If (element.Kind = kind) Then
                     Return True
                 End If
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Friend Function GetWithSeparators() As SyntaxList(Of VisualBasicSyntaxNode)
-            Return Me._list
+            Return _list
         End Function
 
         ' for debugging
@@ -75,8 +75,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Get
                 Dim arr As TNode() = New TNode(Me.Count - 1) {}
 
-                For i = 0 To Me.Count - 1
-                    arr(i) = Me.Item(i)
+                For i = 0 To Count - 1
+                    arr(i) = Item(i)
                 Next
                 Return arr
             End Get

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SimpleIdentifierSyntax.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SimpleIdentifierSyntax.vb
@@ -49,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend Overrides ReadOnly Property IdentifierText As String
             Get
-                Return Me.Text
+                Return Text
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxList.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxList.vb
@@ -1,15 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend MustInherit Class SyntaxList
@@ -132,37 +122,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Private Sub New(errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), child0 As VisualBasicSyntaxNode, child1 As VisualBasicSyntaxNode)
                 MyBase.New(errors, annotations)
-
-                MyBase._slotCount = 2
-
-                MyBase.AdjustFlagsAndWidth(child0)
-                Me._child0 = child0
-
-                MyBase.AdjustFlagsAndWidth(child1)
-                Me._child1 = child1
+                _slotCount = 2
+                AdjustFlagsAndWidth(child0) : _child0 = child0
+                AdjustFlagsAndWidth(child1) : _child1 = child1
             End Sub
 
             Friend Sub New(child0 As VisualBasicSyntaxNode, child1 As VisualBasicSyntaxNode)
                 MyBase.New()
-
-                MyBase._slotCount = 2
-
-                MyBase.AdjustFlagsAndWidth(child0)
-                Me._child0 = child0
-
-                MyBase.AdjustFlagsAndWidth(child1)
-                Me._child1 = child1
+                _slotCount = 2
+                AdjustFlagsAndWidth(child0) : _child0 = child0
+                AdjustFlagsAndWidth(child1) : _child1 = child1
             End Sub
 
             Friend Sub New(reader As ObjectReader)
                 MyBase.New(reader)
-
-                MyBase._slotCount = 2
-
-                Me._child0 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
-                MyBase.AdjustFlagsAndWidth(_child0)
-                Me._child1 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
-                MyBase.AdjustFlagsAndWidth(_child1)
+                _slotCount = 2
+                _child0 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode) : AdjustFlagsAndWidth(_child0)
+                _child1 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode) : AdjustFlagsAndWidth(_child1)
             End Sub
 
             Friend Overrides Function GetReader() As Func(Of ObjectReader, Object)
@@ -171,21 +147,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Friend Overrides Sub WriteTo(writer As ObjectWriter)
                 MyBase.WriteTo(writer)
-                writer.WriteValue(Me._child0)
-                writer.WriteValue(Me._child1)
+                writer.WriteValue(_child0)
+                writer.WriteValue(_child1)
             End Sub
 
             Friend Overrides Sub CopyTo(array As ArrayElement(Of VisualBasicSyntaxNode)(), offset As Integer)
-                array(offset).Value = Me._child0
-                array((offset + 1)).Value = Me._child1
+                array(offset).Value = _child0
+                array((offset + 1)).Value = _child1
             End Sub
 
             Friend Overrides Function GetSlot(index As Integer) As GreenNode
                 Select Case index
                     Case 0
-                        Return Me._child0
+                        Return _child0
                     Case 1
-                        Return Me._child1
+                        Return _child1
                 End Select
                 Return Nothing
             End Function
@@ -195,61 +171,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End Function
 
             Friend Overrides Function SetDiagnostics(errors() As DiagnosticInfo) As GreenNode
-                Return New WithTwoChildren(errors, Me.GetAnnotations(), Me._child0, Me._child1)
+                Return New WithTwoChildren(errors, GetAnnotations(), _child0, _child1)
             End Function
 
             Friend Overrides Function SetAnnotations(annotations() As SyntaxAnnotation) As GreenNode
-                Return New WithTwoChildren(Me.GetDiagnostics(), annotations, Me._child0, Me._child1)
+                Return New WithTwoChildren(GetDiagnostics(), annotations, _child0, _child1)
             End Function
         End Class
 
         Friend NotInheritable Class WithThreeChildren
             Inherits SyntaxList
 
-            Private ReadOnly _child0 As VisualBasicSyntaxNode
-            Private ReadOnly _child1 As VisualBasicSyntaxNode
-            Private ReadOnly _child2 As VisualBasicSyntaxNode
+            Private ReadOnly _child0, _child1, _child2 As VisualBasicSyntaxNode
 
-            Private Sub New(errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), child0 As VisualBasicSyntaxNode, child1 As VisualBasicSyntaxNode, child2 As VisualBasicSyntaxNode)
+            Private Sub New(errors As DiagnosticInfo(), annotations As SyntaxAnnotation(),
+                            child0 As VisualBasicSyntaxNode, child1 As VisualBasicSyntaxNode, child2 As VisualBasicSyntaxNode)
                 MyBase.New(errors, annotations)
-
-                MyBase._slotCount = 3
-
-                MyBase.AdjustFlagsAndWidth(child0)
-                Me._child0 = child0
-
-                MyBase.AdjustFlagsAndWidth(child1)
-                Me._child1 = child1
-
-                MyBase.AdjustFlagsAndWidth(child2)
-                Me._child2 = child2
+                _slotCount = 3
+                AdjustFlagsAndWidth(child0) : _child0 = child0
+                AdjustFlagsAndWidth(child1) : _child1 = child1
+                AdjustFlagsAndWidth(child2) : _child2 = child2
             End Sub
 
             Friend Sub New(child0 As VisualBasicSyntaxNode, child1 As VisualBasicSyntaxNode, child2 As VisualBasicSyntaxNode)
                 MyBase.New()
-
-                MyBase._slotCount = 3
-
-                MyBase.AdjustFlagsAndWidth(child0)
-                Me._child0 = child0
-
-                MyBase.AdjustFlagsAndWidth(child1)
-                Me._child1 = child1
-
-                MyBase.AdjustFlagsAndWidth(child2)
-                Me._child2 = child2
+                _slotCount = 3
+                AdjustFlagsAndWidth(child0) : _child0 = child0
+                AdjustFlagsAndWidth(child1) : _child1 = child1
+                AdjustFlagsAndWidth(child2) : _child2 = child2
             End Sub
 
             Friend Sub New(reader As ObjectReader)
                 MyBase.New(reader)
-                MyBase._slotCount = 3
-
-                Me._child0 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
-                MyBase.AdjustFlagsAndWidth(_child0)
-                Me._child1 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
-                MyBase.AdjustFlagsAndWidth(_child1)
-                Me._child2 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
-                MyBase.AdjustFlagsAndWidth(_child2)
+                _slotCount = 3
+                _child0 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode) : AdjustFlagsAndWidth(_child0)
+                _child1 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode) : AdjustFlagsAndWidth(_child1)
+                _child2 = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode) : AdjustFlagsAndWidth(_child2)
             End Sub
 
             Friend Overrides Function GetReader() As Func(Of ObjectReader, Object)
@@ -258,39 +215,39 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Friend Overrides Sub WriteTo(writer As ObjectWriter)
                 MyBase.WriteTo(writer)
-                writer.WriteValue(Me._child0)
-                writer.WriteValue(Me._child1)
-                writer.WriteValue(Me._child2)
+                writer.WriteValue(_child0)
+                writer.WriteValue(_child1)
+                writer.WriteValue(_child2)
             End Sub
 
             Friend Overrides Sub CopyTo(array As ArrayElement(Of VisualBasicSyntaxNode)(), offset As Integer)
-                array(offset).Value = Me._child0
-                array(offset + 1).Value = Me._child1
-                array(offset + 2).Value = Me._child2
+                array(offset).Value = _child0
+                array(offset + 1).Value = _child1
+                array(offset + 2).Value = _child2
             End Sub
 
             Friend Overrides Function GetSlot(index As Integer) As GreenNode
                 Select Case index
                     Case 0
-                        Return Me._child0
+                        Return _child0
                     Case 1
-                        Return Me._child1
+                        Return _child1
                     Case 2
-                        Return Me._child2
+                        Return _child2
                 End Select
                 Return Nothing
             End Function
 
             Friend Overrides Function CreateRed(parent As SyntaxNode, startLocation As Integer) As SyntaxNode
-                Return New VisualBasic.Syntax.SyntaxList.WithThreeChildren(Me, parent, startLocation)
+                Return New Syntax.SyntaxList.WithThreeChildren(Me, parent, startLocation)
             End Function
 
             Friend Overrides Function SetDiagnostics(errors() As DiagnosticInfo) As GreenNode
-                Return New WithThreeChildren(errors, Me.GetAnnotations(), Me._child0, Me._child1, Me._child2)
+                Return New WithThreeChildren(errors, GetAnnotations(), _child0, _child1, _child2)
             End Function
 
             Friend Overrides Function SetAnnotations(annotations() As SyntaxAnnotation) As GreenNode
-                Return New WithThreeChildren(Me.GetDiagnostics(), annotations, Me._child0, Me._child1, Me._child2)
+                Return New WithThreeChildren(GetDiagnostics(), annotations, _child0, _child1, _child2)
             End Function
         End Class
 
@@ -301,32 +258,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Protected Sub New(errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), children As ArrayElement(Of VisualBasicSyntaxNode)())
                 MyBase.New(errors, annotations)
-                Me._children = children
+                _children = children
                 InitChildren()
             End Sub
 
             Friend Sub New(children As ArrayElement(Of VisualBasicSyntaxNode)())
                 MyBase.New()
-                Me._children = children
+                _children = children
                 InitChildren()
             End Sub
 
             Private Sub InitChildren()
                 Dim n = _children.Length
                 If (n < Byte.MaxValue) Then
-                    Me._slotCount = CByte(n)
+                    _slotCount = CByte(n)
                 Else
-                    Me._slotCount = Byte.MaxValue
+                    _slotCount = Byte.MaxValue
                 End If
 
                 For i = 0 To _children.Length - 1
                     Dim child = _children(i)
-                    MyBase.AdjustFlagsAndWidth(child)
+                    AdjustFlagsAndWidth(child)
                 Next i
             End Sub
 
             Protected Overrides Function GetSlotCount() As Integer
-                Return Me._children.Length
+                Return _children.Length
             End Function
 
             Protected Sub New(reader As ObjectReader)
@@ -334,9 +291,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 Dim length = reader.ReadInt32()
 
-                Me._children = New ArrayElement(Of VisualBasicSyntaxNode)(length - 1) {}
+                _children = New ArrayElement(Of VisualBasicSyntaxNode)(length - 1) {}
                 For i = 0 To length - 1
-                    Me._children(i).Value = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
+                    _children(i).Value = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
                 Next
 
                 InitChildren()
@@ -347,46 +304,46 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 ' PERF Write the array out manually.Profiling shows that this Is cheaper than converting to 
                 ' an array in order to use writer.WriteValue.
-                writer.WriteInt32(Me._children.Length)
+                writer.WriteInt32(_children.Length)
 
-                For i = 0 To Me._children.Length - 1
-                    writer.WriteValue(Me._children(i).Value)
+                For i = 0 To _children.Length - 1
+                    writer.WriteValue(_children(i).Value)
                 Next
             End Sub
 
             Friend Overrides Sub CopyTo(nodes As ArrayElement(Of VisualBasicSyntaxNode)(), offset As Integer)
-                Array.Copy(Me._children, 0, nodes, offset, Me._children.Length)
+                Array.Copy(_children, 0, nodes, offset, _children.Length)
             End Sub
 
             Friend Overrides Function GetSlot(index As Integer) As GreenNode
-                Return Me._children(index)
+                Return _children(index)
             End Function
 
 
             'TODO: weakening heuristic may need some tuning.
             Private Shared Function ShouldMakeWeakList(parent As SyntaxNode) As Boolean
-                Return parent IsNot Nothing AndAlso TypeOf parent Is VisualBasic.Syntax.MethodBlockBaseSyntax
+                Return parent IsNot Nothing AndAlso TypeOf parent Is Syntax.MethodBlockBaseSyntax
             End Function
 
             Friend Overrides Function CreateRed(parent As SyntaxNode, startLocation As Integer) As SyntaxNode
                 Dim isSeparated = SlotCount > 1 AndAlso HasNodeTokenPattern()
                 If ShouldMakeWeakList(parent) Then
                     If isSeparated Then
-                        Return New VisualBasic.Syntax.SyntaxList.WeakSeparatedWithManyChildren(Me, parent, startLocation)
+                        Return New Syntax.SyntaxList.WeakSeparatedWithManyChildren(Me, parent, startLocation)
                     End If
-                    Return New VisualBasic.Syntax.SyntaxList.WeakWithManyChildren(Me, parent, startLocation)
+                    Return New Syntax.SyntaxList.WeakWithManyChildren(Me, parent, startLocation)
                 Else
                     If isSeparated Then
-                        Return New VisualBasic.Syntax.SyntaxList.SeparatedWithManyChildren(Me, parent, startLocation)
+                        Return New Syntax.SyntaxList.SeparatedWithManyChildren(Me, parent, startLocation)
                     End If
-                    Return New VisualBasic.Syntax.SyntaxList.WithManyChildren(Me, parent, startLocation)
+                    Return New Syntax.SyntaxList.WithManyChildren(Me, parent, startLocation)
                 End If
             End Function
 
             Private Function HasNodeTokenPattern() As Boolean
                 For i = 0 To Me.SlotCount - 1
                     ' even slots must not be tokens and odd slots must be
-                    If Me.GetSlot(i).IsToken = ((i And 1) = 0) Then
+                    If GetSlot(i).IsToken = ((i And 1) = 0) Then
                         Return False
                     End If
                 Next
@@ -420,11 +377,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End Function
 
             Friend Overrides Function SetDiagnostics(errors() As DiagnosticInfo) As GreenNode
-                Return New WithManyChildren(errors, Me.GetAnnotations(), Me._children)
+                Return New WithManyChildren(errors, Me.GetAnnotations(), _children)
             End Function
 
             Friend Overrides Function SetAnnotations(annotations() As SyntaxAnnotation) As GreenNode
-                Return New WithManyChildren(Me.GetDiagnostics(), annotations, Me._children)
+                Return New WithManyChildren(Me.GetDiagnostics(), annotations, _children)
             End Function
         End Class
 
@@ -470,11 +427,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End Function
 
             Friend Overrides Function SetDiagnostics(errors() As DiagnosticInfo) As GreenNode
-                Return New WithLotsOfChildren(errors, Me.GetAnnotations(), Me._children, Me._childOffsets)
+                Return New WithLotsOfChildren(errors, Me.GetAnnotations(), _children, _childOffsets)
             End Function
 
             Friend Overrides Function SetAnnotations(annotations() As SyntaxAnnotation) As GreenNode
-                Return New WithLotsOfChildren(Me.GetDiagnostics(), annotations, Me._children, Me._childOffsets)
+                Return New WithLotsOfChildren(Me.GetDiagnostics(), annotations, _children, _childOffsets)
             End Function
 
             Private Shared Function CalculateOffsets(children As ArrayElement(Of VisualBasicSyntaxNode)()) As Integer()
@@ -500,42 +457,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Public Sub New(size As Integer)
-            Me._nodes = New ArrayElement(Of VisualBasicSyntaxNode)(size - 1) {}
+            _nodes = New ArrayElement(Of VisualBasicSyntaxNode)(size - 1) {}
         End Sub
 
         Public Function Add(item As VisualBasicSyntaxNode) As SyntaxListBuilder
             EnsureAdditionalCapacity(1)
-            Return Me.AddUnsafe(item)
+            Return AddUnsafe(item)
         End Function
 
         Private Function AddUnsafe(item As GreenNode) As SyntaxListBuilder
             Debug.Assert(item IsNot Nothing)
-            Me._nodes(Me._count).Value = DirectCast(item, VisualBasicSyntaxNode)
-            Me._count += 1
+            _nodes(_count).Value = DirectCast(item, VisualBasicSyntaxNode)
+            _count += 1
             Return Me
         End Function
 
         Public Function AddRange(Of TNode As VisualBasicSyntaxNode)(list As SyntaxList(Of TNode)) As SyntaxListBuilder
-            Return Me.AddRange(Of TNode)(list, 0, list.Count)
+            Return AddRange(Of TNode)(list, 0, list.Count)
         End Function
 
         Public Function AddRange(Of TNode As VisualBasicSyntaxNode)(list As SyntaxList(Of TNode), offset As Integer, length As Integer) As SyntaxListBuilder
             EnsureAdditionalCapacity(length - offset)
 
-            Dim oldCount = Me._count
+            Dim oldCount = _count
 
             For i = offset To offset + length - 1
                 AddUnsafe(list.ItemUntyped(i))
             Next i
 
-            Me.Validate(oldCount, Me._count)
+            Validate(oldCount, _count)
             Return Me
         End Function
 
         Public Function Any(kind As SyntaxKind) As Boolean
             Dim i As Integer
-            For i = 0 To Me._count - 1
-                If (Me._nodes(i).Value.Kind = kind) Then
+            For i = 0 To _count - 1
+                If (_nodes(i).Value.Kind = kind) Then
                     Return True
                 End If
             Next i
@@ -543,17 +500,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Friend Sub RemoveLast()
-            Me._count -= 1
-            Me._nodes(Me._count) = Nothing
+            _count -= 1
+            _nodes(_count) = Nothing
         End Sub
 
         Public Sub Clear()
-            Me._count = 0
+            _count = 0
         End Sub
 
         Private Sub EnsureAdditionalCapacity(additionalCount As Integer)
-            Dim currentSize As Integer = Me._nodes.Length
-            Dim requiredSize As Integer = Me._count + additionalCount
+            Dim currentSize As Integer = _nodes.Length
+            Dim requiredSize As Integer = _count + additionalCount
 
             If requiredSize <= currentSize Then
                 Return
@@ -565,18 +522,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Math.Max(requiredSize, currentSize * 2))) ' Guaranteed to at least double
             Debug.Assert(newSize >= requiredSize)
 
-            Array.Resize(Me._nodes, newSize)
+            Array.Resize(_nodes, newSize)
         End Sub
 
         Friend Function ToArray() As ArrayElement(Of VisualBasicSyntaxNode)()
-            Dim dst As ArrayElement(Of VisualBasicSyntaxNode)() = New ArrayElement(Of VisualBasicSyntaxNode)(Me._count - 1) {}
+            Dim dst As ArrayElement(Of VisualBasicSyntaxNode)() = New ArrayElement(Of VisualBasicSyntaxNode)(_count - 1) {}
 
             'TODO: workaround for range check hoisting bug
             ' <<< FOR LOOP
             Dim i As Integer = 0
             GoTo enter
             Do
-                dst(i) = Me._nodes(i)
+                dst(i) = _nodes(i)
                 i += 1
 enter:
             Loop While i < dst.Length
@@ -586,15 +543,15 @@ enter:
         End Function
 
         Friend Function ToListNode() As VisualBasicSyntaxNode
-            Select Case Me._count
+            Select Case _count
                 Case 0
                     Return Nothing
                 Case 1
-                    Return Me._nodes(0)
+                    Return _nodes(0)
                 Case 2
-                    Return SyntaxList.List(Me._nodes(0), Me._nodes(1))
+                    Return SyntaxList.List(_nodes(0), _nodes(1))
                 Case 3
-                    Return SyntaxList.List(Me._nodes(0), Me._nodes(1), Me._nodes(2))
+                    Return SyntaxList.List(_nodes(0), _nodes(1), _nodes(2))
             End Select
             Return SyntaxList.List(Me.ToArray)
         End Function
@@ -603,22 +560,22 @@ enter:
         Private Sub Validate(start As Integer, [end] As Integer)
             Dim i As Integer
             For i = start To [end] - 1
-                Debug.Assert(Me._nodes(i).Value IsNot Nothing)
+                Debug.Assert(_nodes(i).Value IsNot Nothing)
             Next i
         End Sub
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._count
+                Return _count
             End Get
         End Property
 
         Default Public Property Item(index As Integer) As VisualBasicSyntaxNode
             Get
-                Return Me._nodes(index)
+                Return _nodes(index)
             End Get
             Set(value As VisualBasicSyntaxNode)
-                Me._nodes(index).Value = value
+                _nodes(index).Value = value
             End Set
         End Property
 
@@ -643,62 +600,62 @@ enter:
         End Sub
 
         Friend Sub New(builder As SyntaxListBuilder)
-            Me._builder = builder
+            _builder = builder
         End Sub
 
         Public ReadOnly Property IsNull As Boolean
             Get
-                Return (Me._builder Is Nothing)
+                Return (_builder Is Nothing)
             End Get
         End Property
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._builder.Count
+                Return _builder.Count
             End Get
         End Property
 
         Default Public Property Item(index As Integer) As TNode
             Get
-                Return DirectCast(Me._builder.Item(index), TNode)
+                Return DirectCast(_builder.Item(index), TNode)
             End Get
             Set(value As TNode)
-                Me._builder.Item(index) = value
+                _builder.Item(index) = value
             End Set
         End Property
 
         Friend Sub RemoveLast()
-            Me._builder.RemoveLast()
+            _builder.RemoveLast()
         End Sub
 
         Public Sub Clear()
-            Me._builder.Clear()
+            _builder.Clear()
         End Sub
 
         Public Sub Add(node As TNode)
-            Me._builder.Add(node)
+            _builder.Add(node)
         End Sub
 
         Public Sub AddRange(nodes As SyntaxList(Of TNode))
-            Me._builder.AddRange(Of TNode)(nodes)
+            _builder.AddRange(Of TNode)(nodes)
         End Sub
 
         Public Sub AddRange(nodes As SyntaxList(Of TNode), offset As Integer, length As Integer)
-            Me._builder.AddRange(Of TNode)(nodes, offset, length)
+            _builder.AddRange(Of TNode)(nodes, offset, length)
         End Sub
 
         Public Function Any(kind As SyntaxKind) As Boolean
-            Return Me._builder.Any(kind)
+            Return _builder.Any(kind)
         End Function
 
         Public Function ToList() As SyntaxList(Of TNode)
-            Debug.Assert(Me._builder IsNot Nothing)
-            Return Me._builder.ToList(Of TNode)()
+            Debug.Assert(_builder IsNot Nothing)
+            Return _builder.ToList(Of TNode)()
         End Function
 
         Public Function ToList(Of TDerivedNode As TNode)() As SyntaxList(Of TDerivedNode)
-            Debug.Assert(Me._builder IsNot Nothing)
-            Return Me._builder.ToList(Of TDerivedNode)()
+            Debug.Assert(_builder IsNot Nothing)
+            Return _builder.ToList(Of TDerivedNode)()
         End Function
 
         Public Shared Widening Operator CType(builder As SyntaxListBuilder(Of TNode)) As SyntaxListBuilder
@@ -717,61 +674,61 @@ enter:
         End Sub
 
         Friend Sub New(builder As SyntaxListBuilder)
-            Me._builder = builder
+            _builder = builder
         End Sub
 
         Public ReadOnly Property IsNull As Boolean
             Get
-                Return (Me._builder Is Nothing)
+                Return (_builder Is Nothing)
             End Get
         End Property
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._builder.Count
+                Return _builder.Count
             End Get
         End Property
 
         Default Public Property Item(index As Integer) As VisualBasicSyntaxNode
             Get
-                Return Me._builder.Item(index)
+                Return _builder.Item(index)
             End Get
             Set(value As VisualBasicSyntaxNode)
-                Me._builder.Item(index) = value
+                _builder.Item(index) = value
             End Set
         End Property
 
         Public Sub Clear()
-            Me._builder.Clear()
+            _builder.Clear()
         End Sub
 
         Public Sub Add(node As TNode)
-            Me._builder.Add(node)
+            _builder.Add(node)
         End Sub
 
         Friend Sub AddSeparator(separatorToken As SyntaxToken)
-            Me._builder.Add(separatorToken)
+            _builder.Add(separatorToken)
         End Sub
 
         Friend Sub AddRange(nodes As SeparatedSyntaxList(Of TNode), count As Integer)
             Dim list = nodes.GetWithSeparators
-            Me._builder.AddRange(list, Me.Count, Math.Min(count * 2, list.Count))
+            _builder.AddRange(list, Me.Count, Math.Min(count * 2, list.Count))
         End Sub
 
         Friend Sub RemoveLast()
-            Me._builder.RemoveLast()
+            _builder.RemoveLast()
         End Sub
 
         Public Function Any(kind As SyntaxKind) As Boolean
-            Return Me._builder.Any(kind)
+            Return _builder.Any(kind)
         End Function
 
         Public Function ToList() As SeparatedSyntaxList(Of TNode)
-            Return New SeparatedSyntaxList(Of TNode)(New SyntaxList(Of VisualBasicSyntaxNode)(Me._builder.ToListNode))
+            Return New SeparatedSyntaxList(Of TNode)(New SyntaxList(Of VisualBasicSyntaxNode)(_builder.ToListNode))
         End Function
 
         Public Function ToList(Of TDerivedNode As TNode)() As SeparatedSyntaxList(Of TDerivedNode)
-            Return New SeparatedSyntaxList(Of TDerivedNode)(New SyntaxList(Of VisualBasicSyntaxNode)(Me._builder.ToListNode))
+            Return New SeparatedSyntaxList(Of TDerivedNode)(New SyntaxList(Of VisualBasicSyntaxNode)(_builder.ToListNode))
         End Function
 
         Public Shared Widening Operator CType(builder As SeparatedSyntaxListBuilder(Of TNode)) As SyntaxListBuilder
@@ -785,24 +742,24 @@ enter:
         Private ReadOnly _node As GreenNode
 
         Friend Sub New(node As GreenNode)
-            Me._node = node
+            _node = node
         End Sub
 
         Friend ReadOnly Property Node As VisualBasicSyntaxNode
             Get
-                Return DirectCast(Me._node, VisualBasicSyntaxNode)
+                Return DirectCast(_node, VisualBasicSyntaxNode)
             End Get
         End Property
 
         Public ReadOnly Property Count As Integer
             Get
-                Return If((Me._node Is Nothing), 0, If(Me._node.IsList, Me._node.SlotCount, 1))
+                Return If((_node Is Nothing), 0, If(_node.IsList, _node.SlotCount, 1))
             End Get
         End Property
 
         Public ReadOnly Property Last As TNode
             Get
-                Dim node = Me._node
+                Dim node = _node
                 If node.IsList Then
                     Return DirectCast(node.GetSlot(node.SlotCount - 1), TNode)
                 End If
@@ -812,7 +769,7 @@ enter:
 
         Default Public ReadOnly Property Item(index As Integer) As TNode
             Get
-                Dim node = Me._node
+                Dim node = _node
                 If node.IsList Then
                     Return DirectCast(node.GetSlot(index), TNode)
                 End If
@@ -823,7 +780,7 @@ enter:
 
         Friend ReadOnly Property ItemUntyped(index As Integer) As GreenNode
             Get
-                Dim node = Me._node
+                Dim node = _node
                 If node.IsList Then
                     Return node.GetSlot(index)
                 End If
@@ -833,7 +790,7 @@ enter:
         End Property
 
         Public Function Any() As Boolean
-            Return Me._node IsNot Nothing
+            Return _node IsNot Nothing
         End Function
 
         Public Function Any(kind As SyntaxKind) As Boolean
@@ -869,15 +826,15 @@ enter:
         End Function
 
         Public Overloads Function Equals(other As SyntaxList(Of TNode)) As Boolean Implements IEquatable(Of SyntaxList(Of TNode)).Equals
-            Return Me._node Is other._node
+            Return _node Is other._node
         End Function
 
         Public Overrides Function GetHashCode() As Integer
-            Return If((Not Me._node Is Nothing), Me._node.GetHashCode, 0)
+            Return If((Not _node Is Nothing), _node.GetHashCode, 0)
         End Function
 
         Friend Function AsSeparatedList(Of TOther As VisualBasicSyntaxNode)() As SeparatedSyntaxList(Of TOther)
-            Return New SeparatedSyntaxList(Of TOther)(New SyntaxList(Of TOther)(Me._node))
+            Return New SeparatedSyntaxList(Of TOther)(New SyntaxList(Of TOther)(_node))
         End Function
 
         Public Shared Widening Operator CType(node As TNode) As SyntaxList(Of TNode)

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxLiterals.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Partial Class CharacterLiteralTokenSyntax
         Friend NotOverridable Overrides ReadOnly Property ObjectValue As Object
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
     End Class
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Partial Class DateLiteralTokenSyntax
         Friend NotOverridable Overrides ReadOnly Property ObjectValue As Object
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
     End Class
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Partial Class DecimalLiteralTokenSyntax
         Friend NotOverridable Overrides ReadOnly Property ObjectValue As Object
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
     End Class
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend NotOverridable Overrides ReadOnly Property ValueText As String
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
     End Class
@@ -49,17 +49,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Sub New(kind As SyntaxKind, text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, base As LiteralBase, typeSuffix As TypeCharacter, value As T)
             MyBase.New(kind, text, leadingTrivia, trailingTrivia, base, typeSuffix)
-            Me._value = value
+            _value = value
         End Sub
 
         Friend Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, base As LiteralBase, typeSuffix As TypeCharacter, value As T)
             MyBase.New(kind, errors, annotations, text, leadingTrivia, trailingTrivia, base, typeSuffix)
-            Me._value = value
+            _value = value
         End Sub
 
         Friend Sub New(reader As ObjectReader)
             MyBase.New(reader)
-            Me._value = CType(reader.ReadValue(), T)
+            _value = CType(reader.ReadValue(), T)
         End Sub
 
         Friend Overrides Function GetReader() As Func(Of ObjectReader, Object)
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
-            writer.WriteValue(Me._value)
+            writer.WriteValue(_value)
         End Sub
 
         ''' <summary>
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend ReadOnly Property Value As T
             Get
-                Return Me._value
+                Return _value
             End Get
         End Property
 
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Overrides ReadOnly Property ObjectValue As Object
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
 
@@ -120,26 +120,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Sub New(kind As SyntaxKind, text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, base As LiteralBase, typeSuffix As TypeCharacter)
             MyBase.New(kind, text, leadingTrivia, trailingTrivia)
-            Me._base = base
-            Me._typeSuffix = typeSuffix
+            _base = base
+            _typeSuffix = typeSuffix
         End Sub
 
         Friend Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, base As LiteralBase, typeSuffix As TypeCharacter)
             MyBase.New(kind, errors, annotations, text, leadingTrivia, trailingTrivia)
-            Me._base = base
-            Me._typeSuffix = typeSuffix
+            _base = base
+            _typeSuffix = typeSuffix
         End Sub
 
         Friend Sub New(reader As ObjectReader)
             MyBase.New(reader)
-            Me._base = CType(reader.ReadByte(), LiteralBase)
-            Me._typeSuffix = CType(reader.ReadByte(), TypeCharacter)
+            _base = CType(reader.ReadByte(), LiteralBase)
+            _typeSuffix = CType(reader.ReadByte(), TypeCharacter)
         End Sub
 
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
-            writer.WriteByte(CType(Me._base, Byte))
-            writer.WriteByte(CType(Me._typeSuffix, Byte))
+            writer.WriteByte(CType(_base, Byte))
+            writer.WriteByte(CType(_typeSuffix, Byte))
         End Sub
 
         ''' <summary>
@@ -147,7 +147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend ReadOnly Property Base As LiteralBase
             Get
-                Return Me._base
+                Return _base
             End Get
         End Property
 
@@ -157,7 +157,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend ReadOnly Property TypeSuffix As TypeCharacter
             Get
-                Return Me._typeSuffix
+                Return _typeSuffix
             End Get
         End Property
 
@@ -173,17 +173,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Sub New(kind As SyntaxKind, text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, typeSuffix As TypeCharacter, value As T)
             MyBase.New(kind, text, leadingTrivia, trailingTrivia, typeSuffix)
-            Me._value = value
+            _value = value
         End Sub
 
         Friend Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, typeSuffix As TypeCharacter, value As T)
             MyBase.New(kind, errors, annotations, text, leadingTrivia, trailingTrivia, typeSuffix)
-            Me._value = value
+            _value = value
         End Sub
 
         Friend Sub New(reader As ObjectReader)
             MyBase.New(reader)
-            Me._value = CType(reader.ReadValue(), T)
+            _value = CType(reader.ReadValue(), T)
         End Sub
 
         Friend Overrides Function GetReader() As Func(Of ObjectReader, Object)
@@ -192,7 +192,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
-            writer.WriteValue(Me._value)
+            writer.WriteValue(_value)
         End Sub
 
         ''' <summary>
@@ -200,7 +200,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend ReadOnly Property Value As T
             Get
-                Return Me._value
+                Return _value
             End Get
         End Property
 
@@ -212,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Overrides ReadOnly Property ObjectValue As Object
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
 
@@ -243,22 +243,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Sub New(kind As SyntaxKind, text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, typeSuffix As TypeCharacter)
             MyBase.New(kind, text, leadingTrivia, trailingTrivia)
-            Me._typeSuffix = typeSuffix
+            _typeSuffix = typeSuffix
         End Sub
 
         Friend Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), text As String, leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode, typeSuffix As TypeCharacter)
             MyBase.New(kind, errors, annotations, text, leadingTrivia, trailingTrivia)
-            Me._typeSuffix = typeSuffix
+            _typeSuffix = typeSuffix
         End Sub
 
         Friend Sub New(reader As ObjectReader)
             MyBase.New(reader)
-            Me._typeSuffix = CType(reader.ReadByte(), TypeCharacter)
+            _typeSuffix = CType(reader.ReadByte(), TypeCharacter)
         End Sub
 
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
-            writer.WriteByte(CType(Me._typeSuffix, Byte))
+            writer.WriteByte(CType(_typeSuffix, Byte))
         End Sub
 
         ''' <summary>
@@ -267,7 +267,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend ReadOnly Property TypeSuffix As TypeCharacter
             Get
-                Return Me._typeSuffix
+                Return _typeSuffix
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNode.vb
@@ -62,8 +62,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Friend Function MatchesFactoryContext(context As ISyntaxFactoryContext) As Boolean
-            Return context.IsWithinAsyncMethodOrLambda = Me.ParsedInAsync AndAlso
-                context.IsWithinIteratorContext = Me.ParsedInIterator
+            Return context.IsWithinAsyncMethodOrLambda = ParsedInAsync AndAlso (context.IsWithinIteratorContext = ParsedInIterator)
         End Function
 
         ''' <summary>
@@ -74,14 +73,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             stack.Push(Me)
 
             While stack.Count > 0
-                DirectCast(stack.Pop(), InternalSyntax.VisualBasicSyntaxNode).WriteToOrFlatten(writer, stack)
+                DirectCast(stack.Pop(), VisualBasicSyntaxNode).WriteToOrFlatten(writer, stack)
             End While
 
             stack.Free()
         End Sub
 
         Protected Overrides Sub WriteTo(writer As IO.TextWriter, leading As Boolean, trailing As Boolean)
-            Me.WriteTo(writer)
+            WriteTo(writer)
         End Sub
 
         ''' <summary>
@@ -89,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' </summary>
         Friend Overridable Sub WriteToOrFlatten(writer As IO.TextWriter, stack As ArrayBuilder(Of GreenNode))
             ' By default just push children to the stack
-            For i = Me.SlotCount() - 1 To 0 Step -1
+            For i = SlotCount() - 1 To 0 Step -1
                 Dim node As GreenNode = GetSlot(i)
                 If node IsNot Nothing Then
                     stack.Push(GetSlot(i))
@@ -112,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' This implementation is overridden for tokens; this is the implementation for non-token nodes.
 
             ' Add diagnostics.
-            Dim diagnostics As DiagnosticInfo() = Me.GetDiagnostics()
+            Dim diagnostics As DiagnosticInfo() = GetDiagnostics()
             If diagnostics IsNot Nothing AndAlso diagnostics.Length > 0 Then
                 For Each diag In diagnostics
                     nonTokenDiagnostics.Add(diag)
@@ -141,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' grab the part that doesn't contain the preceding and trailing trivia.
 
             Dim builder = Collections.PooledStringBuilder.GetInstance()
-            Dim writer As New IO.StringWriter(builder, System.Globalization.CultureInfo.InvariantCulture)
+            Dim writer As New IO.StringWriter(builder, Globalization.CultureInfo.InvariantCulture)
 
             WriteTo(writer)
 
@@ -161,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' <remarks>The length of the returned string is always the same as FullSpan.Length</remarks>
         Public Overrides Function ToFullString() As String
             Dim builder = Collections.PooledStringBuilder.GetInstance()
-            Dim writer As New IO.StringWriter(builder, System.Globalization.CultureInfo.InvariantCulture)
+            Dim writer As New IO.StringWriter(builder, Globalization.CultureInfo.InvariantCulture)
 
             WriteTo(writer)
 
@@ -213,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Public Overrides Function GetLeadingTriviaCore() As GreenNode
-            Return Me.GetLeadingTrivia()
+            Return GetLeadingTrivia()
         End Function
 
         ' Get the trailing trivia a green array, recursively to first token.
@@ -231,32 +230,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Protected Sub New(kind As SyntaxKind)
-            MyBase.New(CType(kind, UInt16))
+            MyBase.New(kind)
             GreenStats.NoteGreen(Me)
         End Sub
 
         Protected Sub New(kind As SyntaxKind, width As Integer)
-            MyBase.New(CType(kind, UInt16), width)
+            MyBase.New(kind, width)
             GreenStats.NoteGreen(Me)
         End Sub
 
         Protected Sub New(kind As SyntaxKind, errors As DiagnosticInfo())
-            MyBase.New(CType(kind, UInt16), errors)
+            MyBase.New(kind, errors)
             GreenStats.NoteGreen(Me)
         End Sub
 
         Protected Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), width As Integer)
-            MyBase.New(CType(kind, UInt16), errors, width)
+            MyBase.New(kind, errors, width)
             GreenStats.NoteGreen(Me)
         End Sub
 
         Friend Sub New(kind As SyntaxKind, diagnostics As DiagnosticInfo(), annotations As SyntaxAnnotation())
-            MyBase.New(CType(kind, UInt16), diagnostics, annotations)
+            MyBase.New(kind, diagnostics, annotations)
             GreenStats.NoteGreen(Me)
         End Sub
 
         Friend Sub New(kind As SyntaxKind, diagnostics As DiagnosticInfo(), annotations As SyntaxAnnotation(), fullWidth As Integer)
-            MyBase.New(CType(kind, UInt16), diagnostics, annotations, fullWidth)
+            MyBase.New(kind, diagnostics, annotations, fullWidth)
             GreenStats.NoteGreen(Me)
         End Sub
 
@@ -301,8 +300,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Friend Overridable Sub AddSyntaxErrors(accumulatedErrors As List(Of DiagnosticInfo))
-            If Me.GetDiagnostics IsNot Nothing Then
-                accumulatedErrors.AddRange(Me.GetDiagnostics)
+            If GetDiagnostics() IsNot Nothing Then
+                accumulatedErrors.AddRange(GetDiagnostics)
             End If
 
             Dim cnt = SlotCount()
@@ -423,7 +422,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Dim parent = trivia.Token.Parent
             If parent Is Nothing Then
-                Return VisualBasic.Syntax.StructuredTriviaSyntax.Create(trivia)
+                Return Syntax.StructuredTriviaSyntax.Create(trivia)
             End If
 
             Dim [structure] As SyntaxNode = Nothing
@@ -431,7 +430,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             SyncLock structsInParent
                 If Not structsInParent.TryGetValue(trivia, [structure]) Then
-                    [structure] = VisualBasic.Syntax.StructuredTriviaSyntax.Create(trivia)
+                    [structure] = Syntax.StructuredTriviaSyntax.Create(trivia)
                     structsInParent.Add(trivia, [structure])
                 End If
             End SyncLock
@@ -450,7 +449,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return Nothing
             End If
 
-            Dim list = nodes.Select(Function(n) DirectCast(n, InternalSyntax.VisualBasicSyntaxNode)).ToArray()
+            Dim list = nodes.Select(Function(n) DirectCast(n, VisualBasicSyntaxNode)).ToArray()
 
             Dim count = list.Length
             Select Case count
@@ -480,7 +479,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Public Overrides Function IsTriviaWithEndOfLine() As Boolean
-            Return Me.Kind = SyntaxKind.EndOfLineTrivia OrElse Me.Kind = SyntaxKind.CommentTrivia
+            Return (Kind = SyntaxKind.EndOfLineTrivia) OrElse (Kind = SyntaxKind.CommentTrivia)
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeCache.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxNodeCache.vb
@@ -150,7 +150,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Shared Function AllChildrenInCache(node As GreenNode) As Boolean
             For i As Integer = 0 To node.SlotCount - 1
-                If (Not ChildInCache(DirectCast(node.GetSlot(i), GreenNode))) Then
+                If (Not ChildInCache(node.GetSlot(i))) Then
                     Return False
                 End If
             Next
@@ -251,7 +251,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Shared Function GetCacheHash(kind As Integer, flags As GreenNode.NodeFlags, child1 As GreenNode) As Integer
             Dim code As Integer = CInt(flags) Xor kind
             ' the only child is never null
-            code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code)
+            code = Hash.Combine(Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code)
 
             ' ensure nonnegative hash
             Return code And Int32.MaxValue
@@ -261,10 +261,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim code As Integer = CInt(flags) Xor kind
 
             If (child1 IsNot Nothing) Then
-                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code)
+                code = Hash.Combine(Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code)
             End If
             If (child2 IsNot Nothing) Then
-                code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child2), code)
+                code = Hash.Combine(Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child2), code)
             End If
 
             ' ensure nonnegative hash

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxReplacer.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxReplacer.vb
@@ -1,8 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Class FirstTokenReplacer
         Inherits VisualBasicSyntaxRewriter

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxRewriter.vb
@@ -1,8 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Partial Friend MustInherit Class VisualBasicSyntaxVisitor

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxToken.vb
@@ -18,8 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Implements IObjectWritable, IObjectReadable
 
             Private Sub New(leadingTrivia As VisualBasicSyntaxNode, trailingTrivia As VisualBasicSyntaxNode)
-                Me._leadingTrivia = leadingTrivia
-                Me._trailingTrivia = trailingTrivia
+                _leadingTrivia = leadingTrivia
+                _trailingTrivia = trailingTrivia
             End Sub
 
             Private Const s_maximumCachedTriviaWidth As Integer = 40
@@ -85,8 +85,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Public _trailingTrivia As VisualBasicSyntaxNode
 
             Public Sub New(reader As ObjectReader)
-                Me._leadingTrivia = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
-                Me._trailingTrivia = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
+                _leadingTrivia = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
+                _trailingTrivia = DirectCast(reader.ReadValue(), VisualBasicSyntaxNode)
             End Sub
 
             Public Function GetReader() As Func(Of ObjectReader, Object) Implements IObjectReadable.GetReader
@@ -101,19 +101,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Protected Sub New(kind As SyntaxKind, text As String, precedingTrivia As VisualBasicSyntaxNode, followingTrivia As VisualBasicSyntaxNode)
             MyBase.New(kind, text.Length)
-            Me.SetFlags(NodeFlags.IsNotMissing)
+            SetFlags(NodeFlags.IsNotMissing)
 
-            Me._text = text
+            _text = text
             If followingTrivia IsNot Nothing Then
                 ' Don't propagate NoMissing in Init
                 AdjustFlagsAndWidth(followingTrivia)
-                Me._trailingTriviaOrTriviaInfo = followingTrivia
+                _trailingTriviaOrTriviaInfo = followingTrivia
             End If
 
             If precedingTrivia IsNot Nothing Then
                 ' Don't propagate NoMissing in Init
                 AdjustFlagsAndWidth(precedingTrivia)
-                Me._trailingTriviaOrTriviaInfo = TriviaInfo.Create(precedingTrivia, DirectCast(Me._trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
+                _trailingTriviaOrTriviaInfo = TriviaInfo.Create(precedingTrivia, DirectCast(_trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
             End If
 
             ClearFlagIfMissing()
@@ -123,17 +123,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             MyBase.New(kind, errors, text.Length)
             Me.SetFlags(NodeFlags.IsNotMissing)
 
-            Me._text = text
+            _text = text
             If followingTrivia IsNot Nothing Then
                 ' Don't propagate NoMissing in Init
                 AdjustFlagsAndWidth(followingTrivia)
-                Me._trailingTriviaOrTriviaInfo = followingTrivia
+                _trailingTriviaOrTriviaInfo = followingTrivia
             End If
 
             If precedingTrivia IsNot Nothing Then
                 ' Don't propagate NoMissing in Init
                 AdjustFlagsAndWidth(precedingTrivia)
-                Me._trailingTriviaOrTriviaInfo = TriviaInfo.Create(precedingTrivia, DirectCast(Me._trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
+                _trailingTriviaOrTriviaInfo = TriviaInfo.Create(precedingTrivia, DirectCast(_trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
             End If
 
             ClearFlagIfMissing()
@@ -141,19 +141,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Protected Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), text As String, precedingTrivia As VisualBasicSyntaxNode, followingTrivia As VisualBasicSyntaxNode)
             MyBase.New(kind, errors, annotations, text.Length)
-            Me.SetFlags(NodeFlags.IsNotMissing)
+            SetFlags(NodeFlags.IsNotMissing)
 
-            Me._text = text
+            _text = text
             If followingTrivia IsNot Nothing Then
                 ' Don't propagate NoMissing in Init
                 AdjustFlagsAndWidth(followingTrivia)
-                Me._trailingTriviaOrTriviaInfo = followingTrivia
+                _trailingTriviaOrTriviaInfo = followingTrivia
             End If
 
             If precedingTrivia IsNot Nothing Then
                 ' Don't propagate NoMissing in Init
                 AdjustFlagsAndWidth(precedingTrivia)
-                Me._trailingTriviaOrTriviaInfo = TriviaInfo.Create(precedingTrivia, DirectCast(Me._trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
+                _trailingTriviaOrTriviaInfo = TriviaInfo.Create(precedingTrivia, DirectCast(_trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
             End If
 
             ClearFlagIfMissing()
@@ -161,16 +161,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Sub New(reader As ObjectReader)
             MyBase.New(reader)
-            Me.SetFlags(NodeFlags.IsNotMissing)
+            SetFlags(NodeFlags.IsNotMissing)
 
-            Me._text = reader.ReadString()
-            Me.FullWidth = Me._text.Length
+            _text = reader.ReadString()
+            FullWidth = _text.Length
 
-            Me._trailingTriviaOrTriviaInfo = reader.ReadValue()
+            _trailingTriviaOrTriviaInfo = reader.ReadValue()
 
-            Dim info = TryCast(Me._trailingTriviaOrTriviaInfo, TriviaInfo)
+            Dim info = TryCast(_trailingTriviaOrTriviaInfo, TriviaInfo)
 
-            Dim followingTrivia = If(info IsNot Nothing, info._trailingTrivia, TryCast(Me._trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
+            Dim followingTrivia = If(info IsNot Nothing, info._trailingTrivia, TryCast(_trailingTriviaOrTriviaInfo, VisualBasicSyntaxNode))
             Dim precedingTrivia = If(info IsNot Nothing, info._leadingTrivia, Nothing)
 
             If followingTrivia IsNot Nothing Then
@@ -190,19 +190,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             If Text.Length = 0 AndAlso Kind <> SyntaxKind.EndOfFileToken AndAlso Kind <> SyntaxKind.EmptyToken Then
                 ' If a token has text then it is not missing.  The only 0 length tokens that are not considered missing are the end of file token because no text exists for this token 
                 ' and the empty token which exists solely so that the empty statement has a token.
-                Me.ClearFlags(NodeFlags.IsNotMissing)
+                ClearFlags(NodeFlags.IsNotMissing)
             End If
         End Sub
 
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
-            writer.WriteString(Me._text)
-            writer.WriteValue(Me._trailingTriviaOrTriviaInfo)
+            writer.WriteString(_text)
+            writer.WriteValue(_trailingTriviaOrTriviaInfo)
         End Sub
 
         Friend ReadOnly Property Text As String
             Get
-                Return Me._text
+                Return _text
             End Get
         End Property
 
@@ -253,7 +253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Friend NotOverridable Overrides Sub AddSyntaxErrors(accumulatedErrors As List(Of DiagnosticInfo))
-            If Me.GetDiagnostics IsNot Nothing Then
+            If GetDiagnostics() IsNot Nothing Then
                 accumulatedErrors.AddRange(Me.GetDiagnostics)
             End If
 
@@ -301,7 +301,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Public Overrides Function ToString() As String
-            Return Me._text
+            Return _text
         End Function
 
         Public NotOverridable Overrides ReadOnly Property IsToken As Boolean
@@ -326,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Property
 
         Public Overrides Function GetValue() As Object
-            Return Me.ObjectValue
+            Return ObjectValue
         End Function
 
         Friend Overridable ReadOnly Property ValueText As String
@@ -336,7 +336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Property
 
         Public Overrides Function GetValueText() As String
-            Return Me.ValueText
+            Return ValueText
         End Function
 
         ''' <summary>
@@ -467,7 +467,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Public Shared Narrowing Operator CType(token As SyntaxToken) As Microsoft.CodeAnalysis.SyntaxToken
-            Return New Microsoft.CodeAnalysis.SyntaxToken(Nothing, token, position:=0, index:=0)
+            Return New CodeAnalysis.SyntaxToken(Nothing, token, position:=0, index:=0)
         End Operator
 
         Public Overrides Function IsEquivalentTo(other As GreenNode) As Boolean
@@ -481,16 +481,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return False
             End If
 
-            If Me.HasLeadingTrivia <> otherToken.HasLeadingTrivia OrElse
-               Me.HasTrailingTrivia <> otherToken.HasTrailingTrivia Then
+            If (HasLeadingTrivia <> otherToken.HasLeadingTrivia) OrElse
+               (HasTrailingTrivia <> otherToken.HasTrailingTrivia) Then
                 Return False
             End If
 
-            If Me.HasLeadingTrivia AndAlso Not Me.GetLeadingTrivia().IsEquivalentTo(otherToken.GetLeadingTrivia()) Then
+            If HasLeadingTrivia AndAlso Not GetLeadingTrivia().IsEquivalentTo(otherToken.GetLeadingTrivia()) Then
                 Return False
             End If
 
-            If Me.HasTrailingTrivia AndAlso Not Me.GetTrailingTrivia().IsEquivalentTo(otherToken.GetTrailingTrivia()) Then
+            If HasTrailingTrivia AndAlso Not GetTrailingTrivia().IsEquivalentTo(otherToken.GetTrailingTrivia()) Then
                 Return False
             End If
 
@@ -505,7 +505,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Partial Class XmlTextTokenSyntax
         Friend NotOverridable Overrides ReadOnly Property ValueText As String
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
     End Class
@@ -513,7 +513,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Partial Class InterpolatedStringTextTokenSyntax
         Friend NotOverridable Overrides ReadOnly Property ValueText As String
             Get
-                Return Me.Value
+                Return Value
             End Get
         End Property
     End Class
@@ -522,7 +522,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend NotOverridable Overrides ReadOnly Property ObjectValue As Object
             Get
-                Select Case MyBase.Kind
+                Select Case Kind
                     Case SyntaxKind.NothingKeyword
                         Return Nothing
                     Case SyntaxKind.TrueKeyword

--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxTrivia.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/SyntaxTrivia.vb
@@ -16,32 +16,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Sub New(kind As SyntaxKind, errors As DiagnosticInfo(), annotations As SyntaxAnnotation(), text As String)
             MyBase.New(kind, errors, annotations, text.Length)
-            Me._text = text
+            _text = text
             If text.Length > 0 Then
-                Me.SetFlags(NodeFlags.IsNotMissing)
+                SetFlags(NodeFlags.IsNotMissing)
             End If
         End Sub
 
         Friend Sub New(kind As SyntaxKind, text As String, context As ISyntaxFactoryContext)
             Me.New(kind, text)
-            Me.SetFactoryContext(context)
+            SetFactoryContext(context)
         End Sub
 
         Friend Sub New(kind As SyntaxKind, text As String)
             MyBase.New(kind, text.Length)
-            Me._text = text
+            _text = text
             If text.Length > 0 Then
-                Me.SetFlags(NodeFlags.IsNotMissing)
+                SetFlags(NodeFlags.IsNotMissing)
             End If
         End Sub
 
         Friend Sub New(reader As ObjectReader)
             MyBase.New(reader)
 
-            Me._text = reader.ReadString()
-            Me.FullWidth = Me._text.Length
+            _text = reader.ReadString()
+            FullWidth = _text.Length
             If Text.Length > 0 Then
-                Me.SetFlags(NodeFlags.IsNotMissing)
+                SetFlags(NodeFlags.IsNotMissing)
             End If
         End Sub
 
@@ -51,12 +51,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Friend Overrides Sub WriteTo(writer As ObjectWriter)
             MyBase.WriteTo(writer)
-            writer.WriteString(Me._text)
+            writer.WriteString(_text)
         End Sub
 
         Friend ReadOnly Property Text As String
             Get
-                Return Me._text
+                Return _text
             End Get
         End Property
 
@@ -85,16 +85,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Sub
 
         Public NotOverridable Overrides Function ToFullString() As String
-            Return Me._text
+            Return _text
         End Function
 
         Public Overrides Function ToString() As String
-            Return Me._text
+            Return _text
         End Function
 
         Friend NotOverridable Overrides Sub AddSyntaxErrors(accumulatedErrors As List(Of DiagnosticInfo))
-            If Me.GetDiagnostics IsNot Nothing Then
-                accumulatedErrors.AddRange(Me.GetDiagnostics)
+            If GetDiagnostics() IsNot Nothing Then
+                accumulatedErrors.AddRange(GetDiagnostics)
             End If
         End Sub
 
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Public Shared Narrowing Operator CType(trivia As SyntaxTrivia) As Microsoft.CodeAnalysis.SyntaxTrivia
-            Return New Microsoft.CodeAnalysis.SyntaxTrivia(Nothing, trivia, position:=0, index:=0)
+            Return New CodeAnalysis.SyntaxTrivia(Nothing, trivia, position:=0, index:=0)
         End Operator
 
         Public Overrides Function IsEquivalentTo(other As GreenNode) As Boolean
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             End If
 
             Dim otherTrivia = DirectCast(other, SyntaxTrivia)
-            Return String.Equals(Me.Text, otherTrivia.Text, StringComparison.Ordinal)
+            Return String.Equals(Text, otherTrivia.Text, StringComparison.Ordinal)
         End Function
 
         Friend Overrides Function CreateRed(parent As SyntaxNode, position As Integer) As SyntaxNode

--- a/src/Compilers/VisualBasic/Portable/Syntax/SeparatedSyntaxListBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SeparatedSyntaxListBuilder.vb
@@ -19,23 +19,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Sub
 
         Friend Sub New(builder As SyntaxListBuilder)
-            Me._builder = builder
+            _builder = builder
         End Sub
 
         Public ReadOnly Property IsNull As Boolean
             Get
-                Return (Me._builder Is Nothing)
+                Return (_builder Is Nothing)
             End Get
         End Property
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._builder.Count
+                Return _builder.Count
             End Get
         End Property
 
         Public Sub Clear()
-            Me._builder.Clear()
+            _builder.Clear()
         End Sub
 
         Public Sub Add(node As TNode)
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 Throw New InvalidOperationException("separator is expected")
             End If
             _expectSeparator = True
-            Me._builder.Add(DirectCast(DirectCast(node, SyntaxNode), VisualBasicSyntaxNode))
+            _builder.Add(DirectCast(DirectCast(node, SyntaxNode), VisualBasicSyntaxNode))
         End Sub
 
         Friend Sub AddSeparator(separatorToken As InternalSyntax.SyntaxToken)
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 Throw New InvalidOperationException("element is expected")
             End If
             _expectSeparator = False
-            Me._builder.AddInternal(separatorToken)
+            _builder.AddInternal(separatorToken)
         End Sub
 
         Public Sub AddSeparator(separatorToken As SyntaxToken)
@@ -63,8 +63,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 Throw New InvalidOperationException("separator is expected")
             End If
             Dim list = nodes.GetWithSeparators
-            Me._builder.AddRange(list)
-            _expectSeparator = ((Me._builder.Count And 1) <> 0)
+            _builder.AddRange(list)
+            _expectSeparator = ((_builder.Count And 1) <> 0)
         End Sub
 
         Friend Sub AddRange(nodes As SeparatedSyntaxList(Of TNode), count As Integer)
@@ -72,16 +72,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 Throw New InvalidOperationException("separator is expected")
             End If
             Dim list = nodes.GetWithSeparators
-            Me._builder.AddRange(list, Me.Count, Math.Min(count * 2, list.Count))
-            _expectSeparator = ((Me._builder.Count And 1) <> 0)
+            _builder.AddRange(list, Me.Count, Math.Min(count * 2, list.Count))
+            _expectSeparator = ((_builder.Count And 1) <> 0)
         End Sub
 
         Friend Sub RemoveLast()
-            Me._builder.RemoveLast()
+            _builder.RemoveLast()
         End Sub
 
         Public Function Any(kind As SyntaxKind) As Boolean
-            Return Me._builder.Any(kind)
+            Return _builder.Any(kind)
         End Function
 
         Public Function ToList() As SeparatedSyntaxList(Of TNode)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxExtensions.vb
@@ -49,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Returns the TypeSyntax of the given NewExpressionSyntax if specified.
         ''' </summary>
-        <Extension()> _
+        <Extension()>
         Public Function Type(newExpressionSyntax As NewExpressionSyntax) As TypeSyntax
             Select Case newExpressionSyntax.Kind
                 Case SyntaxKind.ObjectCreationExpression
@@ -66,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Returns the TypeSyntax of the given AsClauseSyntax if specified.
         ''' </summary>
-        <Extension()> _
+        <Extension()>
         Public Function Type(asClauseSyntax As AsClauseSyntax) As TypeSyntax
             Select Case asClauseSyntax.Kind
                 Case SyntaxKind.SimpleAsClause
@@ -81,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Returns the AttributeBlockSyntax of the given AsClauseSyntax if specified.
         ''' </summary>
-        <Extension()> _
+        <Extension()>
         Public Function Attributes(asClauseSyntax As AsClauseSyntax) As SyntaxList(Of AttributeListSyntax)
             Select Case asClauseSyntax.Kind
                 Case SyntaxKind.SimpleAsClause
@@ -102,9 +102,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The given simple name updated with the given identifier.</returns>
         <Extension>
         Public Function WithIdentifier(simpleName As SimpleNameSyntax, identifier As SyntaxToken) As SimpleNameSyntax
-            Return If(simpleName.Kind = SyntaxKind.IdentifierName,
-                      DirectCast(DirectCast(simpleName, IdentifierNameSyntax).WithIdentifier(identifier), SimpleNameSyntax),
-                      DirectCast(DirectCast(simpleName, GenericNameSyntax).WithIdentifier(identifier), SimpleNameSyntax))
+            If simpleName.Kind = SyntaxKind.IdentifierName Then
+                Return DirectCast(simpleName, IdentifierNameSyntax).WithIdentifier(identifier)
+            Else
+                Return DirectCast(simpleName, GenericNameSyntax).WithIdentifier(identifier)
+            End If
         End Function
     End Module
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -414,16 +414,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function TypeBlock(ByVal blockKind As SyntaxKind, ByVal begin As TypeStatementSyntax, Optional ByVal [inherits] As SyntaxList(Of InheritsStatementSyntax) = Nothing, Optional ByVal [implements] As SyntaxList(Of ImplementsStatementSyntax) = Nothing, Optional ByVal members As SyntaxList(Of StatementSyntax) = Nothing, Optional ByVal [end] As EndBlockStatementSyntax = Nothing) As TypeBlockSyntax
             Select Case blockKind
                 Case SyntaxKind.ModuleBlock
-                    Return SyntaxFactory.ModuleBlock(DirectCast(begin, ModuleStatementSyntax), [inherits], [implements], members, [end])
+                    Return ModuleBlock(DirectCast(begin, ModuleStatementSyntax), [inherits], [implements], members, [end])
 
                 Case SyntaxKind.ClassBlock
-                    Return SyntaxFactory.ClassBlock(DirectCast(begin, ClassStatementSyntax), [inherits], [implements], members, [end])
+                    Return ClassBlock(DirectCast(begin, ClassStatementSyntax), [inherits], [implements], members, [end])
 
                 Case SyntaxKind.StructureBlock
-                    Return SyntaxFactory.StructureBlock(DirectCast(begin, StructureStatementSyntax), [inherits], [implements], members, [end])
+                    Return StructureBlock(DirectCast(begin, StructureStatementSyntax), [inherits], [implements], members, [end])
 
                 Case SyntaxKind.InterfaceBlock
-                    Return SyntaxFactory.InterfaceBlock(DirectCast(begin, InterfaceStatementSyntax), [inherits], [implements], members, [end])
+                    Return InterfaceBlock(DirectCast(begin, InterfaceStatementSyntax), [inherits], [implements], members, [end])
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(blockKind)
@@ -433,16 +433,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function TypeStatement(ByVal statementKind As SyntaxKind, Optional ByVal attributes As SyntaxList(Of AttributeListSyntax) = Nothing, Optional ByVal modifiers As SyntaxTokenList = Nothing, Optional ByVal keyword As SyntaxToken = Nothing, Optional ByVal identifier As SyntaxToken = Nothing, Optional ByVal typeParameterList As TypeParameterListSyntax = Nothing) As TypeStatementSyntax
             Select Case statementKind
                 Case SyntaxKind.ModuleStatement
-                    Return SyntaxFactory.ModuleStatement(attributes, modifiers, keyword, identifier, typeParameterList)
+                    Return ModuleStatement(attributes, modifiers, keyword, identifier, typeParameterList)
 
                 Case SyntaxKind.ClassStatement
-                    Return SyntaxFactory.ClassStatement(attributes, modifiers, keyword, identifier, typeParameterList)
+                    Return ClassStatement(attributes, modifiers, keyword, identifier, typeParameterList)
 
                 Case SyntaxKind.StructureStatement
-                    Return SyntaxFactory.StructureStatement(attributes, modifiers, keyword, identifier, typeParameterList)
+                    Return StructureStatement(attributes, modifiers, keyword, identifier, typeParameterList)
 
                 Case SyntaxKind.InterfaceStatement
-                    Return SyntaxFactory.InterfaceStatement(attributes, modifiers, keyword, identifier, typeParameterList)
+                    Return InterfaceStatement(attributes, modifiers, keyword, identifier, typeParameterList)
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(statementKind)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
@@ -224,10 +224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Determines if possibleLambda is a lambda expression and position is in the interior.
         ''' </summary>
-        Friend Shared Function InLambdaInterior(
-            possibleLambda As SyntaxNode,
-            position As Integer
-        ) As Boolean
+        Friend Shared Function InLambdaInterior(possibleLambda As SyntaxNode, position As Integer) As Boolean
 
             Dim afterBegin As Boolean
             Dim beforeEnd As Boolean

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.vb
@@ -1,15 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
     Friend Partial Class SyntaxList
         Friend Class SeparatedWithManyChildren
@@ -19,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Friend Sub New(green As InternalSyntax.SyntaxList, parent As SyntaxNode, position As Integer)
                 MyBase.New(green, parent, position)
-                Me._children = New ArrayElement(Of SyntaxNode)(((green.SlotCount + 1) >> 1) - 1) {}
+                _children = New ArrayElement(Of SyntaxNode)(((green.SlotCount + 1) >> 1) - 1) {}
             End Sub
 
             Friend Overrides Function GetNodeSlot(i As Integer) As SyntaxNode
@@ -28,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                     Return Nothing
                 End If
 
-                Return GetRedElement(Me._children(i >> 1).Value, i)
+                Return GetRedElement(_children(i >> 1).Value, i)
             End Function
 
             Friend Overrides Function GetCachedSlot(i As Integer) As SyntaxNode
@@ -37,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                     Return Nothing
                 End If
 
-                Return TryCast(Me._children(i >> 1).Value, VisualBasicSyntaxNode)
+                Return TryCast(_children(i >> 1).Value, VisualBasicSyntaxNode)
             End Function
 
             Public Overrides Function Accept(Of TResult)(visitor As VisualBasicSyntaxVisitor(Of TResult)) As TResult

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WeakSeparatedWithManyChildren.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WeakSeparatedWithManyChildren.vb
@@ -1,15 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
     Friend Partial Class SyntaxList
         Friend Class WeakSeparatedWithManyChildren
@@ -19,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Friend Sub New(green As InternalSyntax.SyntaxList, parent As SyntaxNode, position As Integer)
                 MyBase.New(green, parent, position)
-                Me._children = New ArrayElement(Of WeakReference(Of SyntaxNode))(((green.SlotCount + 1) >> 1) - 1) {}
+                _children = New ArrayElement(Of WeakReference(Of SyntaxNode))(((green.SlotCount + 1) >> 1) - 1) {}
             End Sub
 
             Friend Overrides Function GetNodeSlot(i As Integer) As SyntaxNode
@@ -27,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
                 If (i And 1) = 0 Then
                     'not a separator
-                    result = GetWeakRedElement(Me._children(i >> 1).Value, i)
+                    result = GetWeakRedElement(_children(i >> 1).Value, i)
                 End If
 
                 Return result
@@ -38,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
                 If (i And 1) = 0 Then
                     'not a separator
-                    Dim weak = Me._children(i >> 1).Value
+                    Dim weak = _children(i >> 1).Value
                     If weak IsNot Nothing Then
                         weak.TryGetTarget(result)
                     End If

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WeakWithManyChildren.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WeakWithManyChildren.vb
@@ -1,18 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
-    Friend Partial Class SyntaxList
+    Partial Friend Class SyntaxList
 
         Friend Class WeakWithManyChildren
             Inherits SyntaxList
@@ -21,17 +11,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Friend Sub New(green As InternalSyntax.SyntaxList, parent As SyntaxNode, position As Integer)
                 MyBase.New(green, parent, position)
-                Me._children = New ArrayElement(Of WeakReference(Of SyntaxNode))(green.SlotCount - 1) {}
+                _children = New ArrayElement(Of WeakReference(Of SyntaxNode))(green.SlotCount - 1) {}
             End Sub
 
             Friend Overrides Function GetNodeSlot(index As Integer) As SyntaxNode
-                Return GetWeakRedElement(Me._children(index).Value, index)
+                Return GetWeakRedElement(_children(index).Value, index)
             End Function
 
             Friend Overrides Function GetCachedSlot(i As Integer) As SyntaxNode
                 Dim result As SyntaxNode = Nothing
 
-                Dim weak = Me._children(i).Value
+                Dim weak = _children(i).Value
                 If weak IsNot Nothing Then
                     weak.TryGetTarget(result)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WithManyChildren.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WithManyChildren.vb
@@ -1,15 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
     Friend Partial Class SyntaxList
@@ -21,15 +11,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Friend Sub New(green As InternalSyntax.SyntaxList, parent As SyntaxNode, position As Integer)
                 MyBase.New(green, parent, position)
-                Me._children = New ArrayElement(Of SyntaxNode)(green.SlotCount - 1) {}
+                _children = New ArrayElement(Of SyntaxNode)(green.SlotCount - 1) {}
             End Sub
 
             Friend Overrides Function GetNodeSlot(index As Integer) As SyntaxNode
-                Return GetRedElement(Me._children(index).Value, index)
+                Return GetRedElement(_children(index).Value, index)
             End Function
 
             Friend Overrides Function GetCachedSlot(i As Integer) As SyntaxNode
-                Return TryCast(Me._children(i).Value, VisualBasicSyntaxNode)
+                Return TryCast(_children(i).Value, VisualBasicSyntaxNode)
             End Function
         End Class
     End Class

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WithThreeChildren.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WithThreeChildren.vb
@@ -1,18 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
-    Friend Partial Class SyntaxList
+    Partial Friend Class SyntaxList
 
         Friend Class WithThreeChildren
             Inherits SyntaxList
@@ -28,11 +18,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Friend Overrides Function GetNodeSlot(index As Integer) As SyntaxNode
                 Select Case index
                     Case 0
-                        Return GetRedElement(Me._child0, 0)
+                        Return GetRedElement(_child0, 0)
                     Case 1
-                        Return GetRedElementIfNotToken(Me._child1)
+                        Return GetRedElementIfNotToken(_child1)
                     Case 2
-                        Return GetRedElement(Me._child2, 2)
+                        Return GetRedElement(_child2, 2)
                 End Select
                 Return Nothing
             End Function
@@ -40,11 +30,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Friend Overrides Function GetCachedSlot(i As Integer) As SyntaxNode
                 Select Case i
                     Case 0
-                        Return TryCast(Me._child0, VisualBasicSyntaxNode)
+                        Return TryCast(_child0, VisualBasicSyntaxNode)
                     Case 1
-                        Return TryCast(Me._child1, VisualBasicSyntaxNode)
+                        Return TryCast(_child1, VisualBasicSyntaxNode)
                     Case 2
-                        Return TryCast(Me._child2, VisualBasicSyntaxNode)
+                        Return TryCast(_child2, VisualBasicSyntaxNode)
                     Case Else
                         Return Nothing
                 End Select

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WithTwoChildren.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.WithTwoChildren.vb
@@ -1,15 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
     Friend Partial Class SyntaxList
@@ -27,9 +17,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Friend Overrides Function GetNodeSlot(index As Integer) As SyntaxNode
                 Select Case index
                     Case 0
-                        Return GetRedElement(Me._child0, 0)
+                        Return GetRedElement(_child0, 0)
                     Case 1
-                        Return GetRedElementIfNotToken(Me._child1)
+                        Return GetRedElementIfNotToken(_child1)
                 End Select
                 Return Nothing
             End Function

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxList.vb
@@ -1,15 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections
-Imports System.Collections.Generic
-Imports System.Linq
-Imports System.Runtime.CompilerServices
-Imports System.Text
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
     Partial Friend MustInherit Class SyntaxList
@@ -33,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         Private _nodes As ArrayElement(Of GreenNode)()
 
         Friend Sub New(size As Integer)
-            Me._nodes = New ArrayElement(Of GreenNode)(size - 1) {}
+            _nodes = New ArrayElement(Of GreenNode)(size - 1) {}
         End Sub
 
         Friend Function Add(item As SyntaxNode) As SyntaxListBuilder
@@ -42,93 +32,93 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
         Friend Function AddInternal(item As GreenNode) As SyntaxListBuilder
             Debug.Assert(item IsNot Nothing)
-            If Me._count >= Me._nodes.Length Then
-                Me.Grow(Math.Max(8, Me._nodes.Length * 2))
+            If _count >= _nodes.Length Then
+                Grow(Math.Max(8, _nodes.Length * 2))
             End If
-            Me._nodes(Me._count).Value = item
-            Me._count += 1
+            _nodes(_count).Value = item
+            _count += 1
             Return Me
         End Function
 
         Friend Function AddRange(Of TNode As SyntaxNode)(list As SyntaxList(Of TNode)) As SyntaxListBuilder
-            Return Me.AddRange(Of TNode)(list, 0, list.Count)
+            Return AddRange(Of TNode)(list, 0, list.Count)
         End Function
 
         Friend Function AddRange(items As SyntaxNode()) As SyntaxListBuilder
-            Return Me.AddRange(items, 0, items.Length)
+            Return AddRange(items, 0, items.Length)
         End Function
 
         Friend Function AddRange(list As SyntaxList(Of SyntaxNode)) As SyntaxListBuilder
-            Return Me.AddRange(list, 0, list.Count)
+            Return AddRange(list, 0, list.Count)
         End Function
 
         Friend Function AddRange(list As SyntaxNodeOrTokenList) As SyntaxListBuilder
-            Return Me.AddRange(list, 0, list.Count)
+            Return AddRange(list, 0, list.Count)
         End Function
 
         Friend Function AddRange(list As SyntaxList(Of SyntaxNode), offset As Integer, length As Integer) As SyntaxListBuilder
-            If (Me._count + length) > Me._nodes.Length Then
-                Me.Grow(Me._count + length)
+            If (_count + length) > _nodes.Length Then
+                Grow(_count + length)
             End If
 
             Dim dst = _count
             For i = offset To offset + length - 1
-                Me._nodes(dst).Value = list.ItemInternal(i).Green
+                _nodes(dst).Value = list.ItemInternal(i).Green
                 dst += 1
             Next i
 
-            Dim start As Integer = Me._count
-            Me._count = (Me._count + length)
-            Me.Validate(start, Me._count)
+            Dim start As Integer = _count
+            _count += length
+            Validate(start, _count)
             Return Me
         End Function
 
         Friend Function AddRange(items As SyntaxNode(), offset As Integer, length As Integer) As SyntaxListBuilder
-            If (Me._count + length) > Me._nodes.Length Then
-                Me.Grow(Me._count + length)
+            If (_count + length) > _nodes.Length Then
+                Grow(_count + length)
             End If
 
             Dim dst = _count
             For i = offset To offset + length - 1
-                Me._nodes(dst).Value = items(i).Green
+                _nodes(dst).Value = items(i).Green
                 dst += 1
             Next i
 
-            Dim start As Integer = Me._count
-            Me._count = start + length
-            Me.Validate(start, Me._count)
+            Dim start As Integer = _count
+            _count = start + length
+            Validate(start, _count)
             Return Me
         End Function
 
         Friend Function AddRange(Of TNode As SyntaxNode)(list As SyntaxList(Of TNode), offset As Integer, length As Integer) As SyntaxListBuilder
-            Return Me.AddRange(New SyntaxList(Of SyntaxNode)(list.Node), offset, length)
+            Return AddRange(New SyntaxList(Of SyntaxNode)(list.Node), offset, length)
         End Function
 
         Friend Function AddRange(list As SyntaxNodeOrTokenList, offset As Integer, length As Integer) As SyntaxListBuilder
-            If (Me._count + length) > Me._nodes.Length Then
-                Me.Grow(Me._count + length)
+            If (_count + length) > _nodes.Length Then
+                Grow(_count + length)
             End If
 
             Dim dst = _count
             For i = offset To offset + length - 1
-                Me._nodes(dst).Value = list(i).UnderlyingNode
+                _nodes(dst).Value = list(i).UnderlyingNode
                 dst += 1
             Next i
 
-            Dim start As Integer = Me._count
-            Me._count = start + length
-            Me.Validate(start, Me._count)
+            Dim start As Integer = _count
+            _count = start + length
+            Validate(start, _count)
             Return Me
         End Function
 
         Friend Function AddRange(list As SyntaxTokenList, offset As Integer, length As Integer) As SyntaxListBuilder
-            Return Me.AddRange(New SyntaxList(Of SyntaxNode)(list.Node.CreateRed), offset, length)
+            Return AddRange(New SyntaxList(Of SyntaxNode)(list.Node.CreateRed), offset, length)
         End Function
 
         Friend Function Any(kind As SyntaxKind) As Boolean
             Dim i As Integer
-            For i = 0 To Me._count - 1
-                If (Me._nodes(i).Value.RawKind = kind) Then
+            For i = 0 To _count - 1
+                If (_nodes(i).Value.RawKind = kind) Then
                     Return True
                 End If
             Next i
@@ -136,37 +126,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Function
 
         Friend Sub RemoveLast()
-            Me._count -= 1
-            Me._nodes(_count) = Nothing
+            _count -= 1
+            _nodes(_count) = Nothing
         End Sub
 
         Friend Sub Clear()
-            Me._count = 0
+            _count = 0
         End Sub
 
         Private Sub Grow(size As Integer)
-            Array.Resize(Me._nodes, size)
+            Array.Resize(_nodes, size)
         End Sub
 
         Friend Function ToGreenArray() As ArrayElement(Of InternalSyntax.VisualBasicSyntaxNode)()
-            Dim array = New ArrayElement(Of InternalSyntax.VisualBasicSyntaxNode)(Me._count - 1) {}
+            Dim array = New ArrayElement(Of InternalSyntax.VisualBasicSyntaxNode)(_count - 1) {}
             Dim i As Integer
             For i = 0 To array.Length - 1
-                array(i).Value = DirectCast(Me._nodes(i).Value, InternalSyntax.VisualBasicSyntaxNode)
+                array(i).Value = DirectCast(_nodes(i).Value, InternalSyntax.VisualBasicSyntaxNode)
             Next i
             Return array
         End Function
 
         Friend Function ToListNode() As GreenNode
-            Select Case Me._count
+            Select Case _count
                 Case 0
                     Return Nothing
                 Case 1
-                    Return DirectCast(Me._nodes(0).Value, InternalSyntax.VisualBasicSyntaxNode)
+                    Return DirectCast(_nodes(0).Value, InternalSyntax.VisualBasicSyntaxNode)
                 Case 2
-                    Return InternalSyntax.SyntaxList.List(DirectCast(Me._nodes(0).Value, InternalSyntax.VisualBasicSyntaxNode), DirectCast(Me._nodes(1).Value, InternalSyntax.VisualBasicSyntaxNode))
+                    Return InternalSyntax.SyntaxList.List(DirectCast(_nodes(0).Value, InternalSyntax.VisualBasicSyntaxNode), DirectCast(_nodes(1).Value, InternalSyntax.VisualBasicSyntaxNode))
                 Case 3
-                    Return InternalSyntax.SyntaxList.List(DirectCast(Me._nodes(0).Value, InternalSyntax.VisualBasicSyntaxNode), DirectCast(Me._nodes(1).Value, InternalSyntax.VisualBasicSyntaxNode), DirectCast(Me._nodes(2).Value, InternalSyntax.VisualBasicSyntaxNode))
+                    Return InternalSyntax.SyntaxList.List(DirectCast(_nodes(0).Value, InternalSyntax.VisualBasicSyntaxNode), DirectCast(_nodes(1).Value, InternalSyntax.VisualBasicSyntaxNode), DirectCast(_nodes(2).Value, InternalSyntax.VisualBasicSyntaxNode))
             End Select
             Return InternalSyntax.SyntaxList.List(Me.ToGreenArray)
         End Function
@@ -175,13 +165,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         Private Sub Validate(start As Integer, [end] As Integer)
             Dim i As Integer
             For i = start To [end] - 1
-                Debug.Assert(Me._nodes(i).Value IsNot Nothing)
+                Debug.Assert(_nodes(i).Value IsNot Nothing)
             Next i
         End Sub
 
         Friend ReadOnly Property Count As Integer
             Get
-                Return Me._count
+                Return _count
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxListBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxListBuilder.vb
@@ -24,51 +24,51 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Sub
 
         Friend Sub New(builder As SyntaxListBuilder)
-            Me._builder = builder
+            _builder = builder
         End Sub
 
         Public ReadOnly Property IsNull As Boolean
             Get
-                Return (Me._builder Is Nothing)
+                Return (_builder Is Nothing)
             End Get
         End Property
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._builder.Count
+                Return _builder.Count
             End Get
         End Property
 
         Public Sub Clear()
-            Me._builder.Clear()
+            _builder.Clear()
         End Sub
 
         Public Function Add(node As TNode) As SyntaxListBuilder(Of TNode)
-            Me._builder.Add(node)
+            _builder.Add(node)
             Return Me
         End Function
 
         Public Function AddRange(items As TNode(), offset As Integer, length As Integer) As SyntaxListBuilder(Of TNode)
-            Me._builder.AddRange(DirectCast(items, SyntaxNode()), offset, length)
+            _builder.AddRange(DirectCast(items, SyntaxNode()), offset, length)
             Return Me
         End Function
 
         Public Function AddRange(nodes As SyntaxList(Of TNode)) As SyntaxListBuilder(Of TNode)
-            Me._builder.AddRange(Of TNode)(nodes)
+            _builder.AddRange(Of TNode)(nodes)
             Return Me
         End Function
 
         Public Function AddRange(nodes As SyntaxList(Of TNode), offset As Integer, length As Integer) As SyntaxListBuilder(Of TNode)
-            Me._builder.AddRange(Of TNode)(nodes, offset, length)
+            _builder.AddRange(Of TNode)(nodes, offset, length)
             Return Me
         End Function
 
         Public Function Any(kind As SyntaxKind) As Boolean
-            Return Me._builder.Any(kind)
+            Return _builder.Any(kind)
         End Function
 
         Public Function ToList() As SyntaxList(Of TNode)
-            Return Me._builder.ToList(Of TNode)()
+            Return _builder.ToList(Of TNode)()
         End Function
 
         Public Shared Widening Operator CType(builder As SyntaxListBuilder(Of TNode)) As SyntaxList(Of TNode)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeFactories.vb
@@ -63,8 +63,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseLeadingTrivia(text As String, Optional offset As Integer = 0) As SyntaxTriviaList
-            Dim s = New InternalSyntax.Scanner(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
-            Using s
+            Using s As New InternalSyntax.Scanner(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 Return New SyntaxTriviaList(Nothing, s.ScanMultilineTrivia().Node, 0, 0)
             End Using
         End Function
@@ -75,8 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseTrailingTrivia(text As String, Optional offset As Integer = 0) As SyntaxTriviaList
-            Dim s = New InternalSyntax.Scanner(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
-            Using s
+            Using s As New InternalSyntax.Scanner(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 Return New SyntaxTriviaList(Nothing, s.ScanMultilineTrivia().Node, 0, 0)
             End Using
         End Function
@@ -88,8 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="offset">The starting offset in the string</param>
         ''' <param name="startStatement">Scan using rules for the start of a statement</param>
         Public Shared Function ParseToken(text As String, Optional offset As Integer = 0, Optional startStatement As Boolean = False) As SyntaxToken
-            Dim s = New InternalSyntax.Scanner(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
-            Using s
+            Using s As New InternalSyntax.Scanner(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 Dim state = If(startStatement,
                                InternalSyntax.ScannerState.VBAllowLeadingMultilineTrivia,
                                InternalSyntax.ScannerState.VB)
@@ -134,7 +131,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseName(text As String, Optional offset As Integer = 0, Optional consumeFullText As Boolean = True) As NameSyntax
-            Using p = New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
+            Using p As New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 p.GetNextToken()
                 ' "allow everything" arguments
                 Dim node = p.ParseName(
@@ -155,7 +152,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseTypeName(text As String, Optional offset As Integer = 0, Optional consumeFullText As Boolean = True) As TypeSyntax
-            Using p = New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
+            Using p As New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 p.GetNextToken()
                 Dim node = p.ParseGeneralType()
                 Return DirectCast(If(consumeFullText, p.ConsumeUnexpectedTokens(node), node).CreateRed(Nothing, 0), TypeSyntax)
@@ -168,7 +165,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseExpression(text As String, Optional offset As Integer = 0, Optional consumeFullText As Boolean = True) As ExpressionSyntax
-            Using p = New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
+            Using p As New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 p.GetNextToken()
                 Dim node = p.ParseExpression()
                 Return DirectCast(If(consumeFullText, p.ConsumeUnexpectedTokens(node), node).CreateRed(Nothing, 0), ExpressionSyntax)
@@ -193,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseCompilationUnit(text As String, Optional offset As Integer = 0, Optional options As VisualBasicParseOptions = Nothing) As CompilationUnitSyntax
-            Using p = New InternalSyntax.Parser(MakeSourceText(text, offset), If(options, VisualBasicParseOptions.Default))
+            Using p As New InternalSyntax.Parser(MakeSourceText(text, offset), If(options, VisualBasicParseOptions.Default))
                 Return DirectCast(p.ParseCompilationUnit().CreateRed(Nothing, 0), CompilationUnitSyntax)
             End Using
         End Function
@@ -204,7 +201,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseParameterList(text As String, Optional offset As Integer = 0, Optional consumeFullText As Boolean = True) As ParameterListSyntax
-            Using p = New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
+            Using p As New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 p.GetNextToken()
                 Dim node = p.ParseParameterList()
                 Return DirectCast(If(consumeFullText, p.ConsumeUnexpectedTokens(node), node).CreateRed(Nothing, 0), ParameterListSyntax)
@@ -217,7 +214,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="text">The input string</param>
         ''' <param name="offset">The starting offset in the string</param>
         Public Shared Function ParseArgumentList(text As String, Optional offset As Integer = 0, Optional consumeFullText As Boolean = True) As ArgumentListSyntax
-            Using p = New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
+            Using p As New InternalSyntax.Parser(MakeSourceText(text, offset), VisualBasicParseOptions.Default)
                 p.GetNextToken()
                 Dim node = p.ParseParenthesizedArguments()
                 Return DirectCast(If(consumeFullText, p.ConsumeUnexpectedTokens(node), node).CreateRed(Nothing, 0), ArgumentListSyntax)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeOrTokenListBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeOrTokenListBuilder.vb
@@ -14,32 +14,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Function
 
         Friend Sub New(size As Integer)
-            Me._nodes = New InternalSyntax.VisualBasicSyntaxNode(size - 1) {}
-            Me._count = 0
+            _nodes = New InternalSyntax.VisualBasicSyntaxNode(size - 1) {}
+            _count = 0
         End Sub
 
         Friend Sub Add(item As InternalSyntax.VisualBasicSyntaxNode)
-            If ((Me._nodes Is Nothing) OrElse (Me._count >= Me._nodes.Length)) Then
-                Me.Grow(If((Me._count = 0), 8, (Me._nodes.Length * 2)))
+            If ((_nodes Is Nothing) OrElse (_count >= _nodes.Length)) Then
+                Grow(If((_count = 0), 8, (_nodes.Length * 2)))
             End If
-            Me._nodes(Me._count) = item
-            Me._count += 1
+            _nodes(_count) = item
+            _count += 1
         End Sub
 
         Public Sub Add(item As SyntaxNodeOrToken)
-            Me.Add(DirectCast(item.UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode))
+            Add(DirectCast(item.UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode))
         End Sub
 
         Public Sub AddRange(list As SyntaxNodeOrTokenList)
-            Me.AddRange(list, 0, list.Count)
+            AddRange(list, 0, list.Count)
         End Sub
 
         Public Sub AddRange(list As SyntaxNodeOrTokenList, offset As Integer, length As Integer)
-            If ((Me._nodes Is Nothing) OrElse ((Me._count + length) > Me._nodes.Length)) Then
-                Me.Grow((Me._count + length))
+            If ((_nodes Is Nothing) OrElse ((_count + length) > _nodes.Length)) Then
+                Grow((_count + length))
             End If
-            list.CopyTo(offset, Me._nodes, Me._count, length)
-            Me._count = (Me._count + length)
+            list.CopyTo(offset, _nodes, _count, length)
+            _count += length
         End Sub
 
         Public Sub AddRange(list As IEnumerable(Of SyntaxNodeOrToken))
@@ -49,34 +49,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Sub
 
         Friend Sub RemoveLast()
-            Me._count -= 1
-            Me._nodes(_count) = Nothing
+            _count -= 1
+            _nodes(_count) = Nothing
         End Sub
 
         Public Sub Clear()
-            Me._count = 0
+            _count = 0
         End Sub
 
         Private Sub Grow(size As Integer)
             Dim tmp = New InternalSyntax.VisualBasicSyntaxNode(size - 1) {}
-            Array.Copy(Me._nodes, tmp, Me._nodes.Length)
-            Me._nodes = tmp
+            Array.Copy(_nodes, tmp, _nodes.Length)
+            _nodes = tmp
         End Sub
 
         Public Function ToList() As SyntaxNodeOrTokenList
-            If (Me._count > 0) Then
-                Select Case Me._count
+            If (_count > 0) Then
+                Select Case _count
                     Case 1
-                        Return New SyntaxNodeOrTokenList(Me._nodes(0).CreateRed(Nothing, 0), 0)
+                        Return New SyntaxNodeOrTokenList(_nodes(0).CreateRed(Nothing, 0), 0)
                     Case 2
-                        Return New SyntaxNodeOrTokenList(InternalSyntax.SyntaxList.List(Me._nodes(0), Me._nodes(1)).CreateRed(Nothing, 0), 0)
+                        Return New SyntaxNodeOrTokenList(InternalSyntax.SyntaxList.List(_nodes(0), _nodes(1)).CreateRed(Nothing, 0), 0)
                     Case 3
-                        Return New SyntaxNodeOrTokenList(InternalSyntax.SyntaxList.List(Me._nodes(0), Me._nodes(1), Me._nodes(2)).CreateRed(Nothing, 0), 0)
+                        Return New SyntaxNodeOrTokenList(InternalSyntax.SyntaxList.List(_nodes(0), _nodes(1), _nodes(2)).CreateRed(Nothing, 0), 0)
                 End Select
-                Dim tmp = New ArrayElement(Of InternalSyntax.VisualBasicSyntaxNode)(Me._count - 1) {}
+                Dim tmp = New ArrayElement(Of InternalSyntax.VisualBasicSyntaxNode)(_count - 1) {}
                 Dim i As Integer
-                For i = 0 To Me._count - 1
-                    tmp(i).Value = Me._nodes(i)
+                For i = 0 To _count - 1
+                    tmp(i).Value = _nodes(i)
                 Next i
                 Return New SyntaxNodeOrTokenList(InternalSyntax.SyntaxList.List(tmp).CreateRed(Nothing, 0), 0)
             End If
@@ -85,13 +85,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._count
+                Return _count
             End Get
         End Property
 
         Default Public Property Item(index As Integer) As SyntaxNodeOrToken
             Get
-                Dim innerNode = Me._nodes(index)
+                Dim innerNode = _nodes(index)
                 Dim tk = TryCast(innerNode, InternalSyntax.SyntaxToken)
                 If tk IsNot Nothing Then
                     ' getting internal token so we do not know the position
@@ -101,7 +101,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 End If
             End Get
             Set(value As SyntaxNodeOrToken)
-                Me._nodes(index) = DirectCast(value.UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)
+                _nodes(index) = DirectCast(value.UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)
             End Set
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodePartials.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodePartials.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
     Public Partial Class DocumentationCommentTriviaSyntax
         Friend Function GetInteriorXml() As String
             ' NOTE: is only used in parse tests
-            Return DirectCast(Me.Green, InternalSyntax.DocumentationCommentTriviaSyntax).GetInteriorXml
+            Return DirectCast(Green, InternalSyntax.DocumentationCommentTriviaSyntax).GetInteriorXml
         End Function
     End Class
 
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         Private Shared ReadOnly s_hasDirectivesFunction As Func(Of SyntaxToken, Boolean) = Function(n) n.ContainsDirectives
 
         Public Function GetNextDirective(Optional predicate As Func(Of DirectiveTriviaSyntax, Boolean) = Nothing) As DirectiveTriviaSyntax
-            Dim token = CType(MyBase.ParentTrivia.Token, SyntaxToken)
+            Dim token = MyBase.ParentTrivia.Token
 
             Dim [next] As Boolean = False
             Do While (token.Kind <> SyntaxKind.None)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeRemover.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeRemover.vb
@@ -40,10 +40,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Public Sub New(nodes As SyntaxNode(), options As SyntaxRemoveOptions)
                 MyBase.New(nodes.Any(Function(n) n.IsPartOfStructuredTrivia()))
-                Me._nodesToRemove = New HashSet(Of SyntaxNode)(nodes)
-                Me._options = options
-                Me._searchSpan = ComputeTotalSpan(nodes)
-                Me._residualTrivia = SyntaxTriviaListBuilder.Create()
+                _nodesToRemove = New HashSet(Of SyntaxNode)(nodes)
+                _options = options
+                _searchSpan = ComputeTotalSpan(nodes)
+                _residualTrivia = SyntaxTriviaListBuilder.Create()
             End Sub
 
             Private Shared Function ComputeTotalSpan(nodes As SyntaxNode()) As TextSpan
@@ -64,8 +64,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Friend ReadOnly Property ResidualTrivia As SyntaxTriviaList
                 Get
-                    If Me._residualTrivia IsNot Nothing Then
-                        Return Me._residualTrivia.ToList()
+                    If _residualTrivia IsNot Nothing Then
+                        Return _residualTrivia.ToList()
                     Else
                         Return Nothing
                     End If
@@ -77,12 +77,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                     AddEndOfLine()
                 End If
 
-                Me._residualTrivia.Add(trivia)
+                _residualTrivia.Add(trivia)
             End Sub
 
             Private Sub AddEndOfLine()
-                If Me._residualTrivia.Count = 0 OrElse Not IsEndOfLine(Me._residualTrivia(Me._residualTrivia.Count - 1)) Then
-                    Me._residualTrivia.Add(SyntaxFactory.CarriageReturnLineFeed)
+                If _residualTrivia.Count = 0 OrElse Not IsEndOfLine(_residualTrivia(_residualTrivia.Count - 1)) Then
+                    _residualTrivia.Add(SyntaxFactory.CarriageReturnLineFeed)
                 End If
             End Sub
             Private Shared Function IsEndOfLine(trivia As SyntaxTrivia) As Boolean
@@ -94,21 +94,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End Function
 
             Private Function IsForRemoval(node As SyntaxNode) As Boolean
-                Return Me._nodesToRemove.Contains(node)
+                Return _nodesToRemove.Contains(node)
             End Function
 
             Private Function ShouldVisit(node As SyntaxNode) As Boolean
-                Return node.FullSpan.IntersectsWith(Me._searchSpan) OrElse (Me._residualTrivia IsNot Nothing AndAlso Me._residualTrivia.Count > 0)
+                Return node.FullSpan.IntersectsWith(_searchSpan) OrElse (_residualTrivia IsNot Nothing AndAlso _residualTrivia.Count > 0)
             End Function
 
             Public Overrides Function Visit(node As SyntaxNode) As SyntaxNode
                 Dim result = node
 
                 If node IsNot Nothing Then
-                    If Me.IsForRemoval(node) Then
-                        Me.AddTrivia(node)
+                    If IsForRemoval(node) Then
+                        AddTrivia(node)
                         result = Nothing
-                    ElseIf Me.ShouldVisit(node) Then
+                    ElseIf ShouldVisit(node) Then
                         result = MyBase.Visit(node)
                     End If
                 End If
@@ -119,15 +119,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Public Overrides Function VisitToken(token As SyntaxToken) As SyntaxToken
                 Dim result = token
 
-                If Me.VisitIntoStructuredTrivia Then ' only bother visiting trivia if we are removing a node in structured trivia
+                If VisitIntoStructuredTrivia Then ' only bother visiting trivia if we are removing a node in structured trivia
                     result = MyBase.VisitToken(token)
                 End If
 
                 ' the next token gets the accrued trivia.
-                If result.Kind <> SyntaxKind.None AndAlso Me._residualTrivia IsNot Nothing AndAlso Me._residualTrivia.Count > 0 Then
-                    Me._residualTrivia.Add(result.LeadingTrivia)
-                    result = result.WithLeadingTrivia(Me._residualTrivia.ToList())
-                    Me._residualTrivia.Clear()
+                If result.Kind <> SyntaxKind.None AndAlso _residualTrivia IsNot Nothing AndAlso _residualTrivia.Count > 0 Then
+                    _residualTrivia.Add(result.LeadingTrivia)
+                    result = result.WithLeadingTrivia(_residualTrivia.ToList())
+                    _residualTrivia.Clear()
                 End If
 
                 Return result
@@ -155,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                     Else
                         Dim node = DirectCast(DirectCast(item.AsNode(), SyntaxNode), TNode)
 
-                        If Me.IsForRemoval(node) Then
+                        If IsForRemoval(node) Then
                             If alternate Is Nothing Then
                                 alternate = New SyntaxNodeOrTokenListBuilder(n)
                                 alternate.AddRange(withSeps, 0, i)
@@ -164,20 +164,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                             If alternate.Count > 0 AndAlso alternate(alternate.Count - 1).IsToken Then
                                 ' remove preceding separator if any
                                 Dim separator = alternate(alternate.Count - 1).AsToken()
-                                Me.AddTrivia(separator, node)
+                                AddTrivia(separator, node)
                                 alternate.RemoveLast()
                             ElseIf i + 1 < n AndAlso withSeps(i + 1).IsToken Then
                                 ' otherwise remove trailing separator if any
                                 Dim separator = withSeps(i + 1).AsToken()
-                                Me.AddTrivia(node, separator)
+                                AddTrivia(node, separator)
                                 removeNextSeparator = True
                             Else
-                                Me.AddTrivia(node)
+                                AddTrivia(node)
                             End If
 
                             visited = Nothing
                         Else
-                            visited = Me.VisitListElement(node)
+                            visited = VisitListElement(node)
                         End If
                     End If
 
@@ -199,87 +199,87 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End Function
 
             Private Sub AddTrivia(node As SyntaxNode)
-                If (Me._options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
-                    Me.AddResidualTrivia(node.GetLeadingTrivia())
-                ElseIf (Me._options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetLeadingTrivia()) Then
-                    Me.AddEndOfLine()
+                If (_options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
+                    AddResidualTrivia(node.GetLeadingTrivia())
+                ElseIf (_options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetLeadingTrivia()) Then
+                    AddEndOfLine()
                 End If
 
-                If (Me._options And (SyntaxRemoveOptions.KeepDirectives Or SyntaxRemoveOptions.KeepUnbalancedDirectives)) <> 0 Then
-                    Me.AddDirectives(node, GetRemovedSpan(node.Span, node.FullSpan))
+                If (_options And (SyntaxRemoveOptions.KeepDirectives Or SyntaxRemoveOptions.KeepUnbalancedDirectives)) <> 0 Then
+                    AddDirectives(node, GetRemovedSpan(node.Span, node.FullSpan))
                 End If
 
-                If (Me._options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
-                    Me.AddResidualTrivia(node.GetTrailingTrivia())
-                ElseIf (Me._options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetTrailingTrivia()) Then
-                    Me.AddEndOfLine()
+                If (_options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
+                    AddResidualTrivia(node.GetTrailingTrivia())
+                ElseIf (_options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetTrailingTrivia()) Then
+                    AddEndOfLine()
                 End If
 
-                If (Me._options And SyntaxRemoveOptions.AddElasticMarker) <> 0 Then
-                    Me.AddResidualTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
+                If (_options And SyntaxRemoveOptions.AddElasticMarker) <> 0 Then
+                    AddResidualTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
                 End If
             End Sub
 
             Private Sub AddTrivia(token As SyntaxToken, node As SyntaxNode)
-                If (Me._options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
-                    Me.AddResidualTrivia(token.LeadingTrivia)
-                    Me.AddResidualTrivia(token.TrailingTrivia)
-                    Me.AddResidualTrivia(node.GetLeadingTrivia())
-                ElseIf (Me._options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso
+                If (_options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
+                    AddResidualTrivia(token.LeadingTrivia)
+                    AddResidualTrivia(token.TrailingTrivia)
+                    AddResidualTrivia(node.GetLeadingTrivia())
+                ElseIf (_options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso
                     (HasEndOfLine(token.LeadingTrivia) OrElse HasEndOfLine(token.TrailingTrivia) OrElse HasEndOfLine(node.GetLeadingTrivia())) Then
-                    Me.AddEndOfLine()
+                    AddEndOfLine()
                 End If
 
-                If (Me._options And (SyntaxRemoveOptions.KeepDirectives Or SyntaxRemoveOptions.KeepUnbalancedDirectives)) <> 0 Then
+                If (_options And (SyntaxRemoveOptions.KeepDirectives Or SyntaxRemoveOptions.KeepUnbalancedDirectives)) <> 0 Then
                     Dim fullSpan = TextSpan.FromBounds(token.FullSpan.Start, node.FullSpan.End)
                     Dim span = TextSpan.FromBounds(token.Span.Start, node.Span.End)
-                    Me.AddDirectives(node.Parent, GetRemovedSpan(span, fullSpan))
+                    AddDirectives(node.Parent, GetRemovedSpan(span, fullSpan))
                 End If
 
-                If (Me._options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
-                    Me.AddResidualTrivia(node.GetTrailingTrivia())
-                ElseIf (Me._options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetTrailingTrivia()) Then
-                    Me.AddEndOfLine()
+                If (_options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
+                    AddResidualTrivia(node.GetTrailingTrivia())
+                ElseIf (_options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetTrailingTrivia()) Then
+                    AddEndOfLine()
                 End If
 
-                If (Me._options And SyntaxRemoveOptions.AddElasticMarker) <> 0 Then
-                    Me.AddResidualTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
+                If (_options And SyntaxRemoveOptions.AddElasticMarker) <> 0 Then
+                    AddResidualTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
                 End If
             End Sub
 
             Private Sub AddTrivia(node As SyntaxNode, token As SyntaxToken)
-                If (Me._options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
-                    Me.AddResidualTrivia(node.GetLeadingTrivia())
-                ElseIf (Me._options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetLeadingTrivia()) Then
-                    Me.AddEndOfLine()
+                If (_options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
+                    AddResidualTrivia(node.GetLeadingTrivia())
+                ElseIf (_options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso HasEndOfLine(node.GetLeadingTrivia()) Then
+                    AddEndOfLine()
                 End If
 
-                If (Me._options And (SyntaxRemoveOptions.KeepDirectives Or SyntaxRemoveOptions.KeepUnbalancedDirectives)) <> 0 Then
+                If (_options And (SyntaxRemoveOptions.KeepDirectives Or SyntaxRemoveOptions.KeepUnbalancedDirectives)) <> 0 Then
                     Dim fullSpan = TextSpan.FromBounds(node.FullSpan.Start, token.FullSpan.End)
                     Dim span = TextSpan.FromBounds(node.Span.Start, token.Span.End)
-                    Me.AddDirectives(node.Parent, GetRemovedSpan(span, fullSpan))
+                    AddDirectives(node.Parent, GetRemovedSpan(span, fullSpan))
                 End If
 
-                If (Me._options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
-                    Me.AddResidualTrivia(node.GetTrailingTrivia())
-                    Me.AddResidualTrivia(token.LeadingTrivia)
-                    Me.AddResidualTrivia(token.TrailingTrivia)
-                ElseIf (Me._options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso
+                If (_options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
+                    AddResidualTrivia(node.GetTrailingTrivia())
+                    AddResidualTrivia(token.LeadingTrivia)
+                    AddResidualTrivia(token.TrailingTrivia)
+                ElseIf (_options And SyntaxRemoveOptions.KeepEndOfLine) <> 0 AndAlso
                         (HasEndOfLine(node.GetTrailingTrivia()) OrElse HasEndOfLine(token.LeadingTrivia) OrElse HasEndOfLine(token.TrailingTrivia)) Then
-                    Me.AddEndOfLine()
+                    AddEndOfLine()
                 End If
 
-                If (Me._options And SyntaxRemoveOptions.AddElasticMarker) <> 0 Then
-                    Me.AddResidualTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
+                If (_options And SyntaxRemoveOptions.AddElasticMarker) <> 0 Then
+                    AddResidualTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
                 End If
             End Sub
 
             Private Function GetRemovedSpan(span As TextSpan, fullSpan As TextSpan) As TextSpan
                 Dim removedSpan = fullSpan
-                If (Me._options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
+                If (_options And SyntaxRemoveOptions.KeepLeadingTrivia) <> 0 Then
                     removedSpan = TextSpan.FromBounds(span.Start, removedSpan.End)
                 End If
-                If (Me._options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
+                If (_options And SyntaxRemoveOptions.KeepTrailingTrivia) <> 0 Then
                     removedSpan = TextSpan.FromBounds(removedSpan.Start, span.End)
                 End If
                 Return removedSpan
@@ -287,10 +287,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Private Sub AddDirectives(node As SyntaxNode, span As TextSpan)
                 If node.ContainsDirectives Then
-                    If Me._directivesToKeep Is Nothing Then
-                        Me._directivesToKeep = New HashSet(Of SyntaxNode)()
+                    If _directivesToKeep Is Nothing Then
+                        _directivesToKeep = New HashSet(Of SyntaxNode)()
                     Else
-                        Me._directivesToKeep.Clear()
+                        _directivesToKeep.Clear()
                     End If
 
                     Dim directivesInSpan = node.DescendantTrivia(span, Function(n) n.ContainsDirectives, descendIntoTrivia:=True) _
@@ -298,8 +298,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                                                 .Select(Function(tr) DirectCast(tr.GetStructure(), DirectiveTriviaSyntax))
 
                     For Each directive In directivesInSpan
-                        If (Me._options And SyntaxRemoveOptions.KeepDirectives) <> 0 Then
-                            Me._directivesToKeep.Add(directive)
+                        If (_options And SyntaxRemoveOptions.KeepDirectives) <> 0 Then
+                            _directivesToKeep.Add(directive)
                         ElseIf HasRelatedDirectives(directive) Then
                             ' a balanced directive with respect to a given node has all related directives rooted under that node
                             Dim relatedDirectives = directive.GetRelatedDirectives()
@@ -308,12 +308,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                             If Not balanced Then
                                 ' if not fully balanced, all related directives under the node are considered unbalanced.
                                 For Each unbalancedDirective In relatedDirectives.Where(Function(rd) rd.FullSpan.OverlapsWith(span))
-                                    Me._directivesToKeep.Add(unbalancedDirective)
+                                    _directivesToKeep.Add(unbalancedDirective)
                                 Next
                             End If
                         End If
 
-                        If Me._directivesToKeep.Contains(directive) Then
+                        If _directivesToKeep.Contains(directive) Then
                             AddResidualTrivia(SyntaxFactory.TriviaList(directive.ParentTrivia), requiresNewLine:=True)
                         End If
                     Next

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNormalizer.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNormalizer.vb
@@ -41,13 +41,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         Private Sub New(consideredSpan As TextSpan, indentWhitespace As String, eolWhitespace As String, useElasticTrivia As Boolean, useDefaultCasing As Boolean)
             MyBase.New(visitIntoStructuredTrivia:=True)
 
-            Me._consideredSpan = consideredSpan
-            Me._indentWhitespace = indentWhitespace
-            Me._useElasticTrivia = useElasticTrivia
-            Me._eolTrivia = If(useElasticTrivia, SyntaxFactory.ElasticEndOfLine(eolWhitespace), SyntaxFactory.EndOfLine(eolWhitespace))
-            Me._useDefaultCasing = useDefaultCasing
+            _consideredSpan = consideredSpan
+            _indentWhitespace = indentWhitespace
+            _useElasticTrivia = useElasticTrivia
+            _eolTrivia = If(useElasticTrivia, SyntaxFactory.ElasticEndOfLine(eolWhitespace), SyntaxFactory.EndOfLine(eolWhitespace))
+            _useDefaultCasing = useDefaultCasing
 
-            Me._afterLineBreak = True
+            _afterLineBreak = True
         End Sub
 
         Friend Shared Function Normalize(Of TNode As SyntaxNode)(node As TNode, indentWhitespace As String, eolWhitespace As String, useElasticTrivia As Boolean, useDefaultCasing As Boolean) As SyntaxNode
@@ -91,8 +91,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End If
 
             For i As Integer = _indentations.Count To count
-                Dim text As String = If(i = 0, "", _indentations(i - 1).ToString() + Me._indentWhitespace)
-                _indentations.Add(If(Me._useElasticTrivia, SyntaxFactory.ElasticWhitespace(text), SyntaxFactory.Whitespace(text)))
+                Dim text As String = If(i = 0, "", _indentations(i - 1).ToString() + _indentWhitespace)
+                _indentations.Add(If(_useElasticTrivia, SyntaxFactory.ElasticWhitespace(text), SyntaxFactory.Whitespace(text)))
             Next
 
             Return _indentations(count)
@@ -140,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
                 Dim nextToken As SyntaxToken = GetNextRelevantToken(token)
 
-                Me._afterIndentation = False
+                _afterIndentation = False
 
                 ' we only add one of the line breaks to trivia of this token. The remaining ones will be leading trivia 
                 ' for the next token
@@ -169,7 +169,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 Return newToken
 
             Finally
-                Me._previousToken = token
+                _previousToken = token
             End Try
 
             Return token
@@ -320,8 +320,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         ''' of these blocks (e.g. the if statement), it is a level less
         ''' </summary>
         Private Function GetIndentationDepth() As Integer
-            Debug.Assert(Me._indentationDepth >= 0)
-            Return Me._indentationDepth
+            Debug.Assert(_indentationDepth >= 0)
+            Return _indentationDepth
         End Function
 
         Private Function GetIndentationDepth(trivia As SyntaxTrivia) As Integer
@@ -333,7 +333,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Function
 
         Private Function GetSpace() As SyntaxTrivia
-            Return If(Me._useElasticTrivia, SyntaxFactory.ElasticSpace, SyntaxFactory.Space)
+            Return If(_useElasticTrivia, SyntaxFactory.ElasticSpace, SyntaxFactory.Space)
         End Function
 
         Private Function GetEndOfLine() As SyntaxTrivia
@@ -649,16 +649,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Function
 
         Private Overloads Function VisitStructuredTrivia(trivia As SyntaxTrivia) As SyntaxTrivia
-            Dim oldIsInStructuredTrivia As Boolean = Me._isInStructuredTrivia
-            Me._isInStructuredTrivia = True
+            Dim oldIsInStructuredTrivia As Boolean = _isInStructuredTrivia
+            _isInStructuredTrivia = True
 
-            Dim oldPreviousToken = Me._previousToken
-            Me._previousToken = Nothing
+            Dim oldPreviousToken = _previousToken
+            _previousToken = Nothing
 
             Dim result As SyntaxTrivia = VisitTrivia(trivia)
 
-            Me._isInStructuredTrivia = oldIsInStructuredTrivia
-            Me._previousToken = oldPreviousToken
+            _isInStructuredTrivia = oldIsInStructuredTrivia
+            _previousToken = oldPreviousToken
 
             Return result
         End Function
@@ -697,7 +697,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
         Private Sub AddLinebreaksAfterTokenIfNeeded(node As SyntaxToken, linebreaksAfterToken As Integer)
             If Not EndsWithColonSeparator(node) Then
-                Me._lineBreaksAfterToken(node) = linebreaksAfterToken
+                _lineBreaksAfterToken(node) = linebreaksAfterToken
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxReplacer.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxReplacer.vb
@@ -70,40 +70,40 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 trivia As IEnumerable(Of SyntaxTrivia),
                 computeReplacementTrivia As Func(Of SyntaxTrivia, SyntaxTrivia, SyntaxTrivia))
 
-                Me._computeReplacementNode = computeReplacementNode
-                Me._computeReplacementToken = computeReplacementToken
-                Me._computeReplacementTrivia = computeReplacementTrivia
+                _computeReplacementNode = computeReplacementNode
+                _computeReplacementToken = computeReplacementToken
+                _computeReplacementTrivia = computeReplacementTrivia
 
-                Me._nodeSet = If(nodes IsNot Nothing, New HashSet(Of SyntaxNode)(nodes), s_noNodes)
-                Me._tokenSet = If(tokens IsNot Nothing, New HashSet(Of SyntaxToken)(tokens), s_noTokens)
-                Me._triviaSet = If(trivia IsNot Nothing, New HashSet(Of SyntaxTrivia)(trivia), s_noTrivia)
+                _nodeSet = If(nodes IsNot Nothing, New HashSet(Of SyntaxNode)(nodes), s_noNodes)
+                _tokenSet = If(tokens IsNot Nothing, New HashSet(Of SyntaxToken)(tokens), s_noTokens)
+                _triviaSet = If(trivia IsNot Nothing, New HashSet(Of SyntaxTrivia)(trivia), s_noTrivia)
 
-                Me._spanSet = New HashSet(Of TextSpan)(Me._nodeSet.Select(Function(n) n.FullSpan).Concat(
-                                                      Me._tokenSet.Select(Function(t) t.FullSpan)).Concat(
-                                                      Me._triviaSet.Select(Function(t) t.FullSpan)))
+                _spanSet = New HashSet(Of TextSpan)(_nodeSet.Select(Function(n) n.FullSpan).Concat(
+                                                      _tokenSet.Select(Function(t) t.FullSpan)).Concat(
+                                                      _triviaSet.Select(Function(t) t.FullSpan)))
 
-                Me._totalSpan = ComputeTotalSpan(Me._spanSet)
+                _totalSpan = ComputeTotalSpan(_spanSet)
 
-                Me._visitStructuredTrivia = Me._nodeSet.Any(Function(n) n.IsPartOfStructuredTrivia()) OrElse
-                    Me._tokenSet.Any(Function(t) t.IsPartOfStructuredTrivia()) OrElse
-                    Me._triviaSet.Any(Function(t) t.IsPartOfStructuredTrivia())
+                _visitStructuredTrivia = _nodeSet.Any(Function(n) n.IsPartOfStructuredTrivia()) OrElse
+                    _tokenSet.Any(Function(t) t.IsPartOfStructuredTrivia()) OrElse
+                    _triviaSet.Any(Function(t) t.IsPartOfStructuredTrivia())
 
-                Me._shouldVisitTrivia = Me._triviaSet.Count > 0 OrElse Me._visitStructuredTrivia
+                _shouldVisitTrivia = _triviaSet.Count > 0 OrElse _visitStructuredTrivia
             End Sub
 
-            Private Shared ReadOnly s_noNodes As HashSet(Of SyntaxNode) = New HashSet(Of SyntaxNode)()
-            Private Shared ReadOnly s_noTokens As HashSet(Of SyntaxToken) = New HashSet(Of SyntaxToken)()
-            Private Shared ReadOnly s_noTrivia As HashSet(Of SyntaxTrivia) = New HashSet(Of SyntaxTrivia)()
+            Private Shared ReadOnly s_noNodes As New HashSet(Of SyntaxNode)()
+            Private Shared ReadOnly s_noTokens As New HashSet(Of SyntaxToken)()
+            Private Shared ReadOnly s_noTrivia As New HashSet(Of SyntaxTrivia)()
 
             Public Overrides ReadOnly Property VisitIntoStructuredTrivia As Boolean
                 Get
-                    Return Me._visitStructuredTrivia
+                    Return _visitStructuredTrivia
                 End Get
             End Property
 
             Public ReadOnly Property HasWork As Boolean
                 Get
-                    Return Me._nodeSet.Count + Me._tokenSet.Count + Me._triviaSet.Count > 0
+                    Return _nodeSet.Count + _tokenSet.Count + _triviaSet.Count > 0
                 End Get
             End Property
 
@@ -127,11 +127,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End Function
 
             Private Function ShouldVisit(span As TextSpan) As Boolean
-                If Not span.IntersectsWith(Me._totalSpan) Then
+                If Not span.IntersectsWith(_totalSpan) Then
                     Return False
                 End If
 
-                For Each s In Me._spanSet
+                For Each s In _spanSet
                     If span.IntersectsWith(s) Then
                         Return True
                     End If
@@ -143,12 +143,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Public Overrides Function Visit(node As SyntaxNode) As SyntaxNode
                 Dim rewritten = node
                 If node IsNot Nothing Then
-                    If Me.ShouldVisit(node.FullSpan) Then
+                    If ShouldVisit(node.FullSpan) Then
                         rewritten = MyBase.Visit(node)
                     End If
 
-                    If Me._nodeSet.Contains(node) AndAlso Me._computeReplacementNode IsNot Nothing Then
-                        rewritten = Me._computeReplacementNode(DirectCast(node, TNode), DirectCast(rewritten, TNode))
+                    If _nodeSet.Contains(node) AndAlso _computeReplacementNode IsNot Nothing Then
+                        rewritten = _computeReplacementNode(DirectCast(node, TNode), DirectCast(rewritten, TNode))
                     End If
                 End If
 
@@ -158,12 +158,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Public Overrides Function VisitToken(token As SyntaxToken) As SyntaxToken
                 Dim rewritten = token
 
-                If Me._shouldVisitTrivia AndAlso Me.ShouldVisit(token.FullSpan) Then
+                If _shouldVisitTrivia AndAlso ShouldVisit(token.FullSpan) Then
                     rewritten = MyBase.VisitToken(token)
                 End If
 
-                If Me._tokenSet.Contains(token) AndAlso Me._computeReplacementToken IsNot Nothing Then
-                    rewritten = Me._computeReplacementToken(token, rewritten)
+                If _tokenSet.Contains(token) AndAlso _computeReplacementToken IsNot Nothing Then
+                    rewritten = _computeReplacementToken(token, rewritten)
                 End If
 
                 Return rewritten
@@ -172,12 +172,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             Public Overrides Function VisitListElement(trivia As SyntaxTrivia) As SyntaxTrivia
                 Dim rewritten = trivia
 
-                If Me.VisitIntoStructuredTrivia AndAlso trivia.HasStructure AndAlso Me.ShouldVisit(trivia.FullSpan) Then
-                    rewritten = Me.VisitTrivia(trivia)
+                If Me.VisitIntoStructuredTrivia AndAlso trivia.HasStructure AndAlso ShouldVisit(trivia.FullSpan) Then
+                    rewritten = VisitTrivia(trivia)
                 End If
 
-                If Me._triviaSet.Contains(trivia) AndAlso Me._computeReplacementTrivia IsNot Nothing Then
-                    rewritten = Me._computeReplacementTrivia(trivia, rewritten)
+                If _triviaSet.Contains(trivia) AndAlso _computeReplacementTrivia IsNot Nothing Then
+                    rewritten = _computeReplacementTrivia(trivia, rewritten)
                 End If
 
                 Return rewritten
@@ -239,20 +239,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                 editKind As ListEditKind,
                 visitTrivia As Boolean,
                 visitIntoStructuredTrivia As Boolean)
-                Me._elementSpan = elementSpan
-                Me._editKind = editKind
-                Me._visitTrivia = visitTrivia Or visitIntoStructuredTrivia
-                Me._visitIntoStructuredTrivia = visitIntoStructuredTrivia
+                _elementSpan = elementSpan
+                _editKind = editKind
+                _visitTrivia = visitTrivia Or visitIntoStructuredTrivia
+                _visitIntoStructuredTrivia = visitIntoStructuredTrivia
             End Sub
 
             Public Overrides ReadOnly Property VisitIntoStructuredTrivia As Boolean
                 Get
-                    Return Me._visitIntoStructuredTrivia
+                    Return _visitIntoStructuredTrivia
                 End Get
             End Property
 
             Private Function ShouldVisit(span As TextSpan) As Boolean
-                Return span.IntersectsWith(Me._elementSpan)
+                Return span.IntersectsWith(_elementSpan)
             End Function
 
             Public Overrides Function Visit(node As SyntaxNode) As SyntaxNode
@@ -265,7 +265,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Public Overrides Function VisitToken(token As SyntaxToken) As SyntaxToken
                 Dim rewritten = token
-                If Me._visitTrivia AndAlso Me.ShouldVisit(token.FullSpan) Then
+                If _visitTrivia AndAlso Me.ShouldVisit(token.FullSpan) Then
                     rewritten = MyBase.VisitToken(token)
                 End If
                 Return rewritten
@@ -273,7 +273,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Public Overrides Function VisitListElement(element As SyntaxTrivia) As SyntaxTrivia
                 Dim rewritten = element
-                If Me._visitIntoStructuredTrivia AndAlso element.HasStructure AndAlso Me.ShouldVisit(element.FullSpan) Then
+                If _visitIntoStructuredTrivia AndAlso element.HasStructure AndAlso Me.ShouldVisit(element.FullSpan) Then
                     rewritten = MyBase.VisitTrivia(element)
                 End If
                 Return rewritten
@@ -288,8 +288,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Public Sub New(originalNode As SyntaxNode, replacementNodes As IEnumerable(Of SyntaxNode), editKind As ListEditKind)
                 MyBase.New(originalNode.FullSpan, editKind, visitTrivia:=False, visitIntoStructuredTrivia:=originalNode.IsPartOfStructuredTrivia())
-                Me._originalNode = originalNode
-                Me._replacementNodes = replacementNodes
+                _originalNode = originalNode
+                _replacementNodes = replacementNodes
             End Sub
 
             Public Overrides Function Visit(node As SyntaxNode) As SyntaxNode
@@ -301,16 +301,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End Function
 
             Public Overrides Function VisitList(Of TNode As SyntaxNode)(list As SeparatedSyntaxList(Of TNode)) As SeparatedSyntaxList(Of TNode)
-                If TypeOf Me._originalNode Is TNode Then
-                    Dim index = list.IndexOf(DirectCast(Me._originalNode, TNode))
+                If TypeOf _originalNode Is TNode Then
+                    Dim index = list.IndexOf(DirectCast(_originalNode, TNode))
                     If index >= 0 AndAlso index < list.Count Then
-                        Select Case Me._editKind
+                        Select Case _editKind
                             Case ListEditKind.Replace
-                                Return list.ReplaceRange(DirectCast(Me._originalNode, TNode), Me._replacementNodes.Cast(Of TNode))
+                                Return list.ReplaceRange(DirectCast(_originalNode, TNode), _replacementNodes.Cast(Of TNode))
                             Case ListEditKind.InsertBefore
-                                Return list.InsertRange(index, Me._replacementNodes.Cast(Of TNode))
+                                Return list.InsertRange(index, _replacementNodes.Cast(Of TNode))
                             Case ListEditKind.InsertAfter
-                                Return list.InsertRange(index + 1, Me._replacementNodes.Cast(Of TNode))
+                                Return list.InsertRange(index + 1, _replacementNodes.Cast(Of TNode))
                         End Select
                     End If
                 End If
@@ -318,16 +318,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End Function
 
             Public Overrides Function VisitList(Of TNode As SyntaxNode)(list As SyntaxList(Of TNode)) As SyntaxList(Of TNode)
-                If TypeOf Me._originalNode Is TNode Then
-                    Dim index = list.IndexOf(DirectCast(Me._originalNode, TNode))
+                If TypeOf _originalNode Is TNode Then
+                    Dim index = list.IndexOf(DirectCast(_originalNode, TNode))
                     If index >= 0 AndAlso index < list.Count Then
-                        Select Case Me._editKind
+                        Select Case _editKind
                             Case ListEditKind.Replace
-                                Return list.ReplaceRange(DirectCast(Me._originalNode, TNode), Me._replacementNodes.Cast(Of TNode))
+                                Return list.ReplaceRange(DirectCast(_originalNode, TNode), _replacementNodes.Cast(Of TNode))
                             Case ListEditKind.InsertBefore
-                                Return list.InsertRange(index, Me._replacementNodes.Cast(Of TNode))
+                                Return list.InsertRange(index, _replacementNodes.Cast(Of TNode))
                             Case ListEditKind.InsertAfter
-                                Return list.InsertRange(index + 1, Me._replacementNodes.Cast(Of TNode))
+                                Return list.InsertRange(index + 1, _replacementNodes.Cast(Of TNode))
                         End Select
                     End If
                 End If
@@ -343,8 +343,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Public Sub New(originalToken As SyntaxToken, newTokens As IEnumerable(Of SyntaxToken), editKind As ListEditKind)
                 MyBase.New(originalToken.FullSpan, editKind, visitTrivia:=False, visitIntoStructuredTrivia:=originalToken.IsPartOfStructuredTrivia())
-                Me._originalToken = originalToken
-                Me._newTokens = newTokens
+                _originalToken = originalToken
+                _newTokens = newTokens
             End Sub
 
             Public Overrides Function VisitToken(token As SyntaxToken) As SyntaxToken
@@ -356,15 +356,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
             End Function
 
             Public Overrides Function VisitList(list As SyntaxTokenList) As SyntaxTokenList
-                Dim index = list.IndexOf(Me._originalToken)
+                Dim index = list.IndexOf(_originalToken)
                 If index >= 0 AndAlso index < list.Count Then
-                    Select Case Me._editKind
+                    Select Case _editKind
                         Case ListEditKind.Replace
-                            Return list.ReplaceRange(Me._originalToken, Me._newTokens)
+                            Return list.ReplaceRange(_originalToken, _newTokens)
                         Case ListEditKind.InsertBefore
-                            Return list.InsertRange(index, Me._newTokens)
+                            Return list.InsertRange(index, _newTokens)
                         Case ListEditKind.InsertAfter
-                            Return list.InsertRange(index + 1, Me._newTokens)
+                            Return list.InsertRange(index + 1, _newTokens)
                     End Select
                 End If
                 Return MyBase.VisitList(list)
@@ -379,20 +379,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
             Public Sub New(originalTrivia As SyntaxTrivia, newTrivia As IEnumerable(Of SyntaxTrivia), editKind As ListEditKind)
                 MyBase.New(originalTrivia.FullSpan, editKind, visitTrivia:=True, visitIntoStructuredTrivia:=originalTrivia.IsPartOfStructuredTrivia())
-                Me._originalTrivia = originalTrivia
-                Me._newTrivia = newTrivia
+                _originalTrivia = originalTrivia
+                _newTrivia = newTrivia
             End Sub
 
             Public Overrides Function VisitList(list As SyntaxTriviaList) As SyntaxTriviaList
-                Dim index = list.IndexOf(Me._originalTrivia)
+                Dim index = list.IndexOf(_originalTrivia)
                 If index >= 0 AndAlso index < list.Count Then
-                    Select Case Me._editKind
+                    Select Case _editKind
                         Case ListEditKind.Replace
-                            Return list.ReplaceRange(Me._originalTrivia, Me._newTrivia)
+                            Return list.ReplaceRange(_originalTrivia, _newTrivia)
                         Case ListEditKind.InsertBefore
-                            Return list.InsertRange(index, Me._newTrivia)
+                            Return list.InsertRange(index, _newTrivia)
                         Case ListEditKind.InsertAfter
-                            Return list.InsertRange(index + 1, Me._newTrivia)
+                            Return list.InsertRange(index + 1, _newTrivia)
                     End Select
                 End If
                 Return MyBase.VisitList(list)

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxTokenListBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxTokenListBuilder.vb
@@ -11,8 +11,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         Private _nodes As InternalSyntax.VisualBasicSyntaxNode()
 
         Public Sub New(size As Integer)
-            Me._nodes = New InternalSyntax.VisualBasicSyntaxNode(size - 1) {}
-            Me._count = 0
+            _nodes = New InternalSyntax.VisualBasicSyntaxNode(size - 1) {}
+            _count = 0
         End Sub
 
         Public Shared Function Create() As SyntaxTokenListBuilder
@@ -21,61 +21,61 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._count
+                Return _count
             End Get
         End Property
 
         Friend Function Add(item As InternalSyntax.SyntaxToken) As SyntaxTokenListBuilder
             Debug.Assert(item IsNot Nothing)
-            If ((Me._nodes Is Nothing) OrElse (Me._count >= Me._nodes.Length)) Then
-                Me.Grow(If((Me._count = 0), 8, (Me._nodes.Length * 2)))
+            If ((_nodes Is Nothing) OrElse (_count >= _nodes.Length)) Then
+                Grow(If((_count = 0), 8, (_nodes.Length * 2)))
             End If
-            Me._nodes(Me._count) = item
-            Me._count += 1
+            _nodes(_count) = item
+            _count += 1
             Return Me
         End Function
 
         Public Function Add(item As SyntaxToken) As SyntaxTokenListBuilder
-            Return Me.Add(DirectCast(item.Node, InternalSyntax.SyntaxToken))
+            Return Add(DirectCast(item.Node, InternalSyntax.SyntaxToken))
         End Function
 
         Public Function Add(list As SyntaxTokenList) As SyntaxTokenListBuilder
-            Return Me.Add(list, 0, list.Count)
+            Return Add(list, 0, list.Count)
         End Function
 
         Public Function Add(list As SyntaxTokenList, offset As Integer, length As Integer) As SyntaxTokenListBuilder
-            If ((Me._nodes Is Nothing) OrElse ((Me._count + length) > Me._nodes.Length)) Then
-                Me.Grow((Me._count + length))
+            If ((_nodes Is Nothing) OrElse ((_count + length) > _nodes.Length)) Then
+                Grow((_count + length))
             End If
-            list.CopyTo(offset, Me._nodes, Me._count, length)
+            list.CopyTo(offset, _nodes, _count, length)
 #If DEBUG Then
             For i = 0 To length - 1
-                Debug.Assert(Me._nodes(Me._count + i) IsNot Nothing)
+                Debug.Assert(_nodes(_count + i) IsNot Nothing)
             Next
 #End If
-            Me._count = (Me._count + length)
+            _count += length
             Return Me
         End Function
 
         Public Sub Add(list As SyntaxToken())
-            Me.Add(list, 0, list.Length)
+            Add(list, 0, list.Length)
         End Sub
 
         Public Sub Add(list As SyntaxToken(), offset As Integer, length As Integer)
-            If ((Me._nodes Is Nothing) OrElse ((Me._count + length) > Me._nodes.Length)) Then
-                Me.Grow((Me._count + length))
+            If ((_nodes Is Nothing) OrElse ((_count + length) > _nodes.Length)) Then
+                Grow((_count + length))
             End If
 
             For i As Integer = 0 To length - 1
-                Me._nodes(Count + i) = DirectCast(list(offset + i).Node, InternalSyntax.SyntaxToken)
+                _nodes(Count + i) = DirectCast(list(offset + i).Node, InternalSyntax.SyntaxToken)
             Next
-            Me._count = (Me._count + length)
+            _count += length
         End Sub
 
         Private Sub Grow(size As Integer)
             Dim tmp = New InternalSyntax.VisualBasicSyntaxNode(size - 1) {}
-            Array.Copy(Me._nodes, tmp, Me._nodes.Length)
-            Me._nodes = tmp
+            Array.Copy(_nodes, tmp, _nodes.Length)
+            _nodes = tmp
         End Sub
 
         Public Shared Widening Operator CType(builder As SyntaxTokenListBuilder) As SyntaxTokenList
@@ -83,16 +83,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Operator
 
         Public Function ToList() As SyntaxTokenList
-            If (Me._count > 0) Then
-                Select Case Me._count
+            If (_count > 0) Then
+                Select Case _count
                     Case 1
-                        Return New SyntaxTokenList(Nothing, Me._nodes(0), 0, 0)
+                        Return New SyntaxTokenList(Nothing, _nodes(0), 0, 0)
                     Case 2
-                        Return New SyntaxTokenList(Nothing, InternalSyntax.SyntaxList.List(Me._nodes(0), Me._nodes(1)), 0, 0)
+                        Return New SyntaxTokenList(Nothing, InternalSyntax.SyntaxList.List(_nodes(0), _nodes(1)), 0, 0)
                     Case 3
-                        Return New SyntaxTokenList(Nothing, InternalSyntax.SyntaxList.List(Me._nodes(0), Me._nodes(1), Me._nodes(2)), 0, 0)
+                        Return New SyntaxTokenList(Nothing, InternalSyntax.SyntaxList.List(_nodes(0), _nodes(1), _nodes(2)), 0, 0)
                 End Select
-                Return New SyntaxTokenList(Nothing, InternalSyntax.SyntaxList.List(Me._nodes, Me._count), 0, 0)
+                Return New SyntaxTokenList(Nothing, InternalSyntax.SyntaxList.List(_nodes, _count), 0, 0)
             End If
             Return New SyntaxTokenList
         End Function

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxTriviaListBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxTriviaListBuilder.vb
@@ -14,58 +14,58 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
         Public ReadOnly Property Count As Integer
             Get
-                Return Me._count
+                Return _count
             End Get
         End Property
 
         Public Sub New(size As Integer)
-            Me._nodes = New SyntaxTrivia(size - 1) {}
+            _nodes = New SyntaxTrivia(size - 1) {}
         End Sub
 
         Default Public ReadOnly Property Item(index As Integer) As SyntaxTrivia
             Get
                 Debug.Assert(index >= 0)
-                Debug.Assert(index < Me._count)
+                Debug.Assert(index < _count)
 
-                Return Me._nodes(index)
+                Return _nodes(index)
             End Get
         End Property
 
         Public Sub Add(list As SyntaxTriviaList)
-            Me.Add(list, 0, list.Count)
+            Add(list, 0, list.Count)
         End Sub
 
         Public Sub Add(items As SyntaxTrivia())
-            Me.Add(items, 0, items.Length)
+            Add(items, 0, items.Length)
         End Sub
 
         Public Function Add(item As SyntaxTrivia) As SyntaxTriviaListBuilder
-            If ((Me._nodes Is Nothing) OrElse (Me._count >= Me._nodes.Length)) Then
-                Me.Grow(If((Me._count = 0), 8, (Me._nodes.Length * 2)))
+            If ((_nodes Is Nothing) OrElse (_count >= _nodes.Length)) Then
+                Grow(If((_count = 0), 8, (_nodes.Length * 2)))
             End If
-            Me._nodes(Me._count) = item
-            Me._count += 1
+            _nodes(_count) = item
+            _count += 1
             Return Me
         End Function
 
         Public Sub Add(items As SyntaxTrivia(), sourceOffset As Integer, length As Integer)
-            If ((Me._nodes Is Nothing) OrElse ((Me._count + length) > Me._nodes.Length)) Then
-                Me.Grow((Me._count + length))
+            If ((_nodes Is Nothing) OrElse ((_count + length) > _nodes.Length)) Then
+                Grow((_count + length))
             End If
-            Array.Copy(items, sourceOffset, Me._nodes, Me._count, length)
-            Me._count = (Me._count + length)
+            Array.Copy(items, sourceOffset, _nodes, _count, length)
+            _count += length
         End Sub
 
         Public Sub Add(list As SyntaxTriviaList, sourceOffset As Integer, length As Integer)
-            If ((Me._nodes Is Nothing) OrElse ((Me._count + length) > Me._nodes.Length)) Then
-                Me.Grow((Me._count + length))
+            If ((_nodes Is Nothing) OrElse ((_count + length) > _nodes.Length)) Then
+                Grow((_count + length))
             End If
-            list.CopyTo(sourceOffset, Me._nodes, Me._count, length)
-            Me._count = (Me._count + length)
+            list.CopyTo(sourceOffset, _nodes, _count, length)
+            _count += length
         End Sub
 
         Public Sub Clear()
-            Me._count = 0
+            _count = 0
         End Sub
 
         Public Shared Function Create() As SyntaxTriviaListBuilder
@@ -74,8 +74,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
 
         Private Sub Grow(size As Integer)
             Dim tmp As SyntaxTrivia() = New SyntaxTrivia(size - 1) {}
-            Array.Copy(Me._nodes, tmp, Me._nodes.Length)
-            Me._nodes = tmp
+            Array.Copy(_nodes, tmp, _nodes.Length)
+            _nodes = tmp
         End Sub
 
         Public Shared Widening Operator CType(builder As SyntaxTriviaListBuilder) As SyntaxTriviaList
@@ -83,21 +83,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
         End Operator
 
         Public Function ToList() As SyntaxTriviaList
-            If (Me._count <= 0) Then
+            If (_count <= 0) Then
                 Return New SyntaxTriviaList
             End If
-            Select Case Me._count
+            Select Case _count
                 Case 1
-                    Return New SyntaxTriviaList(Nothing, Me._nodes(0).UnderlyingNode, 0, 0)
+                    Return New SyntaxTriviaList(Nothing, _nodes(0).UnderlyingNode, 0, 0)
                 Case 2
-                    Return New SyntaxTriviaList(Nothing, InternalSyntax.SyntaxList.List(DirectCast(Me._nodes(0).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode), DirectCast(Me._nodes(1).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
+                    Return New SyntaxTriviaList(Nothing, InternalSyntax.SyntaxList.List(DirectCast(_nodes(0).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode), DirectCast(_nodes(1).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
                 Case 3
-                    Return New SyntaxTriviaList(Nothing, InternalSyntax.SyntaxList.List(DirectCast(Me._nodes(0).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode), DirectCast(Me._nodes(1).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode), DirectCast(Me._nodes(2).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
+                    Return New SyntaxTriviaList(Nothing, InternalSyntax.SyntaxList.List(DirectCast(_nodes(0).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode), DirectCast(_nodes(1).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode), DirectCast(_nodes(2).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)), 0, 0)
             End Select
-            Dim tmp = New ArrayElement(Of InternalSyntax.VisualBasicSyntaxNode)(Me._count - 1) {}
+            Dim tmp = New ArrayElement(Of InternalSyntax.VisualBasicSyntaxNode)(_count - 1) {}
             Dim i As Integer
-            For i = 0 To Me._count - 1
-                tmp(i).Value = DirectCast(Me._nodes(i).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)
+            For i = 0 To _count - 1
+                tmp(i).Value = DirectCast(_nodes(i).UnderlyingNode, InternalSyntax.VisualBasicSyntaxNode)
             Next i
             Return New SyntaxTriviaList(Nothing, InternalSyntax.SyntaxList.List(tmp), 0, 0)
         End Function

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -63,7 +63,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend Shadows ReadOnly Property SyntaxTree As SyntaxTree
             Get
-                If Me._syntaxTree Is Nothing Then
+                If _syntaxTree Is Nothing Then
                     Dim stack = ArrayBuilder(Of SyntaxNode).GetInstance()
                     Dim tree As SyntaxTree = Nothing
 
@@ -98,7 +98,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     stack.Free()
                 End If
 
-                Return Me._syntaxTree
+                Return _syntaxTree
             End Get
         End Property
 
@@ -110,12 +110,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Returns the <see cref="SyntaxKind"/> of the node.
         ''' </summary>
         Public Function Kind() As SyntaxKind
-            Return CType(Me.Green.RawKind, SyntaxKind)
+            Return CType(Green.RawKind, SyntaxKind)
         End Function
 
         Protected Overrides ReadOnly Property KindText As String
             Get
-                Return Me.Kind.ToString()
+                Return Kind.ToString()
             End Get
         End Property
 
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The string representation of this node, not including its leading and trailing trivia.</returns>
         ''' <remarks>The length of the returned string is always the same as Span.Length</remarks>
         Public NotOverridable Overrides Function ToString() As String
-            Return Me.Green.ToString()
+            Return Green.ToString()
         End Function
 
         ''' <summary>
@@ -153,14 +153,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>The full string representation of this node including its leading and trailing trivia.</returns>
         ''' <remarks>The length of the returned string is always the same as FullSpan.Length</remarks>
         Public NotOverridable Overrides Function ToFullString() As String
-            Return Me.Green.ToFullString()
+            Return Green.ToFullString()
         End Function
 
         ''' <summary>
         ''' Writes the full text of this node to the specified TextWriter
         ''' </summary>
         Public Overrides Sub WriteTo(writer As IO.TextWriter)
-            Me.Green.WriteTo(writer)
+            Green.WriteTo(writer)
         End Sub
 
 #Region "Serialization"
@@ -170,8 +170,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Serialize this node to a byte stream.
         ''' </summary>
         Public Overrides Sub SerializeTo(stream As IO.Stream, Optional cancellationToken As CancellationToken = Nothing)
-            Using writer = New ObjectWriter(stream, GetDefaultObjectWriterData(), binder:=s_binder, cancellationToken:=cancellationToken)
-                writer.WriteValue(Me.Green)
+            Using writer As New ObjectWriter(stream, GetDefaultObjectWriterData(), binder:=s_binder, cancellationToken:=cancellationToken)
+                writer.WriteValue(Green)
             End Using
         End Sub
 
@@ -205,28 +205,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If s_serializationData Is Nothing Then
                 Dim data = New Object() {
                     GetType(Object).GetTypeInfo().Assembly.FullName,
-                    GetType(Microsoft.CodeAnalysis.DiagnosticInfo).GetTypeInfo().Assembly.FullName,
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode).GetTypeInfo().Assembly.FullName,
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxToken.TriviaInfo),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SimpleIdentifierSyntax),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.ComplexIdentifierSyntax),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList.WithTwoChildren),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList.WithThreeChildren),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList.WithManyChildren),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList.WithLotsOfChildren),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of Int32)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of Int16)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of Int64)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of UInt32)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of UInt16)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of UInt64)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of Byte)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IntegerLiteralTokenSyntax(Of SByte)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.FloatingLiteralTokenSyntax(Of Single)),
-                    GetType(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.FloatingLiteralTokenSyntax(Of Double)),
-                    GetType(Microsoft.CodeAnalysis.DiagnosticInfo),
-                    GetType(Microsoft.CodeAnalysis.SyntaxAnnotation)
+                    GetType(DiagnosticInfo).GetTypeInfo().Assembly.FullName,
+                    GetType(VisualBasicSyntaxNode).GetTypeInfo().Assembly.FullName,
+                    GetType(InternalSyntax.SyntaxToken.TriviaInfo),
+                    GetType(InternalSyntax.SimpleIdentifierSyntax),
+                    GetType(InternalSyntax.ComplexIdentifierSyntax),
+                    GetType(InternalSyntax.SyntaxList),
+                    GetType(InternalSyntax.SyntaxList.WithTwoChildren),
+                    GetType(InternalSyntax.SyntaxList.WithThreeChildren),
+                    GetType(InternalSyntax.SyntaxList.WithManyChildren),
+                    GetType(InternalSyntax.SyntaxList.WithLotsOfChildren),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of Int32)),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of Int16)),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of Int64)),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of UInt32)),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of UInt16)),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of UInt64)),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of Byte)),
+                    GetType(InternalSyntax.IntegerLiteralTokenSyntax(Of SByte)),
+                    GetType(InternalSyntax.FloatingLiteralTokenSyntax(Of Single)),
+                    GetType(InternalSyntax.FloatingLiteralTokenSyntax(Of Double)),
+                    GetType(DiagnosticInfo),
+                    GetType(SyntaxAnnotation)
                 } _
                 .Concat(InternalSyntax.SyntaxFactory.GetNodeTypes()) _
                 .Concat(InternalSyntax.SyntaxFactory.GetWellKnownTrivia()) _
@@ -244,7 +244,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public ReadOnly Property IsDirective As Boolean
             Get
-                Return Me.Green.IsDirective
+                Return Green.IsDirective
             End Get
         End Property
 
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </remarks>
         Public Shadows ReadOnly Property SpanStart As Integer
             Get
-                Return Position + Me.Green.GetLeadingTriviaWidth()
+                Return Position + Green.GetLeadingTriviaWidth()
             End Get
         End Property
 
@@ -287,7 +287,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property HasErrors As Boolean
             Get
                 ' TODO (tomat): share impl with C#
-                Return Me.ContainsDiagnostics AndAlso Me.GetSyntaxErrors(Me.SyntaxTree).Any(Function(i) i.Severity = DiagnosticSeverity.Error)
+                Return ContainsDiagnostics AndAlso GetSyntaxErrors(SyntaxTree).Any(Function(i) i.Severity = DiagnosticSeverity.Error)
             End Get
         End Property
 
@@ -452,7 +452,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                              Optional includeSkipped As Boolean = False,
                                              Optional includeDirectives As Boolean = False,
                                              Optional includeDocumentationComments As Boolean = False) As SyntaxToken
-            Return CType(MyBase.GetLastToken(includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments), SyntaxToken)
+            Return MyBase.GetLastToken(includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments)
         End Function
 
         Public Function GetDirectives(Optional filter As Func(Of DirectiveTriviaSyntax, Boolean) = Nothing) As IList(Of DirectiveTriviaSyntax)
@@ -577,7 +577,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #Region "Core Overloads"
         Protected NotOverridable Overrides Function EquivalentToCore(other As SyntaxNode) As Boolean
-            Return Me.IsEquivalentTo(TryCast(other, VisualBasicSyntaxNode))
+            Return IsEquivalentTo(TryCast(other, VisualBasicSyntaxNode))
         End Function
 
         Protected NotOverridable Overrides Function FindTokenCore(position As Integer, findInsideTrivia As Boolean) As SyntaxToken
@@ -594,7 +594,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected Overrides ReadOnly Property SyntaxTreeCore As SyntaxTree
             Get
-                Return Me.SyntaxTree
+                Return SyntaxTree
             End Get
         End Property
 
@@ -646,12 +646,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shadows Function GetLocation() As Location
             ' Note that we want to return 'no location' for all nodes from embedded syntax trees
-            If Me.SyntaxTree IsNot Nothing Then
-                Dim tree = Me.SyntaxTree
+            If SyntaxTree IsNot Nothing Then
+                Dim tree = SyntaxTree
                 If tree.IsEmbeddedSyntaxTree Then
-                    Return New EmbeddedTreeLocation(tree.GetEmbeddedKind, Me.Span)
+                    Return New EmbeddedTreeLocation(tree.GetEmbeddedKind, Span)
                 ElseIf tree.IsMyTemplate Then
-                    Return New MyTemplateLocation(tree, Me.Span)
+                    Return New MyTemplateLocation(tree, Span)
                 End If
             End If
             Return New SourceLocation(Me)

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode_TreeTraversalHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode_TreeTraversalHelpers.vb
@@ -69,13 +69,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function TryGetLastTokenAt(position As Integer, ByRef lastToken As SyntaxToken) As Boolean
-            If position = Me.EndPosition Then
+            If position = EndPosition Then
                 Dim cu = TryCast(Me, CompilationUnitSyntax)
                 If cu IsNot Nothing Then
                     lastToken = cu.EndOfFileToken
                     Debug.Assert(lastToken.EndPosition = position)
                 Else
-                    lastToken = Me.GetLastToken
+                    lastToken = GetLastToken()
+
                     If (lastToken.EndPosition <> position) Then
                         Return False
                     End If
@@ -104,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return lastToken
                 End If
 
-                If Not Me.FullSpan.Contains(position) Then
+                If Not FullSpan.Contains(position) Then
                     Throw New IndexOutOfRangeException(NameOf(position))
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxRewriter.vb
@@ -20,12 +20,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _visitIntoStructuredTrivia As Boolean
 
         Public Sub New(Optional visitIntoStructuredTrivia As Boolean = False)
-            Me._visitIntoStructuredTrivia = visitIntoStructuredTrivia
+            _visitIntoStructuredTrivia = visitIntoStructuredTrivia
         End Sub
 
         Public Overridable ReadOnly Property VisitIntoStructuredTrivia As Boolean
             Get
-                Return Me._visitIntoStructuredTrivia
+                Return _visitIntoStructuredTrivia
             End Get
         End Property
 
@@ -47,8 +47,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overridable Function VisitToken(token As SyntaxToken) As SyntaxToken
-            Dim leading = Me.VisitList(token.LeadingTrivia)
-            Dim trailing = Me.VisitList(token.TrailingTrivia)
+            Dim leading = VisitList(token.LeadingTrivia)
+            Dim trailing = VisitList(token.TrailingTrivia)
             If leading <> token.LeadingTrivia OrElse trailing <> token.TrailingTrivia Then
                 If leading <> token.LeadingTrivia Then
                     token = token.WithLeadingTrivia(leading)
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overridable Function VisitTrivia(trivia As SyntaxTrivia) As SyntaxTrivia
             If Me.VisitIntoStructuredTrivia AndAlso trivia.HasStructure Then
                 Dim [structure] = DirectCast(trivia.GetStructure(), VisualBasicSyntaxNode)
-                Dim newStructure = DirectCast(Me.Visit([structure]), StructuredTriviaSyntax)
+                Dim newStructure = DirectCast(Visit([structure]), StructuredTriviaSyntax)
                 If newStructure IsNot [structure] Then
                     If newStructure IsNot Nothing Then
                         Return SyntaxFactory.Trivia(newStructure)
@@ -102,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overridable Function VisitListElement(Of TNode As SyntaxNode)(node As TNode) As TNode
-            Return DirectCast(Me.Visit(node), TNode)
+            Return DirectCast(Visit(node), TNode)
         End Function
 
         Public Overridable Function VisitList(list As SyntaxTokenList) As SyntaxTokenList
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overridable Function VisitListElement(token As SyntaxToken) As SyntaxToken
-            Return Me.VisitToken(token)
+            Return VisitToken(token)
         End Function
 
         Public Overridable Function VisitList(Of TNode As SyntaxNode)(list As SeparatedSyntaxList(Of TNode)) As SeparatedSyntaxList(Of TNode)
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overridable Function VisitListSeparator(token As SyntaxToken) As SyntaxToken
-            Return Me.VisitToken(token)
+            Return VisitToken(token)
         End Function
 
         Public Overridable Function VisitList(list As SyntaxTriviaList) As SyntaxTriviaList
@@ -221,7 +221,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overridable Function VisitListElement(element As SyntaxTrivia) As SyntaxTrivia
-            Return Me.VisitTrivia(element)
+            Return VisitTrivia(element)
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.ConditionalSymbolsMap.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.ConditionalSymbolsMap.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Next
                 Next
 #End If
-                Me._conditionalsMap = conditionalsMap
+                _conditionalsMap = conditionalsMap
             End Sub
 
 #Region "Build conditional symbols map"
@@ -63,24 +63,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Private _preprocessorState As PreprocessorState
 
                 Friend Function Build(root As SyntaxNodeOrToken, options As VisualBasicParseOptions) As ImmutableDictionary(Of String, Stack(Of Tuple(Of InternalSyntax.CConst, Integer)))
-                    Me._conditionalsMap = New Dictionary(Of String, Stack(Of Tuple(Of InternalSyntax.CConst, Integer)))(IdentifierComparison.Comparer)
+                    _conditionalsMap = New Dictionary(Of String, Stack(Of Tuple(Of InternalSyntax.CConst, Integer)))(IdentifierComparison.Comparer)
 
                     ' Process command line preprocessor symbol definitions.
                     Dim preprocessorSymbolsMap As ImmutableDictionary(Of String, InternalSyntax.CConst) = Scanner.GetPreprocessorConstants(options)
-                    Me.ProcessCommandLinePreprocessorSymbols(preprocessorSymbolsMap)
-                    Me._preprocessorState = New PreprocessorState(preprocessorSymbolsMap)
+                    ProcessCommandLinePreprocessorSymbols(preprocessorSymbolsMap)
+                    _preprocessorState = New PreprocessorState(preprocessorSymbolsMap)
 
                     ' Get and process source directives.
                     Dim directives As IEnumerable(Of DirectiveTriviaSyntax) = root.GetDirectives(Of DirectiveTriviaSyntax)()
                     Debug.Assert(directives IsNot Nothing)
                     ProcessSourceDirectives(directives)
 
-                    Return If(Me._conditionalsMap.Any(), ImmutableDictionary.CreateRange(IdentifierComparison.Comparer, Me._conditionalsMap), Nothing)
+                    Return If(_conditionalsMap.Any(), ImmutableDictionary.CreateRange(IdentifierComparison.Comparer, _conditionalsMap), Nothing)
                 End Function
 
                 Private Sub ProcessCommandLinePreprocessorSymbols(preprocessorSymbolsMap As ImmutableDictionary(Of String, InternalSyntax.CConst))
                     For Each kvPair In preprocessorSymbolsMap
-                        Me.ProcessConditionalSymbolDefinition(kvPair.Key, kvPair.Value, 0)
+                        ProcessConditionalSymbolDefinition(kvPair.Key, kvPair.Value, 0)
                     Next
                 End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.DummySyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.DummySyntaxTree.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private ReadOnly _node As CompilationUnitSyntax
 
             Public Sub New()
-                _node = Me.CloneNodeAsRoot(SyntaxFactory.ParseCompilationUnit(String.Empty))
+                _node = CloneNodeAsRoot(SyntaxFactory.ParseCompilationUnit(String.Empty))
             End Sub
 
             Public Overrides Function ToString() As String

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.ParsedSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.ParsedSyntaxTree.vb
@@ -124,33 +124,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Function
 
             Public Overrides Function WithRootAndOptions(root As SyntaxNode, options As ParseOptions) As SyntaxTree
-                If Me._root Is root AndAlso Me._options Is options Then
+                If _root Is root AndAlso _options Is options Then
                     Return Me
                 End If
 
-                Return New ParsedSyntaxTree(
-                    Nothing,
-                    Me._encodingOpt,
-                    Me._checksumAlgorithm,
-                    Me._path,
-                    DirectCast(options, VisualBasicParseOptions),
-                    DirectCast(root, VisualBasicSyntaxNode),
-                    Me._isMyTemplate)
+                Return New ParsedSyntaxTree(Nothing, _encodingOpt, _checksumAlgorithm, _path,
+                                            DirectCast(options, VisualBasicParseOptions), DirectCast(root, VisualBasicSyntaxNode), _isMyTemplate)
             End Function
 
             Public Overrides Function WithFilePath(path As String) As SyntaxTree
-                If String.Equals(Me._path, path) Then
+                If String.Equals(_path, path) Then
                     Return Me
                 End If
 
-                Return New ParsedSyntaxTree(
-                    Me._lazyText,
-                    Me._encodingOpt,
-                    Me._checksumAlgorithm,
-                    path,
-                    Me._options,
-                    Me._root,
-                    Me._isMyTemplate)
+                Return New ParsedSyntaxTree(_lazyText, _encodingOpt, _checksumAlgorithm, path, _options, _root, _isMyTemplate)
             End Function
         End Class
     End Class

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxTree.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </remarks>
         Public Overridable Shadows Function GetRootAsync(Optional cancellationToken As CancellationToken = Nothing) As Task(Of VisualBasicSyntaxNode)
             Dim node As VisualBasicSyntaxNode = Nothing
-            Return Task.FromResult(If(Me.TryGetRoot(node), node, Me.GetRoot(cancellationToken)))
+            Return Task.FromResult(If(TryGetRoot(node), node, GetRoot(cancellationToken)))
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxWalker.vb
@@ -39,11 +39,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim asNode = child.AsNode()
                 If asNode IsNot Nothing Then
                     If Depth >= SyntaxWalkerDepth.Node Then
-                        Me.Visit(asNode)
+                        Visit(asNode)
                     End If
                 Else
                     If Depth >= SyntaxWalkerDepth.Token Then
-                        Me.VisitToken(child.AsToken())
+                        VisitToken(child.AsToken())
                     End If
                 End If
             Loop While i < childCnt
@@ -52,8 +52,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overridable Sub VisitToken(token As SyntaxToken)
             If Depth >= SyntaxWalkerDepth.Trivia Then
-                Me.VisitLeadingTrivia(token)
-                Me.VisitTrailingTrivia(token)
+                VisitLeadingTrivia(token)
+                VisitTrailingTrivia(token)
             End If
         End Sub
 

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/project.lock.json
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/project.lock.json
@@ -3,6 +3,23 @@
   "version": 1,
   "targets": {
     ".NETFramework,Version=v4.5": {
+      "Microsoft.CodeAnalysis.Test.Resources.Proprietary/1.2.0-beta-20151016-11": {
+        "compile": {
+          "lib/net45/Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll": {}
+        }
+      },
+      "Microsoft.DiaSymReader/1.0.6": {
+        "compile": {
+          "lib/net20/Microsoft.DiaSymReader.dll": {}
+        },
+        "runtime": {
+          "lib/net20/Microsoft.DiaSymReader.dll": {}
+        }
+      },
+      "Microsoft.DiaSymReader.Native/1.3.3": {},
       "System.Collections/4.0.0": {
         "compile": {
           "ref/net45/_._": {}
@@ -45,7 +62,63 @@
           "lib/net45/_._": {}
         }
       },
+      "System.IO/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
       "System.Linq/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0": {
+        "dependencies": {
+          "System.Collections": "[4.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
+        },
+        "compile": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
         "compile": {
           "ref/net45/_._": {}
         },
@@ -70,6 +143,30 @@
         }
       },
       "System.Runtime.Extensions/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Text.Encoding/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.0": {
         "compile": {
           "ref/net45/_._": {}
         },
@@ -138,6 +235,48 @@
     }
   },
   "libraries": {
+    "Microsoft.CodeAnalysis.Test.Resources.Proprietary/1.2.0-beta-20151016-11": {
+      "sha512": "zsE8FvVez0iaoyWutVewackGkJsJXjavomMMdme5NZTXS2/5aG6gdLuaFvGeslq/XMsh4CqIgdvMOOFr5TmpFQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.CodeAnalysis.Test.Resources.Proprietary.dll",
+        "Microsoft.CodeAnalysis.Test.Resources.Proprietary.nuspec",
+        "package/services/metadata/core-properties/f64bfc9a6f91426492917a4c8a1b955e.psmdcp"
+      ]
+    },
+    "Microsoft.DiaSymReader/1.0.6": {
+      "sha512": "ai2eBJrXlHa0hecUKnEyacH0iXxGNOMpc9X0s7VAeqqh5TSTW70QMhTRZ0FNCtf3R/W67K4a+uf3R7MASmAjrg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net20/Microsoft.DiaSymReader.dll",
+        "lib/net20/Microsoft.DiaSymReader.xml",
+        "lib/portable-net45+win8/Microsoft.DiaSymReader.dll",
+        "lib/portable-net45+win8/Microsoft.DiaSymReader.xml",
+        "Microsoft.DiaSymReader.nuspec",
+        "package/services/metadata/core-properties/ead7dc5d4bf24fbe8708f348725a9b02.psmdcp"
+      ]
+    },
+    "Microsoft.DiaSymReader.Native/1.3.3": {
+      "sha512": "mjATkm+L2UlP35gO/ExNutLDfgX4iiwz1l/8sYVoeGHp5WnkEDu0NfIEsC4Oy/pCYeRw0/6SGB+kArJVNNvENQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "build/Microsoft.DiaSymReader.Native.props",
+        "Microsoft.DiaSymReader.Native.nuspec",
+        "package/services/metadata/core-properties/fdc58d35421849398d4c224d791a4bc4.psmdcp",
+        "runtimes/win/native/Microsoft.DiaSymReader.Native.amd64.dll",
+        "runtimes/win/native/Microsoft.DiaSymReader.Native.arm.dll",
+        "runtimes/win/native/Microsoft.DiaSymReader.Native.x86.dll",
+        "runtimes/win8-arm/native/Microsoft.DiaSymReader.Native.arm.dll",
+        "runtimes/win-x64/native/Microsoft.DiaSymReader.Native.amd64.dll",
+        "runtimes/win-x86/native/Microsoft.DiaSymReader.Native.x86.dll"
+      ]
+    },
     "System.Collections/4.0.0": {
       "sha512": "i2vsGDIEbWdHcUSNDPKZP/ZWod6o740el7mGTCy0dqbCxQh74W4QoC+klUwPEtGEFuvzJ7bJgvwJqscosVNyZQ==",
       "type": "Package",
@@ -299,6 +438,55 @@
         "System.Globalization.nuspec"
       ]
     },
+    "System.IO/4.0.0": {
+      "sha512": "MoCHQ0u5n0OMwUS8OX4Gl48qKiQziSW5cXvt82d+MmAcsLq9OL90+ihnu/aJ1h6OOYcBswrZAEuApfZha9w2lg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "package/services/metadata/core-properties/93bf03c6f6d24eaf9a358a72856daa5f.psmdcp",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.IO.xml",
+        "ref/netcore50/es/System.IO.xml",
+        "ref/netcore50/fr/System.IO.xml",
+        "ref/netcore50/it/System.IO.xml",
+        "ref/netcore50/ja/System.IO.xml",
+        "ref/netcore50/ko/System.IO.xml",
+        "ref/netcore50/ru/System.IO.xml",
+        "ref/netcore50/System.IO.dll",
+        "ref/netcore50/System.IO.xml",
+        "ref/netcore50/zh-hans/System.IO.xml",
+        "ref/netcore50/zh-hant/System.IO.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.nuspec"
+      ]
+    },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
@@ -330,6 +518,137 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "System.Linq.nuspec"
+      ]
+    },
+    "System.Reflection/4.0.0": {
+      "sha512": "g96Rn8XuG7y4VfxPj/jnXroRJdQ8L3iN3k3zqsuzk4k3Nq4KMXARYiIO4BLW4GwX06uQpuYwRMcAC/aF117knQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "package/services/metadata/core-properties/1e935117d401458384a90c2c69f60bd2.psmdcp",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Reflection.xml",
+        "ref/netcore50/es/System.Reflection.xml",
+        "ref/netcore50/fr/System.Reflection.xml",
+        "ref/netcore50/it/System.Reflection.xml",
+        "ref/netcore50/ja/System.Reflection.xml",
+        "ref/netcore50/ko/System.Reflection.xml",
+        "ref/netcore50/ru/System.Reflection.xml",
+        "ref/netcore50/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.xml",
+        "ref/netcore50/zh-hans/System.Reflection.xml",
+        "ref/netcore50/zh-hant/System.Reflection.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Extensions/4.0.0": {
+      "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/DNXCore50/System.Reflection.Extensions.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
+        "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
+        "ref/dotnet/fr/System.Reflection.Extensions.xml",
+        "ref/dotnet/it/System.Reflection.Extensions.xml",
+        "ref/dotnet/ja/System.Reflection.Extensions.xml",
+        "ref/dotnet/ko/System.Reflection.Extensions.xml",
+        "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Extensions.dll",
+        "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
+      ]
+    },
+    "System.Reflection.Metadata/1.1.0": {
+      "sha512": "a8VsRm/B0Ik1o5FumSMWmpwbG7cvIIajAYhzTTy9VB9XItByJDQHGZkQTIAdsvVJ6MI5O3uH/lb0izgQDlDIWA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet5.2/System.Reflection.Metadata.dll",
+        "lib/dotnet5.2/System.Reflection.Metadata.xml",
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/644d6c945e3d43e2806bf6892201a6ef.psmdcp",
+        "System.Reflection.Metadata.nuspec"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
@@ -462,6 +781,151 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Runtime.Extensions.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.0": {
+      "sha512": "J8GBB0OsVuKJXR412x6uZdoyNi4y9OMjjJRHPutRHjqujuvthus6Xdxn/i8J1lL2PK+2jWCLpZp72h8x73hkLg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "package/services/metadata/core-properties/cb937f04833048a9948507c9ef331a18.psmdcp",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Runtime.InteropServices.xml",
+        "ref/netcore50/es/System.Runtime.InteropServices.xml",
+        "ref/netcore50/fr/System.Runtime.InteropServices.xml",
+        "ref/netcore50/it/System.Runtime.InteropServices.xml",
+        "ref/netcore50/ja/System.Runtime.InteropServices.xml",
+        "ref/netcore50/ko/System.Runtime.InteropServices.xml",
+        "ref/netcore50/ru/System.Runtime.InteropServices.xml",
+        "ref/netcore50/System.Runtime.InteropServices.dll",
+        "ref/netcore50/System.Runtime.InteropServices.xml",
+        "ref/netcore50/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/netcore50/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Runtime.InteropServices.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.0": {
+      "sha512": "AMxFNOXpA6Ab8swULbXuJmoT2K5w6TnV3ObF5wsmEcIHQUJghoZtDVfVHb08O2wW15mOSI1i9Wg0Dx0pY13o8g==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "package/services/metadata/core-properties/8740abce9d6a472db9f21ed43f2fb149.psmdcp",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Text.Encoding.xml",
+        "ref/netcore50/es/System.Text.Encoding.xml",
+        "ref/netcore50/fr/System.Text.Encoding.xml",
+        "ref/netcore50/it/System.Text.Encoding.xml",
+        "ref/netcore50/ja/System.Text.Encoding.xml",
+        "ref/netcore50/ko/System.Text.Encoding.xml",
+        "ref/netcore50/ru/System.Text.Encoding.xml",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "ref/netcore50/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hans/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hant/System.Text.Encoding.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.0": {
+      "sha512": "FktA77+2DC0S5oRhgM569pbzFrcA45iQpYiI7+YKl68B6TfI2N5TQbXqSWlh2YXKoFXHi2RFwPMha2lxiFJZ6A==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "package/services/metadata/core-properties/c37aa1347f574e6c8df522449486a4d2.psmdcp",
+        "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/es/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/fr/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/it/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/ja/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/ko/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/ru/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/netcore50/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Threading/4.0.0": {


### PR DESCRIPTION
[Compiler VB SyntaxNode] Tidy Up
- Remove redundant `Me.`,`MyBase`, Casts, Namespace etc