### PR TITLE
Enforce that WpfFact tests must run serially

### DIFF
--- a/src/EditorFeatures/TestUtilities/Threading/StaTaskScheduler.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/StaTaskScheduler.cs
@@ -34,7 +34,7 @@ namespace Roslyn.Test.Utilities
         {
             // Validate arguments
             if (numberOfThreads < 1)
-                throw new ArgumentOutOfRangeException("concurrencyLevel");
+                throw new ArgumentOutOfRangeException(nameof(numberOfThreads));
 
             // Initialize the tasks collection
             _tasks = new BlockingCollection<Task>();

--- a/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -9,12 +10,19 @@ namespace Roslyn.Test.Utilities
     {
         private readonly IMessageSink _diagnosticMessageSink;
 
+        /// <summary>
+        /// A <see cref="SemaphoreSlim"/> used to ensure that only a single <see cref="WpfFactAttribute"/>-attributed test runs at once.
+        /// This requirement must be made because, currently, <see cref="WpfTestCase"/>'s logic sets various static state before a method
+        /// runs. If two tests run interleaved on the same scheduler (i.e. if one yields with an await) then all bets are off.
+        /// </summary>
+        private readonly SemaphoreSlim _wpfTestSerializationGate = new SemaphoreSlim(initialCount: 1);
+
         public WpfFactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
         {
             _diagnosticMessageSink = diagnosticMessageSink;
         }
 
         protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
-            => new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            => new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, _wpfTestSerializationGate);
     }
 }

--- a/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
@@ -11,14 +11,19 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Utilities;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+using Roslyn.Utilities;
 
 namespace Roslyn.Test.Utilities
 {
     public class WpfTestCase : XunitTestCase
     {
-        public WpfTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
+        private readonly SemaphoreSlim _wpfTestSerializationGate;
+
+        public WpfTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, SemaphoreSlim wpfTestSerializationGate, object[] testMethodArguments = null)
             : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
-        { }
+        {
+            _wpfTestSerializationGate = wpfTestSerializationGate;
+        }
 
         public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
         {
@@ -28,48 +33,51 @@ namespace Roslyn.Test.Utilities
                 Debug.Assert(sta.Threads.Length == 1);
                 Debug.Assert(sta.Threads[0] == Thread.CurrentThread);
 
-                try
+                using (await _wpfTestSerializationGate.DisposableWaitAsync())
                 {
-                    // Sync up FTAO to the context that we are creating here. 
-                    ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = new ForegroundThreadData(
-                        Thread.CurrentThread,
-                        StaTaskScheduler.DefaultSta,
-                        ForegroundThreadDataKind.StaUnitTest);
-
-                    // All WPF Tests need a DispatcherSynchronizationContext and we dont want to block pending keyboard
-                    // or mouse input from the user. So use background priority which is a single level below user input.
-                    var dispatcherSynchronizationContext = new DispatcherSynchronizationContext();
-
-                    // xUnit creates its own synchronization context and wraps any existing context so that messages are
-                    // still pumped as necessary. So we are safe setting it here, where we are not safe setting it in test.
-                    SynchronizationContext.SetSynchronizationContext(dispatcherSynchronizationContext);
-
-                    // Just call back into the normal xUnit dispatch process now that we are on an STA Thread with no synchronization context.
-                    var baseTask = base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
-                    do
+                    try
                     {
-                        var delay = Task.Delay(TimeSpan.FromMilliseconds(10), cancellationTokenSource.Token);
-                        var completed = await Task.WhenAny(baseTask, delay).ConfigureAwait(false);
-                        if (completed == baseTask)
+                        // Sync up FTAO to the context that we are creating here. 
+                        ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = new ForegroundThreadData(
+                            Thread.CurrentThread,
+                            StaTaskScheduler.DefaultSta,
+                            ForegroundThreadDataKind.StaUnitTest);
+
+                        // All WPF Tests need a DispatcherSynchronizationContext and we dont want to block pending keyboard
+                        // or mouse input from the user. So use background priority which is a single level below user input.
+                        var dispatcherSynchronizationContext = new DispatcherSynchronizationContext();
+
+                        // xUnit creates its own synchronization context and wraps any existing context so that messages are
+                        // still pumped as necessary. So we are safe setting it here, where we are not safe setting it in test.
+                        SynchronizationContext.SetSynchronizationContext(dispatcherSynchronizationContext);
+
+                        // Just call back into the normal xUnit dispatch process now that we are on an STA Thread with no synchronization context.
+                        var baseTask = base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+                        do
                         {
-                            return await baseTask.ConfigureAwait(false);
+                            var delay = Task.Delay(TimeSpan.FromMilliseconds(10), cancellationTokenSource.Token);
+                            var completed = await Task.WhenAny(baseTask, delay).ConfigureAwait(false);
+                            if (completed == baseTask)
+                            {
+                                return await baseTask.ConfigureAwait(false);
+                            }
+
+                            // Schedule a task to pump messages on the UI thread.  
+                            await Task.Factory.StartNew(
+                                () => WaitHelper.WaitForDispatchedOperationsToComplete(DispatcherPriority.ApplicationIdle),
+                                cancellationTokenSource.Token,
+                                TaskCreationOptions.None,
+                                sta).ConfigureAwait(false);
                         }
-
-                        // Schedule a task to pump messages on the UI thread.  
-                        await Task.Factory.StartNew(
-                            () => WaitHelper.WaitForDispatchedOperationsToComplete(DispatcherPriority.ApplicationIdle),
-                            cancellationTokenSource.Token,
-                            TaskCreationOptions.None,
-                            sta).ConfigureAwait(false);
+                        while (true);
                     }
-                    while (true);
-                }
-                finally
-                {
-                    ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = null;
+                    finally
+                    {
+                        ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = null;
 
-                    // Cleanup the synchronization context even if the test is failing exceptionally
-                    SynchronizationContext.SetSynchronizationContext(null);
+                        // Cleanup the synchronization context even if the test is failing exceptionally
+                        SynchronizationContext.SetSynchronizationContext(null);
+                    }
                 }
             }, cancellationTokenSource.Token, TaskCreationOptions.None, sta);
 


### PR DESCRIPTION
For now, WpfTestCase, when running tests, sets various bits of global static state. Because of this, it's not safe to let two tests interleave on the same test thread, and so we should explicitly prevent this.

This change we should revert in the hypothetical future where we can run multiple WpfFact threads in parallel.

*Review:* @dotnet/roslyn-ide, @dotnet/roslyn-infrastructure, @jaredpar, @Pilchie, @CyrusNajmabadi