### PR TITLE
Temporarily disable warning until we get an AnyCPU MSBuild NuGet ref

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Portable/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/Portable/MSBuildTask.csproj
@@ -21,6 +21,7 @@
     <TargetFrameworkProfile />
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);PORTABLE50</DefineConstants>
+    <!-- Remove when the Microsoft.Build.Framework package is updated. See issue #6986. -->
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Compilers/Core/MSBuildTask/Portable/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/Portable/MSBuildTask.csproj
@@ -21,6 +21,7 @@
     <TargetFrameworkProfile />
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);PORTABLE50</DefineConstants>
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>


### PR DESCRIPTION
MSBuild is unhappy that we're building the build task as AnyCPU because the
MSBuild core task reference is x86. The proper fix is for the MSBuild Core task
to also be compiled as AnyCPU, but until we can get an updated task this should
suffice. See issue #6986.

/cc @jasonmalinowski @jaredpar 