### PR TITLE
Implement View.SynchronizeClassView command

### DIFF
--- a/src/EditorFeatures/Core/Commands/SyncClassViewCommandArgs.cs
+++ b/src/EditorFeatures/Core/Commands/SyncClassViewCommandArgs.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.CodeAnalysis.Editor.Commands
+{
+    [ExcludeFromCodeCoverage]
+    internal class SyncClassViewCommandArgs : CommandArgs
+    {
+        public SyncClassViewCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Commands\SortAndRemoveUnnecessaryImportsCommandArgs.cs" />
     <Compile Include="Commands\SortImportsCommandArgs.cs" />
     <Compile Include="Commands\SurroundWithCommandArgs.cs" />
+    <Compile Include="Commands\SyncClassViewCommandArgs.cs" />
     <Compile Include="Commands\TabKeyCommandArgs.cs" />
     <Compile Include="Commands\ToggleCompletionModeCommandArgs.cs" />
     <Compile Include="Commands\TypeCharCommandArgs.cs" />

--- a/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
@@ -25,6 +25,11 @@ namespace Microsoft.CodeAnalysis.Editor
         public const string ChangeSignature = "Change Signature";
 
         /// <summary>
+        /// Command handler name for Class View.
+        /// </summary>
+        public const string ClassView = "Class View";
+
+        /// <summary>
         /// Command handler name for Comment Selection.
         /// </summary>
         /// <remarks></remarks>

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -25,6 +25,7 @@ namespace Roslyn.Test.Utilities
             public const string CaseCorrection = "CaseCorrection";
             public const string ChangeSignature = "ChangeSignature";
             public const string Classification = "Classification";
+            public const string ClassView = "ClassView";
             public const string CodeActionsAddConstructorParameters = "CodeActions.AddConstructorParameters";
             public const string CodeActionsAddAsync = "CodeActions.AddAsync";
             public const string CodeActionsAddAwait = "CodeActions.AddAwait";

--- a/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
+++ b/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Debugging\LocationInfoGetter.cs" />
     <Compile Include="LanguageService\HACK_CSharpCreateServicesOnUIThread.cs" />
     <Compile Include="ObjectBrowser\CSharpLibraryService.cs" />
+    <Compile Include="ObjectBrowser\CSharpSyncClassViewCommandHandler.cs" />
     <Compile Include="ObjectBrowser\ListItemFactory.cs" />
     <Compile Include="Options\AdvancedOptionPageStrings.cs" />
     <Compile Include="Options\IntelliSenseOptionPageStrings.cs" />

--- a/src/VisualStudio/CSharp/Impl/ObjectBrowser/CSharpSyncClassViewCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/ObjectBrowser/CSharpSyncClassViewCommandHandler.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
+{
+    [ExportCommandHandler(PredefinedCommandHandlerNames.ClassView, ContentTypeNames.CSharpContentType)]
+    internal class CSharpSyncClassViewCommandHandler : AbstractSyncClassViewCommandHandler
+    {
+        [ImportingConstructor]
+        private CSharpSyncClassViewCommandHandler(SVsServiceProvider serviceProvider, IWaitIndicator waitIndicator)
+            : base(serviceProvider, waitIndicator)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Execute.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Execute.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -14,6 +13,7 @@ using Microsoft.VisualStudio.Utilities;
 using InteractiveCommandIds = Microsoft.VisualStudio.LanguageServices.InteractiveWindow.CommandIds;
 using InteractiveGuids = Microsoft.VisualStudio.LanguageServices.InteractiveWindow.Guids;
 #endif
+
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     internal abstract partial class AbstractOleCommandTarget
@@ -176,6 +176,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 case VSConstants.VSStd97CmdID.FindReferences:
                     ExecuteFindReferences(subjectBuffer, contentType, executeNextCommandTarget);
+                    break;
+
+                case VSConstants.VSStd97CmdID.SyncClassView:
+                    ExecuteSyncClassView(subjectBuffer, contentType, executeNextCommandTarget);
                     break;
 
                 case VSConstants.VSStd97CmdID.Paste:
@@ -540,7 +544,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         private void ExecuteEncapsulateField(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<EncapsulateFieldCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new EncapsulateFieldCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
@@ -600,275 +604,276 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return result;
         }
 #endif
+
         private void ExecuteMoveSelectedLinesUp(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<MoveSelectedLinesUpCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new MoveSelectedLinesUpCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteMoveSelectedLinesDown(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<MoveSelectedLinesDownCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new MoveSelectedLinesDownCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteAutomaticLineEnder(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<AutomaticLineEnderCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new AutomaticLineEnderCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteExtractInterface(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<ExtractInterfaceCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new ExtractInterfaceCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteExtractMethod(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<ExtractMethodCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new ExtractMethodCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteViewCallHierarchy(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<ViewCallHierarchyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new ViewCallHierarchyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteInsertSnippet(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<InsertSnippetCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new InsertSnippetCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteSurroundWith(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<SurroundWithCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new SurroundWithCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteRename(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<RenameCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new RenameCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteQuickInfo(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<InvokeQuickInfoCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new InvokeQuickInfoCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteParameterInfo(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<InvokeSignatureHelpCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new InvokeSignatureHelpCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteCommitUniqueCompletionItem(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<CommitUniqueCompletionListItemCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new CommitUniqueCompletionListItemCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteInvokeCompletionList(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<InvokeCompletionListCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new InvokeCompletionListCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteUncommentBlock(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<UncommentSelectionCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new UncommentSelectionCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteCommentBlock(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<CommentSelectionCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new CommentSelectionCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecutePreviousHighlightedReference(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<NavigateToHighlightedReferenceCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new NavigateToHighlightedReferenceCommandArgs(ConvertTextView(), subjectBuffer, NavigateDirection.Up),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteNextHighlightedReference(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<NavigateToHighlightedReferenceCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new NavigateToHighlightedReferenceCommandArgs(ConvertTextView(), subjectBuffer, NavigateDirection.Down),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteToggleConsumeFirstMode(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<ToggleCompletionModeCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new ToggleCompletionModeCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteInsertComment(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<InsertCommentCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new InsertCommentCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteFormatDocument(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<FormatDocumentCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new FormatDocumentCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteFormatSelection(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<FormatSelectionCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new FormatSelectionCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteBackspace(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<BackspaceKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new BackspaceKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteDelete(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<DeleteKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new DeleteKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteWordDeleteToStart(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<WordDeleteToStartCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new WordDeleteToStartCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteWordDeleteToEnd(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<WordDeleteToEndCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new WordDeleteToEndCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteCancel(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<EscapeKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new EscapeKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecutePageUp(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<PageUpKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new PageUpKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecutePageDown(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<PageDownKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new PageDownKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteDown(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<DownKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new DownKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteUp(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<UpKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new UpKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteDocumentStart(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<DocumentStartCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new DocumentStartCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteDocumentEnd(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<DocumentEndCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new DocumentEndCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteLineStart(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<LineStartCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new LineStartCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteLineStartExtend(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<LineStartExtendCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new LineStartExtendCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteLineEnd(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<LineEndCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new LineEndCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteLineEndExtend(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<LineEndExtendCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new LineEndExtendCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteSelectAll(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<SelectAllCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new SelectAllCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteOpenLineAbove(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<OpenLineAboveCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new OpenLineAboveCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteOpenLineBelow(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<OpenLineBelowCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new OpenLineBelowCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
@@ -889,21 +894,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         protected void ExecuteTab(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<TabKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new TabKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteBackTab(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<BackTabKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new BackTabKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecuteReturn(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<ReturnKeyCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new ReturnKeyCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
@@ -911,70 +916,77 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         protected void ExecuteTypeCharacter(IntPtr pvaIn, ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
             var typedChar = (char)(ushort)Marshal.GetObjectForNativeVariant(pvaIn);
-            CurrentHandlers.Execute<TypeCharCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new TypeCharCommandArgs(ConvertTextView(), subjectBuffer, typedChar),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteGoToDefinition(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<GoToDefinitionCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new GoToDefinitionCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteGoToImplementation(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<GoToImplementationCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new GoToImplementationCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteFindReferences(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<FindReferencesCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new FindReferencesCommandArgs(ConvertTextView(), subjectBuffer),
+                lastHandler: executeNextCommandTarget);
+        }
+
+        private void ExecuteSyncClassView(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
+        {
+            CurrentHandlers.Execute(contentType,
+                args: new SyncClassViewCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         protected void ExecutePaste(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<PasteCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new PasteCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteSortUsings(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<SortImportsCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new SortImportsCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteRemoveUnusedUsings(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<RemoveUnnecessaryImportsCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new RemoveUnnecessaryImportsCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteSortAndRemoveUnusedUsings(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<SortAndRemoveUnnecessaryImportsCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new SortAndRemoveUnnecessaryImportsCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteExecuteInInteractiveWindow(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<ExecuteInInteractiveCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new ExecuteInInteractiveCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 
         private void ExecuteCopyToToInteractiveWindow(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
         {
-            CurrentHandlers.Execute<CopyToInteractiveCommandArgs>(contentType,
+            CurrentHandlers.Execute(contentType,
                 args: new CopyToInteractiveCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Query.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Query.cs
@@ -5,11 +5,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.OrganizeImports;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -19,6 +16,7 @@ using Roslyn.Utilities;
 using InteractiveCommandIds = Microsoft.VisualStudio.LanguageServices.InteractiveWindow.CommandIds;
 using InteractiveGuids = Microsoft.VisualStudio.LanguageServices.InteractiveWindow.Guids;
 #endif
+
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     internal abstract partial class AbstractOleCommandTarget
@@ -103,6 +101,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 case VSConstants.VSStd97CmdID.FindReferences:
                     return QueryFindReferencesStatus(prgCmds);
+
+                case VSConstants.VSStd97CmdID.SyncClassView:
+                    return QuerySyncClassView(prgCmds);
 
                 default:
                     return NextCommandTarget.QueryStatus(ref pguidCmdGroup, commandCount, prgCmds, commandText);
@@ -246,6 +247,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 #endif
+
         private int GetCommandState<T>(
             Func<ITextView, ITextBuffer, T> createArgs,
             ref Guid pguidCmdGroup,
@@ -326,6 +328,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         }
 
         private int QueryFindReferencesStatus(OLECMD[] prgCmds)
+        {
+            prgCmds[0].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
+            return VSConstants.S_OK;
+        }
+
+        private int QuerySyncClassView(OLECMD[] prgCmds)
         {
             prgCmds[0].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
             return VSConstants.S_OK;

--- a/src/VisualStudio/Core/Def/Implementation/Extensions/ServiceProviderExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Extensions/ServiceProviderExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Extensions
+{
+    internal static class ServiceProviderExtensions
+    {
+        public static TInterface GetService<TService, TInterface>(this IServiceProvider serviceProvider)
+        {
+            var service = (TInterface)serviceProvider.GetService(typeof(TService));
+            Debug.Assert(service != null);
+            return service;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Library/ClassView/AbstractSyncClassViewCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ClassView/AbstractSyncClassViewCommandHandler.cs
@@ -19,6 +19,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassVi
     internal abstract class AbstractSyncClassViewCommandHandler : ForegroundThreadAffinitizedObject,
         ICommandHandler<SyncClassViewCommandArgs>
     {
+        private const string ClassView = "Class View";
+
         private readonly IServiceProvider _serviceProvider;
         private readonly IWaitIndicator _waitIndicator;
 
@@ -47,8 +49,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassVi
             var snapshot = args.SubjectBuffer.CurrentSnapshot;
 
             _waitIndicator.Wait(
-                title: ServicesVSResources.SynchronizeClassView,
-                message: ServicesVSResources.SynchronizingClassView,
+                title: string.Format(ServicesVSResources.SynchronizeClassView, ClassView),
+                message: string.Format(ServicesVSResources.SynchronizingWithClassView, ClassView),
                 allowCancel: true,
                 action: context =>
                 {

--- a/src/VisualStudio/Core/Def/Implementation/Library/ClassView/AbstractSyncClassViewCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ClassView/AbstractSyncClassViewCommandHandler.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView
+{
+    internal abstract class AbstractSyncClassViewCommandHandler : ForegroundThreadAffinitizedObject,
+        ICommandHandler<SyncClassViewCommandArgs>
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IWaitIndicator _waitIndicator;
+
+        protected AbstractSyncClassViewCommandHandler(
+            SVsServiceProvider serviceProvider,
+            IWaitIndicator waitIndicator)
+        {
+            Contract.ThrowIfNull(serviceProvider);
+            Contract.ThrowIfNull(waitIndicator);
+
+            _serviceProvider = serviceProvider;
+            _waitIndicator = waitIndicator;
+        }
+
+        public void ExecuteCommand(SyncClassViewCommandArgs args, Action nextHandler)
+        {
+            this.AssertIsForeground();
+
+            var caretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer) ?? -1;
+            if (caretPosition < 0)
+            {
+                nextHandler();
+                return;
+            }
+
+            var snapshot = args.SubjectBuffer.CurrentSnapshot;
+
+            _waitIndicator.Wait(
+                title: ServicesVSResources.SynchronizeClassView,
+                message: ServicesVSResources.SynchronizingClassView,
+                allowCancel: true,
+                action: context =>
+                {
+                    var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
+                    if (document == null)
+                    {
+                        return;
+                    }
+
+                    var syntaxFactsService = document.Project.LanguageServices.GetService<ISyntaxFactsService>();
+                    if (syntaxFactsService == null)
+                    {
+                        return;
+                    }
+
+                    var libraryService = document.Project.LanguageServices.GetService<ILibraryService>();
+                    if (libraryService == null)
+                    {
+                        return;
+                    }
+
+                    var semanticModel = document
+                        .GetSemanticModelAsync(context.CancellationToken)
+                        .WaitAndGetResult(context.CancellationToken);
+
+                    var root = semanticModel.SyntaxTree
+                        .GetRootAsync(context.CancellationToken)
+                        .WaitAndGetResult(context.CancellationToken);
+
+                    var memberDeclaration = syntaxFactsService.GetContainingMemberDeclaration(root, caretPosition);
+
+                    var symbol = memberDeclaration != null
+                        ? semanticModel.GetDeclaredSymbol(memberDeclaration, context.CancellationToken)
+                        : null;
+
+                    while (symbol != null && !IsValidSymbolToSynchronize(symbol))
+                    {
+                        symbol = symbol.ContainingSymbol;
+                    }
+
+                    IVsNavInfo navInfo = null;
+                    if (symbol != null)
+                    {
+                        navInfo = libraryService.NavInfoFactory.CreateForSymbol(symbol, document.Project, semanticModel.Compilation, useExpandedHierarchy: true);
+                    }
+
+                    if (navInfo == null)
+                    {
+                        navInfo = libraryService.NavInfoFactory.CreateForProject(document.Project);
+                    }
+
+                    if (navInfo == null)
+                    {
+                        return;
+                    }
+
+                    var navigationTool = _serviceProvider.GetService<SVsClassView, IVsNavigationTool>();
+                    navigationTool.NavigateToNavInfo(navInfo);
+                });
+        }
+
+        private static bool IsValidSymbolToSynchronize(ISymbol symbol) =>
+            symbol.Kind == SymbolKind.Event ||
+            symbol.Kind == SymbolKind.Field ||
+            symbol.Kind == SymbolKind.Method ||
+            symbol.Kind == SymbolKind.NamedType ||
+            symbol.Kind == SymbolKind.Property;
+
+        public CommandState GetCommandState(SyncClassViewCommandArgs args, Func<CommandState> nextHandler)
+        {
+            return nextHandler();
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
@@ -43,7 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _serviceProvider = serviceProvider;
             _outliningTaggerProvider = outliningTaggerProvider;
 
-            var componentModel = GetService<SComponentModel, IComponentModel>();
+            var componentModel = _serviceProvider.GetService<SComponentModel, IComponentModel>();
             _editorAdaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
             _textEditorFactoryService = componentModel.GetService<ITextEditorFactoryService>();
             _textDocumentFactoryService = componentModel.GetService<ITextDocumentFactoryService>();
@@ -102,7 +103,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 if (navInfo != null)
                 {
-                    var navigationTool = GetService<SVsObjBrowser, IVsNavigationTool>();
+                    var navigationTool = _serviceProvider.GetService<SVsObjBrowser, IVsNavigationTool>();
                     return navigationTool.NavigateToNavInfo(navInfo) == VSConstants.S_OK;
                 }
 
@@ -112,10 +113,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             // Generate new source or retrieve existing source for the symbol in question
             var result = _metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, cancellationToken).WaitAndGetResult(cancellationToken);
 
-            var vsRunningDocumentTable4 = GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>();
+            var vsRunningDocumentTable4 = _serviceProvider.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>();
             var fileAlreadyOpen = vsRunningDocumentTable4.IsMonikerValid(result.FilePath);
 
-            var openDocumentService = GetService<SVsUIShellOpenDocument, IVsUIShellOpenDocument>();
+            var openDocumentService = _serviceProvider.GetService<SVsUIShellOpenDocument, IVsUIShellOpenDocument>();
 
             IVsUIHierarchy hierarchy;
             uint itemId;
@@ -322,16 +323,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return false;
         }
 
-        private TInterface GetService<TService, TInterface>()
-        {
-            var service = (TInterface)_serviceProvider.GetService(typeof(TService));
-            Debug.Assert(service != null);
-            return service;
-        }
-
         private IVsRunningDocumentTable GetRunningDocumentTable()
         {
-            var runningDocumentTable = GetService<SVsRunningDocumentTable, IVsRunningDocumentTable>();
+            var runningDocumentTable = _serviceProvider.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable>();
             Debug.Assert(runningDocumentTable != null);
             return runningDocumentTable;
         }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1084,7 +1084,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Synchronize Class View.
+        ///   Looks up a localized string similar to Synchronize {0}.
         /// </summary>
         internal static string SynchronizeClassView {
             get {
@@ -1093,11 +1093,11 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Synchronizing Class View....
+        ///   Looks up a localized string similar to Synchronizing with {0}....
         /// </summary>
-        internal static string SynchronizingClassView {
+        internal static string SynchronizingWithClassView {
             get {
-                return ResourceManager.GetString("SynchronizingClassView", resourceCulture);
+                return ResourceManager.GetString("SynchronizingWithClassView", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1084,6 +1084,24 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Synchronize Class View.
+        /// </summary>
+        internal static string SynchronizeClassView {
+            get {
+                return ResourceManager.GetString("SynchronizeClassView", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Synchronizing Class View....
+        /// </summary>
+        internal static string SynchronizingClassView {
+            get {
+                return ResourceManager.GetString("SynchronizingClassView", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This workspace only supports opening documents on the UI thread..
         /// </summary>
         internal static string ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread {
@@ -1192,7 +1210,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Analyzer assembly &apos;{0}&apos; depends on &apos;{1}&apos; but it was not found. Analyzers may not run correctly..
+        ///   Looks up a localized string similar to Analyzer assembly &apos;{0}&apos; depends on &apos;{1}&apos; but it was not found. Analyzers may not run correctly unless the missing assembly is added as an analyzer reference as well..
         /// </summary>
         internal static string WRN_MissingAnalyzerReferenceMessage {
             get {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -507,4 +507,10 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   <data name="ThisWorkspaceOnlySupportsOpeningDocumentsOnTheUIThread" xml:space="preserve">
     <value>This workspace only supports opening documents on the UI thread.</value>
   </data>
+  <data name="SynchronizeClassView" xml:space="preserve">
+    <value>Synchronize Class View</value>
+  </data>
+  <data name="SynchronizingClassView" xml:space="preserve">
+    <value>Synchronizing Class View...</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -508,9 +508,9 @@ Use the dropdown to view and switch to other projects this file may belong to.</
     <value>This workspace only supports opening documents on the UI thread.</value>
   </data>
   <data name="SynchronizeClassView" xml:space="preserve">
-    <value>Synchronize Class View</value>
+    <value>Synchronize {0}</value>
   </data>
-  <data name="SynchronizingClassView" xml:space="preserve">
-    <value>Synchronizing Class View...</value>
+  <data name="SynchronizingWithClassView" xml:space="preserve">
+    <value>Synchronizing with {0}...</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -42,9 +42,11 @@
     <Compile Include="Implementation\EditAndContinue\Interop\NativeMethods.cs" />
     <Compile Include="Implementation\AnalyzerDependency\IIgnorableAssemblyList.cs" />
     <Compile Include="Implementation\AnalyzerDependency\IBindingRedirectionService.cs" />
+    <Compile Include="Implementation\Extensions\ServiceProviderExtensions.cs" />
     <Compile Include="Implementation\Interop\CleanableWeakComHandleTable.cs" />
     <Compile Include="Implementation\LanguageService\AbstractLanguageService`2.IVsLanguageBlock.cs" />
     <Compile Include="Implementation\Library\AbstractLibraryService.cs" />
+    <Compile Include="Implementation\Library\ClassView\AbstractSyncClassViewCommandHandler.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\AbstractSourceTreeItem.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\MetadataDefinitionTreeItem.cs" />
     <Compile Include="Implementation\Library\FindResults\TreeItems\SourceDefinitionTreeItem.cs" />

--- a/src/VisualStudio/Core/Test/ClassView/MockNavigationTool.vb
+++ b/src/VisualStudio/Core/Test/ClassView/MockNavigationTool.vb
@@ -1,0 +1,53 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.Utilities.VsNavInfo
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
+    Friend Class MockNavigationTool
+        Implements IVsNavigationTool
+
+        Private ReadOnly _canonicalNodes As NodeVerifier()
+        Private ReadOnly _presentationNodes As NodeVerifier()
+        Private _navInfo As IVsNavInfo
+
+        Public Sub New(canonicalNodes As NodeVerifier(), presentationNodes As NodeVerifier())
+            _canonicalNodes = canonicalNodes
+            _presentationNodes = presentationNodes
+        End Sub
+
+        Public Function GetSelectedSymbols(ByRef ppIVsSelectedSymbols As IVsSelectedSymbols) As Integer Implements IVsNavigationTool.GetSelectedSymbols
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function NavigateToNavInfo(pNavInfo As IVsNavInfo) As Integer Implements IVsNavigationTool.NavigateToNavInfo
+            Assert.Null(_navInfo)
+            _navInfo = pNavInfo
+
+            Return VSConstants.S_OK
+        End Function
+
+        Public Function NavigateToSymbol(ByRef guidLib As Guid, rgSymbolNodes() As SYMBOL_DESCRIPTION_NODE, ulcNodes As UInteger) As Integer Implements IVsNavigationTool.NavigateToSymbol
+            Throw New NotImplementedException()
+        End Function
+
+        Public Sub VerifyNavInfo()
+            Assert.NotNull(_navInfo)
+
+            If _canonicalNodes IsNot Nothing Then
+                Dim enumerator As IVsEnumNavInfoNodes = Nothing
+                IsOK(Function() _navInfo.EnumCanonicalNodes(enumerator))
+
+                VerifyNodes(enumerator, _canonicalNodes)
+            End If
+
+            If _presentationNodes IsNot Nothing Then
+                Dim enumerator As IVsEnumNavInfoNodes = Nothing
+                IsOK(Function() _navInfo.EnumPresentationNodes(CUInt(_LIB_LISTFLAGS.LLF_NONE), enumerator))
+
+                VerifyNodes(enumerator, _presentationNodes)
+            End If
+
+        End Sub
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ClassView/MockNavigationTool.vb
+++ b/src/VisualStudio/Core/Test/ClassView/MockNavigationTool.vb
@@ -36,14 +36,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 
             If _canonicalNodes IsNot Nothing Then
                 Dim enumerator As IVsEnumNavInfoNodes = Nothing
-                IsOK(Function() _navInfo.EnumCanonicalNodes(enumerator))
+                IsOK(_navInfo.EnumCanonicalNodes(enumerator))
 
                 VerifyNodes(enumerator, _canonicalNodes)
             End If
 
             If _presentationNodes IsNot Nothing Then
                 Dim enumerator As IVsEnumNavInfoNodes = Nothing
-                IsOK(Function() _navInfo.EnumPresentationNodes(CUInt(_LIB_LISTFLAGS.LLF_NONE), enumerator))
+                IsOK(_navInfo.EnumPresentationNodes(CUInt(_LIB_LISTFLAGS.LLF_NONE), enumerator))
 
                 VerifyNodes(enumerator, _presentationNodes)
             End If

--- a/src/VisualStudio/Core/Test/ClassView/MockSyncClassViewCommandHandler.vb
+++ b/src/VisualStudio/Core/Test/ClassView/MockSyncClassViewCommandHandler.vb
@@ -1,0 +1,15 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView
+Imports Microsoft.VisualStudio.Shell
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
+    Friend Class MockSyncClassViewCommandHandler
+        Inherits AbstractSyncClassViewCommandHandler
+
+        Public Sub New(serviceProvider As SVsServiceProvider, waitIndicator As IWaitIndicator)
+            MyBase.New(serviceProvider, waitIndicator)
+        End Sub
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ClassView/MockVsServiceProvider.vb
+++ b/src/VisualStudio/Core/Test/ClassView/MockVsServiceProvider.vb
@@ -1,0 +1,25 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.VisualStudio.Shell
+Imports Microsoft.VisualStudio.Shell.Interop
+Imports Roslyn.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
+    Friend Class MockServiceProvider
+        Implements SVsServiceProvider
+
+        Private ReadOnly _navigationTool As IVsNavigationTool
+
+        Public Sub New(navigationTool As IVsNavigationTool)
+            _navigationTool = navigationTool
+        End Sub
+
+        Public Function GetService(serviceType As Type) As Object Implements SVsServiceProvider.GetService
+            If serviceType Is GetType(SVsClassView) Then
+                Return _navigationTool
+            End If
+
+            Return Contract.FailWithReturn(Of Object)($"GetService only handles {NameOf(SVsClassView)}")
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
+++ b/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
@@ -30,16 +30,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -59,16 +52,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -88,16 +74,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -117,16 +96,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -149,16 +121,62 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestClassInNestedNamespaces1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace X.Y
+            {
+                class C
+                {  $$
+                    void M()
+                    {
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("X.Y"),
+                [Class]("C"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestClassInNestedNamespaces2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace X
+            {
+                namespace Y
+                {
+                    class C
+                    {  $$
+                        void M()
+                        {
+                        }
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("X.Y"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -181,18 +199,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -215,18 +225,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -249,18 +251,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -283,18 +277,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -317,18 +303,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("CSharpTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
 #End Region
@@ -351,16 +329,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -378,16 +349,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -405,16 +369,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -432,16 +389,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -461,16 +411,55 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestClassInNestedNamespaces1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace X.Y
+                Class C$$
+                    Sub M()
+                    End Sub
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("X.Y"),
+                [Class]("C"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestClassInNestedNamespaces2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace X
+                Namespace Y
+                    Class C$$
+                        Sub M()
+                        End Sub
+                    End Class
+                End Namespace
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("X.Y"),
+                [Class]("C"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -491,18 +480,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -522,18 +503,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -553,18 +526,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -584,18 +549,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
@@ -615,26 +572,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 </Workspace>
 
             Await TestAsync(workspace,
-                 canonicalNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 },
-                 presentationNodes:={
-                    Package("VBTestAssembly"),
-                    [Namespace]("N"),
-                    [Class]("C"),
-                    Member("M()")
-                 })
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("M()"))
         End Function
 
 #End Region
 
         Private Async Function TestAsync(
             workspaceDefinition As XElement,
-            Optional canonicalNodes As NodeVerifier() = Nothing,
-            Optional presentationNodes As NodeVerifier() = Nothing
+            ParamArray presentationNodes As NodeVerifier()
         ) As Task
 
             Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(workspaceDefinition, exportProvider:=VisualStudioTestExportProvider.ExportProvider)
@@ -644,7 +592,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Dim textView = hostDocument.GetTextView()
                 Dim subjectBuffer = hostDocument.GetTextBuffer()
 
-                Dim navigationTool = New MockNavigationTool(canonicalNodes, presentationNodes)
+                Dim navigationTool = New MockNavigationTool(canonicalNodes:=Nothing, presentationNodes:=presentationNodes)
                 Dim serviceProvider = New MockServiceProvider(navigationTool)
                 Dim commandHandler = New MockSyncClassViewCommandHandler(serviceProvider, workspace.GetService(Of IWaitIndicator))
 

--- a/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
+++ b/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 
 #Region "C# Tests"
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestClass1() As Task
             Dim workspace =
 <Workspace>
@@ -35,7 +35,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestClass2() As Task
             Dim workspace =
 <Workspace>
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestClass3() As Task
             Dim workspace =
 <Workspace>
@@ -79,7 +79,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestClass4() As Task
             Dim workspace =
 <Workspace>
@@ -101,7 +101,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestClass5() As Task
             Dim workspace =
 <Workspace>
@@ -126,7 +126,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestClassInNestedNamespaces1() As Task
             Dim workspace =
 <Workspace>
@@ -151,7 +151,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestClassInNestedNamespaces2() As Task
             Dim workspace =
 <Workspace>
@@ -179,7 +179,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestMethod1() As Task
             Dim workspace =
 <Workspace>
@@ -205,7 +205,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestMethod2() As Task
             Dim workspace =
 <Workspace>
@@ -231,7 +231,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestMethod3() As Task
             Dim workspace =
 <Workspace>
@@ -257,7 +257,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestMethod4() As Task
             Dim workspace =
 <Workspace>
@@ -283,7 +283,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestMethod5() As Task
             Dim workspace =
 <Workspace>
@@ -309,7 +309,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestField1() As Task
             Dim workspace =
 <Workspace>
@@ -333,7 +333,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("i"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestField2() As Task
             Dim workspace =
 <Workspace>
@@ -357,7 +357,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("i"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestProperty1() As Task
             Dim workspace =
 <Workspace>
@@ -381,7 +381,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("P"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestProperty2() As Task
             Dim workspace =
 <Workspace>
@@ -405,7 +405,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("P"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestEvent1() As Task
             Dim workspace =
 <Workspace>
@@ -429,7 +429,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("E"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function CSharp_TestEvent2() As Task
             Dim workspace =
 <Workspace>
@@ -457,7 +457,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 
 #Region "Visual Basic Tests"
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestClass1() As Task
             Dim workspace =
 <Workspace>
@@ -478,7 +478,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestClass2() As Task
             Dim workspace =
 <Workspace>
@@ -498,7 +498,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestClass3() As Task
             Dim workspace =
 <Workspace>
@@ -518,7 +518,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestClass4() As Task
             Dim workspace =
 <Workspace>
@@ -538,7 +538,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestClass5() As Task
             Dim workspace =
 <Workspace>
@@ -560,7 +560,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestClassInNestedNamespaces1() As Task
             Dim workspace =
 <Workspace>
@@ -582,7 +582,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestClassInNestedNamespaces2() As Task
             Dim workspace =
 <Workspace>
@@ -606,7 +606,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Class]("C"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestMethod1() As Task
             Dim workspace =
 <Workspace>
@@ -630,7 +630,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestMethod2() As Task
             Dim workspace =
 <Workspace>
@@ -653,7 +653,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestMethod3() As Task
             Dim workspace =
 <Workspace>
@@ -676,7 +676,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestMethod4() As Task
             Dim workspace =
 <Workspace>
@@ -699,7 +699,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestMethod5() As Task
             Dim workspace =
 <Workspace>
@@ -722,7 +722,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestField1() As Task
             Dim workspace =
 <Workspace>
@@ -744,7 +744,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("i As Integer"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestField2() As Task
             Dim workspace =
 <Workspace>
@@ -766,7 +766,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("i As Integer"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestProperty1() As Task
             Dim workspace =
 <Workspace>
@@ -788,7 +788,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("P As Integer"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestProperty2() As Task
             Dim workspace =
 <Workspace>
@@ -810,7 +810,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("P As Integer"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestEvent1() As Task
             Dim workspace =
 <Workspace>
@@ -832,7 +832,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("E()"))
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ClassView)>
         Public Async Function VisualBasic_TestEvent2() As Task
             Dim workspace =
 <Workspace>

--- a/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
+++ b/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
@@ -1,0 +1,661 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Editor.Commands
+Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.Utilities.VsNavInfo
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
+    Public Class SyncClassViewTests
+
+#Region "C# Tests"
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestClass1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    $$
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestClass2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C$$
+                {
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestClass3() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class $$C
+                {
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestClass4() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                $$class C
+                {
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestClass5() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {  $$
+                    void M()
+                    {
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestMethod1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    void M()
+                    {$$
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestMethod2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    void M()
+                    $${
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestMethod3() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    void $$M()
+                    {
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestMethod4() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    $$void M()
+                    {
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestMethod5() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+            $$        void M()
+                    {
+                    }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("CSharpTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+#End Region
+
+#Region "Visual Basic Tests"
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestClass1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    $$
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestClass2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C$$
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestClass3() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class $$C
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestClass4() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                $$Class C
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestClass5() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C  $$
+                    Sub M()
+                    End Sub
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestMethod1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    Sub M()
+                        $$
+                    End Sub
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestMethod2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    Sub M()$$
+                    End Sub
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestMethod3() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    Sub $$M()
+                    End Sub
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestMethod4() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    $$Sub M()
+                    End Sub
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestMethod5() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+            $$        Sub M()
+                    End Sub
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                 canonicalNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 },
+                 presentationNodes:={
+                    Package("VBTestAssembly"),
+                    [Namespace]("N"),
+                    [Class]("C"),
+                    Member("M()")
+                 })
+        End Function
+
+#End Region
+
+        Private Async Function TestAsync(
+            workspaceDefinition As XElement,
+            Optional canonicalNodes As NodeVerifier() = Nothing,
+            Optional presentationNodes As NodeVerifier() = Nothing
+        ) As Task
+
+            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(workspaceDefinition, exportProvider:=VisualStudioTestExportProvider.ExportProvider)
+                Dim hostDocument = workspace.DocumentWithCursor
+                Assert.True(hostDocument IsNot Nothing, "Test defined without cursor position")
+
+                Dim textView = hostDocument.GetTextView()
+                Dim subjectBuffer = hostDocument.GetTextBuffer()
+
+                Dim navigationTool = New MockNavigationTool(canonicalNodes, presentationNodes)
+                Dim serviceProvider = New MockServiceProvider(navigationTool)
+                Dim commandHandler = New MockSyncClassViewCommandHandler(serviceProvider, workspace.GetService(Of IWaitIndicator))
+
+                commandHandler.ExecuteCommand(
+                    args:=New SyncClassViewCommandArgs(textView, subjectBuffer),
+                    nextHandler:=Sub() Exit Sub)
+
+                navigationTool.VerifyNavInfo()
+            End Using
+
+        End Function
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
+++ b/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
@@ -309,6 +309,150 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 Member("M()"))
         End Function
 
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestField1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+            $$        int i;
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("i"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestField2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    int $$i;
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("i"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestProperty1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+            $$        int P { get; }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("P"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestProperty2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    int $$P { get; }
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("P"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestEvent1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+            $$        event System.EventHandler E;
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("E"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function CSharp_TestEvent2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="CSharpTestAssembly">
+        <Document>
+            namespace N
+            {
+                class C
+                {
+                    event System.EventHandler $$E;
+                }
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("CSharpTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("E"))
+        End Function
+
 #End Region
 
 #Region "Visual Basic Tests"
@@ -576,6 +720,138 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
                 [Namespace]("N"),
                 [Class]("C"),
                 Member("M()"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestField1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+            $$        Private i As Integer
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("i As Integer"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestField2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    Private $$i As Integer
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("i As Integer"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestProperty1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+            $$        ReadOnly Property P As Integer = 42
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("P As Integer"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestProperty2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    ReadOnly Property $$P As Integer = 42
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("P As Integer"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestEvent1() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+            $$        Event E()
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("E()"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.VsNavInfo)>
+        Public Async Function VisualBasic_TestEvent2() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBTestAssembly">
+        <Document>
+            Namespace N
+                Class C
+                    Event $$E()
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace,
+                Package("VBTestAssembly"),
+                [Namespace]("N"),
+                [Class]("C"),
+                Member("E()"))
         End Function
 
 #End Region

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -232,6 +232,10 @@
     <Compile Include="AnalyzerSupport\AnalyzerDependencyCheckerTests.vb" />
     <Compile Include="ChangeSignature\ChangeSignatureViewModelTests.vb" />
     <Compile Include="ChangeSignature\ChangeSignatureViewModelTestState.vb" />
+    <Compile Include="ClassView\MockNavigationTool.vb" />
+    <Compile Include="ClassView\MockVsServiceProvider.vb" />
+    <Compile Include="ClassView\MockSyncClassViewCommandHandler.vb" />
+    <Compile Include="ClassView\SyncClassViewTests.vb" />
     <Compile Include="CodeModel\AbstractCodeAttributeTests.vb" />
     <Compile Include="CodeModel\AbstractCodeClassTests.vb" />
     <Compile Include="CodeModel\AbstractCodeDelegateTests.vb" />
@@ -364,6 +368,7 @@
     <Compile Include="Help\HelpTests.vb" />
     <Compile Include="LanguageBlockTests.vb" />
     <Compile Include="MockComponentModel.vb" />
+    <Compile Include="Utilities\VsNavInfoHelpers.vb" />
     <Compile Include="VsNavInfo\VsNavInfoTests.vb" />
     <Compile Include="ObjectBrowser\AbstractObjectBrowserTests.vb" />
     <Compile Include="ObjectBrowser\CSharp\ObjectBrowerTests.vb" />

--- a/src/VisualStudio/Core/Test/Utilities/VsNavInfoHelpers.vb
+++ b/src/VisualStudio/Core/Test/Utilities/VsNavInfoHelpers.vb
@@ -1,0 +1,64 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Runtime.CompilerServices
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Utilities.VsNavInfo
+    Friend Module VsNavInfoHelpers
+
+        Public Sub IsOK(comAction As Func(Of Integer))
+            Assert.Equal(VSConstants.S_OK, comAction())
+        End Sub
+
+        Public Delegate Sub NodeVerifier(vsNavInfoNode As IVsNavInfoNode)
+
+        Private Function Node(expectedListType As _LIB_LISTTYPE, expectedName As String) As NodeVerifier
+            Return Sub(vsNavInfoNode)
+                       Dim listType As UInteger
+                       IsOK(Function() vsNavInfoNode.get_Type(listType))
+                       Assert.Equal(CUInt(expectedListType), listType)
+
+                       Dim actualName As String = Nothing
+                       IsOK(Function() vsNavInfoNode.get_Name(actualName))
+                       Assert.Equal(expectedName, actualName)
+                   End Sub
+        End Function
+
+        Public Function Package(expectedName As String) As NodeVerifier
+            Return Node(_LIB_LISTTYPE.LLT_PACKAGE, expectedName)
+        End Function
+
+        Public Function [Namespace](expectedName As String) As NodeVerifier
+            Return Node(_LIB_LISTTYPE.LLT_NAMESPACES, expectedName)
+        End Function
+
+        Public Function [Class](expectedName As String) As NodeVerifier
+            Return Node(_LIB_LISTTYPE.LLT_CLASSES, expectedName)
+        End Function
+
+        Public Function Member(expectedName As String) As NodeVerifier
+            Return Node(_LIB_LISTTYPE.LLT_MEMBERS, expectedName)
+        End Function
+
+        Public Function Hierarchy(expectedName As String) As NodeVerifier
+            Return Node(_LIB_LISTTYPE.LLT_HIERARCHY, expectedName)
+        End Function
+
+        <Extension>
+        Public Sub VerifyNodes(enumerator As IVsEnumNavInfoNodes, verifiers() As NodeVerifier)
+            Dim index = 0
+            Dim actualNode = New IVsNavInfoNode(0) {}
+            Dim fetched As UInteger
+            While enumerator.Next(1, actualNode, fetched) = VSConstants.S_OK
+                Assert.True(index < verifiers.Length)
+
+                Dim verifier = verifiers(index)
+                index += 1
+
+                verifier(actualNode(0))
+            End While
+        End Sub
+
+
+    End Module
+End Namespace

--- a/src/VisualStudio/Core/Test/Utilities/VsNavInfoHelpers.vb
+++ b/src/VisualStudio/Core/Test/Utilities/VsNavInfoHelpers.vb
@@ -6,8 +6,8 @@ Imports Microsoft.VisualStudio.Shell.Interop
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Utilities.VsNavInfo
     Friend Module VsNavInfoHelpers
 
-        Public Sub IsOK(comAction As Func(Of Integer))
-            Assert.Equal(VSConstants.S_OK, comAction())
+        Public Sub IsOK(result As Integer)
+            Assert.Equal(VSConstants.S_OK, result)
         End Sub
 
         Public Delegate Sub NodeVerifier(vsNavInfoNode As IVsNavInfoNode)
@@ -15,11 +15,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Utilities.VsNavInfo
         Private Function Node(expectedListType As _LIB_LISTTYPE, expectedName As String) As NodeVerifier
             Return Sub(vsNavInfoNode)
                        Dim listType As UInteger
-                       IsOK(Function() vsNavInfoNode.get_Type(listType))
+                       IsOK(vsNavInfoNode.get_Type(listType))
                        Assert.Equal(CUInt(expectedListType), listType)
 
                        Dim actualName As String = Nothing
-                       IsOK(Function() vsNavInfoNode.get_Name(actualName))
+                       IsOK(vsNavInfoNode.get_Name(actualName))
                        Assert.Equal(expectedName, actualName)
                    End Sub
         End Function

--- a/src/VisualStudio/Core/Test/VsNavInfo/VsNavInfoTests.vb
+++ b/src/VisualStudio/Core/Test/VsNavInfo/VsNavInfoTests.vb
@@ -836,14 +836,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.VsNavInfo
 
                 If canonicalNodes IsNot Nothing Then
                     Dim enumerator As IVsEnumNavInfoNodes = Nothing
-                    IsOK(Function() navInfo.EnumCanonicalNodes(enumerator))
+                    IsOK(navInfo.EnumCanonicalNodes(enumerator))
 
                     VerifyNodes(enumerator, canonicalNodes)
                 End If
 
                 If presentationNodes IsNot Nothing Then
                     Dim enumerator As IVsEnumNavInfoNodes = Nothing
-                    IsOK(Function() navInfo.EnumPresentationNodes(CUInt(_LIB_LISTFLAGS.LLF_NONE), enumerator))
+                    IsOK(navInfo.EnumPresentationNodes(CUInt(_LIB_LISTFLAGS.LLF_NONE), enumerator))
 
                     VerifyNodes(enumerator, presentationNodes)
                 End If

--- a/src/VisualStudio/Core/Test/VsNavInfo/VsNavInfoTests.vb
+++ b/src/VisualStudio/Core/Test/VsNavInfo/VsNavInfoTests.vb
@@ -1,8 +1,11 @@
-﻿Imports System.Threading
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.Utilities.VsNavInfo
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Roslyn.Test.Utilities
 
@@ -807,64 +810,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.VsNavInfo
 
 #End Region
 
-        Private Shared Sub IsOK(comAction As Func(Of Integer))
-            Assert.Equal(VSConstants.S_OK, comAction())
-        End Sub
-
-        Private Delegate Sub NodeVerifier(vsNavInfoNode As IVsNavInfoNode)
-
-        Private Shared Function Node(expectedListType As _LIB_LISTTYPE, expectedName As String) As NodeVerifier
-            Return Sub(vsNavInfoNode)
-                       Dim listType As UInteger
-                       IsOK(Function() vsNavInfoNode.get_Type(listType))
-                       Assert.Equal(CUInt(expectedListType), listType)
-
-                       Dim actualName As String = Nothing
-                       IsOK(Function() vsNavInfoNode.get_Name(actualName))
-                       Assert.Equal(expectedName, actualName)
-                   End Sub
-        End Function
-
-        Private Shared Function Package(expectedName As String) As NodeVerifier
-            Return Node(_LIB_LISTTYPE.LLT_PACKAGE, expectedName)
-        End Function
-
-        Private Shared Function [Namespace](expectedName As String) As NodeVerifier
-            Return Node(_LIB_LISTTYPE.LLT_NAMESPACES, expectedName)
-        End Function
-
-        Private Shared Function [Class](expectedName As String) As NodeVerifier
-            Return Node(_LIB_LISTTYPE.LLT_CLASSES, expectedName)
-        End Function
-
-        Private Shared Function Member(expectedName As String) As NodeVerifier
-            Return Node(_LIB_LISTTYPE.LLT_MEMBERS, expectedName)
-        End Function
-
-        Private Shared Function Hierarchy(expectedName As String) As NodeVerifier
-            Return Node(_LIB_LISTTYPE.LLT_HIERARCHY, expectedName)
-        End Function
-
-        Private Shared Sub VerifyNodes(enumerator As IVsEnumNavInfoNodes, verifiers() As NodeVerifier)
-            Dim index = 0
-            Dim actualNode = New IVsNavInfoNode(0) {}
-            Dim fetched As UInteger
-            While enumerator.Next(1, actualNode, fetched) = VSConstants.S_OK
-                Dim verifier = verifiers(index)
-                index += 1
-
-                verifier(actualNode(0))
-            End While
-
-            Assert.Equal(index, verifiers.Length)
-        End Sub
-
         Private Shared Async Function TestAsync(
             workspaceDefinition As XElement,
             Optional useExpandedHierarchy As Boolean = False,
             Optional canonicalNodes As NodeVerifier() = Nothing,
             Optional presentationNodes As NodeVerifier() = Nothing
-        ) As Tasks.Task
+        ) As Task
 
             Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(workspaceDefinition, exportProvider:=VisualStudioTestExportProvider.ExportProvider)
                 Dim hostDocument = workspace.DocumentWithCursor
@@ -902,7 +853,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.VsNavInfo
         Private Shared Async Function TestIsNullAsync(
             workspaceDefinition As XElement,
             Optional useExpandedHierarchy As Boolean = False
-        ) As Tasks.Task
+        ) As Task
 
             Using workspace = Await TestWorkspaceFactory.CreateWorkspaceAsync(workspaceDefinition, exportProvider:=VisualStudioTestExportProvider.ExportProvider)
                 Dim hostDocument = workspace.DocumentWithCursor

--- a/src/VisualStudio/VisualBasic/Impl/BasicVisualStudio.vbproj
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVisualStudio.vbproj
@@ -128,6 +128,7 @@
     <Compile Include="ObjectBrowser\ListItemFactory.vb" />
     <Compile Include="ObjectBrowser\ObjectBrowserLibraryManager.vb" />
     <Compile Include="ObjectBrowser\VisualBasicLibraryService.vb" />
+    <Compile Include="ObjectBrowser\VisualBasicSyncClassViewCommandHandler.vb" />
     <Compile Include="Options\AdvancedOptionPageStrings.vb" />
     <Compile Include="Options\AutomationObject.vb" />
     <Compile Include="Options\VisualBasicLanguageSettingsSerializer.vb" />

--- a/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/VisualBasicSyncClassViewCommandHandler.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/VisualBasicSyncClassViewCommandHandler.vb
@@ -1,0 +1,19 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.ComponentModel.Composition
+Imports Microsoft.CodeAnalysis.Editor
+Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView
+Imports Microsoft.VisualStudio.Shell
+
+Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
+    <ExportCommandHandler(PredefinedCommandHandlerNames.ClassView, ContentTypeNames.VisualBasicContentType)>
+    Friend Class VisualBasicSyncClassViewCommandHandler
+        Inherits AbstractSyncClassViewCommandHandler
+
+        <ImportingConstructor>
+        Private Sub New(serviceProvider As SVsServiceProvider, waitIndicator As IWaitIndicator)
+            MyBase.New(serviceProvider, waitIndicator)
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
Fixes #7034

We completely forgot about the View.SynchronizeClassView command in Roslyn (probably because it doesn't have a keybinding by default). It's a fairly useful command (when bound :smile:) that the declaration containing the cursor in the Class View.

Tagging @dotnet/roslyn-ide, @Pilchie