### PR TITLE
Code Model: GetTypeSymbolFromFullName should not return unpredictable results when the type name was in an unsupported format

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -3027,6 +3027,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             {
                 var parsedTypeName = SyntaxFactory.ParseTypeName(fullName);
 
+                // Check to see if the name we parsed has any skipped text. If it does, don't bother trying to
+                // speculatively bind it because we'll likely just get the wrong thing since we found a bunch
+                // of non-sensical tokens.
+
+                if (parsedTypeName.ContainsSkippedText)
+                {
+                    return null;
+                }
+
                 // If we couldn't get the name, we just grab the first tree in the compilation to
                 // speculatively bind at position zero. However, if there *aren't* any trees, we fork the
                 // compilation with an empty tree for the purposes of speculative binding.

--- a/src/VisualStudio/Core/Impl/CodeModel/MetadataNameHelpers.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/MetadataNameHelpers.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -59,6 +60,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         public static string GetMetadataName(ITypeSymbol typeSymbol)
         {
+            if (typeSymbol.Kind == SymbolKind.TypeParameter)
+            {
+                throw new ArgumentException("Type parameters are not suppported", nameof(typeSymbol));
+            }
+
             var parts = new Stack<ISymbol>();
 
             ISymbol symbol = typeSymbol;

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
@@ -28,7 +28,7 @@ class Foo { }
 #End Region
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestDotNetNameFromLanguageSpecific() As Task
+        Public Async Function TestDotNetNameFromLanguageSpecific1() As Task
             Dim code =
 <code>
 using N.M;
@@ -46,6 +46,23 @@ namespace N
                 Sub(rootCodeModel)
                     Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("N.M.Generic<string>")
                     Assert.Equal("N.M.Generic`1[System.String]", dotNetName)
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDotNetNameFromLanguageSpecific2() As Task
+            Await TestRootCodeModelWithCodeFile(<code></code>,
+                Sub(rootCodeModel)
+                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List<int>")
+                    Assert.Equal("System.Collections.Generic.List`1[System.Int32]", dotNetName)
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDotNetNameFromLanguageSpecificWithAssemblyQualifiedName() As Task
+            Await TestRootCodeModelWithCodeFile(<code></code>,
+                Sub(rootCodeModel)
+                    Assert.Throws(Of ArgumentException)(Sub() rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List<int>, mscorlib"))
                 End Sub)
         End Function
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/RootCodeModelTests.vb
@@ -53,8 +53,8 @@ namespace N
         Public Async Function TestDotNetNameFromLanguageSpecific2() As Task
             Await TestRootCodeModelWithCodeFile(<code></code>,
                 Sub(rootCodeModel)
-                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List<int>")
-                    Assert.Equal("System.Collections.Generic.List`1[System.Int32]", dotNetName)
+                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.Dictionary<int, string>")
+                    Assert.Equal("System.Collections.Generic.Dictionary`2[System.Int32,System.String]", dotNetName)
                 End Sub)
         End Function
 
@@ -62,7 +62,7 @@ namespace N
         Public Async Function TestDotNetNameFromLanguageSpecificWithAssemblyQualifiedName() As Task
             Await TestRootCodeModelWithCodeFile(<code></code>,
                 Sub(rootCodeModel)
-                    Assert.Throws(Of ArgumentException)(Sub() rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List<int>, mscorlib"))
+                    Assert.Throws(Of ArgumentException)(Sub() rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.Dictionary<int, string>, mscorlib"))
                 End Sub)
         End Function
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
@@ -231,7 +231,7 @@ End Namespace
 #End Region
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestDotNetNameFromLanguageSpecific() As Task
+        Public Async Function TestDotNetNameFromLanguageSpecific1() As Task
             Dim code =
 <code>
 Imports N.M
@@ -248,6 +248,23 @@ End Namespace
                 Sub(rootCodeModel)
                     Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("N.M.Generic(Of String)")
                     Assert.Equal("N.M.Generic`1[System.String]", dotNetName)
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDotNetNameFromLanguageSpecific2() As Task
+            Await TestRootCodeModelWithCodeFile(<code></code>,
+                Sub(rootCodeModel)
+                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List(Of Integer)")
+                    Assert.Equal("System.Collections.Generic.List`1[System.Int32]", dotNetName)
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDotNetNameFromLanguageSpecificWithAssemblyQualifiedName() As Task
+            Await TestRootCodeModelWithCodeFile(<code></code>,
+                Sub(rootCodeModel)
+                    Assert.Throws(Of ArgumentException)(Sub() rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List(Of Integer), mscorlib"))
                 End Sub)
         End Function
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/RootCodeModelTests.vb
@@ -255,8 +255,8 @@ End Namespace
         Public Async Function TestDotNetNameFromLanguageSpecific2() As Task
             Await TestRootCodeModelWithCodeFile(<code></code>,
                 Sub(rootCodeModel)
-                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List(Of Integer)")
-                    Assert.Equal("System.Collections.Generic.List`1[System.Int32]", dotNetName)
+                    Dim dotNetName = rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.Dictionary(Of Integer, String)")
+                    Assert.Equal("System.Collections.Generic.Dictionary`2[System.Int32,System.String]", dotNetName)
                 End Sub)
         End Function
 
@@ -264,7 +264,7 @@ End Namespace
         Public Async Function TestDotNetNameFromLanguageSpecificWithAssemblyQualifiedName() As Task
             Await TestRootCodeModelWithCodeFile(<code></code>,
                 Sub(rootCodeModel)
-                    Assert.Throws(Of ArgumentException)(Sub() rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.List(Of Integer), mscorlib"))
+                    Assert.Throws(Of ArgumentException)(Sub() rootCodeModel.DotNetNameFromLanguageSpecific("System.Collections.Generic.Dictionary(Of Integer, String), mscorlib"))
                 End Sub)
         End Function
 


### PR DESCRIPTION
Fixes #7179 

Tagging @dotnet/roslyn-ide