### PR TITLE
Do not allow any form of inline lambda to be ref/out

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1768,7 +1768,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // The old native compiler ignores ref/out in a delegate creation expression.
             // For compatibility we implement the same bug except in strict mode.
-            RefKind refKind = (!isDelegateCreation || Compilation.FeatureStrictEnabled)
+            // Note: An inline delegate should still be rejected
+            RefKind refKind = (!isDelegateCreation || Compilation.FeatureStrictEnabled || (isDelegateCreation && argumentSyntax.Expression.IsAnonymousFunction()))
                 ? argumentSyntax.RefOrOutKeyword.Kind().GetRefKind()
                 : RefKind.None;
 


### PR DESCRIPTION
Fixes #6646. Specifically for `new Action<string>(ref b => b = "hello")` that is not for compat with legacy compiler. The case is handled correctly for strict mode. `new Action<string>(ref Foo)` is valid for compat.

Added tests for both compat and strict mode.

Side-note: Many tests missing for this. There are probably more syntax kinds not allowed. 