### PR TITLE
Explicitly remove code model elements from the CleanableWeakComHandleTable when they are deleted

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -199,6 +199,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _codeElementTable.Add(nodeKey, element);
         }
 
+        internal void OnCodeElementDeleted(SyntaxNodeKey nodeKey)
+        {
+            _codeElementTable.Remove(nodeKey);
+        }
+
         internal T GetOrCreateCodeElement<T>(SyntaxNode node)
         {
             var nodeKey = CodeModelService.TryGetNodeKey(node);
@@ -612,7 +617,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             if (codeElement == null)
             {
-                throw new ArgumentException(ServicesVSResources.ElementIsNotValid, "element");
+                throw new ArgumentException(ServicesVSResources.ElementIsNotValid, nameof(element));
             }
 
             codeElement.Delete();

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
@@ -249,6 +249,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             CodeModelService.Rename(LookupSymbol(), newName, this.Workspace.CurrentSolution);
         }
 
+        protected virtual Document DeleteCore(Document document)
+        {
+            var node = LookupNode();
+            return CodeModelService.Delete(document, node);
+        }
+
         /// <summary>
         /// Delete the element from the source file.
         /// </summary>
@@ -256,8 +262,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
             FileCodeModel.PerformEdit(document =>
             {
-                var node = LookupNode();
-                return CodeModelService.Delete(document, node);
+                return DeleteCore(document);
             });
         }
 

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
@@ -95,6 +95,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             });
         }
 
+        protected override Document DeleteCore(Document document)
+        {
+            var result = base.DeleteCore(document);
+
+            FileCodeModel.OnCodeElementDeleted(_nodeKey);
+
+            return result;
+        }
+
         protected override string GetName()
         {
             if (IsUnknown)

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -3813,6 +3813,24 @@ class $$C : Generic&lt;string&gt;
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestAddDeleteManyTimes() As Task
+            Dim code =
+<Code>
+class C$$
+{
+}
+</Code>
+
+            Await TestElement(code,
+                Sub(codeClass)
+                    For i = 1 To 100
+                        Dim variable = codeClass.AddVariable("x", "System.Int32")
+                        codeClass.RemoveMember(variable)
+                    Next
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestTypeDescriptor_GetProperties() As Task
             Dim code =
 <Code>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -3125,6 +3125,23 @@ End Class
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestAddDeleteManyTimes() As Task
+            Dim code =
+<Code>
+Class C$$
+End Class
+</Code>
+
+            Await TestElement(code,
+                Sub(codeClass)
+                    For i = 1 To 100
+                        Dim variable = codeClass.AddVariable("x", "System.Int32")
+                        codeClass.RemoveMember(variable)
+                    Next
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestExternalClass_ImplementedInterfaces() As Task
             Dim code =
 <Code>


### PR DESCRIPTION
Fixes #7216

There are WinForms scenarios where code model elements can be deleted and re-added, for example, when the modifiers of a control on the designer surface are changed the control will be deleted and immediately re-added. We must be sure to delete the element's node key from the CleanableWeakComHandleTable or else an exception will be thrown when the element is re-added with the same node key.

Tagging @dotnet/roslyn-ide for review