### PR TITLE
Fix bug when rewriting expressions with converted enum literals

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -450,7 +450,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var conversion = (BoundConversion)operand;
                 if (!conversion.ConversionKind.IsUserDefinedConversion() &&
-                    conversion.ConversionKind.IsImplicitConversion() && 
+                    conversion.ConversionKind.IsImplicitConversion() &&
+                    conversion.ConversionKind != ConversionKind.NullLiteral &&
                     conversion.Type.StrippedType().IsEnumType())
                 {
                     operand = conversion.Operand;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -4782,6 +4782,48 @@ namespace ConsoleApplication1
                 expectedOutput: expectedOutput);
         }
 
+        [Fact, WorkItem(7241, "https://github.com/dotnet/roslyn/issues/7241")]
+        public void EnumEquality005()
+        {
+            string source =
+@"
+using System;
+using System.Linq.Expressions;
+
+namespace ConsoleApplication1
+{
+    enum YesNo
+    {
+        Yes,
+        No
+    }
+
+    class MyType
+    {
+        public string Name { get; set; }
+        public YesNo? YesNo { get; set; }
+
+        public int? Age { get; set; }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+
+            Expression<Func<MyType, bool>> expr = (MyType x) => x.YesNo == (YesNo?)null;
+            Console.WriteLine(expr.Dump());
+        }
+    }
+
+}";
+            string expectedOutput = "Equal(Convert(MemberAccess(Parameter(x Type:ConsoleApplication1.MyType).YesNo Type:System.Nullable`1[ConsoleApplication1.YesNo]) Lifted LiftedToNull Type:System.Nullable`1[System.Int32]) Convert(Convert(Constant(null Type:System.Object) Lifted LiftedToNull Type:System.Nullable`1[ConsoleApplication1.YesNo]) Lifted LiftedToNull Type:System.Nullable`1[System.Int32]) Lifted Type:System.Boolean)";
+            CompileAndVerify(
+                new[] { source, ExpressionTestLibrary },
+                new[] { ExpressionAssemblyRef },
+                expectedOutput: expectedOutput);
+        }
+
         [WorkItem(546618, "DevDiv")]
         [Fact]
         public void TildeNullableEnum()


### PR DESCRIPTION
See http://stackoverflow.com/questions/34085367/why-does-roslyn-crash-when-trying-to-rewrite-this-lambda-visual-studio-2015-up
Fixes #7241