### PR TITLE
Add missing ERRID to HasDuplicateTypesOrAssemblies...

### DIFF
--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -621,7 +621,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Friend Overrides Function HasDuplicateTypesOrAssemblies(diagnostic As Diagnostic) As Boolean
             Select Case CType(diagnostic.Code, ERRID)
-                Case ERRID.ERR_DuplicateReferenceStrong,
+                Case ERRID.ERR_DuplicateReference2,
+                     ERRID.ERR_DuplicateReferenceStrong,
                      ERRID.ERR_AmbiguousInUnnamedNamespace1,
                      ERRID.ERR_AmbiguousInNamespace2,
                      ERRID.ERR_NoMostSpecificOverload2,


### PR DESCRIPTION
Duplicate references between weak named assemblies have a different error code in VB.

Fixes https://connect.microsoft.com/VisualStudio/feedback/details/1419986/project-already-has-a-reference-to-assembly-when-try-to-view-variable-value