### PR TITLE
Port PR #7212 to stabilization

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -58,14 +58,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
 
         private static readonly SymbolDisplayFormat s_externalNameFormat =
             new SymbolDisplayFormat(
-                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeName);
 
         private static readonly SymbolDisplayFormat s_externalFullNameFormat =
             new SymbolDisplayFormat(
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
                 memberOptions: SymbolDisplayMemberOptions.IncludeContainingType | SymbolDisplayMemberOptions.IncludeExplicitInterface,
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
+                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeName);
 
         private static readonly SymbolDisplayFormat s_setTypeFormat =
             new SymbolDisplayFormat(

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeParameter.cs
@@ -2,7 +2,6 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
@@ -2,7 +2,6 @@
 
 Imports EnvDTE
 Imports EnvDTE80
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Public MustInherit Class AbstractCodeParameterTests

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -103,8 +103,10 @@ class C : System.Console
 
 #Region "Name tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName1() As Task
+        Public Sub TestName1()
             Dim code =
 <Code>
 class C
@@ -115,11 +117,13 @@ class C
 }
 </Code>
 
-            Await TestName(code, "s")
-        End Function
+            TestName(code, "s")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName2() As Task
+        Public Sub TestName2()
             Dim code =
 <Code>
 class C
@@ -130,11 +134,13 @@ class C
 }
 </Code>
 
-            Await TestName(code, "s")
-        End Function
+            TestName(code, "s")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName3() As Task
+        Public Sub TestName3()
             Dim code =
 <Code>
 class C
@@ -145,13 +151,15 @@ class C
 }
 </Code>
 
-            Await TestName(code, "s")
-        End Function
+            TestName(code, "s")
+        End Sub
 
 #End Region
 
 #Region "FullName tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Sub FullName()
             Dim code =
@@ -167,8 +175,10 @@ class C
             TestFullName(code, "s")
         End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName2() As Task
+        Public Sub TestFullName2()
             Dim code =
 <Code>
 class C
@@ -179,11 +189,13 @@ class C
 }
 </Code>
 
-            Await TestFullName(code, "s")
-        End Function
+            TestFullName(code, "s")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName3() As Task
+        Public Sub TestFullName3()
             Dim code =
 <Code>
 class C
@@ -194,8 +206,8 @@ class C
 }
 </Code>
 
-            Await TestFullName(code, "s")
-        End Function
+            TestFullName(code, "s")
+        End Sub
 
 #End Region
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -101,6 +101,55 @@ class C : System.Console
 
 #End Region
 
+#Region "Name tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestName(code, "s")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(ref string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestName(code, "s")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName3() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(out string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestName(code, "s")
+        End Function
+
+#End Region
+
 #Region "FullName tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
@@ -117,6 +166,36 @@ class C
 
             TestFullName(code, "s")
         End Sub
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(ref string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestFullName(code, "s")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName3() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(out string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestFullName(code, "s")
+        End Function
 
 #End Region
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeFunctionTests.vb
@@ -1,0 +1,51 @@
+﻿Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
+    Public Class ExternalCodeFunctionTests
+        Inherits AbstractCodeFunctionTests
+
+#Region "FullName tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void $$Foo(string s)
+    {
+    }
+}
+</Code>
+
+            Await TestFullName(code, "C.Foo")
+        End Function
+
+#End Region
+
+#Region "Name tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void $$Foo(string s)
+    {
+    }
+}
+</Code>
+
+            Await TestName(code, "Foo")
+        End Function
+
+#End Region
+
+        Protected Overrides ReadOnly Property LanguageName As String = LanguageNames.CSharp
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean = True
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeFunctionTests.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Roslyn.Test.Utilities
 
@@ -10,8 +9,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
 
 #Region "FullName tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName1() As Task
+        Public Sub TestFullName1()
             Dim code =
 <Code>
 class C
@@ -22,15 +23,17 @@ class C
 }
 </Code>
 
-            Await TestFullName(code, "C.Foo")
-        End Function
+            TestFullName(code, "C.Foo")
+        End Sub
 
 #End Region
 
 #Region "Name tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName1() As Task
+        Public Sub TestName1()
             Dim code =
 <Code>
 class C
@@ -41,8 +44,8 @@ class C
 }
 </Code>
 
-            Await TestName(code, "Foo")
-        End Function
+            TestName(code, "Foo")
+        End Sub
 
 #End Region
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeFunctionTests.vb
@@ -1,4 +1,6 @@
-﻿Imports System.Threading.Tasks
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Roslyn.Test.Utilities
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeParameterTests.vb
@@ -1,0 +1,113 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
+    Public Class ExternalCodeParameterTests
+        Inherits AbstractCodeParameterTests
+
+#Region "FullName tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestFullName(code, "s")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(ref string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestFullName(code, "s")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName3() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(out string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestFullName(code, "s")
+        End Function
+
+#End Region
+
+#Region "Name tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestName(code, "s")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(ref string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestName(code, "s")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName3() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(out string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestName(code, "s")
+        End Function
+
+#End Region
+
+        Protected Overrides ReadOnly Property LanguageName As String = LanguageNames.CSharp
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean = True
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodeParameterTests.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Roslyn.Test.Utilities
 
@@ -10,8 +9,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
 
 #Region "FullName tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName1() As Task
+        Public Sub TestFullName1()
             Dim code =
 <Code>
 class C
@@ -22,11 +23,13 @@ class C
 }
 </Code>
 
-            Await TestFullName(code, "s")
-        End Function
+            TestFullName(code, "s")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName2() As Task
+        Public Sub TestFullName2()
             Dim code =
 <Code>
 class C
@@ -37,11 +40,13 @@ class C
 }
 </Code>
 
-            Await TestFullName(code, "s")
-        End Function
+            TestFullName(code, "s")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName3() As Task
+        Public Sub TestFullName3()
             Dim code =
 <Code>
 class C
@@ -52,15 +57,17 @@ class C
 }
 </Code>
 
-            Await TestFullName(code, "s")
-        End Function
+            TestFullName(code, "s")
+        End Sub
 
 #End Region
 
 #Region "Name tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName1() As Task
+        Public Sub TestName1()
             Dim code =
 <Code>
 class C
@@ -71,11 +78,13 @@ class C
 }
 </Code>
 
-            Await TestName(code, "s")
-        End Function
+            TestName(code, "s")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName2() As Task
+        Public Sub TestName2()
             Dim code =
 <Code>
 class C
@@ -86,11 +95,13 @@ class C
 }
 </Code>
 
-            Await TestName(code, "s")
-        End Function
+            TestName(code, "s")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName3() As Task
+        Public Sub TestName3()
             Dim code =
 <Code>
 class C
@@ -101,8 +112,8 @@ class C
 }
 </Code>
 
-            Await TestName(code, "s")
-        End Function
+            TestName(code, "s")
+        End Sub
 
 #End Region
 

--- a/src/VisualStudio/Core/Test/CodeModel/CodeModelTestHelpers.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CodeModelTestHelpers.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.ExternalElements
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
@@ -172,6 +173,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
             Assert.True(codeElement IsNot Nothing, "Expected code element")
             Assert.True(codeElement.InfoLocation = EnvDTE.vsCMInfoLocation.vsCMInfoLocationProject, "Expected internal code element")
+
+            If TypeOf codeElement Is EnvDTE.CodeParameter Then
+                Dim codeParameter = DirectCast(codeElement, EnvDTE.CodeParameter)
+                Dim externalParentCodeElement = codeParameter.Parent.AsExternal()
+                Dim externalParentCodeElementImpl = ComAggregate.GetManagedObject(Of AbstractExternalCodeMember)(externalParentCodeElement)
+
+                Return DirectCast(externalParentCodeElementImpl.Parameters.Item(codeParameter.Name), T)
+            End If
 
             Dim codeElementImpl = ComAggregate.GetManagedObject(Of AbstractCodeElement)(codeElement)
             Dim state = codeElementImpl.State

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Roslyn.Test.Utilities
 
@@ -10,8 +9,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp.Vis
 
 #Region "FullName tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName1() As Task
+        Public Sub TestFullName1()
             Dim code =
 <Code>
 Class C
@@ -20,15 +21,17 @@ Class C
 End Class
 </Code>
 
-            Await TestFullName(code, "C.Foo")
-        End Function
+            TestFullName(code, "C.Foo")
+        End Sub
 
 #End Region
 
 #Region "Name tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName1() As Task
+        Public Sub TestName1()
             Dim code =
 <Code>
 Class C
@@ -37,8 +40,8 @@ Class C
 End Class
 </Code>
 
-            Await TestName(code, "Foo")
-        End Function
+            TestName(code, "Foo")
+        End Sub
 
 #End Region
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
@@ -1,0 +1,47 @@
+﻿Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp.VisualBasic
+    Public Class ExternalCodeFunctionTests
+        Inherits AbstractCodeFunctionTests
+
+#Region "FullName tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub $$Foo(string s)
+    End Sub
+End Class
+</Code>
+
+            Await TestFullName(code, "C.Foo")
+        End Function
+
+#End Region
+
+#Region "Name tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub $$Foo(string s)
+    End Sub
+End Class
+</Code>
+
+            Await TestName(code, "Foo")
+        End Function
+
+#End Region
+
+        Protected Overrides ReadOnly Property LanguageName As String = LanguageNames.VisualBasic
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean = True
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
@@ -1,4 +1,6 @@
-﻿Imports System.Threading.Tasks
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Roslyn.Test.Utilities
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeParameterTests.vb
@@ -1,0 +1,125 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasic
+    Public Class ExternalCodeParameterTests
+        Inherits AbstractCodeParameterTests
+
+#Region "FullName tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestFullName1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub Foo($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestFullName(code, "s")
+        End Function
+#End Region
+
+#Region "Name tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName_NoModifiers() As Task
+            Dim code =
+<Code>
+Public Class C1
+
+   Public Sub S1($$p1 As Integer)
+   End Sub
+
+End Class
+</Code>
+
+            Await TestName(code, "p1")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName_ByValModifier() As Task
+            Dim code =
+<Code>
+Public Class C1
+
+   Public Sub S2(ByVal $$p2 As Integer)
+   End Sub
+
+End Class
+</Code>
+
+            Await TestName(code, "p2")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName_ByRefModifier() As Task
+            Dim code =
+<Code>
+Public Class C1
+
+   Public Sub S3(ByRef $$p3 As Integer)
+   End Sub
+
+End Class
+</Code>
+
+            Await TestName(code, "p3")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName_OptionalByValModifiers() As Task
+            Dim code =
+<Code>
+Public Class C1
+
+   Public Sub S4(Optional ByVal $$p4 As Integer = 0)
+   End Sub
+
+End Class
+</Code>
+
+            Await TestName(code, "p4")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName_ByValParamArrayModifiers() As Task
+            Dim code =
+<Code>
+Public Class C1
+
+   Public Sub S5(ByVal ParamArray $$p5() As Integer)
+   End Sub
+
+End Class
+</Code>
+
+            Await TestName(code, "p5")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestName_TypeCharacter() As Task
+            Dim code =
+<Code>
+Public Class C1
+
+   Public Sub S6($$p6%)
+   End Sub
+
+End Class
+</Code>
+
+            Await TestName(code, "p6")
+        End Function
+
+#End Region
+
+        Protected Overrides ReadOnly Property LanguageName As String = LanguageNames.VisualBasic
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean = True
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeParameterTests.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Roslyn.Test.Utilities
 
@@ -10,8 +9,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasi
 
 #Region "FullName tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestFullName1() As Task
+        Public Sub TestFullName1()
             Dim code =
 <Code>
 Class C
@@ -20,14 +21,16 @@ Class C
 End Class
 </Code>
 
-            Await TestFullName(code, "s")
-        End Function
+            TestFullName(code, "s")
+        End Sub
 #End Region
 
 #Region "Name tests"
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName_NoModifiers() As Task
+        Public Sub TestName_NoModifiers()
             Dim code =
 <Code>
 Public Class C1
@@ -38,11 +41,13 @@ Public Class C1
 End Class
 </Code>
 
-            Await TestName(code, "p1")
-        End Function
+            TestName(code, "p1")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName_ByValModifier() As Task
+        Public Sub TestName_ByValModifier()
             Dim code =
 <Code>
 Public Class C1
@@ -53,11 +58,13 @@ Public Class C1
 End Class
 </Code>
 
-            Await TestName(code, "p2")
-        End Function
+            TestName(code, "p2")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName_ByRefModifier() As Task
+        Public Sub TestName_ByRefModifier()
             Dim code =
 <Code>
 Public Class C1
@@ -68,11 +75,13 @@ Public Class C1
 End Class
 </Code>
 
-            Await TestName(code, "p3")
-        End Function
+            TestName(code, "p3")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName_OptionalByValModifiers() As Task
+        Public Sub TestName_OptionalByValModifiers()
             Dim code =
 <Code>
 Public Class C1
@@ -83,11 +92,13 @@ Public Class C1
 End Class
 </Code>
 
-            Await TestName(code, "p4")
-        End Function
+            TestName(code, "p4")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName_ByValParamArrayModifiers() As Task
+        Public Sub TestName_ByValParamArrayModifiers()
             Dim code =
 <Code>
 Public Class C1
@@ -98,11 +109,13 @@ Public Class C1
 End Class
 </Code>
 
-            Await TestName(code, "p5")
-        End Function
+            TestName(code, "p5")
+        End Sub
 
+        ' Note: This unit test has diverged and is not asynchronous in stabilization. If merged into master,
+        ' take the master version and remove this comment.
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestName_TypeCharacter() As Task
+        Public Sub TestName_TypeCharacter()
             Dim code =
 <Code>
 Public Class C1
@@ -113,8 +126,8 @@ Public Class C1
 End Class
 </Code>
 
-            Await TestName(code, "p6")
-        End Function
+            TestName(code, "p6")
+        End Sub
 
 #End Region
 

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -285,6 +285,8 @@
     <Compile Include="CodeModel\CSharp\CodeVariableTests.vb" />
     <Compile Include="CodeModel\CSharp\EventCollectorTests.vb" />
     <Compile Include="CodeModel\CSharp\ExternalCodeClassTests.vb" />
+    <Compile Include="CodeModel\CSharp\ExternalCodeFunctionTests.vb" />
+    <Compile Include="CodeModel\CSharp\ExternalCodeParameterTests.vb" />
     <Compile Include="CodeModel\CSharp\FileCodeModelTests.vb" />
     <Compile Include="CodeModel\CSharp\RootCodeModelTests.vb" />
     <Compile Include="CodeModel\CSharp\SyntaxNodeKeyTests.vb" />
@@ -319,6 +321,8 @@
     <Compile Include="CodeModel\VisualBasic\CodeVariableTests.vb" />
     <Compile Include="CodeModel\VisualBasic\EventCollectorTests.vb" />
     <Compile Include="CodeModel\VisualBasic\ExternalCodeClassTests.vb" />
+    <Compile Include="CodeModel\VisualBasic\ExternalCodeFunctionTests.vb" />
+    <Compile Include="CodeModel\VisualBasic\ExternalCodeParameterTests.vb" />
     <Compile Include="CodeModel\VisualBasic\FileCodeModelTests.vb" />
     <Compile Include="CodeModel\VisualBasic\ImplementsStatementTests.vb" />
     <Compile Include="CodeModel\VisualBasic\InheritsStatementTests.vb" />

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -56,14 +56,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
         Private Shared ReadOnly s_externalNameFormat As SymbolDisplayFormat =
             New SymbolDisplayFormat(
                 genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
-                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.ExpandNullable)
+                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.ExpandNullable,
+                parameterOptions:=SymbolDisplayParameterOptions.IncludeName)
 
         Private Shared ReadOnly s_externalfullNameFormat As SymbolDisplayFormat =
             New SymbolDisplayFormat(
                 typeQualificationStyle:=SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
                 genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 memberOptions:=SymbolDisplayMemberOptions.IncludeContainingType,
-                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.ExpandNullable)
+                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.ExpandNullable,
+                parameterOptions:=SymbolDisplayParameterOptions.IncludeName)
 
         Private Shared ReadOnly s_setTypeFormat As SymbolDisplayFormat =
             New SymbolDisplayFormat(


### PR DESCRIPTION
This is the same as PR #7212 except that unit tests are updated to be synchronous since the unit test infrastructure has diverged in master. The same tests are there. They just aren't async.

Tagging @dotnet/roslyn-ide 