### PR TITLE
Change version for 1.1.1 NuGet package

### DIFF
--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -71,8 +71,7 @@
     <MicrosoftDiaSymReaderNativeVersion>1.3.3</MicrosoftDiaSymReaderNativeVersion>
     <NuGetCommandLineVersion>$(NuGetCommandLineAssemblyVersion)</NuGetCommandLineVersion>
     <MicrosoftCompositionVersion>$(MicrosoftCompositionAssemblyVersion)</MicrosoftCompositionVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersionStable Condition="'$(MicrosoftCodeAnalysisAnalyzersVersionStable)' == ''">1.0.0</MicrosoftCodeAnalysisAnalyzersVersionStable>
-    <MicrosoftCodeAnalysisAnalyzersVersionNext Condition="'$(MicrosoftCodeAnalysisAnalyzersVersionNext)' == ''">1.2.0</MicrosoftCodeAnalysisAnalyzersVersionNext>
+    <CodeAnalysisAnalyzersVersion Condition="'$(CodeAnalysisAnalyzersVersion)' == ''">1.1.0</CodeAnalysisAnalyzersVersion>
 
     <!-- If we're on Visual Studio 2015 RTM and  we still have Roslyn installed, our VSIX-producing packages are not going to install, so let's not even try.
          Update 1 supports this, so we'll use csi.exe's existence as a simple proxy for whether we have Update 1 installed or not.
@@ -316,7 +315,7 @@
       $(BuildNumberSuffix.Split('.')[1].PadLeft(2,'0'))
     </BuildNumberPart2>
 
-    <NuGetReleaseVersion>$(RoslynSemanticVersion)</NuGetReleaseVersion>
+    <NuGetReleaseVersion>1.1.1</NuGetReleaseVersion>
     <NuGetPreReleaseVersion>$(NuGetReleaseVersion)-rc1</NuGetPreReleaseVersion>
     <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(NuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
   </PropertyGroup>

--- a/build/Targets/VSL.Settings.targets
+++ b/build/Targets/VSL.Settings.targets
@@ -71,6 +71,7 @@
     <MicrosoftDiaSymReaderNativeVersion>1.3.3</MicrosoftDiaSymReaderNativeVersion>
     <NuGetCommandLineVersion>$(NuGetCommandLineAssemblyVersion)</NuGetCommandLineVersion>
     <MicrosoftCompositionVersion>$(MicrosoftCompositionAssemblyVersion)</MicrosoftCompositionVersion>
+    <!-- Versioning is independent, this should not be the Roslyn semantic version -->
     <CodeAnalysisAnalyzersVersion Condition="'$(CodeAnalysisAnalyzersVersion)' == ''">1.1.0</CodeAnalysisAnalyzersVersion>
 
     <!-- If we're on Visual Studio 2015 RTM and  we still have Roslyn installed, our VSIX-producing packages are not going to install, so let's not even try.


### PR DESCRIPTION
Includes an update to the NuGet release version to 1.1.1 as well
as a change to the analyzer reference to 1.1.0.

This will also require an internal change.

@dotnet/roslyn-infrastructure @jasonmalinowski @davkean @amcasey Please review.