### PR TITLE
Don't parse out a local declaration where there clearly isn't one.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4709,6 +4709,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 SyntaxFacts.IsBinaryExpressionOperatorToken(currentTokenKind);
 
                             if (currentTokenKind == SyntaxKind.DotToken ||
+                                currentTokenKind == SyntaxKind.OpenParenToken ||
                                 currentTokenKind == SyntaxKind.MinusGreaterThanToken ||
                                 isNonEqualsBinaryToken)
                             {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4685,10 +4685,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // Console->WriteLine();
                 //
                 // C 
-                // A + B; // etc.
+                // A + B;
                 //
                 // C 
                 // A ? B : D;
+                //
+                // C 
+                // A()
                 var resetPoint = this.GetResetPoint();
                 try
                 {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -1184,6 +1184,29 @@ class Program
         }
 
         [Fact]
+        public void CS1001ERR_IdentifierExpected_7()
+        {
+            var test = @"
+using System;
+class C
+{
+  void M()
+  {
+    DateTime
+    M();
+  }
+}
+";
+            CreateCompilationWithMscorlib(test).VerifyDiagnostics(
+                // (7,13): error CS1001: Identifier expected
+                //     DateTime
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(7, 13),
+                // (7,13): error CS1002: ; expected
+                //     DateTime
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(7, 13));
+        }
+
+        [Fact]
         public void CS1002ERR_SemicolonExpected()
         {
             var test = @"

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6910,6 +6910,46 @@ class Program
 }", changedOptionSet: optionSet);
         }
 
+        [WorkItem(4014, "https://github.com/dotnet/roslyn/issues/4014")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormattingCodeWithBrokenLocalDeclarationShouldRespectFormatTabsOption()
+        {
+            var optionSet = new Dictionary<OptionKey, object> { { new OptionKey(FormattingOptions.UseTabs, LanguageNames.CSharp), true } };
+
+            await AssertFormatAsync(@"class AClass
+{
+	void AMethod(Object anArgument)
+	{
+		if (anArgument == null)
+		{
+			throw new ArgumentNullException(nameof(anArgument));
+		}
+		anArgument
+
+		DoSomething();
+	}
+
+	void DoSomething()
+	{
+	}
+}", @"class AClass
+{
+	void AMethod(Object anArgument)
+	{
+		if (anArgument == null)
+		{
+			throw new ArgumentNullException(nameof(anArgument));
+		}anArgument
+
+		DoSomething();
+	}
+
+	void DoSomething()
+	{
+	}
+}", changedOptionSet: optionSet);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(84, "https://github.com/dotnet/roslyn/issues/84")]
         [WorkItem(849870, "DevDiv")]


### PR DESCRIPTION
If we see:

```c#
  Identifier1
  Identifier2();
```

Don't parse that out as a declaration of a local called "Identifier2".

Fixes: https://github.com/dotnet/roslyn/issues/4014