### PR TITLE
Remove LTTNG warnings on Linux

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -17,6 +17,9 @@ USE_CACHE=true
 MONO_ARGS='--debug=mdb-optimizations --attach=disable'
 MSBUILD_ADDITIONALARGS='/v:m /consoleloggerparameters:Verbosity=minimal /filelogger /fileloggerparameters:Verbosity=normal'
 
+# LTTNG is the logging infrastructure used by coreclr.  Need this variable set 
+# so it doesn't output warnings to the console.
+export LTTNG_HOME=$HOME
 export MONO_THREADS_PER_CPU=50
 
 # There are some stability issues that are causing Jenkins builds to fail at an 


### PR DESCRIPTION
The LTTNG library version used in CoreCLR requires LTTNG_HOME be set
else it issues a warning on process startup.  This was cluttering up our
linux build output.  Fixing this by exporting the value.