### PR TITLE
Fix VB using `ISingleValueCaseClause` as `ElseCaseClause`'s corresponding node in IOperation tree

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
@@ -141,7 +141,7 @@ class C
         }
 
         [Fact]
-        public void SparseSwitchCSharp()
+        public void SwitchCSharp()
         {
             const string source = @"
 class C
@@ -167,14 +167,35 @@ class C
             default:
                 break;
         }
+
+        switch (x)
+        {
+            case 1:
+                break;
+            case 1000:
+                break;
+        }
+
+        switch (y) 
+        {
+            default:
+                break;
+        }
+
+        switch (y) {}
+
     }
 }
 ";
             CreateCompilationWithMscorlib45(source)
-            .VerifyDiagnostics()
-            .VerifyAnalyzerDiagnostics(new DiagnosticAnalyzer[] { new SparseSwitchTestAnalyzer() }, null, null, false,
-                Diagnostic(SparseSwitchTestAnalyzer.SparseSwitchDescriptor.Id, "y").WithLocation(16, 17)
-                );
+            .VerifyDiagnostics(Diagnostic(ErrorCode.WRN_EmptySwitch, "{").WithLocation(40, 20))
+            .VerifyAnalyzerDiagnostics(new DiagnosticAnalyzer[] { new SwitchTestAnalyzer() }, null, null, false,
+                Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "y").WithLocation(16, 17),
+                Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(26, 17),
+                Diagnostic(SwitchTestAnalyzer.NoDefaultSwitchDescriptor.Id, "x").WithLocation(26, 17),
+                Diagnostic(SwitchTestAnalyzer.OnlyDefaultSwitchDescriptor.Id, "y").WithLocation(34, 17),
+                Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "y").WithLocation(40, 17),
+                Diagnostic(SwitchTestAnalyzer.NoDefaultSwitchDescriptor.Id, "y").WithLocation(40, 17));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
@@ -184,11 +184,20 @@ class C
 
         switch (y) {}
 
+        switch (x)
+        {
+            case :
+                break;
+            case 1000:
+                break;
+        }
+
     }
 }
 ";
             CreateCompilationWithMscorlib45(source)
-            .VerifyDiagnostics(Diagnostic(ErrorCode.WRN_EmptySwitch, "{").WithLocation(40, 20))
+            .VerifyDiagnostics(Diagnostic(ErrorCode.WRN_EmptySwitch, "{").WithLocation(40, 20),
+                Diagnostic(ErrorCode.ERR_ConstantExpected, ":").WithLocation(44, 18))
             .VerifyAnalyzerDiagnostics(new DiagnosticAnalyzer[] { new SwitchTestAnalyzer() }, null, null, false,
                 Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "y").WithLocation(16, 17),
                 Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(26, 17),

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                          hasNonDefault = true;
                                          ISingleValueCaseClause singleValueClause = (ISingleValueCaseClause)clause;
                                          IExpression singleValueExpression = singleValueClause.Value;
-                                         if (singleValueExpression.ConstantValue != null &&
+                                         if (singleValueExpression?.ConstantValue != null &&
                                              singleValueExpression.ResultType.SpecialType == SpecialType.System_Int32)
                                          {
                                              int singleValue = (int)singleValueExpression.ConstantValue;
@@ -244,9 +244,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                          IRangeCaseClause rangeClause = (IRangeCaseClause)clause;
                                          IExpression rangeMinExpression = rangeClause.MinimumValue;
                                          IExpression rangeMaxExpression = rangeClause.MaximumValue;
-                                         if (rangeMinExpression.ConstantValue != null &&
+                                         if (rangeMinExpression?.ConstantValue != null &&
                                              rangeMinExpression.ResultType.SpecialType == SpecialType.System_Int32 &&
-                                             rangeMaxExpression.ConstantValue != null &&
+                                             rangeMaxExpression?.ConstantValue != null &&
                                              rangeMaxExpression.ResultType.SpecialType == SpecialType.System_Int32)
                                          {
                                              int rangeMinValue = (int)rangeMinExpression.ConstantValue;
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                          hasNonDefault = true;
                                          IRelationalCaseClause relationalClause = (IRelationalCaseClause)clause;
                                          IExpression relationalValueExpression = relationalClause.Value;
-                                         if (relationalValueExpression.ConstantValue != null &&
+                                         if (relationalValueExpression?.ConstantValue != null &&
                                              relationalValueExpression.ResultType.SpecialType == SpecialType.System_Int32)
                                          {
                                              int rangeMinValue = int.MaxValue;

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Get
                 ' `CaseElseClauseSyntax` is bound to `BoundCaseStatement` with an empty list of case clauses, 
                 ' so we explicitly create an IOperation node for Case-Else clause to differentiate it from Case clause.
-                If Me.CaseStatement.CaseClauses.IsEmpty Then
+                If Me.CaseStatement.CaseClauses.IsEmpty AndAlso Me.CaseStatement.Syntax.Kind() = SyntaxKind.CaseElseStatement Then
                     Return ImmutableArray.Create(CaseElseClause)
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
@@ -102,7 +102,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Class CaseElse
             Implements ICaseClause
-
             Private ReadOnly Property ICaseClass As CaseKind Implements ICaseClause.CaseKind
                 Get
                     Return CaseKind.Default
@@ -165,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected Overrides ReadOnly Property ICaseClass As CaseKind
             Get
-                Return If(Me.IValue IsNot Nothing, CaseKind.SingleValue, CaseKind.Default)
+                Return CaseKind.SingleValue
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
@@ -86,6 +86,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private ReadOnly Property IClauses As ImmutableArray(Of ICaseClause) Implements ICase.Clauses
             Get
+                ' `CaseElseClauseSyntax` is bound to `BoundCaseStatement` with an empty list of case clauses, 
+                ' so we explicitly create an IOperation node for Case-Else clause to differentiate it from Case clause.
                 If Me.CaseStatement.CaseClauses.IsEmpty Then
                     Return ImmutableArray.Create(CaseElseClause)
                 End If

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
@@ -126,7 +126,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub SparseSwitchVisualBasic()
+        Public Sub SwitchVisualBasic()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -171,11 +171,19 @@ Class C
                 Exit Select
         End Select
 
-         Select Case x
+        Select Case x
             Case 1
                 Exit Select
             Case > 100000
                 Exit Select
+        End Select   
+
+        Select Case x
+            Case Else
+                Exit Select
+        End Select     
+
+        Select Case x
         End Select
     End Sub
 End Class
@@ -185,10 +193,15 @@ End Class
 
             Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New SparseSwitchTestAnalyzer}, Nothing, Nothing, False,
-                                           Diagnostic(SparseSwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(12, 21),
-                                           Diagnostic(SparseSwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(30, 21),
-                                           Diagnostic(SparseSwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(37, 21))
+            comp.VerifyAnalyzerDiagnostics({New SwitchTestAnalyzer}, Nothing, Nothing, False,
+                                           Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(12, 21),
+                                           Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(30, 21),
+                                           Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(37, 21),
+                                           Diagnostic(SwitchTestAnalyzer.NoDefaultSwitchDescriptor.Id, "x").WithLocation(37, 21),
+                                           Diagnostic(SwitchTestAnalyzer.NoDefaultSwitchDescriptor.Id, "x").WithLocation(42, 21),
+                                           Diagnostic(SwitchTestAnalyzer.OnlyDefaultSwitchDescriptor.Id, "x").WithLocation(49, 21),
+                                           Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(54, 21),
+                                           Diagnostic(SwitchTestAnalyzer.NoDefaultSwitchDescriptor.Id, "x").WithLocation(54, 21))
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
@@ -185,6 +185,27 @@ Class C
 
         Select Case x
         End Select
+
+        Select Case x
+            Case 1
+                Exit Select
+            Case
+                Exit Select
+        End Select   
+
+        Select Case x
+            Case 1
+                Exit Select
+            Case =
+                Exit Select
+        End Select  
+
+        Select Case x
+            Case 1
+                Exit Select
+            Case 2 to
+                Exit Select
+        End Select  
     End Sub
 End Class
 ]]>
@@ -192,7 +213,9 @@ End Class
                          </compilation>
 
             Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source)
-            comp.VerifyDiagnostics()
+            comp.VerifyDiagnostics(Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(60, 17),
+                                   Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(68, 1),
+                                   Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(74, 22))
             comp.VerifyAnalyzerDiagnostics({New SwitchTestAnalyzer}, Nothing, Nothing, False,
                                            Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(12, 21),
                                            Diagnostic(SwitchTestAnalyzer.SparseSwitchDescriptor.Id, "x").WithLocation(30, 21),


### PR DESCRIPTION
Unlike C# using a `BoundSwaitchLabel` with  `ExpressionOpt == null` to represent a `default` case, in VB, the bound node for `Case Else` statement is not a `BoundSimpleCaseClause` with both `ValueOpt` and `ConditionOpt` equal to `Nothing`. It actually uses a `BoundCaseStatement` with an empty `CaseClauses` array.

This is a part of #6894

@JohnHamby, you have handled it correctly in `BoundCaseBlock`, could you please take a look to see if this change makes sense?

