### PR TITLE
Fix test issues

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_InvalidAssemblyCulture, @"""\0""").WithLocation(1, 55));
         }
 
-        [Fact(Skip = "Issue #321")]
+        [Fact]
         public void CultureAttributeMismatch()
         {
             var neutral = CreateCompilationWithMscorlib(
@@ -280,7 +280,7 @@ public class en_US
 
             compilation = CreateCompilationWithMscorlib("", new MetadataReference[] { compilation.EmitToImageReference() }, TestOptions.ReleaseDll, assemblyName: assemblyNameBase + "20");
 
-            CompileAndVerify(compilation).VerifyDiagnostics(
+            CompileAndVerify(compilation, verify: false).VerifyDiagnostics(
     // warning CS8009: Referenced assembly 'de, Version=0.0.0.0, Culture=de, PublicKeyToken=null' has different culture setting of 'de'.
     Diagnostic(ErrorCode.WRN_RefCultureMismatch).WithArguments("de, Version=0.0.0.0, Culture=de, PublicKeyToken=null", "de")
                 );
@@ -329,19 +329,6 @@ public class en_US
             compilation = CreateCompilationWithMscorlib("", new MetadataReference[] { compilation.EmitToImageReference() }, TestOptions.ReleaseDll, assemblyName: assemblyNameBase + "40");
 
             CompileAndVerify(compilation,
-                // TODO: KevinH - I'm not sure why PeVerify started requiring this assembly after I refactored some test helpers.
-                //       I verified that the actual assemblies being compiled only differ by MVID before/after, so I don't think
-                //       it's a product issue.  I *think* that one of the CompileAndVerify calls above may have been writing the
-                //       neutral assembly to disk somewhere that Fusion could find and load it (perhaps RefEmit wrote it to disk?).
-                dependencies: new[]
-                {
-                    new ModuleData(
-                        neutral.Assembly.Identity,
-                        OutputKind.DynamicallyLinkedLibrary,
-                        neutral.EmitToArray(options: new EmitOptions(metadataOnly: true)),
-                        pdb: default(ImmutableArray<byte>),
-                        inMemoryModule: true)
-                },
                 sourceSymbolValidator: m =>
                 {
                     Assert.Equal(1, m.GetReferencedAssemblySymbols().Length);
@@ -354,7 +341,8 @@ public class en_US
                 {
                     Assert.Equal(2, ((PEModuleSymbol)m).GetReferencedAssemblySymbols().Length);
                     Assert.Equal("neutral, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", m.GetReferencedAssemblySymbols()[1].ToTestDisplayString());
-                }).VerifyDiagnostics();
+                },
+                verify: false).VerifyDiagnostics();
 
             compilation = CreateCompilationWithMscorlib(
 @"
@@ -375,7 +363,7 @@ public class neutral
 
             compilation = CreateCompilationWithMscorlib("", new MetadataReference[] { compilation.EmitToImageReference() }, TestOptions.ReleaseDll, assemblyName: assemblyNameBase + "60");
 
-            CompileAndVerify(compilation).VerifyDiagnostics(
+            CompileAndVerify(compilation, verify: false).VerifyDiagnostics(
     // warning CS8009: Referenced assembly 'de, Version=0.0.0.0, Culture=de, PublicKeyToken=null' has different culture setting of 'de'.
     Diagnostic(ErrorCode.WRN_RefCultureMismatch).WithArguments("de, Version=0.0.0.0, Culture=de, PublicKeyToken=null", "de")
                 );

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -1920,7 +1920,7 @@ class Driver
             CompileAndVerify(source, "0");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/4300")]
+        [Fact]
         public void Return07_2()
         {
             var source = @"

--- a/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             allModules = allModules.ToArray();
 
-            var runtimeData = GetOrCreateRuntimeData(compilationDependencies);
+            var runtimeData = GetOrCreateRuntimeData(allModules);
 
             // Many prominent assemblys like mscorlib are already in the RuntimeAssemblyManager.  Only 
             // add in the delta values to reduce serialization overhead going across AppDomains.


### PR DESCRIPTION
This fixes as couple of test issues:

- CultureAttributeMismatch: this was a flaky suite whose flakiness was
fixed via the PEVerify changes.  The hardened rules revealed the suite
was setup to consistently fail verification because it didn't fully load
it's dependencies into the Compilation object.  This behavior is
actually expected, we want to get the compiler errors that result from
such a compilation.  Hence we disable verification in those cases.
- Return07_2: This was directly fixed by the PEVerify hardenning.

closes #4300
closes #5866