### PR TITLE
Fix assert failure for FileThatCannotBeDecoded under default codepage 936

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -61,12 +61,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "asdf").WithArguments("asdf").WithLocation(3, 21));
         }
 
-        [ConditionalFact(typeof(IsEnglishLocal))]
+        [Fact]
         public void FileThatCannotBeDecoded()
         {
             var code = "#load \"b.csx\"";
             var resolver = TestSourceReferenceResolver.Create(
-                KeyValuePair.Create<string, object>("a.csx", new byte[] { 0xd8, 0x00, 0x00 }),
+                KeyValuePair.Create<string, object>("a.csx", new byte[] { 0xd8, 0x00, 0x00, 0x00 }),
                 KeyValuePair.Create<string, object>("b.csx", "#load \"a.csx\""));
             var options = TestOptions.DebugDll.WithSourceReferenceResolver(resolver);
             var compilation = CreateCompilationWithMscorlib45(code, sourceFileName: "external1.csx", options: options, parseOptions: TestOptions.Script);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/LoadDirectiveTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "asdf").WithArguments("asdf").WithLocation(3, 21));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         public void FileThatCannotBeDecoded()
         {
             var code = "#load \"b.csx\"";


### PR DESCRIPTION
I got assert failure from this test case from code page 936. I think it's similar to #6633

```
    Microsoft.CodeAnalysis.CSharp.UnitTests.LoadDirectiveTests.FileThatCannotBeDecoded
      Assert.Equal() Failure
      Expected: 3
      Actual:   4
      Stack Trace:
        src\Compilers\CSharp\Test\Symbol\Compilation\LoadDirectiveTests.cs(77,0): at Microsoft.CodeAnalysis.CSharp.UnitTests.LoadDirectiveTests.FileThatCannotBeDecoded()
```