### PR TITLE
Suppress supports warnings

### DIFF
--- a/src/Compilers/CSharp/CscCore/project.json
+++ b/src/Compilers/CSharp/CscCore/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23428",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23428",

--- a/src/Compilers/Server/PortableServer/project.json
+++ b/src/Compilers/Server/PortableServer/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23428",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23428",

--- a/src/Compilers/VisualBasic/VbcCore/project.json
+++ b/src/Compilers/VisualBasic/VbcCore/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23428",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23428",

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb.Tests/project.json
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb.Tests/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
     "System.Collections": "4.0.10",

--- a/src/Interactive/CsiCore/project.json
+++ b/src/Interactive/CsiCore/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": { },
-    "dnxcore50.app": { }
-  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23401",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23401",

--- a/src/Interactive/VbiCore/project.json
+++ b/src/Interactive/VbiCore/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-beta-23401",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23401",

--- a/src/Scripting/CSharp/project.json
+++ b/src/Scripting/CSharp/project.json
@@ -1,8 +1,4 @@
 {
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {},
   "frameworks": {
     "dotnet": {

--- a/src/Scripting/CSharpTest/project.json
+++ b/src/Scripting/CSharpTest/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "xunit.runner.console": "2.1.0"
   },

--- a/src/Scripting/Core/project.json
+++ b/src/Scripting/Core/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1-beta-23401",
     "System.AppContext": "4.0.0",

--- a/src/Scripting/CoreTest/project.json
+++ b/src/Scripting/CoreTest/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.CSharp": "4.0.0",
     "System.Dynamic.Runtime": "4.0.10",

--- a/src/Scripting/VisualBasic/project.json
+++ b/src/Scripting/VisualBasic/project.json
@@ -1,8 +1,4 @@
 {
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.VisualBasic": "10.0.0"
   },

--- a/src/Scripting/VisualBasicTest/project.json
+++ b/src/Scripting/VisualBasicTest/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "xunit.runner.console": "2.1.0"
   },

--- a/src/Test/Utilities/Portable/project.json
+++ b/src/Test/Utilities/Portable/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "supports": {
-    "net46.app": {},
-    "dnxcore50.app": {}
-  },
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
     "System.Collections.Concurrent": "4.0.10"


### PR DESCRIPTION
Remove all the supports sections that are causing warnings since we're using them in projects that don't have Microsoft.NETCore.Targets package references. Some of these projects (the first commit) already have runtime sections and so it's silly to even the supports in the first place. The others (the second project) _should_ have them, but I'm unable to sort out through the endless stream of errors if I try adding the package references. We should sort through those, but until then we should just not have sections that do nothing other than create errors.

*Review:* @tmat, @agocke, @dotnet/roslyn-compiler