### PR TITLE
Fixes CS7038 when calling methods expecting ref/out delegate argument

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -913,7 +913,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!argument.HasExpressionType())
             {
                 // If the problem is that a lambda isn't convertible to the given type, also report why.
-                if (argument.Kind == BoundKind.UnboundLambda)
+                // The argument and parameter type might match, but may not have same in/out modifiers
+                if (argument.Kind == BoundKind.UnboundLambda && refArg == refParm)
                 {
                     ((UnboundLambda)argument).GenerateAnonymousFunctionConversionError(diagnostics, parameter.Type);
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -606,25 +606,37 @@ class C
         {
             string source = @"
 using System;
+using System.Linq.Expressions;
 class p
 {
     static void Foo<T>(ref Func<T,T> a) { }
     static void Bar<T>(out Func<T, T> a) { a = null; }
 
+    static void Foo2<T>(ref Expression<Func<T,T>> a) { }
+    static void Bar2<T>(out Expression<Func<T, T>> a) { a = null; }
+
     static void Main()
     {
         Foo<string>(x => x);
         Bar<string>(x => x);
+        Foo2<string>(x => x);
+        Bar2<string>(x => x);
     }
 }";
 
-            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                // (10,21): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'ref Func<string, string>'
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+                // (14,21): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'ref Func<string, string>'
                 //         Foo<string>(x => x);
-                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "ref System.Func<string, string>").WithLocation(10, 21),
-                // (11,21): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'out Func<string, string>'
+                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "ref System.Func<string, string>").WithLocation(14, 21),
+                // (15,21): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'out Func<string, string>'
                 //         Bar<string>(x => x);
-                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "out System.Func<string, string>").WithLocation(11, 21));
+                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "out System.Func<string, string>").WithLocation(15, 21),
+                // (16,22): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'ref Expression<Func<string, string>>'
+                //         Foo2<string>(x => x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "ref System.Linq.Expressions.Expression<System.Func<string, string>>").WithLocation(16, 22),
+                // (17,22): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'out Expression<Func<string, string>>'
+                //         Bar2<string>(x => x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "out System.Linq.Expressions.Expression<System.Func<string, string>>").WithLocation(17, 22));
         }
 
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -601,6 +601,32 @@ class C
 );
         }
 
+        [Fact]
+        public void TestRefOutAnonymousDelegate()
+        {
+            string source = @"
+using System;
+class p
+{
+    static void Foo<T>(ref Func<T,T> a) { }
+    static void Bar<T>(out Func<T, T> a) { a = null; }
+
+    static void Main()
+    {
+        Foo<string>(x => x);
+        Bar<string>(x => x);
+    }
+}";
+
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (10,21): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'ref Func<string, string>'
+                //         Foo<string>(x => x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "ref System.Func<string, string>").WithLocation(10, 21),
+                // (11,21): error CS1503: Argument 1: cannot convert from 'lambda expression' to 'out Func<string, string>'
+                //         Bar<string>(x => x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x => x").WithArguments("1", "lambda expression", "out System.Func<string, string>").WithLocation(11, 21));
+        }
+
 
         [Fact, WorkItem(1157097, "DevDiv"), WorkItem(2298, "https://github.com/dotnet/roslyn/issues/2298")]
         public void TestOverloadResolutionTiebreaker()


### PR DESCRIPTION
Fixes #7089.

In the legacy compiler, the following is reported
```
error CS1660: Cannot convert lambda expression to type 'ref System.Func<string,string>' because it is not a delegate type
```
That seems a bit confusing.
I have changed it to
```
error CS1503: Argument 1: cannot convert from 'lambda expression' to 'ref Func<string, string>'
```

Should I stick to the original error?

Related: #7047