### PR TITLE
Migrate C# tests to be less sensitive to the precise text of error messages

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
@@ -375,9 +375,10 @@ public class D : A
 public class E : B.N
 {}");
 
-            TestDiagnostics(c.GetDiagnostics(),
-"'iField' error CS1540: Cannot access protected member 'A.iField' via a qualifier of type 'D'; the qualifier must be of type 'B.N.NN' (or derived from it)"
-            );
+            c.VerifyDiagnostics(
+                // (19,27): error CS1540: Cannot access protected member 'A.iField' via a qualifier of type 'D'; the qualifier must be of type 'B.N.NN' (or derived from it)
+                //                 int q = d.iField;
+                Diagnostic(ErrorCode.ERR_BadProtectedAccess, "iField").WithArguments("A.iField", "D", "B.N.NN").WithLocation(19, 27));
         }
 
         [WorkItem(539561, "DevDiv")]
@@ -398,7 +399,7 @@ class C : I<C.D.E>
 }
 ");
 
-            TestDiagnostics(c.GetDiagnostics());
+            c.VerifyDiagnostics();
         }
 
         [WorkItem(539561, "DevDiv")]
@@ -422,8 +423,10 @@ class B
 }
 ");
 
-            TestDiagnostics(c.GetDiagnostics(),
-"'C' error CS0060: Inconsistent accessibility: base class 'X<B.C.D.E>' is less accessible than class 'B.C'");
+            c.VerifyDiagnostics(
+                // (8,11): error CS0060: Inconsistent accessibility: base class 'X<B.C.D.E>' is less accessible than class 'B.C'
+                //     class C : X<C.D.E>
+                Diagnostic(ErrorCode.ERR_BadVisBaseClass, "C").WithArguments("B.C", "X<B.C.D.E>").WithLocation(8, 11));
         }
 
         [Fact]
@@ -458,7 +461,7 @@ public class D : B
 }
 ");
 
-            TestDiagnostics(c.GetDiagnostics());
+            c.VerifyDiagnostics();
         }
 
         [Fact]
@@ -563,7 +566,7 @@ namespace CS1540
 
 ");
 
-            TestDiagnostics(c.GetDiagnostics());
+            c.VerifyDiagnostics();
         }
 
         [WorkItem(539561, "DevDiv")]
@@ -584,7 +587,7 @@ class C : I<C.D.E>
 }
 ");
 
-            TestDiagnostics(c.GetDiagnostics());
+            c.VerifyDiagnostics();
         }
 
         [WorkItem(539561, "DevDiv")]
@@ -608,8 +611,10 @@ class B
 }
 ");
 
-            TestDiagnostics(c.GetDiagnostics(),
-"'C' error CS0060: Inconsistent accessibility: base class 'X<B.C.D.E>' is less accessible than class 'B.C'");
+            c.VerifyDiagnostics(
+                // (8,11): error CS0060: Inconsistent accessibility: base class 'X<B.C.D.E>' is less accessible than class 'B.C'
+                //     class C : X<C.D.E>
+                Diagnostic(ErrorCode.ERR_BadVisBaseClass, "C").WithArguments("B.C", "X<B.C.D.E>").WithLocation(8, 11));
         }
 
         [Fact]
@@ -643,13 +648,22 @@ public class A
     }
 }", new List<MetadataReference>() { new CSharpCompilationReference(other) });
 
-            TestDiagnostics(c.GetDiagnostics(),
-"'c_int' error CS0122: 'C.c_int' is inaccessible due to its protection level",
-"'c_pro' error CS0122: 'C.c_pro' is inaccessible due to its protection level",
-"'c_intpro' error CS0122: 'C.c_intpro' is inaccessible due to its protection level",
-"'c_priv' error CS0122: 'C.c_priv' is inaccessible due to its protection level",
-"'D' error CS0122: 'D' is inaccessible due to its protection level"
-);
+            c.VerifyDiagnostics(
+                // (6,19): error CS0122: 'C.c_int' is inaccessible due to its protection level
+                //         int b = C.c_int;
+                Diagnostic(ErrorCode.ERR_BadAccess, "c_int").WithArguments("C.c_int").WithLocation(6, 19),
+                // (7,19): error CS0122: 'C.c_pro' is inaccessible due to its protection level
+                //         int c = C.c_pro;
+                Diagnostic(ErrorCode.ERR_BadAccess, "c_pro").WithArguments("C.c_pro").WithLocation(7, 19),
+                // (8,19): error CS0122: 'C.c_intpro' is inaccessible due to its protection level
+                //         int d = C.c_intpro;
+                Diagnostic(ErrorCode.ERR_BadAccess, "c_intpro").WithArguments("C.c_intpro").WithLocation(8, 19),
+                // (9,19): error CS0122: 'C.c_priv' is inaccessible due to its protection level
+                //         int e = C.c_priv;
+                Diagnostic(ErrorCode.ERR_BadAccess, "c_priv").WithArguments("C.c_priv").WithLocation(9, 19),
+                // (10,17): error CS0122: 'D' is inaccessible due to its protection level
+                //         int f = D.d_pub;
+                Diagnostic(ErrorCode.ERR_BadAccess, "D").WithArguments("D").WithLocation(10, 17));
         }
 
         [Fact]
@@ -683,11 +697,16 @@ public class A: C
     }
 }", new[] { new CSharpCompilationReference(other) });
 
-            TestDiagnostics(c.GetDiagnostics(),
-"'c_int' error CS0122: 'C.c_int' is inaccessible due to its protection level",
-"'c_priv' error CS0122: 'C.c_priv' is inaccessible due to its protection level",
-"'D' error CS0122: 'D' is inaccessible due to its protection level"
-);
+            c.VerifyDiagnostics(
+                // (6,19): error CS0122: 'C.c_int' is inaccessible due to its protection level
+                //         int b = C.c_int;
+                Diagnostic(ErrorCode.ERR_BadAccess, "c_int").WithArguments("C.c_int").WithLocation(6, 19),
+                // (9,19): error CS0122: 'C.c_priv' is inaccessible due to its protection level
+                //         int e = C.c_priv;
+                Diagnostic(ErrorCode.ERR_BadAccess, "c_priv").WithArguments("C.c_priv").WithLocation(9, 19),
+                // (10,17): error CS0122: 'D' is inaccessible due to its protection level
+                //         int f = D.d_pub;
+                Diagnostic(ErrorCode.ERR_BadAccess, "D").WithArguments("D").WithLocation(10, 17));
         }
 
         [Fact]
@@ -799,8 +818,10 @@ public class A
     protected B(C o) {}
   }
 }", new MetadataReference[] { new CSharpCompilationReference(other) }, assemblyName: "AccessCheckCrossAssemblyParameterProtectedMethod2");
-            TestDiagnostics(c.GetDiagnostics(),
-"'C' error CS0122: 'C' is inaccessible due to its protection level");
+            c.VerifyDiagnostics(
+                // (6,17): error CS0122: 'C' is inaccessible due to its protection level
+                //     protected B(C o) {}
+                Diagnostic(ErrorCode.ERR_BadAccess, "C").WithArguments("C").WithLocation(6, 17));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
@@ -134,12 +134,13 @@ public class Derived2 : Derived<int>
             var comp = CreateCompilationWithMscorlib(text3, ref2, assemblyName: "Test3");
             var diagnostics = comp.GetDiagnostics();
 
-            var diagStrings = new string[] {
-"'Method' warning CS1957: Member 'Derived2.Method(long, int)' overrides 'Derived<int>.Method(long, int)'. There are multiple override candidates at run-time. It is implementation dependent which method will be called.",
-"'Method' error CS0462: The inherited members 'Derived<TInt>.Method(long, TInt)' and 'Derived<TInt>.Method(long, int)' have the same signature in type 'Derived2', so they cannot be overridden"
-           };
-
-            TestDiagnostics(diagnostics, diagStrings);
+            comp.VerifyDiagnostics(
+                // (4,26): error CS0462: The inherited members 'Derived<TInt>.Method(long, TInt)' and 'Derived<TInt>.Method(long, int)' have the same signature in type 'Derived2', so they cannot be overridden
+                //     public override void Method(long l, int i) { }  //CS0462 and CS1957
+                Diagnostic(ErrorCode.ERR_AmbigOverride, "Method").WithArguments("Derived<TInt>.Method(long, TInt)", "Derived<TInt>.Method(long, int)", "Derived2").WithLocation(4, 26),
+                // (4,26): warning CS1957: Member 'Derived2.Method(long, int)' overrides 'Derived<int>.Method(long, int)'. There are multiple override candidates at run-time. It is implementation dependent which method will be called.
+                //     public override void Method(long l, TInt i) { }
+                Diagnostic(ErrorCode.WRN_MultipleRuntimeOverrideMatches, "Method").WithArguments("Derived<int>.Method(long, int)", "Derived2.Method(long, int)").WithLocation(4, 26));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -680,7 +680,7 @@ true != false --> True";
         [Fact]
         public void TestEnumOverflowErrors()
         {
-            TestErrors(
+            string source =
 @"enum S8 : sbyte { Min = sbyte.MinValue, MinPlusOne, Max = sbyte.MaxValue }
 enum U8 : byte { Min = byte.MinValue, MinPlusOne, Max = byte.MaxValue }
 enum S16 : short { Min = short.MinValue, MinPlusOne, Max = short.MaxValue }
@@ -771,47 +771,128 @@ class C
         F(S64.Min - 2); // overflows at compile time in checked mode
         F(U64.Min - 2); // overflows at compile time in checked mode
     }
-}",
-                "'S8.Max + 1' error CS0221: Constant value '128' cannot be converted to a 'S8' (use 'unchecked' syntax to override)",
-                "'U8.Max + 1' error CS0221: Constant value '256' cannot be converted to a 'U8' (use 'unchecked' syntax to override)",
-                "'S16.Max + 1' error CS0221: Constant value '32768' cannot be converted to a 'S16' (use 'unchecked' syntax to override)",
-                "'U16.Max + 1' error CS0221: Constant value '65536' cannot be converted to a 'U16' (use 'unchecked' syntax to override)",
-                "'S32.Max + 1' error CS0220: The operation overflows at compile time in checked mode",
-                "'U32.Max + 1' error CS0220: The operation overflows at compile time in checked mode",
-                "'S64.Max + 1' error CS0220: The operation overflows at compile time in checked mode",
-                "'U64.Max + 1' error CS0220: The operation overflows at compile time in checked mode",
-                "'2 + S8.Max' error CS0221: Constant value '129' cannot be converted to a 'S8' (use 'unchecked' syntax to override)",
-                "'2 + U8.Max' error CS0221: Constant value '257' cannot be converted to a 'U8' (use 'unchecked' syntax to override)",
-                "'2 + S16.Max' error CS0221: Constant value '32769' cannot be converted to a 'S16' (use 'unchecked' syntax to override)",
-                "'2 + U16.Max' error CS0221: Constant value '65537' cannot be converted to a 'U16' (use 'unchecked' syntax to override)",
-                "'2 + S32.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'2 + U32.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'2 + S64.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'2 + U64.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'U8.Min - U8.MinPlusOne' error CS0221: Constant value '-1' cannot be converted to a 'byte' (use 'unchecked' syntax to override)",
-                "'U16.Min - U16.MinPlusOne' error CS0221: Constant value '-1' cannot be converted to a 'ushort' (use 'unchecked' syntax to override)",
-                "'U32.Min - U32.MinPlusOne' error CS0220: The operation overflows at compile time in checked mode",
-                "'U64.Min - U64.MinPlusOne' error CS0220: The operation overflows at compile time in checked mode",
-                "'S8.Min - S8.Max' error CS0221: Constant value '-255' cannot be converted to a 'sbyte' (use 'unchecked' syntax to override)",
-                "'U8.Min - U8.Max' error CS0221: Constant value '-255' cannot be converted to a 'byte' (use 'unchecked' syntax to override)",
-                "'S16.Min - S16.Max' error CS0221: Constant value '-65535' cannot be converted to a 'short' (use 'unchecked' syntax to override)",
-                "'U16.Min - U16.Max' error CS0221: Constant value '-65535' cannot be converted to a 'ushort' (use 'unchecked' syntax to override)",
-                "'S32.Min - S32.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'U32.Min - U32.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'S64.Min - S64.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'U64.Min - U64.Max' error CS0220: The operation overflows at compile time in checked mode",
-                "'S8.Max - S8.Min' error CS0221: Constant value '255' cannot be converted to a 'sbyte' (use 'unchecked' syntax to override)",
-                "'S16.Max - S16.Min' error CS0221: Constant value '65535' cannot be converted to a 'short' (use 'unchecked' syntax to override)",
-                "'S32.Max - S32.Min' error CS0220: The operation overflows at compile time in checked mode",
-                "'S64.Max - S64.Min' error CS0220: The operation overflows at compile time in checked mode",
-                "'S8.Min - 2' error CS0221: Constant value '-130' cannot be converted to a 'S8' (use 'unchecked' syntax to override)",
-                "'U8.Min - 2' error CS0221: Constant value '-2' cannot be converted to a 'U8' (use 'unchecked' syntax to override)",
-                "'S16.Min - 2' error CS0221: Constant value '-32770' cannot be converted to a 'S16' (use 'unchecked' syntax to override)",
-                "'U16.Min - 2' error CS0221: Constant value '-2' cannot be converted to a 'U16' (use 'unchecked' syntax to override)",
-                "'S32.Min - 2' error CS0220: The operation overflows at compile time in checked mode",
-                "'U32.Min - 2' error CS0220: The operation overflows at compile time in checked mode",
-                "'S64.Min - 2' error CS0220: The operation overflows at compile time in checked mode",
-                "'U64.Min - 2' error CS0220: The operation overflows at compile time in checked mode");
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (32,11): error CS0221: Constant value '128' cannot be converted to a 'S8' (use 'unchecked' syntax to override)
+                //         F(S8.Max + 1); // 128 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S8.Max + 1").WithArguments("128", "S8").WithLocation(32, 11),
+                // (33,11): error CS0221: Constant value '256' cannot be converted to a 'U8' (use 'unchecked' syntax to override)
+                //         F(U8.Max + 1); // 256 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U8.Max + 1").WithArguments("256", "U8").WithLocation(33, 11),
+                // (34,11): error CS0221: Constant value '32768' cannot be converted to a 'S16' (use 'unchecked' syntax to override)
+                //         F(S16.Max + 1); // 32768 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S16.Max + 1").WithArguments("32768", "S16").WithLocation(34, 11),
+                // (35,11): error CS0221: Constant value '65536' cannot be converted to a 'U16' (use 'unchecked' syntax to override)
+                //         F(U16.Max + 1); // 65536 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U16.Max + 1").WithArguments("65536", "U16").WithLocation(35, 11),
+                // (36,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S32.Max + 1); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S32.Max + 1").WithLocation(36, 11),
+                // (37,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U32.Max + 1); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U32.Max + 1").WithLocation(37, 11),
+                // (38,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S64.Max + 1); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S64.Max + 1").WithLocation(38, 11),
+                // (39,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U64.Max + 1); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U64.Max + 1").WithLocation(39, 11),
+                // (42,11): error CS0221: Constant value '129' cannot be converted to a 'S8' (use 'unchecked' syntax to override)
+                //         F(2 + S8.Max); // 129 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "2 + S8.Max").WithArguments("129", "S8").WithLocation(42, 11),
+                // (43,11): error CS0221: Constant value '257' cannot be converted to a 'U8' (use 'unchecked' syntax to override)
+                //         F(2 + U8.Max); // 257 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "2 + U8.Max").WithArguments("257", "U8").WithLocation(43, 11),
+                // (44,11): error CS0221: Constant value '32769' cannot be converted to a 'S16' (use 'unchecked' syntax to override)
+                //         F(2 + S16.Max); // 32769 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "2 + S16.Max").WithArguments("32769", "S16").WithLocation(44, 11),
+                // (45,11): error CS0221: Constant value '65537' cannot be converted to a 'U16' (use 'unchecked' syntax to override)
+                //         F(2 + U16.Max); // 65537 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "2 + U16.Max").WithArguments("65537", "U16").WithLocation(45, 11),
+                // (46,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(2 + S32.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "2 + S32.Max").WithLocation(46, 11),
+                // (47,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(2 + U32.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "2 + U32.Max").WithLocation(47, 11),
+                // (48,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(2 + S64.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "2 + S64.Max").WithLocation(48, 11),
+                // (49,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(2 + U64.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "2 + U64.Max").WithLocation(49, 11),
+                // (53,11): error CS0221: Constant value '-1' cannot be converted to a 'byte' (use 'unchecked' syntax to override)
+                //         F(U8.Min - U8.MinPlusOne); // -1 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U8.Min - U8.MinPlusOne").WithArguments("-1", "byte").WithLocation(53, 11),
+                // (55,11): error CS0221: Constant value '-1' cannot be converted to a 'ushort' (use 'unchecked' syntax to override)
+                //         F(U16.Min - U16.MinPlusOne); // -1 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U16.Min - U16.MinPlusOne").WithArguments("-1", "ushort").WithLocation(55, 11),
+                // (57,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U32.Min - U32.MinPlusOne); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U32.Min - U32.MinPlusOne").WithLocation(57, 11),
+                // (59,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U64.Min - U64.MinPlusOne); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U64.Min - U64.MinPlusOne").WithLocation(59, 11),
+                // (62,11): error CS0221: Constant value '-255' cannot be converted to a 'sbyte' (use 'unchecked' syntax to override)
+                //         F(S8.Min - S8.Max); // -255 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S8.Min - S8.Max").WithArguments("-255", "sbyte").WithLocation(62, 11),
+                // (63,11): error CS0221: Constant value '-255' cannot be converted to a 'byte' (use 'unchecked' syntax to override)
+                //         F(U8.Min - U8.Max); // -255 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U8.Min - U8.Max").WithArguments("-255", "byte").WithLocation(63, 11),
+                // (64,11): error CS0221: Constant value '-65535' cannot be converted to a 'short' (use 'unchecked' syntax to override)
+                //         F(S16.Min - S16.Max); // -65535 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S16.Min - S16.Max").WithArguments("-65535", "short").WithLocation(64, 11),
+                // (65,11): error CS0221: Constant value '-65535' cannot be converted to a 'ushort' (use 'unchecked' syntax to override)
+                //         F(U16.Min - U16.Max); // -65535 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U16.Min - U16.Max").WithArguments("-65535", "ushort").WithLocation(65, 11),
+                // (66,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S32.Min - S32.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S32.Min - S32.Max").WithLocation(66, 11),
+                // (67,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U32.Min - U32.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U32.Min - U32.Max").WithLocation(67, 11),
+                // (68,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S64.Min - S64.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S64.Min - S64.Max").WithLocation(68, 11),
+                // (69,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U64.Min - U64.Max); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U64.Min - U64.Max").WithLocation(69, 11),
+                // (72,11): error CS0221: Constant value '255' cannot be converted to a 'sbyte' (use 'unchecked' syntax to override)
+                //         F(S8.Max - S8.Min); // 255 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S8.Max - S8.Min").WithArguments("255", "sbyte").WithLocation(72, 11),
+                // (74,11): error CS0221: Constant value '65535' cannot be converted to a 'short' (use 'unchecked' syntax to override)
+                //         F(S16.Max - S16.Min); // 65535 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S16.Max - S16.Min").WithArguments("65535", "short").WithLocation(74, 11),
+                // (76,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S32.Max - S32.Min); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S32.Max - S32.Min").WithLocation(76, 11),
+                // (78,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S64.Max - S64.Min); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S64.Max - S64.Min").WithLocation(78, 11),
+                // (82,11): error CS0221: Constant value '-130' cannot be converted to a 'S8' (use 'unchecked' syntax to override)
+                //         F(S8.Min - 2); // -130 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S8.Min - 2").WithArguments("-130", "S8").WithLocation(82, 11),
+                // (83,11): error CS0221: Constant value '-2' cannot be converted to a 'U8' (use 'unchecked' syntax to override)
+                //         F(U8.Min - 2); // -2 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U8.Min - 2").WithArguments("-2", "U8").WithLocation(83, 11),
+                // (84,11): error CS0221: Constant value '-32770' cannot be converted to a 'S16' (use 'unchecked' syntax to override)
+                //         F(S16.Min - 2); // -32770 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "S16.Min - 2").WithArguments("-32770", "S16").WithLocation(84, 11),
+                // (85,11): error CS0221: Constant value '-2' cannot be converted to a 'U16' (use 'unchecked' syntax to override)
+                //         F(U16.Min - 2); // -2 cannot be converted to ...
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "U16.Min - 2").WithArguments("-2", "U16").WithLocation(85, 11),
+                // (86,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S32.Min - 2); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S32.Min - 2").WithLocation(86, 11),
+                // (87,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U32.Min - 2); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U32.Min - 2").WithLocation(87, 11),
+                // (88,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(S64.Min - 2); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "S64.Min - 2").WithLocation(88, 11),
+                // (89,11): error CS0220: The operation overflows at compile time in checked mode
+                //         F(U64.Min - 2); // overflows at compile time in checked mode
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "U64.Min - 2").WithLocation(89, 11));
         }
 
         [Fact, WorkItem(528727, "DevDiv")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -218,14 +218,14 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib(code);
-            compilation.VerifyDiagnostics();
+            compilation.VerifyDiagnostics(); // no errors expected
         }
 
         [WorkItem(539538, "DevDiv")]
         [Fact]
         public void TestLambdaErrors03()
         {
-            TestErrors(@"
+            string source = @"
 using System;
 
 interface I : IComparable<IComparable<I>> { }
@@ -239,8 +239,11 @@ class C
         Foo(() => null);
     }
 }
-",
-"'Foo' error CS0121: The call is ambiguous between the following methods or properties: 'C.Foo(Func<IComparable<I>>)' and 'C.Foo(Func<I>)'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (12,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.Foo(Func<IComparable<I>>)' and 'C.Foo(Func<I>)'
+                //         Foo(() => null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Foo").WithArguments("C.Foo(System.Func<System.IComparable<I>>)", "C.Foo(System.Func<I>)").WithLocation(12, 9));
         }
 
         [WorkItem(539976, "DevDiv")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
@@ -468,7 +468,7 @@ class C
         [Fact]
         public void TestMethodTypeInferenceErrors()
         {
-            TestErrors(@"
+            var source = @"
 class C 
 { 
     delegate R F<out R>();
@@ -478,10 +478,11 @@ class C
       Apply(delegate { while (true) { } });
     }
 }
-",
-"'Apply' error CS0411: The type arguments for method 'C.Apply<T>(C.F<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly."
-
-               );
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (8,7): error CS0411: The type arguments for method 'C.Apply<T>(C.F<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //       Apply(delegate { while (true) { } });
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Apply").WithArguments("C.Apply<T>(C.F<T>)").WithLocation(8, 7));
         }
 
         [Fact, WorkItem(578362, "DevDiv")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -1105,7 +1105,7 @@ class C
         [Fact]
         public void TestUnaryOperatorOverloadingErrors()
         {
-            TestErrors(@"
+            var source = @"
 class C 
 { 
 // UNDONE: Write tests for the rest of them
@@ -1114,8 +1114,11 @@ class C
         if(!1) {}
     }
 }
-",
-"'!1' error CS0023: Operator '!' cannot be applied to operand of type 'int'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (7,12): error CS0023: Operator '!' cannot be applied to operand of type 'int'
+                //         if(!1) {}
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!1").WithArguments("!", "int").WithLocation(7, 12));
         }
 
         [Fact]
@@ -1167,7 +1170,7 @@ Diagnostic(ErrorCode.ERR_BadBinaryOps, "s1 == ex1").WithArguments("==", "string"
         [Fact]
         public void TestCompoundOperatorErrors()
         {
-            TestErrors(@"
+            var source = @"
 class C 
 { 
     // UNDONE: Add more error cases
@@ -1209,11 +1212,20 @@ class C
 
 
     }
-}",
-"'c.ReadOnly' error CS0200: Property or indexer 'C.ReadOnly' cannot be assigned to -- it is read only",
-"'c.WriteOnly' error CS0154: The property or indexer 'C.WriteOnly' cannot be used in this context because it lacks the get accessor",
-"'i32 += i64' error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)",
-"'d += c' error CS0266: Cannot implicitly convert type 'C' to 'C.D'. An explicit conversion exists (are you missing a cast?)");
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (17,9): error CS0200: Property or indexer 'C.ReadOnly' cannot be assigned to -- it is read only
+                //         c.ReadOnly += 1;
+                Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "c.ReadOnly").WithArguments("C.ReadOnly").WithLocation(17, 9),
+                // (18,9): error CS0154: The property or indexer 'C.WriteOnly' cannot be used in this context because it lacks the get accessor
+                //         c.WriteOnly += 1;
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "c.WriteOnly").WithArguments("C.WriteOnly").WithLocation(18, 9),
+                // (34,9): error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         i32 += i64;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "i32 += i64").WithArguments("long", "int").WithLocation(34, 9),
+                // (39,9): error CS0266: Cannot implicitly convert type 'C' to 'C.D'. An explicit conversion exists (are you missing a cast?)
+                //         d += c;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "d += c").WithArguments("C", "C.D").WithLocation(39, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -525,7 +525,7 @@ Diagnostic(ErrorCode.ERR_AmbigCall, "M2").WithArguments("P.M2(System.Func<int>, 
         {
             // We should ensure that we do not report "no method M takes n parameters" if in fact
             // there is any method M that could take n parameters.
-            TestAllErrors(
+            var source =
 @"
 class C
 {
@@ -535,16 +535,17 @@ class C
     {
         J(123.0, 456.0m);
     }
-}",
-"'J' error CS0411: The type arguments for method 'C.J<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly."
-
-);
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (8,9): error CS0411: The type arguments for method 'C.J<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         J(123.0, 456.0m);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "J").WithArguments("C.J<T>(T, T)").WithLocation(8, 9));
         }
 
         [Fact]
         public void TestLambdaErrorReporting()
         {
-            TestAllErrors(
+            var source =
 @"
 using System;
 class C
@@ -591,14 +592,23 @@ class C
 
         K(z=>{ Console.WriteLine(z == string.Empty, z - 4.5); });
     }
-}",
-          "'ToStrign' error CS1061: 'string' does not contain a definition for 'ToStrign' and no extension method 'ToStrign' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)",
-          "'y / 4.5' error CS0019: Operator '/' cannot be applied to operands of type 'string' and 'double'",
-          "'y == string.Empty' error CS0019: Operator '==' cannot be applied to operands of type 'int' and 'string'",
-          "'z - 4.5' error CS0019: Operator '-' cannot be applied to operands of type 'string' and 'double'",
-          "'z == string.Empty' error CS0019: Operator '==' cannot be applied to operands of type 'double' and 'string'"
-
-);
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (26,36): error CS1061: 'string' does not contain a definition for 'ToStrign' and no extension method 'ToStrign' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         J(x=>{ Console.WriteLine(x.ToStrign(), x.Length, x * 2); });
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ToStrign").WithArguments("string", "ToStrign").WithLocation(26, 36),
+                // (30,34): error CS0019: Operator '==' cannot be applied to operands of type 'int' and 'string'
+                //         J(y=>{ Console.WriteLine(y == string.Empty, y / 4.5); });
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "y == string.Empty").WithArguments("==", "int", "string").WithLocation(30, 34),
+                // (30,53): error CS0019: Operator '/' cannot be applied to operands of type 'string' and 'double'
+                //         J(y=>{ Console.WriteLine(y == string.Empty, y / 4.5); });
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "y / 4.5").WithArguments("/", "string", "double").WithLocation(30, 53),
+                // (45,53): error CS0019: Operator '-' cannot be applied to operands of type 'string' and 'double'
+                //         K(z=>{ Console.WriteLine(z == string.Empty, z - 4.5); });
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "z - 4.5").WithArguments("-", "string", "double").WithLocation(45, 53),
+                // (45,34): error CS0019: Operator '==' cannot be applied to operands of type 'double' and 'string'
+                //         K(z=>{ Console.WriteLine(z == string.Empty, z - 4.5); });
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "z == string.Empty").WithArguments("==", "double", "string").WithLocation(45, 34));
         }
 
 
@@ -640,7 +650,7 @@ class C
             // error to report. We only report the violation on the formal parameter if the constraint
             // is not violated on the method type parameter.
 
-            TestAllErrors(
+            var source =
 @"
 class C
 {
@@ -709,20 +719,35 @@ class C
     static void Test4(object x) {}
     static void Test5<Y>(Y y, N<Y> ny) { }
     static void Test6<Z>(N<Z> nz) where Z : struct {}
-}",
-"'ny' error CS0453: The type 'Y' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'",
-"'Test1<string>' error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U' in the generic type or method 'C.Test1<U>(U, C.N<U>)'",
-"'Test2' error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'V' in the generic type or method 'C.Test2<V>(V, C.N<V>)'",
-"'Test4' error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'X' in the generic type or method 'C.Test4<X>(X)'",
-"'Test5' error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'",
-"'string' error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'S' in the generic type or method 'C.L<S>'",
-"'Test6<L<string>>' error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'S' in the generic type or method 'C.L<S>'");
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (67,36): error CS0453: The type 'Y' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'
+                //     static void Test5<Y>(Y y, N<Y> ny) { }
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "ny").WithArguments("C.N<T>", "T", "Y").WithLocation(67, 36),
+                // (17,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U' in the generic type or method 'C.Test1<U>(U, C.N<U>)'
+                //         Test1<string>(s, null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test1<string>").WithArguments("C.Test1<U>(U, C.N<U>)", "U", "string").WithLocation(17, 9),
+                // (21,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'V' in the generic type or method 'C.Test2<V>(V, C.N<V>)'
+                //         Test2(s, null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test2").WithArguments("C.Test2<V>(V, C.N<V>)", "V", "string").WithLocation(21, 9),
+                // (36,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'X' in the generic type or method 'C.Test4<X>(X)'
+                //         Test4(s);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test4").WithArguments("C.Test4<X>(X)", "X", "string").WithLocation(36, 9),
+                // (47,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'
+                //         Test5(s, null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test5").WithArguments("C.N<T>", "T", "string").WithLocation(47, 9),
+                // (58,17): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'S' in the generic type or method 'C.L<S>'
+                //         Test6<L<string>>(null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "string").WithArguments("C.L<S>", "S", "string").WithLocation(58, 17),
+                // (58,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'S' in the generic type or method 'C.L<S>'
+                //         Test6<L<string>>(null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test6<L<string>>").WithArguments("C.L<S>", "S", "string").WithLocation(58, 9));
         }
         [Fact]
 
         private void TestBug9583()
         {
-            TestErrors(
+            var source =
 @"
 class C
 {
@@ -731,15 +756,17 @@ class C
         Foo();
     }
     static void Foo<T>(params T[] x) { }
-}",
-
-"'Foo' error CS0411: The type arguments for method 'C.Foo<T>(params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.");
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (6,9): error CS0411: The type arguments for method 'C.Foo<T>(params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Foo();
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Foo").WithArguments("C.Foo<T>(params T[])").WithLocation(6, 9));
         }
 
         [Fact]
         public void TestMoreOverloadResolutionErrors()
         {
-            TestErrors(@"
+            var source = @"
 class C 
 { 
     static void VoidReturning() {}
@@ -748,11 +775,14 @@ class C
         byte b = new byte(1);
         System.Console.WriteLine(VoidReturning());
     }
-}",
-"'byte' error CS1729: 'byte' does not contain a constructor that takes 1 arguments",
-//"'System.Console.WriteLine' error CS1502: The best overloaded method match for 'System.Console.WriteLine(bool)' has some invalid arguments",  //specifically omitted by roslyn
-"'VoidReturning()' error CS1503: Argument 1: cannot convert from 'void' to 'bool'"
-               );
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (7,22): error CS1729: 'byte' does not contain a constructor that takes 1 arguments
+                //         byte b = new byte(1);
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "byte").WithArguments("byte", "1").WithLocation(7, 22),
+                // (8,34): error CS1503: Argument 1: cannot convert from 'void' to 'bool'
+                //         System.Console.WriteLine(VoidReturning());
+                Diagnostic(ErrorCode.ERR_BadArgType, "VoidReturning()").WithArguments("1", "void", "bool").WithLocation(8, 34));
         }
         [Fact]
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -1406,14 +1406,17 @@ namespace ConsoleApplication3
         [Fact]
         public void CS0029ERR_NoImplicitConv02()
         {
-            DiagnosticsUtils.TestDiagnosticsExact("enum E { A = new[] { 1, 2, 3 } }",
-                "'new[] { 1, 2, 3 }' error CS0029: Cannot implicitly convert type 'int[]' to 'int'");
+            var source = "enum E { A = new[] { 1, 2, 3 } }";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (1,14): error CS0029: Cannot implicitly convert type 'int[]' to 'int'
+                // enum E { A = new[] { 1, 2, 3 } }
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "new[] { 1, 2, 3 }").WithArguments("int[]", "int").WithLocation(1, 14));
         }
 
         [Fact]
         public void CS0029ERR_NoImplicitConv03()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"class C
 {
     static void M()
@@ -1428,8 +1431,11 @@ namespace ConsoleApplication3
 class D
 {
 }
-",
-                "'F()' error CS0029: Cannot implicitly convert type 'D' to 'C'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (5,21): error CS0029: Cannot implicitly convert type 'D' to 'C'
+                //         const C d = F();
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "F()").WithArguments("D", "C").WithLocation(5, 21));
         }
 
         [WorkItem(541719, "DevDiv")]
@@ -3286,7 +3292,7 @@ class Test
         [Fact]
         public void CS0126ERR_RetObjectRequired()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace N
 {
     class C
@@ -3297,20 +3303,33 @@ class Test
         Y Q { get { return; } }
     }
 }
-",
-                "'return' error CS0126: An object of a type convertible to 'object' is required",
-                "'X' error CS0246: The type or namespace name 'X' could not be found (are you missing a using directive or an assembly reference?)",
-                "'return' error CS0126: An object of a type convertible to 'X' is required",
-                "'return' error CS0126: An object of a type convertible to 'C' is required",
-                "'Y' error CS0246: The type or namespace name 'Y' could not be found (are you missing a using directive or an assembly reference?)",
-                "'return' error CS0126: An object of a type convertible to 'Y' is required");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (6,9): error CS0246: The type or namespace name 'X' could not be found (are you missing a using directive or an assembly reference?)
+                //         X G() { return; }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "X").WithArguments("X").WithLocation(6, 9),
+                // (8,9): error CS0246: The type or namespace name 'Y' could not be found (are you missing a using directive or an assembly reference?)
+                //         Y Q { get { return; } }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Y").WithArguments("Y").WithLocation(8, 9),
+                // (5,22): error CS0126: An object of a type convertible to 'object' is required
+                //         object F() { return; }
+                Diagnostic(ErrorCode.ERR_RetObjectRequired, "return").WithArguments("object").WithLocation(5, 22),
+                // (6,17): error CS0126: An object of a type convertible to 'X' is required
+                //         X G() { return; }
+                Diagnostic(ErrorCode.ERR_RetObjectRequired, "return").WithArguments("X").WithLocation(6, 17),
+                // (7,21): error CS0126: An object of a type convertible to 'C' is required
+                //         C P { get { return; } }
+                Diagnostic(ErrorCode.ERR_RetObjectRequired, "return").WithArguments("N.C").WithLocation(7, 21),
+                // (8,21): error CS0126: An object of a type convertible to 'Y' is required
+                //         Y Q { get { return; } }
+                Diagnostic(ErrorCode.ERR_RetObjectRequired, "return").WithArguments("Y").WithLocation(8, 21));
         }
 
         [WorkItem(540115, "DevDiv")]
         [Fact]
         public void CS0126ERR_RetObjectRequired_02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace Test
 {
     public delegate object D();
@@ -3355,15 +3374,17 @@ class Test
         }
     }
 }
-",
-"'return' error CS0126: An object of a type convertible to 'object' is required"
-                );
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (18,48): error CS0126: An object of a type convertible to 'object' is required
+                //             return TestClass.Test(delegate() { return; });
+                Diagnostic(ErrorCode.ERR_RetObjectRequired, "return").WithArguments("object").WithLocation(18, 48));
         }
 
         [Fact]
         public void CS0127ERR_RetNoObjectRequired()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"namespace MyNamespace
 {
     public class MyClass
@@ -3376,9 +3397,14 @@ class Test
         }
     }
 }
-",
-                "'return' error CS0127: Since 'MyClass.F()' returns void, a return keyword must not be followed by an object expression",
-                "'return' error CS0127: Since 'MyClass.P.set' returns void, a return keyword must not be followed by an object expression");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (5,27): error CS0127: Since 'MyClass.F()' returns void, a return keyword must not be followed by an object expression
+                //         public void F() { return 0; } // CS0127
+                Diagnostic(ErrorCode.ERR_RetNoObjectRequired, "return").WithArguments("MyNamespace.MyClass.F()").WithLocation(5, 27),
+                // (9,19): error CS0127: Since 'MyClass.P.set' returns void, a return keyword must not be followed by an object expression
+                //             set { return 0; } // CS0127, set has an implicit void return type
+                Diagnostic(ErrorCode.ERR_RetNoObjectRequired, "return").WithArguments("MyNamespace.MyClass.P.set").WithLocation(9, 19));
         }
 
         [Fact]
@@ -3455,7 +3481,7 @@ namespace MyNamespace
         [Fact]
         public void CS0131ERR_AssgLvalueExpected02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class C
 {
     const object NoObject = null;
@@ -3470,13 +3496,26 @@ namespace MyNamespace
         NoObject = ""string"";
     }
 }
-",
-                "'i' error CS0131: The left-hand side of an assignment must be a variable, property or indexer",
-                "'3' error CS0131: The left-hand side of an assignment must be a variable, property or indexer",
-                "'i + 1' error CS0131: The left-hand side of an assignment must be a variable, property or indexer",
-                "'\"string\"' error CS0131: The left-hand side of an assignment must be a variable, property or indexer",
-                "'null' error CS0131: The left-hand side of an assignment must be a variable, property or indexer",
-                "'NoObject' error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (7,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         i += 1;
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "i").WithLocation(7, 9),
+                // (8,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         3 *= 1;
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "3").WithLocation(8, 9),
+                // (9,10): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         (i + 1) -= 1;
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "i + 1").WithLocation(9, 10),
+                // (10,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         "string" = null;
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, @"""string""").WithLocation(10, 9),
+                // (11,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         null = new object();
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "null").WithLocation(11, 9),
+                // (12,9): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         NoObject = "string";
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "NoObject").WithLocation(12, 9));
         }
 
         /// <summary>
@@ -3540,21 +3579,24 @@ class A
         [Fact]
         public void CS0133ERR_NotConstantExpression01()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"class MyClass
 {
    public const int a = b; //no error since b is declared const
    public const int b = c; //CS0133, c is not constant
    public static int c = 1; //change static to const to correct program
 }
-",
-                "'c' error CS0133: The expression being assigned to 'MyClass.b' must be constant");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (4,25): error CS0133: The expression being assigned to 'MyClass.b' must be constant
+                //    public const int b = c; //CS0133, c is not constant
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, "c").WithArguments("MyClass.b").WithLocation(4, 25));
         }
 
         [Fact]
         public void CS0133ERR_NotConstantExpression02()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"enum E
 {
     X,
@@ -3572,15 +3614,20 @@ class C
         return 0;
     }
 }
-",
-                "'C.F()' error CS0266: Cannot implicitly convert type 'E' to 'int'. An explicit conversion exists (are you missing a cast?)",
-                "'C.G() + 1' error CS0133: The expression being assigned to 'E.Z' must be constant");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (4,9): error CS0266: Cannot implicitly convert type 'E' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //     Y = C.F(),
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "C.F()").WithArguments("E", "int").WithLocation(4, 9),
+                // (5,9): error CS0133: The expression being assigned to 'E.Z' must be constant
+                //     Z = C.G() + 1,
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, "C.G() + 1").WithArguments("E.Z").WithLocation(5, 9));
         }
 
         [Fact]
         public void CS0133ERR_NotConstantExpression03()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"class C
 {
     static void M()
@@ -3589,8 +3636,11 @@ class C
         const int x = 2 * y;
     }
 }
-",
-                "'2 * y' error CS0133: The expression being assigned to 'x' must be constant");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (6,23): error CS0133: The expression being assigned to 'x' must be constant
+                //         const int x = 2 * y;
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, "2 * y").WithArguments("x").WithLocation(6, 23));
         }
 
         [Fact]
@@ -4076,7 +4126,7 @@ class Program
         [Fact]
         public void CS0154ERR_PropertyLacksGet02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class A
 {
     public virtual A P { get; set; }
@@ -4098,16 +4148,23 @@ class B : A
     }
     static void M(object o) { }
 }
-",
-                "'Q' error CS0154: The property or indexer 'A.Q' cannot be used in this context because it lacks the get accessor",
-                "'b.Q' error CS0154: The property or indexer 'A.Q' cannot be used in this context because it lacks the get accessor",
-                "'b.P.Q' error CS0154: The property or indexer 'A.Q' cannot be used in this context because it lacks the get accessor");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (11,11): error CS0154: The property or indexer 'A.Q' cannot be used in this context because it lacks the get accessor
+                //         M(Q); // CS0154, no get method
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "Q").WithArguments("A.Q").WithLocation(11, 11),
+                // (16,13): error CS0154: The property or indexer 'A.Q' cannot be used in this context because it lacks the get accessor
+                //         o = b.Q; // CS0154, no get method
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "b.Q").WithArguments("A.Q").WithLocation(16, 13),
+                // (18,13): error CS0154: The property or indexer 'A.Q' cannot be used in this context because it lacks the get accessor
+                //         o = b.P.Q; // CS0154, no get method
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "b.P.Q").WithArguments("A.Q").WithLocation(18, 13));
         }
 
         [Fact]
         public void CS0154ERR_PropertyLacksGet03()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class C
 {
     int P { set { } }
@@ -4116,21 +4173,27 @@ class B : A
         P += 1;
     }
 }
-",
-                "'P' error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (6,9): error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor
+                //         P += 1;
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("C.P").WithLocation(6, 9));
         }
 
         [Fact]
         public void CS0154ERR_PropertyLacksGet04()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class C
 {
     object p;
     object P { set { p = P; } }
 }
-",
-                "'P' error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (4,26): error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor
+                //     object P { set { p = P; } }
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("C.P").WithLocation(4, 26));
         }
 
         [Fact]
@@ -6600,7 +6663,7 @@ public class C
         [Fact, WorkItem(538008, "DevDiv")]
         public void CS0191ERR_AssgReadonly()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class MyClass
 {
     public readonly int TestInt = 6;  // OK to assign to readonly field in declaration
@@ -6631,10 +6694,17 @@ class MyDerived : MyClass
         TestInt = 15; // CS0191 - not in declaring class
     }
 }
-",
-                "'t.TestInt' error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)",
-                "'TestInt' error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)",
-                "'TestInt' error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (28,9): error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)
+                //         TestInt = 15; // CS0191 - not in declaring class
+                Diagnostic(ErrorCode.ERR_AssgReadonly, "TestInt").WithLocation(28, 9),
+                // (11,9): error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)
+                //         t.TestInt = 14; // CS0191 - we can't be sure that the receiver is this
+                Diagnostic(ErrorCode.ERR_AssgReadonly, "t.TestInt").WithLocation(11, 9),
+                // (16,9): error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)
+                //         TestInt = 19;                  // CS0191
+                Diagnostic(ErrorCode.ERR_AssgReadonly, "TestInt").WithLocation(16, 9));
         }
 
         [WorkItem(538009, "DevDiv")]
@@ -8386,19 +8456,22 @@ class MyClass
         [Fact]
         public void CS0266ERR_NoImplicitConvCast02()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"class C
 {
     const int f = 0L;
 }
-",
-                "'0L' error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (3,19): error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //     const int f = 0L;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "0L").WithArguments("long", "int").WithLocation(3, 19));
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast03()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"class C
 {
     static void M()
@@ -8406,14 +8479,17 @@ class MyClass
         const short s = 1L;
     }
 }
-",
-                "'1L' error CS0266: Cannot implicitly convert type 'long' to 'short'. An explicit conversion exists (are you missing a cast?)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (5,25): error CS0266: Cannot implicitly convert type 'long' to 'short'. An explicit conversion exists (are you missing a cast?)
+                //         const short s = 1L;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "1L").WithArguments("long", "short").WithLocation(5, 25));
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast04()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"enum E { A = 1 }
 class C
 {
@@ -8425,58 +8501,71 @@ class C
         g = 'c'; // CS0266
     }
 }
-",
-                "'2' error CS0266: Cannot implicitly convert type 'int' to 'E'. An explicit conversion exists (are you missing a cast?)",
-                "''c'' error CS0266: Cannot implicitly convert type 'char' to 'E'. An explicit conversion exists (are you missing a cast?)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (4,11): error CS0266: Cannot implicitly convert type 'int' to 'E'. An explicit conversion exists (are you missing a cast?)
+                //     E f = 2; // CS0266
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "2").WithArguments("int", "E").WithLocation(4, 11),
+                // (9,13): error CS0266: Cannot implicitly convert type 'char' to 'E'. An explicit conversion exists (are you missing a cast?)
+                //         g = 'c'; // CS0266
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "'c'").WithArguments("char", "E").WithLocation(9, 13));
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast05()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"enum E : byte
 {
     A = 'a', // CS0266
     B = 0xff,
 }
-",
-                "''a'' error CS0266: Cannot implicitly convert type 'char' to 'byte'. An explicit conversion exists (are you missing a cast?)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (3,9): error CS0266: Cannot implicitly convert type 'char' to 'byte'. An explicit conversion exists (are you missing a cast?)
+                //     A = 'a', // CS0266
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "'a'").WithArguments("char", "byte").WithLocation(3, 9));
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast06()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"enum E
 {
     A = 1,
     B = 1L // CS0266
 }
-",
-                "'1L' error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (4,9): error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //     B = 1L // CS0266
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "1L").WithArguments("long", "int").WithLocation(4, 9));
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast07()
         {
             // No errors
-            DiagnosticsUtils.TestDiagnosticsExact("enum E { A, B = A }");
+            var source = "enum E { A, B = A }";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics();
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast08()
         {
             // No errors
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"enum E { A = 1, B }
 enum F { X = E.A + 1, Y }
-");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics();
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast09()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"enum E
 {
     A = F.A,
@@ -8486,15 +8575,20 @@ enum F { X = E.A + 1, Y }
 }
 enum F : short { A = 1, B }
 enum G : long { A = 1, B }
-",
-                "'G.A' error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)",
-                "'G.B' error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (5,9): error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //     C = G.A,
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "G.A").WithArguments("long", "int").WithLocation(5, 9),
+                // (6,9): error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //     D = G.B,
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "G.B").WithArguments("long", "int").WithLocation(6, 9));
         }
 
         [Fact]
         public void CS0266ERR_NoImplicitConvCast10()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"class C
 {
     public const int F = D.G + 1;
@@ -8507,8 +8601,11 @@ class E
 {
     public const int H = 1L;
 }
-",
-                "'1L' error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (11,26): error CS0266: Cannot implicitly convert type 'long' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //     public const int H = 1L;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "1L").WithArguments("long", "int").WithLocation(11, 26));
         }
 
         [Fact()]
@@ -8868,7 +8965,7 @@ class C
             // Test for both ERR_BadConstType and an error for RHS to ensure
             // the RHS is not reported multiple times (when calculating the
             // constant value for the symbol and also when binding).
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"struct S
 {
     static void M(object o)
@@ -8877,9 +8974,14 @@ class C
         M(s);
     }
 }
-",
-                "'S' error CS0283: The type 'S' cannot be declared const",
-                "'2' error CS0029: Cannot implicitly convert type 'int' to 'S'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (5,15): error CS0283: The type 'S' cannot be declared const
+                //         const S s = 2;
+                Diagnostic(ErrorCode.ERR_BadConstType, "S").WithArguments("S").WithLocation(5, 15),
+                // (5,21): error CS0029: Cannot implicitly convert type 'int' to 'S'
+                //         const S s = 2;
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "2").WithArguments("int", "S").WithLocation(5, 21));
         }
 
         [Fact]
@@ -10244,7 +10346,7 @@ public struct cly
         [Fact]
         public void CS0543ERR_EnumeratorOverflow01()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"enum E
 {
     A = int.MaxValue - 1,
@@ -10257,31 +10359,43 @@ public struct cly
     H, // CS0543
     I
 }
-",
-                "'C' error CS0543: 'E.C': the enumerator value is too large to fit in its type",
-                "'H' error CS0543: 'E.H': the enumerator value is too large to fit in its type");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (5,5): error CS0543: 'E.C': the enumerator value is too large to fit in its type
+                //     C, // CS0543
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "C").WithArguments("E.C").WithLocation(5, 5),
+                // (10,5): error CS0543: 'E.H': the enumerator value is too large to fit in its type
+                //     H, // CS0543
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "H").WithArguments("E.H").WithLocation(10, 5));
         }
 
         [Fact]
         public void CS0543ERR_EnumeratorOverflow02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace N
 {
     enum E : byte { A = 255, B, C }
     enum F : short { A = 0x00ff, B = 0x7f00, C = A | B, D }
     enum G : int { X = int.MinValue, Y = X - 1, Z }
 }
-",
-                "'B' error CS0543: 'E.B': the enumerator value is too large to fit in its type",
-                "'D' error CS0543: 'F.D': the enumerator value is too large to fit in its type",
-                "'X - 1' error CS0220: The operation overflows at compile time in checked mode");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (3,30): error CS0543: 'E.B': the enumerator value is too large to fit in its type
+                //     enum E : byte { A = 255, B, C }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "B").WithArguments("N.E.B").WithLocation(3, 30),
+                // (5,42): error CS0220: The operation overflows at compile time in checked mode
+                //     enum G : int { X = int.MinValue, Y = X - 1, Z }
+                Diagnostic(ErrorCode.ERR_CheckedOverflow, "X - 1").WithLocation(5, 42),
+                // (4,57): error CS0543: 'F.D': the enumerator value is too large to fit in its type
+                //     enum F : short { A = 0x00ff, B = 0x7f00, C = A | B, D }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "D").WithArguments("N.F.D").WithLocation(4, 57));
         }
 
         [Fact]
         public void CS0543ERR_EnumeratorOverflow03()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"enum S8 : sbyte { A = sbyte.MinValue, B, C, D = -1, E, F, G = sbyte.MaxValue - 2, H, I, J, K }
 enum S16 : short { A = short.MinValue, B, C, D = -1, E, F, G = short.MaxValue - 2, H, I, J, K }
 enum S32 : int { A = int.MinValue, B, C, D = -1, E, F, G = int.MaxValue - 2, H, I, J, K }
@@ -10290,21 +10404,38 @@ enum U8 : byte { A = 0, B, C, D = byte.MaxValue - 2, E, F, G, H }
 enum U16 : ushort { A = 0, B, C, D = ushort.MaxValue - 2, E, F, G, H }
 enum U32 : uint { A = 0, B, C, D = uint.MaxValue - 2, E, F, G, H }
 enum U64 : ulong { A = 0, B, C, D = ulong.MaxValue - 2, E, F, G, H }
-",
-                "'J' error CS0543: 'S8.J': the enumerator value is too large to fit in its type",
-                "'J' error CS0543: 'S16.J': the enumerator value is too large to fit in its type",
-                "'J' error CS0543: 'S32.J': the enumerator value is too large to fit in its type",
-                "'J' error CS0543: 'S64.J': the enumerator value is too large to fit in its type",
-                "'G' error CS0543: 'U8.G': the enumerator value is too large to fit in its type",
-                "'G' error CS0543: 'U16.G': the enumerator value is too large to fit in its type",
-                "'G' error CS0543: 'U32.G': the enumerator value is too large to fit in its type",
-                "'G' error CS0543: 'U64.G': the enumerator value is too large to fit in its type");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (3,84): error CS0543: 'S32.J': the enumerator value is too large to fit in its type
+                // enum S32 : int { A = int.MinValue, B, C, D = -1, E, F, G = int.MaxValue - 2, H, I, J, K }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "J").WithArguments("S32.J").WithLocation(3, 84),
+                // (4,87): error CS0543: 'S64.J': the enumerator value is too large to fit in its type
+                // enum S64 : long { A = long.MinValue, B, C, D = -1, E, F, G = long.MaxValue - 2, H, I, J, K }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "J").WithArguments("S64.J").WithLocation(4, 87),
+                // (7,61): error CS0543: 'U32.G': the enumerator value is too large to fit in its type
+                // enum U32 : uint { A = 0, B, C, D = uint.MaxValue - 2, E, F, G, H }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "G").WithArguments("U32.G").WithLocation(7, 61),
+                // (6,65): error CS0543: 'U16.G': the enumerator value is too large to fit in its type
+                // enum U16 : ushort { A = 0, B, C, D = ushort.MaxValue - 2, E, F, G, H }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "G").WithArguments("U16.G").WithLocation(6, 65),
+                // (5,60): error CS0543: 'U8.G': the enumerator value is too large to fit in its type
+                // enum U8 : byte { A = 0, B, C, D = byte.MaxValue - 2, E, F, G, H }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "G").WithArguments("U8.G").WithLocation(5, 60),
+                // (2,90): error CS0543: 'S16.J': the enumerator value is too large to fit in its type
+                // enum S16 : short { A = short.MinValue, B, C, D = -1, E, F, G = short.MaxValue - 2, H, I, J, K }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "J").WithArguments("S16.J").WithLocation(2, 90),
+                // (1,89): error CS0543: 'S8.J': the enumerator value is too large to fit in its type
+                // enum S8 : sbyte { A = sbyte.MinValue, B, C, D = -1, E, F, G = sbyte.MaxValue - 2, H, I, J, K }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "J").WithArguments("S8.J").WithLocation(1, 89),
+                // (8,63): error CS0543: 'U64.G': the enumerator value is too large to fit in its type
+                // enum U64 : ulong { A = 0, B, C, D = ulong.MaxValue - 2, E, F, G, H }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "G").WithArguments("U64.G").WithLocation(8, 63));
         }
 
         [Fact]
         public void CS0543ERR_EnumeratorOverflow04()
         {
-            string text = string.Format(
+            string source = string.Format(
 @"enum A {0}
 enum B : byte {1}
 enum C : byte {2}
@@ -10313,10 +10444,14 @@ enum D : sbyte {2}",
                   CreateEnumValues(256, "E"),
                   CreateEnumValues(300, "E"),
                   CreateEnumValues(300, "E", sbyte.MinValue));
-            DiagnosticsUtils.TestDiagnostics(
-                text,
-                "'E256' error CS0543: 'C.E256': the enumerator value is too large to fit in its type",
-                "'E128' error CS0543: 'D.E128': the enumerator value is too large to fit in its type");
+           
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (4,676): error CS0543: 'D.E128': the enumerator value is too large to fit in its type
+                // enum D : sbyte { E0, E1, E2, E3, <snip>, E297, E298, E299,  }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "E128").WithArguments("D.E128").WithLocation(4, 676),
+                // (3,1443): error CS0543: 'C.E256': the enumerator value is too large to fit in its type
+                // enum C : byte { E0, E1, E2, E3, <snip>, E297, E298, E299,  }
+                Diagnostic(ErrorCode.ERR_EnumeratorOverflow, "E256").WithArguments("C.E256").WithLocation(3, 1443));
         }
 
         // Create string "{ E0, E1, ..., En }"
@@ -10342,7 +10477,7 @@ enum D : sbyte {2}",
         [Fact]
         public void CS0571ERR_CantCallSpecialMethod01()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class C
 {
     protected virtual object P { get; set; }
@@ -10358,12 +10493,23 @@ class D : C
 {
     protected override object P { get { return null; } set { } }
 }
-",
-                "'set_P' error CS0571: 'C.P.set': cannot explicitly call operator or accessor",
-                "'get_Q' error CS0571: 'C.Q.get': cannot explicitly call operator or accessor",
-                "'set_Q' error CS0571: 'C.Q.set': cannot explicitly call operator or accessor",
-                "'get_P' error CS0571: 'D.P.get': cannot explicitly call operator or accessor",
-                "'get_P' error CS0571: 'C.P.get': cannot explicitly call operator or accessor");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (7,20): error CS0571: 'C.Q.get': cannot explicitly call operator or accessor
+                //         this.set_P(get_Q());
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "get_Q").WithArguments("C.Q.get").WithLocation(7, 20),
+                // (7,14): error CS0571: 'C.P.set': cannot explicitly call operator or accessor
+                //         this.set_P(get_Q());
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "set_P").WithArguments("C.P.set").WithLocation(7, 14),
+                // (8,19): error CS0571: 'D.P.get': cannot explicitly call operator or accessor
+                //         D.set_Q(d.get_P());
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "get_P").WithArguments("D.P.get").WithLocation(8, 19),
+                // (8,11): error CS0571: 'C.Q.set': cannot explicitly call operator or accessor
+                //         D.set_Q(d.get_P());
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "set_Q").WithArguments("C.Q.set").WithLocation(8, 11),
+                // (9,16): error CS0571: 'C.P.get': cannot explicitly call operator or accessor
+                //         ((this.get_P))();
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "get_P").WithArguments("C.P.get").WithLocation(9, 16));
 
             // CONSIDER: Dev10 reports 'C.P.get' for the fourth error.  Roslyn reports 'D.P.get'
             // because it is in the more-derived type and because Binder.LookupMembersInClass
@@ -10374,7 +10520,7 @@ class D : C
         [Fact]
         public void CS0571ERR_CantCallSpecialMethod02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"using System;
 namespace A.B
 {
@@ -10391,11 +10537,20 @@ namespace A.B
         }
     }
 }
-",
-                "'get_P' error CS0571: 'C.P.get': cannot explicitly call operator or accessor",
-                "'get_Q' error CS0571: 'C.Q.get': cannot explicitly call operator or accessor",
-                "'set_P' error CS0571: 'C.P.set': cannot explicitly call operator or accessor",
-                "'set_Q' error CS0571: 'C.Q.set': cannot explicitly call operator or accessor");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (10,30): error CS0571: 'C.P.get': cannot explicitly call operator or accessor
+                //             Func<object> f = get_P;
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "get_P").WithArguments("A.B.C.P.get").WithLocation(10, 30),
+                // (11,19): error CS0571: 'C.Q.get': cannot explicitly call operator or accessor
+                //             f = C.get_Q;
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "get_Q").WithArguments("A.B.C.Q.get").WithLocation(11, 19),
+                // (12,34): error CS0571: 'C.P.set': cannot explicitly call operator or accessor
+                //             Action<object> a = c.set_P;
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "set_P").WithArguments("A.B.C.P.set").WithLocation(12, 34),
+                // (13,17): error CS0571: 'C.Q.set': cannot explicitly call operator or accessor
+                //             a = set_Q;
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "set_Q").WithArguments("A.B.C.Q.set").WithLocation(13, 17));
         }
 
         /// <summary>
@@ -10405,7 +10560,7 @@ namespace A.B
         [Fact]
         public void CS0571ERR_CantCallSpecialMethod03()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class A
 {
     public object get_P() { return null; }
@@ -10427,7 +10582,8 @@ class C
         o = b.get_P();
     }
 }
-");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics();
         }
 
         [Fact()]
@@ -10454,7 +10610,7 @@ class C
         [Fact]
         public void CS0571ERR_CantCallSpecialMethod05()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"
 using System;
 public class C
@@ -10468,12 +10624,23 @@ public class C
         IntPtr.op_Explicit(0);
     }
 }
-",
-"'op_Addition' error CS0571: 'IntPtr.operator +(IntPtr, int)': cannot explicitly call operator or accessor",
-"'op_Subtraction' error CS0571: 'IntPtr.operator -(IntPtr, int)': cannot explicitly call operator or accessor",
-"'op_Equality' error CS0571: 'IntPtr.operator ==(IntPtr, IntPtr)': cannot explicitly call operator or accessor",
-"'op_Inequality' error CS0571: 'IntPtr.operator !=(IntPtr, IntPtr)': cannot explicitly call operator or accessor",
-"'op_Explicit' error CS0571: 'IntPtr.explicit operator IntPtr(int)': cannot explicitly call operator or accessor");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (7,16): error CS0571: 'IntPtr.operator +(IntPtr, int)': cannot explicitly call operator or accessor
+                //         IntPtr.op_Addition(default(IntPtr), 0);
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "op_Addition").WithArguments("System.IntPtr.operator +(System.IntPtr, int)").WithLocation(7, 16),
+                // (8,16): error CS0571: 'IntPtr.operator -(IntPtr, int)': cannot explicitly call operator or accessor
+                //         IntPtr.op_Subtraction(default(IntPtr), 0);
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "op_Subtraction").WithArguments("System.IntPtr.operator -(System.IntPtr, int)").WithLocation(8, 16),
+                // (9,16): error CS0571: 'IntPtr.operator ==(IntPtr, IntPtr)': cannot explicitly call operator or accessor
+                //         IntPtr.op_Equality(default(IntPtr), default(IntPtr));
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "op_Equality").WithArguments("System.IntPtr.operator ==(System.IntPtr, System.IntPtr)").WithLocation(9, 16),
+                // (10,16): error CS0571: 'IntPtr.operator !=(IntPtr, IntPtr)': cannot explicitly call operator or accessor
+                //         IntPtr.op_Inequality(default(IntPtr), default(IntPtr));
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "op_Inequality").WithArguments("System.IntPtr.operator !=(System.IntPtr, System.IntPtr)").WithLocation(10, 16),
+                // (11,16): error CS0571: 'IntPtr.explicit operator IntPtr(int)': cannot explicitly call operator or accessor
+                //         IntPtr.op_Explicit(0);
+                Diagnostic(ErrorCode.ERR_CantCallSpecialMethod, "op_Explicit").WithArguments("System.IntPtr.explicit operator System.IntPtr(int)").WithLocation(11, 16));
         }
 
         [Fact]
@@ -12412,7 +12579,7 @@ public class TestTheClasses
         [Fact]
         public void CS1061ERR_NoSuchMemberOrExtension02()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"enum E { }
 class C
 {
@@ -12420,8 +12587,11 @@ class C
     {
         object o = e.value__;
     }
-}",
-                "'value__' error CS1061: 'E' does not contain a definition for 'value__' and no extension method 'value__' accepting a first argument of type 'E' could be found (are you missing a using directive or an assembly reference?)");
+}";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (6,22): error CS1061: 'E' does not contain a definition for 'value__' and no extension method 'value__' accepting a first argument of type 'E' could be found (are you missing a using directive or an assembly reference?)
+                //         object o = e.value__;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "value__").WithArguments("E", "value__").WithLocation(6, 22));
         }
 
         [Fact]
@@ -12765,7 +12935,7 @@ namespace x
         [Fact]
         public void CS1503ERR_BadArgType01()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace X
 {
     public class C
@@ -12779,15 +12949,17 @@ namespace x
         }
     }
 }
-",
-                 //"'C' error CS1502: The best overloaded method match for 'X.C.C(int, char)' has some invalid arguments",  //specifically omitted by roslyn
-                 "'2' error CS1503: Argument 2: cannot convert from 'int' to 'char'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (10,22): error CS1503: Argument 2: cannot convert from 'int' to 'char'
+                //             new C(1, 2); // CS1502 & CS1503
+                Diagnostic(ErrorCode.ERR_BadArgType, "2").WithArguments("2", "int", "char").WithLocation(10, 22));
         }
 
         [Fact]
         public void CS1503ERR_BadArgType02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"enum E1 { A, B, C }
 enum E2 { X, Y, Z }
 class C
@@ -12804,22 +12976,27 @@ class C
         G((int)E2.Z); // CS1502 & CS1503
     }
 }
-",
-                 //"'F' error CS1502: The best overloaded method match for 'C.F(int)' has some invalid arguments",    //specifically omitted by roslyn              
-                 "'E1.A' error CS1503: Argument 1: cannot convert from 'E1' to 'int'",
-                 //"'F' error CS1502: The best overloaded method match for 'C.F(int)' has some invalid arguments",  //specifically omitted by roslyn
-                 "'(E2)E1.B' error CS1503: Argument 1: cannot convert from 'E2' to 'int'",
-                 //"'G' error CS1502: The best overloaded method match for 'C.G(E1)' has some invalid arguments",  //specifically omitted by roslyn
-                 "'E2.X' error CS1503: Argument 1: cannot convert from 'E2' to 'E1'",
-                 //"'G' error CS1502: The best overloaded method match for 'C.G(E1)' has some invalid arguments",  //specifically omitted by roslyn
-                 "'(int)E2.Z' error CS1503: Argument 1: cannot convert from 'int' to 'E1'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (9,11): error CS1503: Argument 1: cannot convert from 'E1' to 'int'
+                //         F(E1.A); // CS1502 & CS1503
+                Diagnostic(ErrorCode.ERR_BadArgType, "E1.A").WithArguments("1", "E1", "int").WithLocation(9, 11),
+                // (10,11): error CS1503: Argument 1: cannot convert from 'E2' to 'int'
+                //         F((E2)E1.B); // CS1502 & CS1503
+                Diagnostic(ErrorCode.ERR_BadArgType, "(E2)E1.B").WithArguments("1", "E2", "int").WithLocation(10, 11),
+                // (12,11): error CS1503: Argument 1: cannot convert from 'E2' to 'E1'
+                //         G(E2.X); // CS1502 & CS1503
+                Diagnostic(ErrorCode.ERR_BadArgType, "E2.X").WithArguments("1", "E2", "E1").WithLocation(12, 11),
+                // (14,11): error CS1503: Argument 1: cannot convert from 'int' to 'E1'
+                //         G((int)E2.Z); // CS1502 & CS1503
+                Diagnostic(ErrorCode.ERR_BadArgType, "(int)E2.Z").WithArguments("1", "int", "E1").WithLocation(14, 11));
         }
 
         [WorkItem(538939, "DevDiv")]
         [Fact]
         public void CS1503ERR_BadArgType03()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"class C
 {
     static void F(out int i)
@@ -12831,8 +13008,11 @@ class C
         F(out arg); // CS1503
     }
 }
-",
-                 "'arg' error CS1503: Argument 1: cannot convert from 'out long' to 'out int'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (9,15): error CS1503: Argument 1: cannot convert from 'out long' to 'out int'
+                //         F(out arg); // CS1503
+                Diagnostic(ErrorCode.ERR_BadArgType, "arg").WithArguments("1", "out long", "out int").WithLocation(9, 15));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -6896,16 +6896,21 @@ extern alias FT1;
         [Fact]
         public void CS0442ERR_PrivateAbstractAccessor()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source =
 @"abstract class MyClass
 {
     public abstract int P { get; private set; } // CS0442
     protected abstract object Q { private get; set; } // CS0442
     internal virtual object R { private get; set; } // no error
 }
-",
-                "'set' error CS0442: 'MyClass.P.set': abstract properties cannot have private accessors",
-                "'get' error CS0442: 'MyClass.Q.get': abstract properties cannot have private accessors");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (3,42): error CS0442: 'MyClass.P.set': abstract properties cannot have private accessors
+                //     public abstract int P { get; private set; } // CS0442
+                Diagnostic(ErrorCode.ERR_PrivateAbstractAccessor, "set").WithArguments("MyClass.P.set").WithLocation(3, 42),
+                // (4,43): error CS0442: 'MyClass.Q.get': abstract properties cannot have private accessors
+                //     protected abstract object Q { private get; set; } // CS0442
+                Diagnostic(ErrorCode.ERR_PrivateAbstractAccessor, "get").WithArguments("MyClass.Q.get").WithLocation(4, 43));
         }
 
         [Fact]
@@ -7903,7 +7908,7 @@ Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "GM").WithArguments("GG
         [Fact]
         public void CS0509ERR_CantDeriveFromSealedType01()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace NS
 {
     public struct stx { }
@@ -7912,15 +7917,20 @@ Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "GM").WithArguments("GG
     public class cly : clx {}
     public class clz : stx { }
 }
-",
-                "'cly' error CS0509: 'cly': cannot derive from sealed type 'clx'",
-                "'clz' error CS0509: 'clz': cannot derive from sealed type 'stx'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (7,18): error CS0509: 'clz': cannot derive from sealed type 'stx'
+                //     public class clz : stx { }
+                Diagnostic(ErrorCode.ERR_CantDeriveFromSealedType, "clz").WithArguments("NS.clz", "NS.stx").WithLocation(7, 18),
+                // (6,18): error CS0509: 'cly': cannot derive from sealed type 'clx'
+                //     public class cly : clx {}
+                Diagnostic(ErrorCode.ERR_CantDeriveFromSealedType, "cly").WithArguments("NS.cly", "NS.clx").WithLocation(6, 18));
         }
 
         [Fact]
         public void CS0509ERR_CantDeriveFromSealedType02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace N1 { enum E { A, B } }
 namespace N2
 {
@@ -7928,16 +7938,23 @@ namespace N2
     class D : System.Int32 { }
     class E : int { }
 }
-",
-                "'C' error CS0509: 'C': cannot derive from sealed type 'E'",
-                "'D' error CS0509: 'D': cannot derive from sealed type 'int'",
-                "'E' error CS0509: 'E': cannot derive from sealed type 'int'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (6,11): error CS0509: 'E': cannot derive from sealed type 'int'
+                //     class E : int { }
+                Diagnostic(ErrorCode.ERR_CantDeriveFromSealedType, "E").WithArguments("N2.E", "int").WithLocation(6, 11),
+                // (4,11): error CS0509: 'C': cannot derive from sealed type 'E'
+                //     class C : N1.E { }
+                Diagnostic(ErrorCode.ERR_CantDeriveFromSealedType, "C").WithArguments("N2.C", "N1.E").WithLocation(4, 11),
+                // (5,11): error CS0509: 'D': cannot derive from sealed type 'int'
+                //     class D : System.Int32 { }
+                Diagnostic(ErrorCode.ERR_CantDeriveFromSealedType, "D").WithArguments("N2.D", "int").WithLocation(5, 11));
         }
 
         [Fact]
         public void CS0513ERR_AbstractInConcreteClass01()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace NS
 {
     public class clx
@@ -7948,12 +7965,23 @@ namespace N2
         public abstract object P { get; set; }
     }
 }
-",
-                "'M1' error CS0513: 'clx.M1()' is abstract but it is contained in non-abstract class 'clx'",
-                "'M2' error CS0513: 'clx.M2()' is abstract but it is contained in non-abstract class 'clx'",
-                "'M3' error CS0513: 'clx.M3(sbyte)' is abstract but it is contained in non-abstract class 'clx'",
-                "'get' error CS0513: 'clx.P.get' is abstract but it is contained in non-abstract class 'clx'",
-                "'set' error CS0513: 'clx.P.set' is abstract but it is contained in non-abstract class 'clx'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (8,36): error CS0513: 'clx.P.get' is abstract but it is contained in non-abstract class 'clx'
+                //         public abstract object P { get; set; }
+                Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "get").WithArguments("NS.clx.P.get", "NS.clx").WithLocation(8, 36),
+                // (8,41): error CS0513: 'clx.P.set' is abstract but it is contained in non-abstract class 'clx'
+                //         public abstract object P { get; set; }
+                Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "set").WithArguments("NS.clx.P.set", "NS.clx").WithLocation(8, 41),
+                // (6,34): error CS0513: 'clx.M2()' is abstract but it is contained in non-abstract class 'clx'
+                //         internal abstract object M2();
+                Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "M2").WithArguments("NS.clx.M2()", "NS.clx").WithLocation(6, 34),
+                // (7,42): error CS0513: 'clx.M3(sbyte)' is abstract but it is contained in non-abstract class 'clx'
+                //         protected abstract internal void M3(sbyte p);
+                Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "M3").WithArguments("NS.clx.M3(sbyte)", "NS.clx").WithLocation(7, 42),
+                // (5,30): error CS0513: 'clx.M1()' is abstract but it is contained in non-abstract class 'clx'
+                //         abstract public void M1();
+                Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "M1").WithArguments("NS.clx.M1()", "NS.clx").WithLocation(5, 30));
         }
 
         [Fact]
@@ -9263,7 +9291,7 @@ public class Clx
         public void CS0542ERR_MemberNameSameAsType02()
         {
             // No errors for names from explicit implementations.
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"interface IM
 {
     void C();
@@ -9277,7 +9305,8 @@ class C : IM, IP
     void IM.C() { }
     object IP.C { get { return null; } }
 }
-");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics();
         }
 
         [Fact(), WorkItem(529156, "DevDiv")]
@@ -10644,7 +10673,7 @@ class Class2 { }
         [Fact]
         public void CS0621ERR_VirtualPrivate02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"abstract class A
 {
     abstract object P { get; }
@@ -10653,9 +10682,14 @@ class B
 {
     private virtual object Q { get; set; }
 }
-",
-                "'P' error CS0621: 'A.P': virtual or abstract members cannot be private",
-                "'Q' error CS0621: 'B.Q': virtual or abstract members cannot be private");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (3,21): error CS0621: 'A.P': virtual or abstract members cannot be private
+                //     abstract object P { get; }
+                Diagnostic(ErrorCode.ERR_VirtualPrivate, "P").WithArguments("A.P").WithLocation(3, 21),
+                // (7,28): error CS0621: 'B.Q': virtual or abstract members cannot be private
+                //     private virtual object Q { get; set; }
+                Diagnostic(ErrorCode.ERR_VirtualPrivate, "Q").WithArguments("B.Q").WithLocation(7, 28));
         }
 
         [Fact]
@@ -10870,7 +10904,7 @@ public class Test
         [Fact]
         public void CS0644ERR_DeriveFromEnumOrValueType()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"using System;
 namespace N
 {
@@ -10880,12 +10914,23 @@ namespace N
     static class F : MulticastDelegate { }
     static class G : Array { }
 }
-",
-                "'C' error CS0644: 'C' cannot derive from special class 'Enum'",
-                "'D' error CS0644: 'D' cannot derive from special class 'ValueType'",
-                "'E' error CS0644: 'E' cannot derive from special class 'Delegate'",
-                "'F' error CS0644: 'F' cannot derive from special class 'MulticastDelegate'",
-                "'G' error CS0644: 'G' cannot derive from special class 'Array'");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (5,11): error CS0644: 'D' cannot derive from special class 'ValueType'
+                //     class D : ValueType { }
+                Diagnostic(ErrorCode.ERR_DeriveFromEnumOrValueType, "D").WithArguments("N.D", "System.ValueType").WithLocation(5, 11),
+                // (6,11): error CS0644: 'E' cannot derive from special class 'Delegate'
+                //     class E : Delegate { }
+                Diagnostic(ErrorCode.ERR_DeriveFromEnumOrValueType, "E").WithArguments("N.E", "System.Delegate").WithLocation(6, 11),
+                // (4,11): error CS0644: 'C' cannot derive from special class 'Enum'
+                //     class C : Enum { }
+                Diagnostic(ErrorCode.ERR_DeriveFromEnumOrValueType, "C").WithArguments("N.C", "System.Enum").WithLocation(4, 11),
+                // (8,18): error CS0644: 'G' cannot derive from special class 'Array'
+                //     static class G : Array { }
+                Diagnostic(ErrorCode.ERR_DeriveFromEnumOrValueType, "G").WithArguments("N.G", "System.Array").WithLocation(8, 18),
+                // (7,18): error CS0644: 'F' cannot derive from special class 'MulticastDelegate'
+                //     static class F : MulticastDelegate { }
+                Diagnostic(ErrorCode.ERR_DeriveFromEnumOrValueType, "F").WithArguments("N.F", "System.MulticastDelegate").WithLocation(7, 18));
         }
 
         [Fact]
@@ -12282,7 +12327,7 @@ static class C
         [Fact]
         public void CS0713ERR_StaticDerivedFromNonObject01()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"namespace NS
 {
     public class Base
@@ -12301,22 +12346,32 @@ static class C
     {
     }
 }
-",
-                "'Base' error CS0713: Static class 'Derived' cannot derive from type 'Base'. Static classes must derive from object.",
-                "'Base1<string, V>' error CS0713: Static class 'D<V>' cannot derive from type 'Base1<string, V>'. Static classes must derive from object.");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (7,35): error CS0713: Static class 'Derived' cannot derive from type 'Base'. Static classes must derive from object.
+                //     public static class Derived : Base
+                Diagnostic(ErrorCode.ERR_StaticDerivedFromNonObject, "Base").WithArguments("NS.Derived", "NS.Base").WithLocation(7, 35),
+                // (15,25): error CS0713: Static class 'D<V>' cannot derive from type 'Base1<string, V>'. Static classes must derive from object.
+                //     static class D<V> : Base1<string, V>
+                Diagnostic(ErrorCode.ERR_StaticDerivedFromNonObject, "Base1<string, V>").WithArguments("NS.D<V>", "NS.Base1<string, V>").WithLocation(15, 25));
         }
 
         [Fact]
         public void CS0713ERR_StaticDerivedFromNonObject02()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"delegate void A();
 struct B { }
 static class C : A { }
 static class D : B { }
-",
-                "'A' error CS0713: Static class 'C' cannot derive from type 'A'. Static classes must derive from object.",
-                "'B' error CS0713: Static class 'D' cannot derive from type 'B'. Static classes must derive from object.");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (4,18): error CS0713: Static class 'D' cannot derive from type 'B'. Static classes must derive from object.
+                // static class D : B { }
+                Diagnostic(ErrorCode.ERR_StaticDerivedFromNonObject, "B").WithArguments("D", "B").WithLocation(4, 18),
+                // (3,18): error CS0713: Static class 'C' cannot derive from type 'A'. Static classes must derive from object.
+                // static class C : A { }
+                Diagnostic(ErrorCode.ERR_StaticDerivedFromNonObject, "A").WithArguments("C", "A").WithLocation(3, 18));
         }
 
         [Fact]
@@ -13615,15 +13670,20 @@ namespace TestNamespace
         [Fact]
         public void CS1014ERR_GetOrSetExpected()
         {
-            DiagnosticsUtils.TestDiagnostics(
+            var source = 
 @"partial class C
 {
     public object P { partial get; set; }
     object Q { get { return 0; } add { } }
 }
-",
-                "'partial' error CS1014: A get or set accessor expected",
-                "'add' error CS1014: A get or set accessor expected");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (3,23): error CS1014: A get or set accessor expected
+                //     public object P { partial get; set; }
+                Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 23),
+                // (4,34): error CS1014: A get or set accessor expected
+                //     object Q { get { return 0; } add { } }
+                Diagnostic(ErrorCode.ERR_GetOrSetExpected, "add").WithLocation(4, 34));
         }
 
         [Fact]
@@ -15808,7 +15868,7 @@ namespace x
         [Fact]
         public void CS0108WRN_NewRequired02()
         {
-            DiagnosticsUtils.TestDiagnosticsExact(
+            var source = 
 @"class A
 {
     public static void P() { }
@@ -15831,15 +15891,32 @@ class B : A
     public static void V() { } // CS0108
     public void W() { } // CS0108
 }
-",
-                "'P' warning CS0108: 'B.P' hides inherited member 'A.P()'. Use the new keyword if hiding was intended.",
-                "'Q' warning CS0108: 'B.Q' hides inherited member 'A.Q()'. Use the new keyword if hiding was intended.",
-                "'R' warning CS0108: 'B.R' hides inherited member 'A.R()'. Use the new keyword if hiding was intended.",
-                "'S' warning CS0108: 'B.S' hides inherited member 'A.S()'. Use the new keyword if hiding was intended.",
-                "'T' warning CS0108: 'B.T()' hides inherited member 'A.T'. Use the new keyword if hiding was intended.",
-                "'U' warning CS0108: 'B.U()' hides inherited member 'A.U'. Use the new keyword if hiding was intended.",
-                "'V' warning CS0108: 'B.V()' hides inherited member 'A.V'. Use the new keyword if hiding was intended.",
-                "'W' warning CS0108: 'B.W()' hides inherited member 'A.W'. Use the new keyword if hiding was intended.");
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (15,16): warning CS0108: 'B.Q' hides inherited member 'A.Q()'. Use the new keyword if hiding was intended.
+                //     public int Q { get; set; } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "Q").WithArguments("B.Q", "A.Q()").WithLocation(15, 16),
+                // (16,23): warning CS0108: 'B.R' hides inherited member 'A.R()'. Use the new keyword if hiding was intended.
+                //     public static int R { get; set; } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "R").WithArguments("B.R", "A.R()").WithLocation(16, 23),
+                // (17,16): warning CS0108: 'B.S' hides inherited member 'A.S()'. Use the new keyword if hiding was intended.
+                //     public int S { get; set; } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "S").WithArguments("B.S", "A.S()").WithLocation(17, 16),
+                // (18,24): warning CS0108: 'B.T()' hides inherited member 'A.T'. Use the new keyword if hiding was intended.
+                //     public static void T() { } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "T").WithArguments("B.T()", "A.T").WithLocation(18, 24),
+                // (19,17): warning CS0108: 'B.U()' hides inherited member 'A.U'. Use the new keyword if hiding was intended.
+                //     public void U() { } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "U").WithArguments("B.U()", "A.U").WithLocation(19, 17),
+                // (20,24): warning CS0108: 'B.V()' hides inherited member 'A.V'. Use the new keyword if hiding was intended.
+                //     public static void V() { } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "V").WithArguments("B.V()", "A.V").WithLocation(20, 24),
+                // (21,17): warning CS0108: 'B.W()' hides inherited member 'A.W'. Use the new keyword if hiding was intended.
+                //     public void W() { } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "W").WithArguments("B.W()", "A.W").WithLocation(21, 17),
+                // (14,23): warning CS0108: 'B.P' hides inherited member 'A.P()'. Use the new keyword if hiding was intended.
+                //     public static int P { get; set; } // CS0108
+                Diagnostic(ErrorCode.WRN_NewRequired, "P").WithArguments("B.P", "A.P()").WithLocation(14, 23));
         }
 
         [WorkItem(539624, "DevDiv")]

--- a/src/Compilers/Test/Utilities/CSharp/CompilingTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilingTestBase.cs
@@ -86,12 +86,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 DiagnosticFormatter.Instance.Format(diagnostic.WithLocation(Location.None), EnsureEnglishUICulture.PreferredOrNull));
         }
 
+        [Obsolete("Use VerifyDiagnostics", true)]
         public static void TestDiagnostics(IEnumerable<Diagnostic> diagnostics, params string[] diagStrings)
         {
             AssertEx.SetEqual(diagStrings, diagnostics.Select(DumpDiagnostic));
         }
 
         // Do a full compilation and check all the errors.
+        [Obsolete("Use VerifyDiagnostics", true)]
         public void TestAllErrors(string code, params string[] errors)
         {
             var compilation = CreateCompilationWithMscorlib(code);
@@ -100,6 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         // Tests just the errors found while binding method M in class C.
+        [Obsolete("Use VerifyDiagnostics", true)]
         public void TestErrors(string code, params string[] errors)
         {
             var compilation = CreateCompilationWithMscorlib(code);
@@ -113,6 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             AssertEx.SetEqual(errors, diagnostics.AsEnumerable().Select(DumpDiagnostic));
         }
 
+        [Obsolete("Use VerifyDiagnostics", true)]
         public void TestWarnings(string code, params string[] expectedWarnings)
         {
             var compilation = CreateCompilationWithMscorlib(code);

--- a/src/Compilers/Test/Utilities/CSharp/DiagnosticTestUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/DiagnosticTestUtilities.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         /// <summary>
         /// OBSOLETE: Use VerifyDiagnostics from Roslyn.Compilers.CSharp.Test.Utilities instead.
         /// </summary>
+        [Obsolete("Use VerifyDiagnostics", true)]
         public static void TestDiagnostics(string source, params string[] diagStrings)
         {
             var comp = CSharpTestBase.CreateCompilationWithMscorlib(source);
@@ -51,6 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         /// <summary>
         /// OBSOLETE: Use VerifyDiagnostics from Roslyn.Compilers.CSharp.Test.Utilities instead.
         /// </summary>
+        [Obsolete("Use VerifyDiagnostics", true)]
         public static void TestDiagnosticsExact(string source, params string[] diagStrings)
         {
             var comp = CSharpTestBase.CreateCompilationWithMscorlib(source);


### PR DESCRIPTION
Fixes #7081 

Uses `VerifyDiagnostics(...)`

##### Path: Semantic\Semantics
- [x] SemanticAnalyzerTests.cs
- [x] ConstantTests.cs
- [x] LambdaTests.cs
- [x] MethodTypeInferenceTests.cs
- [x] NamedAndOptionalTests.cs
- [x] OperatorTests.cs
- [x] OverloadResolutionTests.cs
- [x] SemanticErrorTests.cs 
- [x] AccessCheckTests.cs
- [x] AmbiguousOverrideTests.cs

##### Path: Symbol\Symbols
- [x] SymbolErrorTests.cs

### Others
- [x] Mark old test methods as obsolete

There are some commented out tests mentioning 'specific for Roslyn' in the original tests which I feel might need to be included as comments too. Update: I think these can be excluded.

Anything else?