### PR TITLE
Find 'Add Using' results with the same Fuzzy-match algorithm used by the spell-checker.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -74,10 +74,18 @@ index: 1);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
-        public async Task TestGenericWithWrongArgs()
+        public async Task TestGenericWithWrongArgs1()
         {
             await TestMissingAsync(
-@"class Class { [|List<int,string>|] Method() { Foo(); } }");
+@"class Class { [|List<int,string,bool>|] Method() { Foo(); } }");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public async Task TestGenericWithWrongArgs2()
+        {
+            await TestAsync(
+@"class Class { [|List<int,string>|] Method() { Foo(); } }",
+@"using System.Collections.Generic; class Class { SortedList<int,string> Method() { Foo(); } }");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -11,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Roslyn.Test.Utilities;

--- a/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
@@ -310,7 +310,7 @@ End Namespace
 using System.Collections.Generic;
 namespace CSAssembly1
 {
-    public class Class1
+    public class Assembly1Class
     {
     }
 }
@@ -323,7 +323,7 @@ namespace CSAssembly2
 {
     public class Class2
     {
-        $$Class1 c;
+        $$Assembly1Class c;
     }
 }
                         </Document>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -1097,7 +1097,30 @@ NewLines("Imports System.Linq \n Imports System.Runtime.CompilerServices \n Impo
         <WpfFact(), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Async Function TestAddUsingWithOtherExtensionsInScope3() As Task
             Await TestAsync(
-NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Module Program \n Sub Main(args As String()) \n Dim a = 0 \n Dim i = [|a.All|](0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer, v As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"),
+"Imports System.Runtime.CompilerServices 
+Imports X 
+Module Program 
+    Sub Main(args As String()) 
+        Dim a = 0
+        Dim i = [|a.All|](0)
+    End Sub
+End Module 
+Namespace X 
+    Module E 
+        <Extension> 
+        Public Function All(a As Integer) As Integer 
+            Return a 
+        End Function 
+    End Module 
+End Namespace 
+Namespace Y 
+    Module E 
+        <Extension> 
+        Public Function All(a As Integer, v As Integer) As Integer 
+            Return a 
+        End Function 
+    End Module 
+End Namespace",
 NewLines("Imports System.Runtime.CompilerServices \n Imports X \n Imports Y \n Module Program \n Sub Main(args As String()) \n Dim a = 0 \n Dim i = a.All(0) \n End Sub \n End Module \n Namespace X \n Module E \n <Extension> \n Public Function All(a As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace \n Namespace Y \n Module E \n <Extension> \n Public Function All(a As Integer, v As Integer) As Integer \n Return a \n End Function \n End Module \n End Namespace"))
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -159,9 +159,16 @@ NewLines("Imports System.Collections.Generic \n Class Foo \n Function F() As Lis
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
-        Public Async Function TestGenericWithWrongArgs() As Task
+        Public Async Function TestGenericWithWrongArgs1() As Task
             Await TestMissingAsync(
-NewLines("Class Foo \n Function F() As [|List(Of Integer, String)|] \n End Function \n End Class"))
+NewLines("Class Foo \n Function F() As [|List(Of Integer, String, Boolean)|] \n End Function \n End Class"))
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        Public Async Function TestGenericWithWrongArgs2() As Task
+            Await TestAsync(
+NewLines("Class Foo \n Function F() As [|List(Of Integer, String)|] \n End Function \n End Class"),
+NewLines("Imports System.Collections.Generic \n Class Foo \n Function F() As SortedList(Of Integer, String) \n End Function \n End Class"))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
@@ -433,7 +433,7 @@ End Module</File>
 ' Import System.Collections to ensure we get BC32045
 Imports System.Collections
 
-Interface IOrderable(Of T)
+Interface Enumerable(Of T)
 End Interface
 
 Class C
@@ -446,12 +446,12 @@ End Class</File>
 ' Import System.Collections to ensure we get BC32045
 Imports System.Collections
 
-Interface IOrderable(Of T)
+Interface Enumerable(Of T)
 End Interface
 
 Class C
     Sub Main(args As String())
-        Dim x as IOrderable(Of Integer)
+        Dim x as Enumerable(Of Integer)
     End Sub
 End Class</File>
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Spellcheck/SpellcheckTests.vb
@@ -312,7 +312,7 @@ Module Program
     End Sub
 End Module</File>
 
-            Await TestActionCountAsync(text.ConvertTestSourceTag(), 3)
+            Await TestActionCountAsync(text.ConvertTestSourceTag(), 2)
             Await TestAsync(text, expected, index:=0)
         End Function
 

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -391,27 +391,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
         protected override async Task<Document> AddImportAsync(
             SyntaxNode contextNode,
             INamespaceOrTypeSymbol namespaceOrTypeSymbol,
-            string desiredName,
-            SimpleNameSyntax nameNode,
             Document document,
             bool placeSystemNamespaceFirst,
             CancellationToken cancellationToken)
         {
-            var originalDocument = document;
-            var originalContextNode = contextNode;
-            var originalRoot = GetCompilationUnitSyntaxNode(contextNode, cancellationToken);
-
-            var root = originalRoot;
-
-            if (!string.IsNullOrEmpty(desiredName) && nameNode != null && nameNode.Identifier.ValueText != desiredName)
-            {
-                var annotation = new SyntaxAnnotation();
-                root = root.ReplaceToken(nameNode.Identifier,
-                    SyntaxFactory.Identifier(desiredName).WithTriviaFrom(nameNode.Identifier).WithAdditionalAnnotations(annotation));
-                document = document.WithSyntaxRoot(root);
-                contextNode = root.GetAnnotatedTokens(annotation).First().Parent;
-            }
-
+            var root = GetCompilationUnitSyntaxNode(contextNode, cancellationToken);
             var newRoot = await AddImportWorkerAsync(document, root, contextNode, namespaceOrTypeSymbol, placeSystemNamespaceFirst, cancellationToken).ConfigureAwait(false);
             return document.WithSyntaxRoot(newRoot);
         }

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -131,11 +131,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
             }
         }
 
-        protected override bool IgnoreCase
-        {
-            get { return false; }
-        }
-
         protected override bool CanAddImport(SyntaxNode node, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -390,76 +385,100 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
         protected override async Task<Document> AddImportAsync(
             SyntaxNode contextNode,
-            INamespaceOrTypeSymbol namespaceSymbol,
+            INamespaceOrTypeSymbol namespaceOrTypeSymbol,
+            string desiredName,
             Document document,
             bool placeSystemNamespaceFirst,
             CancellationToken cancellationToken)
         {
-            var root = GetCompilationUnitSyntaxNode(contextNode, cancellationToken);
+            var originalDocument = document;
+            var originalContextNode = contextNode;
+            var originalRoot = GetCompilationUnitSyntaxNode(contextNode, cancellationToken);
+
+            var root = originalRoot;
+
+            var firstToken = contextNode.GetFirstToken();
+            if (firstToken.IsKind(SyntaxKind.IdentifierToken) && firstToken.ValueText != desiredName)
+            {
+                var annotation = new SyntaxAnnotation();
+                root = root.ReplaceToken(firstToken, SyntaxFactory.Identifier(desiredName).WithTriviaFrom(firstToken).WithAdditionalAnnotations(annotation));
+                document = document.WithSyntaxRoot(root);
+                contextNode = root.GetAnnotatedTokens(annotation).First().Parent;
+            }
+
+            var newRoot = await AddImportWorkerAsync(document, root, contextNode, namespaceOrTypeSymbol, placeSystemNamespaceFirst, cancellationToken).ConfigureAwait(false);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<CompilationUnitSyntax> AddImportWorkerAsync(
+            Document document, CompilationUnitSyntax root, SyntaxNode contextNode, 
+            INamespaceOrTypeSymbol namespaceOrTypeSymbol, bool placeSystemNamespaceFirst, CancellationToken cancellationToken)
+        {
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var simpleUsingDirective = GetUsingDirective(root, namespaceSymbol, semanticModel, fullyQualify: false);
-            var externAliasUsingDirective = GetExternAliasUsingDirective(root, namespaceSymbol, semanticModel);
+            var simpleUsingDirective = GetUsingDirective(root, namespaceOrTypeSymbol, semanticModel, fullyQualify: false);
+            var externAliasUsingDirective = GetExternAliasUsingDirective(root, namespaceOrTypeSymbol, semanticModel);
+
             if (externAliasUsingDirective != null)
             {
-                root = root.AddExterns(
+                return root.AddExterns(
                     externAliasUsingDirective
                         .WithAdditionalAnnotations(Formatter.Annotation));
             }
 
-            if (simpleUsingDirective != null)
+            if (simpleUsingDirective == null)
             {
-                // Because of the way usings can be nested inside of namespace declarations,
-                // we need to check if the usings must be fully qualified so as not to be
-                // ambiguous with the containing namespace. 
-                if (UsingsAreContainedInNamespace(contextNode))
-                {
-                    // When we add usings we try and place them, as best we can, where the user
-                    // wants them according to their settings.  This means we can't just add the fully-
-                    // qualified usings and expect the simplifier to take care of it, the usings have to be
-                    // simplified before we attempt to add them to the document.
-                    // You might be tempted to think that we could call 
-                    //   AddUsings -> Simplifier -> SortUsings
-                    // But this will clobber the users using settings without asking.  Instead we create a new
-                    // Document and check if our using can be simplified.  Worst case we need to back out the 
-                    // fully qualified change and reapply with the simple name.
-                    var fullyQualifiedUsingDirective = GetUsingDirective(root, namespaceSymbol, semanticModel, fullyQualify: true);
-                    SyntaxNode newRoot = root.AddUsingDirective(
-                                    fullyQualifiedUsingDirective, contextNode, placeSystemNamespaceFirst,
-                                    Formatter.Annotation);
-                    var newUsing = newRoot
-                        .DescendantNodes().OfType<UsingDirectiveSyntax>()
-                        .Where(uds => uds.IsEquivalentTo(fullyQualifiedUsingDirective, topLevel: true))
-                        .Single();
-                    newRoot = newRoot.TrackNodes(newUsing);
-                    var documentWithSyntaxRoot = document.WithSyntaxRoot(newRoot);
-                    var options = document.Project.Solution.Workspace.Options;
-                    var simplifiedDocument = await Simplifier.ReduceAsync(documentWithSyntaxRoot, newUsing.Span, options, cancellationToken).ConfigureAwait(false);
+                return root;
+            }
 
-                    newRoot = await simplifiedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                    var simplifiedUsing = newRoot.GetCurrentNode(newUsing);
-                    if (simplifiedUsing.Name.IsEquivalentTo(newUsing.Name, topLevel: true))
-                    {
-                        // Not fully qualifying the using causes to refer to a different namespace so we need to keep it as is.
-                        return documentWithSyntaxRoot;
-                    }
-                    else
-                    {
-                        // It does not matter if it is fully qualified or simple so lets return the simple name.
-                        return document.WithSyntaxRoot(root.AddUsingDirective(
-                            simplifiedUsing.WithoutTrivia().WithoutAnnotations(), contextNode, placeSystemNamespaceFirst,
-                            Formatter.Annotation));
-                    }
+            // Because of the way usings can be nested inside of namespace declarations,
+            // we need to check if the usings must be fully qualified so as not to be
+            // ambiguous with the containing namespace. 
+            if (UsingsAreContainedInNamespace(contextNode))
+            {
+                // When we add usings we try and place them, as best we can, where the user
+                // wants them according to their settings.  This means we can't just add the fully-
+                // qualified usings and expect the simplifier to take care of it, the usings have to be
+                // simplified before we attempt to add them to the document.
+                // You might be tempted to think that we could call 
+                //   AddUsings -> Simplifier -> SortUsings
+                // But this will clobber the users using settings without asking.  Instead we create a new
+                // Document and check if our using can be simplified.  Worst case we need to back out the 
+                // fully qualified change and reapply with the simple name.
+                var fullyQualifiedUsingDirective = GetUsingDirective(root, namespaceOrTypeSymbol, semanticModel, fullyQualify: true);
+                var newRoot = root.AddUsingDirective(
+                                fullyQualifiedUsingDirective, contextNode, placeSystemNamespaceFirst,
+                                Formatter.Annotation);
+                var newUsing = newRoot
+                    .DescendantNodes().OfType<UsingDirectiveSyntax>()
+                    .Where(uds => uds.IsEquivalentTo(fullyQualifiedUsingDirective, topLevel: true))
+                    .Single();
+                newRoot = newRoot.TrackNodes(newUsing);
+                var documentWithSyntaxRoot = document.WithSyntaxRoot(newRoot);
+                var options = document.Project.Solution.Workspace.Options;
+                var simplifiedDocument = await Simplifier.ReduceAsync(documentWithSyntaxRoot, newUsing.Span, options, cancellationToken).ConfigureAwait(false);
+
+                newRoot = (CompilationUnitSyntax)await simplifiedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var simplifiedUsing = newRoot.GetCurrentNode(newUsing);
+                if (simplifiedUsing.Name.IsEquivalentTo(newUsing.Name, topLevel: true))
+                {
+                    // Not fully qualifying the using causes to refer to a different namespace so we need to keep it as is.
+                    return (CompilationUnitSyntax)await documentWithSyntaxRoot.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    // simple form
-                    return document.WithSyntaxRoot(root.AddUsingDirective(
-                            simpleUsingDirective, contextNode, placeSystemNamespaceFirst,
-                            Formatter.Annotation));
+                    // It does not matter if it is fully qualified or simple so lets return the simple name.
+                    return root.AddUsingDirective(
+                        simplifiedUsing.WithoutTrivia().WithoutAnnotations(), contextNode, placeSystemNamespaceFirst,
+                        Formatter.Annotation);
                 }
             }
-
-            return document.WithSyntaxRoot(root);
+            else
+            {
+                // simple form
+                return root.AddUsingDirective(
+                    simpleUsingDirective, contextNode, placeSystemNamespaceFirst,
+                    Formatter.Annotation);
+            }
         }
 
         private static ExternAliasDirectiveSyntax GetExternAliasUsingDirective(CompilationUnitSyntax root, INamespaceOrTypeSymbol namespaceSymbol, SemanticModel semanticModel)

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -423,7 +423,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
             if (externAliasUsingDirective != null)
             {
-                return root.AddExterns(
+                root = root.AddExterns(
                     externAliasUsingDirective
                         .WithAdditionalAnnotations(Formatter.Annotation));
             }

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -397,13 +397,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
             var root = originalRoot;
 
-            var firstToken = contextNode.GetFirstToken();
-            if (firstToken.IsKind(SyntaxKind.IdentifierToken) && firstToken.ValueText != desiredName)
+            if (!string.IsNullOrEmpty(desiredName))
             {
-                var annotation = new SyntaxAnnotation();
-                root = root.ReplaceToken(firstToken, SyntaxFactory.Identifier(desiredName).WithTriviaFrom(firstToken).WithAdditionalAnnotations(annotation));
-                document = document.WithSyntaxRoot(root);
-                contextNode = root.GetAnnotatedTokens(annotation).First().Parent;
+                var firstToken = contextNode.GetFirstToken();
+                if (firstToken.IsKind(SyntaxKind.IdentifierToken) && firstToken.ValueText != desiredName)
+                {
+                    var annotation = new SyntaxAnnotation();
+                    root = root.ReplaceToken(firstToken, SyntaxFactory.Identifier(desiredName).WithTriviaFrom(firstToken).WithAdditionalAnnotations(annotation));
+                    document = document.WithSyntaxRoot(root);
+                    contextNode = root.GetAnnotatedTokens(annotation).First().Parent;
+                }
             }
 
             var newRoot = await AddImportWorkerAsync(document, root, contextNode, namespaceOrTypeSymbol, placeSystemNamespaceFirst, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
@@ -34,8 +34,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 
                 if (Exact)
                 {
-                    // Exact matches always have a weight of 0.  This way they come before all other matches.
-                    return symbols.Select(s => SearchResult.Create(s.Name, s, weight: 0)).ToList();
+                    // We did an exact, case insensitive, search.  Case sensitive matches should
+                    // be preffered though over insensitive ones.
+                    return symbols.Select(s => SearchResult.Create(s.Name, s, weight: s.Name == name ? 0 : 1)).ToList();
                 }
 
                 // TODO(cyrusn): It's a shame we have to compute this twice.  However, there's no

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 
             public async Task<IEnumerable<SearchResult<ISymbol>>> FindDeclarationsAsync(string name, TSimpleNameSyntax nameNode, SymbolFilter filter)
             {
+                if (name != null && string.IsNullOrWhiteSpace(name))
+                {
+                    return SpecializedCollections.EmptyEnumerable<SearchResult<ISymbol>>();
+                }
+
                 var query = this.Exact ? new SearchQuery(name, ignoreCase: true) : new SearchQuery(GetInexactPredicate(name));
                 var symbols = await FindDeclarationsAsync(name, filter, query).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
@@ -11,7 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 {
-    internal abstract partial class AbstractAddImportCodeFixProvider<TIdentifierNameSyntax>
+    internal abstract partial class AbstractAddImportCodeFixProvider<TSimpleNameSyntax>
     {
         private abstract class SearchScope
         {
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
             protected abstract Task<IEnumerable<ISymbol>> FindDeclarationsAsync(string name, SymbolFilter filter, SearchQuery query);
             public abstract SymbolReference CreateReference<T>(SearchResult<T> symbol) where T : INamespaceOrTypeSymbol;
 
-            public async Task<IEnumerable<SearchResult<ISymbol>>> FindDeclarationsAsync(string name, TIdentifierNameSyntax nameNode, SymbolFilter filter)
+            public async Task<IEnumerable<SearchResult<ISymbol>>> FindDeclarationsAsync(string name, TSimpleNameSyntax nameNode, SymbolFilter filter)
             {
                 var query = this.Exact ? new SearchQuery(name, ignoreCase: true) : new SearchQuery(GetInexactPredicate(name));
                 var symbols = await FindDeclarationsAsync(name, filter, query).ConfigureAwait(false);

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SymbolReference.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SymbolReference.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 {
-    internal abstract partial class AbstractAddImportCodeFixProvider<TIdentifierNameSyntax>
+    internal abstract partial class AbstractAddImportCodeFixProvider<TSimpleNameSyntax>
     {
         private abstract class SymbolReference : IComparable<SymbolReference>, IEquatable<SymbolReference>
         {

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SymbolReference.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SymbolReference.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 {
-    internal abstract partial class AbstractAddImportCodeFixProvider
+    internal abstract partial class AbstractAddImportCodeFixProvider<TIdentifierNameSyntax>
     {
         private abstract class SymbolReference : IComparable<SymbolReference>, IEquatable<SymbolReference>
         {

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SymbolReference.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SymbolReference.cs
@@ -9,16 +9,29 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
     {
         private abstract class SymbolReference : IComparable<SymbolReference>, IEquatable<SymbolReference>
         {
-            public readonly INamespaceOrTypeSymbol Symbol;
+            public readonly SearchResult<INamespaceOrTypeSymbol> SearchResult;
 
-            protected SymbolReference(INamespaceOrTypeSymbol symbol)
+            protected SymbolReference(SearchResult<INamespaceOrTypeSymbol> searchResult)
             {
-                this.Symbol = symbol;
+                this.SearchResult = searchResult;
             }
 
             public int CompareTo(SymbolReference other)
             {
-                return INamespaceOrTypeSymbolExtensions.CompareNamespaceOrTypeSymbols(this.Symbol, other.Symbol);
+                // If references have different weights, order by the ones with lower weight (i.e.
+                // they are better matches).
+                if (this.SearchResult.Weight < other.SearchResult.Weight)
+                {
+                    return -1;
+                }
+
+                if (this.SearchResult.Weight > other.SearchResult.Weight)
+                {
+                    return 1;
+                }
+
+                // If the weight are the same, just order them based on their names.
+                return INamespaceOrTypeSymbolExtensions.CompareNamespaceOrTypeSymbols(this.SearchResult.Symbol, other.SearchResult.Symbol);
             }
 
             public override bool Equals(object obj)
@@ -28,12 +41,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 
             public bool Equals(SymbolReference other)
             {
-                return object.Equals(this.Symbol, other?.Symbol);
+                return object.Equals(this.SearchResult.Symbol, other?.SearchResult.Symbol);
             }
 
             public override int GetHashCode()
             {
-                return this.Symbol.GetHashCode();
+                return this.SearchResult.Symbol.GetHashCode();
             }
 
             public abstract Solution UpdateSolution(Document newDocument);
@@ -43,8 +56,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
         {
             private readonly ProjectId _projectId;
 
-            public ProjectSymbolReference(INamespaceOrTypeSymbol symbol, ProjectId projectId)
-                : base(symbol)
+            public ProjectSymbolReference(SearchResult<INamespaceOrTypeSymbol> searchResult, ProjectId projectId)
+                : base(searchResult)
             {
                 _projectId = projectId;
             }
@@ -71,8 +84,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
         {
             private readonly PortableExecutableReference _reference;
 
-            public MetadataSymbolReference(INamespaceOrTypeSymbol symbol, PortableExecutableReference reference)
-                : base(symbol)
+            public MetadataSymbolReference(SearchResult<INamespaceOrTypeSymbol> searchResult, PortableExecutableReference reference)
+                : base(searchResult)
             {
                 _reference = reference;
             }

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -508,6 +508,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                 int arity;
                 _syntaxFacts.GetNameAndArityOfSimpleName(_node, out name, out arity);
 
+                if (arity > 0)
+                {
+                    return null;
+                }
+
                 if (ExpressionBinds(checkForExtensionMethods: false))
                 {
                     return null;

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -474,8 +474,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                 // also lookup type symbols with the "Attribute" suffix.
                 if (inAttributeContext)
                 {
+                    var attributeSymbols = await searchScope.FindDeclarationsAsync(name + "Attribute", SymbolFilter.Type).ConfigureAwait(false);
+
                     symbols = symbols.Concat(
-                        await searchScope.FindDeclarationsAsync(name + "Attribute", SymbolFilter.Type).ConfigureAwait(false));
+                        attributeSymbols.Select(r => r.WithDesiredName(r.DesiredName.GetWithoutAttributeSuffix(isCaseSensitive: false))));
                 }
 
                 return OfType<ITypeSymbol>(symbols);
@@ -748,6 +750,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
             public SearchResult<T2> WithSymbol<T2>(T2 symbol) where T2 : ISymbol
             {
                 return new SearchResult<T2>(this.DesiredName, symbol, this.Weight);
+            }
+
+            internal SearchResult<T> WithDesiredName(string desiredName)
+            {
+                return new SearchResult<T>(desiredName, Symbol, Weight);
             }
         }
 

--- a/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
@@ -420,7 +420,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         private bool IsInteractiveCodeFixProvider(CodeFixProvider provider)
         {
             // TODO (https://github.com/dotnet/roslyn/issues/4932): Don't restrict CodeFixes in Interactive
-            return provider is AddImport.AbstractAddImportCodeFixProvider ||
+            return provider?.GetType()?.Name == "AbstractAddImportCodeFixProvider`1" ||
                 provider is FullyQualify.AbstractFullyQualifyCodeFixProvider;
         }
 

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -63,24 +63,25 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             var onlyConsiderGenerics = IsGeneric(nameNode);
             var results = new MultiDictionary<double, string>();
 
-            int closeMatchThreshold = EditDistance.GetCloseMatchThreshold(nameText);
-
-            foreach (var item in completionList.Items)
+            using (var editDistance = new EditDistance(nameText))
             {
-                if (onlyConsiderGenerics && !IsGeneric(item))
+                foreach (var item in completionList.Items)
                 {
-                    continue;
-                }
+                    if (onlyConsiderGenerics && !IsGeneric(item))
+                    {
+                        continue;
+                    }
 
-                var candidateText = item.FilterText;
-                double matchCost;
-                if (!EditDistance.IsCloseMatch(nameText, candidateText, closeMatchThreshold, out matchCost))
-                {
-                    continue;
-                }
+                    var candidateText = item.FilterText;
+                    double matchCost;
+                    if (!editDistance.IsCloseMatch(candidateText, out matchCost))
+                    {
+                        continue;
+                    }
 
-                var insertionText = completionRules.GetTextChange(item).NewText;
-                results.Add(matchCost, insertionText);
+                    var insertionText = completionRules.GetTextChange(item).NewText;
+                    results.Add(matchCost, insertionText);
+                }
             }
 
             var matches = results.OrderBy(kvp => kvp.Key)

--- a/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -207,7 +207,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
             Return CanAddImportForTypeOrNamespaceCore(node, nameNode)
         End Function
 
-        Private Shared Function CanAddImportForTypeOrNamespaceCore(node As SyntaxNode, nameNode As SimpleNameSyntax) As Boolean
+        Private Shared Function CanAddImportForTypeOrNamespaceCore(node As SyntaxNode, ByRef nameNode As SimpleNameSyntax) As Boolean
             Dim qn = TryCast(node, QualifiedNameSyntax)
             If qn IsNot Nothing Then
                 node = GetLeftMostSimpleName(qn)

--- a/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -97,12 +97,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
             End Get
         End Property
 
-        Protected Overrides ReadOnly Property IgnoreCase As Boolean
-            Get
-                Return True
-            End Get
-        End Property
-
         Protected Overrides Function CanAddImport(node As SyntaxNode, cancellationToken As CancellationToken) As Boolean
             If node.GetAncestor(Of ImportsStatementSyntax)() IsNot Nothing Then
                 Return False
@@ -294,9 +288,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
         Protected Overloads Overrides Function AddImportAsync(
                 contextNode As SyntaxNode,
                 symbol As INamespaceOrTypeSymbol,
+                desiredName As String,
                 document As Document,
                 placeSystemNamespaceFirst As Boolean,
                 cancellationToken As CancellationToken) As Task(Of Document)
+
             Dim memberImportsClause =
                 SyntaxFactory.SimpleImportsClause(name:=DirectCast(symbol.GenerateTypeSyntax(addGlobal:=False), NameSyntax).WithAdditionalAnnotations(Simplifier.Annotation))
             Dim newImport = SyntaxFactory.ImportsStatement(

--- a/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -105,7 +105,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
             Return node.CanAddImportsStatements(cancellationToken)
         End Function
 
-        Protected Overrides Function CanAddImportForMethod(diagnostic As Diagnostic, syntaxFacts As ISyntaxFactsService, ByRef node As SyntaxNode) As Boolean
+        Protected Overrides Function CanAddImportForMethod(
+                diagnostic As Diagnostic,
+                syntaxFacts As ISyntaxFactsService,
+                node As SyntaxNode,
+                ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnostic.Id
                 Case BC30456, BC30390, BC42309, BC30451
                     Exit Select
@@ -151,15 +155,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
                 Return False
             End If
 
-            Dim simpleName = TryCast(node, SimpleNameSyntax)
-            If simpleName Is Nothing Then
+            nameNode = TryCast(node, SimpleNameSyntax)
+            If nameNode Is Nothing Then
                 Return False
             End If
 
             Return True
         End Function
 
-        Protected Overrides Function CanAddImportForNamespace(diagnostic As Diagnostic, ByRef node As SyntaxNode) As Boolean
+        Protected Overrides Function CanAddImportForNamespace(diagnostic As Diagnostic, node As SyntaxNode, ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnostic.Id
                 Case BC30002, BC30451
                     Exit Select
@@ -167,10 +171,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
                     Return False
             End Select
 
-            Return CanAddImportForTypeOrNamespaceCore(node)
+            Return CanAddImportForTypeOrNamespaceCore(node, nameNode)
         End Function
 
-        Protected Overrides Function CanAddImportForQuery(diagnostic As Diagnostic, ByRef node As SyntaxNode) As Boolean
+        Protected Overrides Function CanAddImportForQuery(diagnostic As Diagnostic, node As SyntaxNode) As Boolean
             If diagnostic.Id <> BC36593 Then
                 Return False
             End If
@@ -184,7 +188,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
             Return True
         End Function
 
-        Protected Overrides Function CanAddImportForType(diagnostic As Diagnostic, ByRef node As SyntaxNode) As Boolean
+        Protected Overrides Function CanAddImportForType(
+                diagnostic As Diagnostic, node As SyntaxNode, ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnostic.Id
                 Case BC30002, BC30451, BC32042, BC32045, BC30389, BC31504, BC36610, BC30182
                     Exit Select
@@ -199,17 +204,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
                     Return False
             End Select
 
-            Return CanAddImportForTypeOrNamespaceCore(node)
+            Return CanAddImportForTypeOrNamespaceCore(node, nameNode)
         End Function
 
-        Private Shared Function CanAddImportForTypeOrNamespaceCore(ByRef node As SyntaxNode) As Boolean
+        Private Shared Function CanAddImportForTypeOrNamespaceCore(node As SyntaxNode, nameNode As SimpleNameSyntax) As Boolean
             Dim qn = TryCast(node, QualifiedNameSyntax)
             If qn IsNot Nothing Then
                 node = GetLeftMostSimpleName(qn)
             End If
 
-            Dim simpleName = TryCast(node, SimpleNameSyntax)
-            Return simpleName.LooksLikeStandaloneTypeName()
+            nameNode = TryCast(node, SimpleNameSyntax)
+            Return nameNode.LooksLikeStandaloneTypeName()
         End Function
 
         Private Shared Function GetLeftMostSimpleName(qn As QualifiedNameSyntax) As SimpleNameSyntax

--- a/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -293,25 +293,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.AddImport
         Protected Overloads Overrides Function AddImportAsync(
                 contextNode As SyntaxNode,
                 symbol As INamespaceOrTypeSymbol,
-                desiredName As String,
-                nameNode As SimpleNameSyntax,
                 document As Document,
                 placeSystemNamespaceFirst As Boolean,
                 cancellationToken As CancellationToken) As Task(Of Document)
 
-            Dim originalDocument = document
-            Dim originalContextNode = contextNode
-            Dim originalRoot = DirectCast(contextNode.SyntaxTree.GetRoot(cancellationToken), CompilationUnitSyntax)
-
-            Dim root = originalRoot
-
-            If Not String.IsNullOrEmpty(desiredName) AndAlso nameNode IsNot Nothing AndAlso nameNode.Identifier.ValueText <> desiredName Then
-                Dim annotation = New SyntaxAnnotation()
-                root = root.ReplaceToken(nameNode.Identifier,
-                    SyntaxFactory.Identifier(desiredName).WithTriviaFrom(nameNode.Identifier).WithAdditionalAnnotations(annotation))
-                document = document.WithSyntaxRoot(root)
-                contextNode = root.GetAnnotatedTokens(annotation).First().Parent
-            End If
+            Dim root = DirectCast(contextNode.SyntaxTree.GetRoot(cancellationToken), CompilationUnitSyntax)
 
             Dim memberImportsClause =
                 SyntaxFactory.SimpleImportsClause(name:=DirectCast(symbol.GenerateTypeSyntax(addGlobal:=False), NameSyntax).WithAdditionalAnnotations(Simplifier.Annotation))

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
@@ -98,6 +98,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 throw new ArgumentNullException(nameof(project));
             }
 
+            if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
+            {
+                return SpecializedTasks.EmptyEnumerable<ISymbol>();
+            }
+
             using (Logger.LogBlock(FunctionId.SymbolFinder_FindDeclarationsAsync, cancellationToken))
             {
                 return FindDeclarationsAsyncImpl(project, query, filter, includeDirectReferences, cancellationToken);
@@ -205,6 +210,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         internal static async Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
             Solution solution, IAssemblySymbol assembly, string filePath, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
+            if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
+            {
+                return SpecializedCollections.EmptyEnumerable<ISymbol>();
+            }
+
             var result = new List<ISymbol>();
             await AddDeclarationsAsync(solution, assembly, filePath, query, filter, result, cancellationToken).ConfigureAwait(false);
             return result;
@@ -271,6 +281,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsyncImpl(
             Solution solution, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
+            if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
+            {
+                return SpecializedCollections.EmptyEnumerable<ISymbol>();
+            }
+
             var result = new List<ISymbol>();
             foreach (var projectId in solution.ProjectIds)
             {
@@ -347,6 +362,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 throw new ArgumentNullException(nameof(solution));
             }
 
+            if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
+            {
+                return SpecializedCollections.EmptyEnumerable<ISymbol>();
+            }
+
             using (Logger.LogBlock(FunctionId.SymbolFinder_Solution_Predicate_FindSourceDeclarationsAsync, cancellationToken))
             {
                 var result = new List<ISymbol>();
@@ -382,6 +402,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             if (project == null)
             {
                 throw new ArgumentNullException(nameof(project));
+            }
+
+            if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
+            {
+                return SpecializedCollections.EmptyEnumerable<ISymbol>();
             }
 
             using (Logger.LogBlock(FunctionId.SymbolFinder_Project_Predicate_FindSourceDeclarationsAsync, cancellationToken))

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
@@ -11,6 +11,40 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
+    // Search query parameters.
+    internal struct SearchQuery
+    {
+        // The predicate for matching names.  Never null.
+        public readonly Func<string, bool> Predicate;
+
+        // The name being searched for may be null in some cases.  But can be used for faster 
+        // index based searching if it is provided.
+        public readonly string Name;
+        public readonly bool IgnoreCase;
+
+        public SearchQuery(string name, bool ignoreCase): 
+            this(n => ignoreCase ? CaseInsensitiveComparison.Comparer.Equals(name, n) : StringComparer.Ordinal.Equals(name, n))
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            this.Name = name;
+            this.IgnoreCase = ignoreCase;
+        }
+
+        public SearchQuery(Func<string, bool> predicate) : this()
+        {
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            this.Predicate = predicate;
+        }
+    }
+
     public static partial class SymbolFinder
     {
         /// <summary>
@@ -18,31 +52,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         public static Task<IEnumerable<ISymbol>> FindDeclarationsAsync(Project project, string name, bool ignoreCase, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return FindDeclarationsAsync(project, name, ignoreCase, includeDirectReferences: true, cancellationToken: cancellationToken);
-        }
-
-        internal static Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
-            Project project, string name, bool ignoreCase, bool includeDirectReferences, CancellationToken cancellationToken)
-        {
-            return FindDeclarationsAsync(project, name, ignoreCase, SymbolFilter.All, includeDirectReferences, cancellationToken);
-        }
-
-        /// <summary>
-        /// Find the declared symbols from either source, referenced projects or metadata assemblies with the specified name.
-        /// </summary>
-        public static Task<IEnumerable<ISymbol>> FindDeclarationsAsync(Project project, string name, bool ignoreCase, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return FindDeclarationsAsync(project, name, ignoreCase, filter, includeDirectReferences: true, cancellationToken: cancellationToken);
-        }
-
-        internal static Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
-            Project project, string name, bool ignoreCase, SymbolFilter filter, bool includeDirectReferences, CancellationToken cancellationToken)
-        {
-            if (project == null)
-            {
-                throw new ArgumentNullException(nameof(project));
-            }
-
             if (name == null)
             {
                 throw new ArgumentNullException(nameof(name));
@@ -53,21 +62,57 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return SpecializedTasks.EmptyEnumerable<ISymbol>();
             }
 
+            return FindDeclarationsAsync(project, new SearchQuery(name, ignoreCase), includeDirectReferences: true, cancellationToken: cancellationToken);
+        }
+
+        internal static Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
+            Project project, SearchQuery query, bool includeDirectReferences, CancellationToken cancellationToken)
+        {
+            return FindDeclarationsAsync(project, query, SymbolFilter.All, includeDirectReferences, cancellationToken);
+        }
+
+        /// <summary>
+        /// Find the declared symbols from either source, referenced projects or metadata assemblies with the specified name.
+        /// </summary>
+        public static Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
+            Project project, string name, bool ignoreCase, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return SpecializedTasks.EmptyEnumerable<ISymbol>();
+            }
+
+            return FindDeclarationsAsync(project, new SearchQuery(name, ignoreCase), filter, includeDirectReferences: true, cancellationToken: cancellationToken);
+        }
+
+        internal static Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
+            Project project, SearchQuery query, SymbolFilter filter, bool includeDirectReferences, CancellationToken cancellationToken)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
             using (Logger.LogBlock(FunctionId.SymbolFinder_FindDeclarationsAsync, cancellationToken))
             {
-                return FindDeclarationsAsyncImpl(project, name, ignoreCase, filter, includeDirectReferences, cancellationToken);
+                return FindDeclarationsAsyncImpl(project, query, filter, includeDirectReferences, cancellationToken);
             }
         }
 
         private static async Task<IEnumerable<ISymbol>> FindDeclarationsAsyncImpl(
-            Project project, string name, bool ignoreCase, SymbolFilter criteria, bool includeDirectReferences, CancellationToken cancellationToken)
+            Project project, SearchQuery query, SymbolFilter criteria, bool includeDirectReferences, CancellationToken cancellationToken)
         {
             var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
             var list = new List<ISymbol>();
 
             // get declarations from the compilation's assembly
-            await AddDeclarationsAsync(project, name, ignoreCase, criteria, list, cancellationToken).ConfigureAwait(false);
+            await AddDeclarationsAsync(project, query, criteria, list, cancellationToken).ConfigureAwait(false);
 
             // get declarations from directly referenced projects and metadata
             if (includeDirectReferences)
@@ -77,11 +122,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     var assemblyProject = project.Solution.GetProject(assembly, cancellationToken);
                     if (assemblyProject != null)
                     {
-                        await AddDeclarationsAsync(assemblyProject, compilation, assembly, name, ignoreCase, criteria, list, cancellationToken).ConfigureAwait(false);
+                        await AddDeclarationsAsync(assemblyProject, query, criteria, list, compilation, assembly, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        await AddDeclarationsAsync(project.Solution, assembly, GetMetadataReferenceFilePath(compilation.GetMetadataReference(assembly)), name, ignoreCase, criteria, list, cancellationToken).ConfigureAwait(false);
+                        await AddDeclarationsAsync(
+                            project.Solution, assembly, GetMetadataReferenceFilePath(compilation.GetMetadataReference(assembly)), 
+                            query, criteria, list, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -113,55 +160,76 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
-        private static async Task AddDeclarationsAsync(Project project, string name, bool ignoreCase, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
+        private static async Task AddDeclarationsAsync(
+            Project project, SearchQuery query, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
         {
-            await AddDeclarationsAsync(project, null, null, name, ignoreCase, filter, list, cancellationToken).ConfigureAwait(false);
+            await AddDeclarationsAsync(
+                project, query, filter, list, 
+                startingCompilation: null, 
+                startingAssembly: null, 
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task AddDeclarationsAsync(Project project, Compilation startingCompilation, IAssemblySymbol startingAssembly, string name, bool ignoreCase, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
+        private static async Task AddDeclarationsAsync(
+            Project project,
+            SearchQuery query,
+            SymbolFilter filter,
+            List<ISymbol> list,
+            Compilation startingCompilation,
+            IAssemblySymbol startingAssembly,
+            CancellationToken cancellationToken)
         {
-            Func<string, bool> predicate = n => ignoreCase ? CaseInsensitiveComparison.Comparer.Equals(name, n) : StringComparer.Ordinal.Equals(name, n);
-
             using (Logger.LogBlock(FunctionId.SymbolFinder_Project_AddDeclarationsAsync, cancellationToken))
             using (var set = SharedPools.Default<HashSet<ISymbol>>().GetPooledObject())
             {
-                if (!await project.ContainsSymbolsWithNameAsync(predicate, filter, cancellationToken).ConfigureAwait(false))
+                if (!await project.ContainsSymbolsWithNameAsync(query.Predicate, filter, cancellationToken).ConfigureAwait(false))
                 {
                     return;
                 }
 
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                if ((startingCompilation != null) && (startingAssembly != null) && (compilation.Assembly != startingAssembly))
+                if (startingCompilation != null && startingAssembly != null && compilation.Assembly != startingAssembly)
                 {
                     // Return symbols from skeleton assembly in this case so that symbols have the same language as startingCompilation.
                     list.AddRange(
-                        FilterByCriteria(compilation.GetSymbolsWithName(predicate, filter, cancellationToken), filter)
+                        FilterByCriteria(compilation.GetSymbolsWithName(query.Predicate, filter, cancellationToken), filter)
                             .Select(s => s.GetSymbolKey().Resolve(startingCompilation, cancellationToken: cancellationToken).Symbol).WhereNotNull());
                 }
                 else
                 {
-                    list.AddRange(FilterByCriteria(compilation.GetSymbolsWithName(predicate, filter, cancellationToken), filter));
+                    list.AddRange(FilterByCriteria(compilation.GetSymbolsWithName(query.Predicate, filter, cancellationToken), filter));
                 }
             }
         }
 
         internal static async Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
-            Solution solution, IAssemblySymbol assembly, string filePath, string name, bool ignoreCase, SymbolFilter filter, CancellationToken cancellationToken)
+            Solution solution, IAssemblySymbol assembly, string filePath, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             var result = new List<ISymbol>();
-            await AddDeclarationsAsync(solution, assembly, filePath, name, ignoreCase, filter, result, cancellationToken).ConfigureAwait(false);
+            await AddDeclarationsAsync(solution, assembly, filePath, query, filter, result, cancellationToken).ConfigureAwait(false);
             return result;
         }
 
         private static async Task AddDeclarationsAsync(
-            Solution solution, IAssemblySymbol assembly, string filePath, string name, bool ignoreCase, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
+            Solution solution, IAssemblySymbol assembly, string filePath, SearchQuery query, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.SymbolFinder_Assembly_AddDeclarationsAsync, cancellationToken))
             {
                 var info = await SymbolTreeInfo.GetInfoForAssemblyAsync(solution, assembly, filePath, cancellationToken).ConfigureAwait(false);
-                if (info.HasSymbols(name, ignoreCase))
+
+                // If the query has a specific string provided, then call into the SymbolTreeInfo
+                // helpers optimized for lookup based on an exact name.
+                if (query.Name != null)
                 {
-                    list.AddRange(FilterByCriteria(info.Find(assembly, name, ignoreCase, cancellationToken), filter));
+                    if (info.HasSymbols(query.Name, query.IgnoreCase))
+                    {
+                        list.AddRange(FilterByCriteria(info.Find(assembly, query.Name, query.IgnoreCase, cancellationToken), filter));
+                    }
+                }
+                else
+                {
+                    // Otherwise, we'll have to do a slow linear search over all possible symbols.
+                    list.AddRange(FilterByCriteria(info.Find(assembly, query.Predicate, cancellationToken), filter));
                 }
             }
         }
@@ -196,18 +264,18 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             using (Logger.LogBlock(FunctionId.SymbolFinder_Solution_Name_FindSourceDeclarationsAsync, cancellationToken))
             {
-                return FindSourceDeclarationsAsyncImpl(solution, name, ignoreCase, filter, cancellationToken);
+                return FindSourceDeclarationsAsyncImpl(solution, new SearchQuery(name, ignoreCase), filter, cancellationToken);
             }
         }
 
         private static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsyncImpl(
-            Solution solution, string name, bool ignoreCase, SymbolFilter filter, CancellationToken cancellationToken)
+            Solution solution, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             var result = new List<ISymbol>();
             foreach (var projectId in solution.ProjectIds)
             {
                 var project = solution.GetProject(projectId);
-                var symbols = await FindSourceDeclarationsAsyncImpl(project, name, ignoreCase, filter, cancellationToken).ConfigureAwait(false);
+                var symbols = await FindSourceDeclarationsAsyncImpl(project, query, filter, cancellationToken).ConfigureAwait(false);
                 result.AddRange(symbols);
             }
 
@@ -244,16 +312,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             using (Logger.LogBlock(FunctionId.SymbolFinder_Project_Name_FindSourceDeclarationsAsync, cancellationToken))
             {
-                return FindSourceDeclarationsAsyncImpl(project, name, ignoreCase, filter, cancellationToken);
+                return FindSourceDeclarationsAsyncImpl(project, new SearchQuery(name, ignoreCase), filter, cancellationToken);
             }
         }
 
         private static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsyncImpl(
-            Project project, string name, bool ignoreCase, SymbolFilter filter, CancellationToken cancellationToken)
+            Project project, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             var list = new List<ISymbol>();
-
-            await AddDeclarationsAsync(project, name, ignoreCase, filter, list, cancellationToken).ConfigureAwait(false);
+            await AddDeclarationsAsync(project, query, filter, list, cancellationToken).ConfigureAwait(false);
             return list;
         }
 
@@ -268,16 +335,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// Find the symbols for declarations made in source with a matching name.
         /// </summary>
-        public static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Solution solution, Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Solution solution, Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return FindSourceDeclarationsAsync(solution, new SearchQuery(predicate), filter, cancellationToken);
+        }
+
+        internal static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Solution solution, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             if (solution == null)
             {
                 throw new ArgumentNullException(nameof(solution));
-            }
-
-            if (predicate == null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
             }
 
             using (Logger.LogBlock(FunctionId.SymbolFinder_Solution_Predicate_FindSourceDeclarationsAsync, cancellationToken))
@@ -286,7 +353,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 foreach (var projectId in solution.ProjectIds)
                 {
                     var project = solution.GetProject(projectId);
-                    var symbols = await FindSourceDeclarationsAsync(project, predicate, filter, cancellationToken).ConfigureAwait(false);
+                    var symbols = await FindSourceDeclarationsAsync(project, query, filter, cancellationToken).ConfigureAwait(false);
                     result.AddRange(symbols);
                 }
 
@@ -297,7 +364,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// Find the symbols for declarations made in source with a matching name.
         /// </summary>
-        public static Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Project project, Func<string, bool> predicate, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Project project, Func<string,bool> predicate, CancellationToken cancellationToken = default(CancellationToken))
         {
             return FindSourceDeclarationsAsync(project, predicate, SymbolFilter.All, cancellationToken);
         }
@@ -305,29 +372,29 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// Find the symbols for declarations made in source with a matching name.
         /// </summary>
-        public static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Project project, Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Project project, Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return FindSourceDeclarationsAsync(project, new SearchQuery(predicate), filter, cancellationToken);
+        }
+
+        internal static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Project project, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             if (project == null)
             {
                 throw new ArgumentNullException(nameof(project));
             }
 
-            if (predicate == null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
-
             using (Logger.LogBlock(FunctionId.SymbolFinder_Project_Predicate_FindSourceDeclarationsAsync, cancellationToken))
             {
                 var result = new List<ISymbol>();
-                if (!await project.ContainsSymbolsWithNameAsync(predicate, filter, cancellationToken).ConfigureAwait(false))
+                if (!await project.ContainsSymbolsWithNameAsync(query.Predicate, filter, cancellationToken).ConfigureAwait(false))
                 {
                     return result;
                 }
 
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
-                result.AddRange(FilterByCriteria(compilation.GetSymbolsWithName(predicate, filter, cancellationToken), filter));
+                result.AddRange(FilterByCriteria(compilation.GetSymbolsWithName(query.Predicate, filter, cancellationToken), filter));
                 return result;
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -40,6 +40,23 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return FindNodes(name, GetComparer(ignoreCase)).Any();
         }
 
+        public IEnumerable<ISymbol> Find(IAssemblySymbol assembly, Func<string, bool> predicate, CancellationToken cancellationToken)
+        {
+            for (int i = 0, n = _nodes.Count; i < n; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var node = _nodes[i];
+                if (predicate(node.Name))
+                {
+                    foreach (var symbol in Bind(i, assembly.GlobalNamespace, cancellationToken))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        yield return symbol;
+                    }
+                }
+            }
+        }
+
         /// <summary>
         /// Get all symbols that have a name matching the specified name.
         /// </summary>
@@ -53,8 +70,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             foreach (var node in FindNodes(name, comparer))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 foreach (var symbol in Bind(node, assembly.GlobalNamespace, cancellationToken))
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     yield return symbol;
                 }
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -419,6 +419,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             cancellationToken.ThrowIfCancellationRequested();
 
             var node = _nodes[index];
+            if (node.IsRoot)
+            {
+                return;
+            }
 
             if (_nodes[node.ParentIndex].IsRoot)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -22,10 +22,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         private readonly IReadOnlyList<Node> _nodes;
 
-        // We first sort in a case insensitive manner.  But, within items htat match insensitively, 
+        // We first sort in a case insensitive manner.  But, within items that match insensitively, 
         // we then sort in a case sensitive manner.  This helps for searching as we'll walk all 
         // the items of a specific casing at once.  This way features can cache values for that
-        // casing and reuse them.  i.e. if we didn't do htis we might get "Prop, prop, Prop, prop"
+        // casing and reuse them.  i.e. if we didn't do this we might get "Prop, prop, Prop, prop"
         // which might cause other features to continually recalculate if that string matches what
         // they're searching for.  However, with this sort of comparison we now get 
         // "prop, prop, Prop, Prop".  Features can take advantage of that by caching their previous
@@ -187,44 +187,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Get all symbols that have a matching name as determined by the predicate.
-        /// </summary>
-        public IEnumerable<ISymbol> Search(
-            IAssemblySymbol assembly,
-            Func<string, bool> predicate,
-            CancellationToken cancellationToken)
-        {
-            string lastName = null;
-            bool lastGood = false;
-
-            for (int i = 0; i < _nodes.Count; i++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var node = _nodes[i];
-                var isSameName = node.Name == (object)lastName;
-                if ((isSameName && lastGood) // check for same string instance to avoid invoking predicate when we already know the outcome (assumes no side effects of predicate.)
-                    || (!string.IsNullOrEmpty(node.Name) // don't consider unnamed things like the global namespace itself.
-                          && predicate(node.Name)))
-                {
-                    lastGood = true;
-
-                    // yield all symbols for this node
-                    foreach (var symbol in Bind(i, assembly.GlobalNamespace, cancellationToken))
-                    {
-                        yield return symbol;
-                    }
-                }
-                else
-                {
-                    lastGood = false;
-                }
-
-                lastName = node.Name;
-            }
         }
 
         #region Construction

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class SymbolTreeInfo : IObjectWritable
     {
         private const string PrefixMetadataSymbolTreeInfo = "<MetadataSymbolTreeInfoPersistence>_";
-        private const string SerializationFormat = "1";
+        private const string SerializationFormat = "2";
 
         /// <summary>
         /// this is for a metadata reference in a solution

--- a/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
@@ -23,7 +23,7 @@ namespace Roslyn.Utilities
             originalTextArray = ConvertToLowercaseArray(text);
 
             // We only allow fairly close matches (in order to prevent too many
-            // spurious hits).  A reasonable heauristic for this is the Log_2(length) (rounded 
+            // spurious hits).  A reasonable heuristic for this is the Log_2(length) (rounded 
             // down).  
             //
             // Strings length 1-3 : 1 edit allowed.

--- a/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
@@ -164,7 +164,7 @@ namespace Roslyn.Utilities
             // characters to lowercase, we do a prepass over the string and convert it to
             // a lowercase char array.  We also pool these arrays to avoid the allocations.
             // By doing this, we only need to convert characters once, and we can then 
-            // access the characters extremely quickly from teh array.
+            // access the characters extremely quickly from the array.
             //
             // Sixth, we optimize for the case where we will be comparing a single string
             // against many potential match strings.  We cache the information about the 
@@ -270,11 +270,11 @@ namespace Roslyn.Utilities
             //    7 e 8|
             //    8 r 9|
             //
-            //          We'll then proceed a column at a time from left ot right producing the new column values.
+            //          We'll then proceed a column at a time from left to right producing the new column values.
             //          In the absense of twiddles we can note something useful:  The value for any given (i,j) we
             //          are computing is only dependent on (i - 1, j), (i, j-1), and (i - 1, j - 1).  These correspond,
             //          respectively, to the costs to delete, insert, or change/keep a character.  In traditional 
-            //          implementations we coudl accomplish this by having an array for the column we are generating
+            //          implementations we could accomplish this by having an array for the column we are generating
             //          and having an array for the previous column as well.  
             //          
             //          However, we can be a bit smarter and use a single array.  How?  Well, instead of writing 
@@ -282,11 +282,11 @@ namespace Roslyn.Utilities
             //          traversing.  After all, if we're writing into (i, j), then (i-1, j) is just the current value
             //          in the cell.  (i, j-1) is the value in the cell right above us that we just computed before 
             //          this cell.  And (i-1, j-1) is the value in the cell right above *before* we computed the 
-            //          new value for it.  The only trickyness is we have to store the value of the cell above us
+            //          new value for it.  The only trickiness is we have to store the value of the cell above us
             //          in a temporary before we overwrite it.  Now we have access to all three values we need to
             //          compute the new (i,j) value.
             //
-            //          No, we do something similar for twiddling. However, because a twiddle cost is "1 + (i-2, j-2)"
+            //          Note, we do something similar for twiddling. However, because a twiddle cost is "1 + (i-2, j-2)"
             //          we need to keep around our i-2 values.  We can't do that if we're overwriting all the values
             //          in the column.  So we do keep around one additional column for the i-2 generation.
             //
@@ -344,7 +344,7 @@ namespace Roslyn.Utilities
                 var checkThreshold = costThreshold < longLength;
 
                 // Some complicated indices here.  We effectively only want to walk the portion
-                // of hte matrix that is 'offset' around the diagonal.  So as we're walking
+                // of the matrix that is 'offset' around the diagonal.  So as we're walking
                 // we check if we're getting past the offset, and if so, we bump our indices
                 // to skip the values we don't need to check.
 
@@ -382,15 +382,14 @@ namespace Roslyn.Utilities
 
                     // Note: we're just setting 'editDistance' here so that it is the initial
                     // 'above' value when we start processing this column.  The above values
-                    // are very simply if we're processing the entire column:
+                    // are very simple if we're processing the entire column:
                     // 
                     //       i<- 0 1 2 3 4 5 6 7
                     //     j    |X l m R e a d e
                     //     ^   0|1 2 3 4 5 6 7 8    <-- above values
                     //
-                    // i.e. the're just equal to i+1.  However, if we're only processing
-                    // a part of a column, then the 'above' value is the value doesn't
-                    // exist.  In this case 
+                    // i.e. they're just equal to i+1.  However, if we're only processing
+                    // a part of a column, then the 'above' value doesn't exist.  In this case 
                     //
                     //      3 R 4|3 2 2 1 2 3 4 
                     //      4 e 5|4 3 3 2 1 2 3 ?    <-- No value above when we're starting at ?
@@ -448,7 +447,7 @@ namespace Roslyn.Utilities
                             // No matter what we have to add one, so we always do that below.
                             // So now we just need to compare (i-1,j-1)   (i-1,j)   and    (i, j-1)
                             //
-                            // editDistance was alreayd set to (i-1,j-1) above.  So all we need to do
+                            // editDistance was already set to (i-1,j-1) above.  So all we need to do
                             // is compare that to (i-1,j) and (i, j-1)  and pick the smallest.
 
                             if (leftEditDistance < editDistance)
@@ -485,7 +484,7 @@ namespace Roslyn.Utilities
                     }
 
                     // Recall that minimumEditCount is simply the difference in length of our two
-                    // strings.  So costArray[i] is the cost for the upper-left diagonal of hte 
+                    // strings.  So costArray[i] is the cost for the upper-left diagonal of the
                     // matrix.  costArray[i+minimumEditCount] is the cost for the lower right diagonal.
                     // Here we are simply getting the lowest cost edit of hese two substrings so far.
                     // If this lowest cost edit is greater than our threshold, then there is no need 

--- a/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
@@ -121,8 +121,8 @@ namespace Roslyn.Utilities
             -------------
 
             And we can cap the search past the diagonals based on the threshold.  For larger strings
-            With a small threshold, this can be very valuable.  For example, if we had 10 char strings
-            with a a threshold of 2, we'd only have to search
+            with a small threshold, this can be very valuable.  For example, if we had 10 char strings
+            with a threshold of 2, we'd only have to search
 
             -------------
             | abcdefghij|

--- a/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
@@ -1,175 +1,507 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using static System.Math;
 
 namespace Roslyn.Utilities
 {
-    internal static class EditDistance
+    internal class EditDistance : IDisposable
     {
-        private const int MaxPooledArraySize = 256;
+        private string originalText;
+        private char[] originalTextArray;
+        private int threshold;
 
-        // Keep around a few arrays of size 256 that we can use for operations without
-        // causing lots of garbage to be created.  If we do compare items larger than
-        // that, then we will just allocate and release those arrays on demand.
-        private static ObjectPool<int[]> s_pool = new ObjectPool<int[]>(() => new int[MaxPooledArraySize]);
+        // Cache the result of the last call to IsCloseMatch.  We'll often be called with the same
+        // value multiple times in a row, so we can avoid expensive computation by returning the
+        // same value immediately.
+        private ValueTuple<string, bool, double> lastIsCloseMatchResult;
 
-        public static int[] GetArray(int size)
+        public EditDistance(string text, int? threshold = null)
         {
-            if (size <= MaxPooledArraySize)
-            {
-                var array = s_pool.Allocate();
-                Array.Clear(array, 0, array.Length);
-                return array;
-            }
+            originalText = text;
+            originalTextArray = ConvertToLowercaseArray(text);
 
-            return new int[size];
+            // We only allow fairly close matches (in order to prevent too many
+            // spurious hits).  A reasonable heauristic for this is the Log_2(length) (rounded 
+            // down).  
+            //
+            // Strings length 1-3 : 1 edit allowed.
+            //         length 4-7 : 2 edits allowed.
+            //         length 8-15: 3 edits allowed.
+            //
+            // and so forth.
+            this.threshold = threshold ?? Max(1, (int)Log(text.Length, 2));
         }
 
-        public static void ReleaseArray(int[] array)
+        private static char[] ConvertToLowercaseArray(string text)
         {
-            if (array.Length <= MaxPooledArraySize)
+            var array = Pool<char>.GetArray(text.Length);
+            for (int i = 0; i < text.Length; i++)
             {
-                s_pool.Free(array);
+                array[i] = char.ToLower(text[i]);
+            }
+
+            return array;
+        }
+
+        public void Dispose()
+        {
+            Pool<char>.ReleaseArray(originalTextArray);
+            originalText = null;
+            originalTextArray = null;
+        }
+
+        public static int GetEditDistance(string s, string t, int? threshold = null)
+        {
+            using (var editDistance = new EditDistance(s, threshold))
+            {
+                return editDistance.GetEditDistance(t);
             }
         }
 
-        public static int GetEditDistance(string oldString, string newString)
+        public int GetEditDistance(string other)
         {
-            // Cost constants
-            const int Copy = 0;
-            const int Insert = 1;
-            const int Delete = 1;
-            const int Replace = 1;
-            const int Twiddle = 1;
-
-            // Expand the counts by one to include the empty string
-            int rowWidth = oldString.Length + 1;
-            int columnHeight = newString.Length + 1;
-
-            // This stores data two rows before the current one
-            int[] rowBefore2 = GetArray(rowWidth);
-
-            // This stores the row before the current one
-            int[] rowBefore1 = GetArray(rowWidth);
-
-            // This stores the current row
-            int[] rowCurrent = GetArray(rowWidth);
+            var otherCharacterArray = ConvertToLowercaseArray(other);
 
             try
             {
-                // Initialize the first row, which represents deleting the entire string
-                for (int column = 1; column < rowWidth; column++)
-                {
-                    rowCurrent[column] = rowCurrent[column - 1] + Delete;
-                }
-
-                for (int row = 1; row < columnHeight; row++)
-                {
-                    // Shift the row data upwards, rowBefore2 falls off and the memory is
-                    // recycled for the current row
-                    var temp = rowBefore2;
-                    rowBefore2 = rowBefore1;
-                    rowBefore1 = rowCurrent;
-                    rowCurrent = temp;
-
-                    // First element of the row represents inserting the new string
-                    rowCurrent[0] = rowBefore1[0] + Insert;
-
-                    for (int column = 1; column < rowWidth; column++)
-                    {
-                        // Copy = top left neighbor + cost_copy      if current chars are equal
-                        //        infinite                           otherwise
-                        int copyCost = (char.ToLower(oldString[column - 1]) == char.ToLower(newString[row - 1])) ?
-                                            rowBefore1[column - 1] + Copy :
-                                            int.MaxValue;
-
-                        // Insert = top neighbor + cost_insert
-                        int insertCost = rowBefore1[column] + Insert;
-
-                        // Delete = left neighbor + cost_delete
-                        int deleteCost = rowCurrent[column - 1] + Delete;
-
-                        // Replace = top left neighbor + cost_replace
-                        int replaceCost = rowBefore1[column - 1] + Replace;
-
-                        // Twiddle = top left neighbor of the top left neighbor + cost_twiddle   if chars are swapped
-                        //           infinite                                                    otherwise
-                        int twiddleCost = (column > 1 && row > 1 &&
-                                        char.ToLower(oldString[column - 1]) == char.ToLower(newString[row - 2]) &&
-                                        char.ToLower(oldString[column - 2]) == char.ToLower(newString[row - 1])) ?
-                                            rowBefore2[column - 2] + Twiddle :
-                                            int.MaxValue;
-
-                        // Store the smallest of the costs
-                        rowCurrent[column] = Math.Min(Math.Min(Math.Min(Math.Min(copyCost, insertCost), deleteCost), replaceCost), twiddleCost);
-                    }
-                }
-
-                // The edit distance is the last element in the current row
-                return rowCurrent[rowWidth - 1];
+                // Swap the strings so the first is always the shortest.  This helps ensure some
+                // nice invariants in the code that walks both strings below.
+                return originalText.Length <= other.Length
+                    ? GetEditDistance(originalTextArray, otherCharacterArray, originalText.Length, other.Length, threshold)
+                    : GetEditDistance(otherCharacterArray, originalTextArray, other.Length, originalText.Length, threshold);
             }
             finally
             {
-                ReleaseArray(rowBefore2);
-                ReleaseArray(rowBefore1);
-                ReleaseArray(rowCurrent);
+                Pool<char>.ReleaseArray(otherCharacterArray);
             }
         }
 
-        // =============================================================================
-        // Get the length of the longest common subsequence of the two given strings
-        // =============================================================================
-        public static int GetLongestCommonSubsequenceLength(string oldString, string newString)
+        private static int GetEditDistance(
+            char[] shortString, char[] longString,
+            int shortLength, int longLength,
+            int costThreshold)
         {
-            // Expand the counts by one to include the empty string
-            int rowWidth = oldString.Length + 1;
-            int columnHeight = newString.Length + 1;
+            // Note: shortLength and longLength values will mutate and represent the lengths 
+            // of the portions of the arrays we want to compare.
+            //
+            // Also note: shortLength will always be smaller or equal to longLength.
+            Debug.Assert(shortLength <= longLength);
 
-            // This stores the row before the current one
-            int[] rowBefore1 = GetArray(rowWidth);
+            // Optimized version of the restricted string edit distance algorithm:
+            // see https://en.wikipedia.org/wiki/Edit_distance.
+            //
+            // The optimized version uses insights from Ukonnen to greatly diminish the amount
+            // of work that needs to be done. http://www.cs.helsinki.fi/u/ukkonen/InfCont85.PDF
+            //
+            // First, because we only need the distance, and don't need the path, we can do the 
+            // standard approach of not requiring a full matrix to store all our edit distances.
+            // 
+            // Second, because a threshold is provided, we only need to search the values in
+            // matrix that are within threshold distance away from the diagonal.  Any paths
+            // outside that diagonal would necessarily have an edit distance that was greater
+            // than the threshold and thus can be avoided.  i.e. if we have a matrix like
+            //
+#if false
+            -------------
+            | abcdefghij|
+            |m          |
+            |n          |
+            |o          |
+            -------------
 
-            // This stores the current row
-            int[] rowCurrent = GetArray(rowWidth);
+            Then the two relevant diagonals are
+
+            -------------
+            | abcdefghij|
+            |m\      \  |
+            |n \      \ |
+            |o  \      \|
+            -------------
+
+            And we can cap the search past the diagonals based on the threshold.  For larger strings
+            With a small threshold, this can be very valuable.  For example, if we had 10 char strings
+            with a a threshold of 2, we'd only have to search
+
+            -------------
+            | abcdefghij|
+            |m\**       |
+            |n*\**      |
+            |o**\**     |
+            |p **\**    |
+            |q  **\**   |
+            |r   **\**  |
+            |s    **\** |
+            |t     **\**|
+            |u      **\*|
+            |v       **\|
+            -------------
+
+            Which greatly decreases the search space.  Any items outside of this range will necessarily
+            have a higher cost than our threshold and thus don't even need to be considered.
+
+#endif
+            //
+            // Third, instead of taking the swapping approach often found in algorithms that 
+            // go a row at a time through the matrix, we can take avantage of the fact that
+            // we know we're always sweeping the matrix from top to bottom and from left to
+            // right.  In that case, as we're producing new row values, we can store it in 
+            // the existing row.  However, we make sure to just keep around the values we're
+            // about to overwrite so we can use them as we continue to populate the row.
+            // This optimization is explained in more detail below.
+            //
+            // Note: because we do look for characater twiddling, we do need to keep around
+            // a single previous row as well.  But this means keeping around two rows instead
+            // of three.
+            //
+            // Fourth, we do fast scans to see if our strings share any common prefix/suffix
+            // portions.  These portions of the string correspond to a 0 edit cost.  We then
+            // only have to do the string edit distance on the portion of the strings that
+            // don't match.
+            //
+            // Fifth, to avoid lots of overhead indexing into strings and converting their
+            // characters to lowercase, we do a prepass over the string and convert it to
+            // a lowercase char array.  We also pool these arrays to avoid the allocations.
+            // By doing this, we only need to convert characters once, and we can then 
+            // access the characters extremely quickly from teh array.
+            //
+            // Sixth, we optimize for the case where we will be comparing a single string
+            // against many potential match strings.  We cache the information about the 
+            // single string (such as it's lower-case char array) so that we don't have to
+            // recompute it.
+            //
+            // With all these changes we see an improvement of about 20x when computing the
+            // edit distance for strings.  In practical terms, what was 4 seconds of searching
+            // for results becomes around 0.2 seconds.
+
+            // First:
+            // Determine the common prefix/suffix portions of the strings.
+            while (shortLength > 0 && shortString[shortLength - 1] == longString[longLength - 1])
+            {
+                shortLength--;
+                longLength--;
+            }
+
+            var startIndex = 0;
+            while (startIndex < shortLength && shortString[startIndex] == longString[startIndex])
+            {
+                startIndex++;
+                shortLength--;
+                longLength--;
+            }
+
+            // 'shortLength' and 'longLength' are now the lengths of the substrings of our strings that we
+            // want to compare. 'startIndex' is the starting point of the substrings in both array.
+
+            // If we've matched all of the 'short' string in the prefix and suffix of 'longString'. then the edit
+            // distance is just whatever operations we have to create the remaining longString substring.
+            if (shortLength == 0)
+            {
+                return longLength;
+            }
+
+#if false
+            // Note: this check is not necessary. Recall that shortLength is always less than 
+            // longLength.  So if longLength was 0 then shortLength would also be zero, and the
+            // above case would hit.
+            //
+            // I'm keeping this in just to help clarify this in case someone wonders why that
+            // check is missing.
+            if (longLength == 0)
+            {
+                return shortLength;
+            }
+#endif
+
+            // The is the minimum number of edits we'd have to make.  i.e. if  'shortString' and 
+            // 'longString' are the same length, then we might not need to make any edits.  However,
+            // if longString has length 10 and shortString has length 7, then we're going to have to
+            // make at least 3 edits.
+
+            var minimumEditCount = longLength - shortLength;
+            Debug.Assert(minimumEditCount >= 0);
+
+            // If our threshold is greater than the number of edits it would take to just produce 'longString'
+            // then just cap the threshold.  In the code below 'threshold' acts as the diagonal
+            // we don't have to look outside of.  By capping the threshold here we make the math
+            // easy below.
+            if (costThreshold > longLength)
+            {
+                costThreshold = longLength;
+            }
+
+            // If the number of edits we'd have to perform is greater than our threshold, then
+            // there's no point in even continuing.
+            if (minimumEditCount > costThreshold)
+            {
+                return int.MaxValue;
+            }
+
+            //  The matrix we are virtually simulating here is indexed in the following fashion:
+            //
+            //      i<- 0 1 2 3 4 5 6 7
+            //    j     X l m R e a d e
+            //    ^  
+            //    0 X
+            //    1 m
+            //    2 l
+            //    3 R
+            //    4 e
+            //    5 a
+            //    6 d
+            //    7 e
+            //    8 r
+            //
+            //          It will be virtually initialized with the following values.  These represent the
+            //          initial 'left' and 'above' values for the algorithm below
+            //
+            //      i<-|0 1 2 3 4 5 6 7
+            //    j    |X l m R e a d e
+            //    ^   0|1 2 3 4 5 6 7 8
+            //    -----+---------------
+            //    0 X 1|
+            //    1 m 2|
+            //    2 l 3|
+            //    3 R 4|
+            //    4 e 5|
+            //    5 a 6|
+            //    6 d 7|
+            //    7 e 8|
+            //    8 r 9|
+            //
+            //          We'll then proceed a column at a time from left ot right producing the new column values.
+            //          In the absense of twiddles we can note something useful:  The value for any given (i,j) we
+            //          are computing is only dependent on (i - 1, j), (i, j-1), and (i - 1, j - 1).  These correspond,
+            //          respectively, to the costs to delete, insert, or change/keep a character.  In traditional 
+            //          implementations we coudl accomplish this by having an array for the column we are generating
+            //          and having an array for the previous column as well.  
+            //          
+            //          However, we can be a bit smarter and use a single array.  How?  Well, instead of writing 
+            //          the new values into a new column, we can write it right back into the column we're currently
+            //          traversing.  After all, if we're writing into (i, j), then (i-1, j) is just the current value
+            //          in the cell.  (i, j-1) is the value in the cell right above us that we just computed before 
+            //          this cell.  And (i-1, j-1) is the value in the cell right above *before* we computed the 
+            //          new value for it.  The only trickyness is we have to store the value of the cell above us
+            //          in a temporary before we overwrite it.  Now we have access to all three values we need to
+            //          compute the new (i,j) value.
+            //
+            //          No, we do something similar for twiddling. However, because a twiddle cost is "1 + (i-2, j-2)"
+            //          we need to keep around our i-2 values.  We can't do that if we're overwriting all the values
+            //          in the column.  So we do keep around one additional column for the i-2 generation.
+            //
+            //          With our heuristic of Log_2(length) changes allowed this will end up producing the following
+            //          set of values:
+            //
+            //      i<- 0 1 2 3 4 5 6 7
+            //    j    |X l m R e a d e
+            //    ^   0|1 2 3 4 5 6 7 8
+            //    -----+---------------
+            //    0 X 1|0 1 2
+            //    1 m 2|1 1 1 2 
+            //    2 l 3|2 1 1 2 3 
+            //    3 R 4|3 2 2 1 2 3 
+            //    4 e 5|  3 3 2 1 2 3 
+            //    5 a 6|    4 3 2 1 2 3
+            //    6 d 7|      4 3 2 1 2
+            //    7 e 8|        4 3 2 1
+            //    8 r 9|          4 3 2
+            //
+            //          Note that we've avoid examining 30 elements in the matrix (out of 8*9=72), or roughly
+            //          40%. 
+
+            var costArray = Pool<int>.GetArray(longLength);
+            var previousCostArray = Pool<int>.GetArray(longLength);
+
             try
             {
-                for (int row = 1; row < columnHeight; row++)
+                // here we are setting the initial 'left' array:
+
+                //      i<-|
+                //    j    |
+                //    ^   0|
+                //    -----+ 
+                //    0 X 1|
+                //    1 m 2|
+                //    2 l 3|
+                //    3 R 4|
+                //    4 e 5|
+                //    5 a 6|
+                //    6 d 7|
+                //    7 e 8|
+                //    8 r 9|
+                //
+                // This is the cost to go from an empty string to the longString, and is essentially
+                // the cost of inserting all the characters.  By doing this, we have access to 'left'
+                // values as we actualy walk through each column.
+                for (var i = 0; i < longLength; i++)
                 {
-                    // Shift the row data upwards, rowBefore1 falls off and the memory is
-                    // recycled for the current row
-                    var temp = rowBefore1;
-                    rowBefore1 = rowCurrent;
-                    rowCurrent = temp;
+                    costArray[i] = i + 1;
+                }
 
-                    // First element of the row is always 0
-                    rowCurrent[0] = 0;
+                // We only need to bother even checking the threshold if it's lower than the 
+                // cost of just creating all of t.
+                var checkThreshold = costThreshold < longLength;
 
-                    for (int column = 1; column < rowWidth; column++)
+                // Some complicated indices here.  We effectively only want to walk the portion
+                // of hte matrix that is 'offset' around the diagonal.  So as we're walking
+                // we check if we're getting past the offset, and if so, we bump our indices
+                // to skip the values we don't need to check.
+
+                var offset = costThreshold - minimumEditCount;
+
+                var jFrom = 0;
+                var jTo = costThreshold;
+
+                var currentShortCharacter = shortString[startIndex];
+                var editDistance = 0;
+
+                // Walk the matrix from left to right, one column at a time.
+                for (int i = 0; i < shortLength; i++)
+                {
+                    // Keep track of the previous character in 'shortString'.  We'll need it for
+                    // the twiddle check.
+                    var previousShortCharacter = currentShortCharacter;
+                    currentShortCharacter = shortString[startIndex + i];
+
+                    var currentLongCharacter = longString[startIndex];
+
+                    // as we start going past the offset increase where we start looking within 
+                    // 'longString'.
+                    if (i > offset)
                     {
-                        int currentLength = 0;
+                        jFrom++;
+                    }
 
-                        if (char.ToLower(oldString[column - 1]) == char.ToLower(newString[row - 1]))
+                    // Keep incrementing jTo (so the length of our window stays the same) as long
+                    // as it wouldn't go past the length of the string we want to check.
+                    if (jTo < longLength)
+                    {
+                        jTo++;
+                    }
+
+                    // Note: we're just setting 'editDistance' here so that it is the initial
+                    // 'above' value when we start processing this column.  The above values
+                    // are very simply if we're processing the entire column:
+                    // 
+                    //       i<- 0 1 2 3 4 5 6 7
+                    //     j    |X l m R e a d e
+                    //     ^   0|1 2 3 4 5 6 7 8    <-- above values
+                    //
+                    // i.e. the're just equal to i+1.  However, if we're only processing
+                    // a part of a column, then the 'above' value is the value doesn't
+                    // exist.  In this case 
+                    //
+                    //      3 R 4|3 2 2 1 2 3 4 
+                    //      4 e 5|4 3 3 2 1 2 3 ?    <-- No value above when we're starting at ?
+                    //
+                    // This is because we can't actually have an edit that comes in through
+                    // the top of the column.  This edit would necessarily be more costly 
+                    // than our threshold.  To handle this, we simply set the edit distance
+                    // to int.Max.  This will make the 'above' value int.Max, and it means
+                    // we'll never pick it as our path.
+                    editDistance = jFrom == 0 ? i + 1 : int.MaxValue;
+
+                    // 'aboveLeft' is computed in a similar fashion, but doesn't have this same
+                    // problem.  In the case where we're at the top aboveLeft is simply i.  And
+                    // in a case where we're starting in the middle of the column, by construction,
+                    // we'll always have the aboveLeft value in location in the column right above
+                    // where we're starting at.
+                    var aboveLeftEditDistance = jFrom == 0 ? i : costArray[jFrom - 1];
+
+                    var nextTwiddleCost = 0;
+                    for (var j = jFrom; j < jTo; j++)
+                    {
+                        // Note: any acceses into costArray *before* we write into it represent values of 
+                        // (i-1,*).  Once we write into it that value will represent (i, *).
+
+                        // As we move down the column our previously written edit distance becomes the 
+                        // 'above' value for the next computation.  i.e. the value we previously wrote 
+                        // into (i, j) is now at (i, j-1).
+                        var aboveEditDistance = editDistance;
+
+                        // Initialize the editDistance for (i,j) to be the edit distance for
+                        // (i-1, j-1).  If they match on characters, we'll keep this edit distance.
+                        // If they differ, then we'll check what gives us the cheapest edit distance.
+                        editDistance = aboveLeftEditDistance;
+
+                        // before we overwrite the current cost at (i,j), keep track of the value
+                        // of (i-1, j).  At this point:
+                        //
+                        //  1) editDistance corresponds to      (i-1, j-1) 
+                        //  2) aboveEditDistance corresponds to (i, j-1)
+                        //  3) leftEditDistance corresponds to   (i-1, j)
+                        var leftEditDistance = costArray[j];
+
+                        var currentTwiddleCost = nextTwiddleCost;
+                        nextTwiddleCost = previousCostArray[j];
+                        previousCostArray[j] = editDistance;
+
+                        var previousLongCharacter = currentLongCharacter;
+                        currentLongCharacter = longString[startIndex + j];
+
+                        if (currentShortCharacter != currentLongCharacter)
                         {
-                            // Both chars are the same, so increment the length
-                            currentLength = rowBefore1[column - 1] + 1;
-                        }
-                        else
-                        {
-                            // The chars are not the same, so pick the maximum of the
-                            // left and upper entries
-                            currentLength = Math.Max(rowCurrent[column - 1], rowBefore1[column]);
+                            // Because the characters didn't match, our edit distance is the min of:
+                            // "(i-1,j-1) + 1"   "(i-1,j) + 1"   "(i, j-1) + 1"
+                            //
+                            // No matter what we have to add one, so we always do that below.
+                            // So now we just need to compare (i-1,j-1)   (i-1,j)   and    (i, j-1)
+                            //
+                            // editDistance was alreayd set to (i-1,j-1) above.  So all we need to do
+                            // is compare that to (i-1,j) and (i, j-1)  and pick the smallest.
+
+                            if (leftEditDistance < editDistance)
+                            {
+                                // (i-1,j) < (i-1,j-1)
+                                editDistance = leftEditDistance;
+                            }
+
+                            if (aboveEditDistance < editDistance)
+                            {
+                                // (i,j-1) < (i-1,j-1) && (i-1, j)
+                                editDistance = aboveEditDistance;
+                            }
+
+                            // We're always one greater than the min edit distance for inserting/deleting/changing.
+                            editDistance++;
+
+                            // Check for twiddles if we're past the first row and column.
+                            if (i != 0 && j != 0 && currentShortCharacter == previousLongCharacter && previousShortCharacter == currentLongCharacter)
+                            {
+                                currentTwiddleCost++;
+                                if (currentTwiddleCost < editDistance)
+                                {
+                                    editDistance = currentTwiddleCost;
+                                }
+                            }
                         }
 
-                        rowCurrent[column] = currentLength;
+                        costArray[j] = editDistance;
+
+                        // Keep track of what is in (i-1, j) now.  The next time through this loop
+                        // it will be (i-1, j-1) (hence 'aboveLeft').
+                        aboveLeftEditDistance = leftEditDistance;
+                    }
+
+                    // Recall that minimumEditCount is simply the difference in length of our two
+                    // strings.  So costArray[i] is the cost for the upper-left diagonal of hte 
+                    // matrix.  costArray[i+minimumEditCount] is the cost for the lower right diagonal.
+                    // Here we are simply getting the lowest cost edit of hese two substrings so far.
+                    // If this lowest cost edit is greater than our threshold, then there is no need 
+                    // to proceed.
+                    if (checkThreshold && (costArray[i + minimumEditCount] > costThreshold))
+                    {
+                        return int.MaxValue;
                     }
                 }
 
-                // The LCS length is the last element in the current row
-                return rowCurrent[rowWidth - 1];
+                return editDistance;
             }
             finally
             {
-                ReleaseArray(rowBefore1);
-                ReleaseArray(rowCurrent);
+                Pool<int>.ReleaseArray(costArray);
+                Pool<int>.ReleaseArray(previousCostArray);
             }
         }
 
@@ -186,24 +518,46 @@ namespace Roslyn.Utilities
         /// </summary>
         public static bool IsCloseMatch(string originalText, string candidateText, out double matchCost)
         {
-            return IsCloseMatch(originalText, candidateText, GetCloseMatchThreshold(originalText), out matchCost);
+            using (var editDistance = new EditDistance(originalText))
+            {
+                return editDistance.IsCloseMatch(candidateText, out matchCost);
+            }
         }
 
-        public static int GetCloseMatchThreshold(string originalText)
+        public bool IsCloseMatch(string candidateText, out double matchCost)
         {
-            return Math.Min(4, originalText.Length / 2);
+            if (this.originalText.Length < 3)
+            {
+                // If we're comparing strings that are too short, we'll find 
+                // far too many spurious hits.  Don't even both in this case.
+                matchCost = double.MaxValue;
+                return false;
+            }
+
+            if (lastIsCloseMatchResult.Item1 == candidateText)
+            {
+                matchCost = lastIsCloseMatchResult.Item3;
+                return lastIsCloseMatchResult.Item2;
+            }
+
+            var result = IsCloseMatchWorker(candidateText, out matchCost);
+            lastIsCloseMatchResult = ValueTuple.Create(candidateText, result, matchCost);
+            return result;
         }
 
-        /// <summary>
-        /// Returns true if 'value1' and 'value2' are likely a misspelling of each other.
-        /// Returns false otherwise.  If it is a likely misspelling a matchCost is provided
-        /// to help rank the match.  Lower costs mean it was a better match.
-        /// </summary>
-        public static bool IsCloseMatch(string originalText, string candidateText, int costThreshold, out double matchCost)
+        private bool IsCloseMatchWorker(string candidateText, out double matchCost)
         {
-            matchCost = EditDistance.GetEditDistance(originalText, candidateText);
+            matchCost = double.MaxValue;
 
-            if (matchCost > costThreshold)
+            // If the two strings differ by more characters than the cost threshold, then there's 
+            // no point in even computing the edit distance as it would necessarily take at least
+            // that many additions/deletions.
+            if (Math.Abs(originalText.Length - candidateText.Length) <= threshold)
+            {
+                matchCost = GetEditDistance(candidateText);
+            }
+
+            if (matchCost > threshold)
             {
                 // it had a high cost.  However, the string the user typed was contained
                 // in the string we're currently looking at.  That's enough to consider it
@@ -211,16 +565,16 @@ namespace Roslyn.Utilities
                 // other matches).
                 if (candidateText.IndexOf(originalText, StringComparison.OrdinalIgnoreCase) >= 0)
                 {
-                    matchCost = costThreshold;
+                    matchCost = threshold;
                 }
             }
 
-            if (matchCost > costThreshold)
+            if (matchCost > threshold)
             {
                 return false;
             }
 
-            matchCost += Penalty(candidateText, originalText);
+            matchCost += Penalty(candidateText, this.originalText);
             return true;
         }
 
@@ -241,6 +595,36 @@ namespace Roslyn.Utilities
             }
 
             return 0;
+        }
+
+        internal static class Pool<T>
+        {
+            private const int MaxPooledArraySize = 256;
+
+            // Keep around a few arrays of size 256 that we can use for operations without
+            // causing lots of garbage to be created.  If we do compare items larger than
+            // that, then we will just allocate and release those arrays on demand.
+            private static ObjectPool<T[]> s_pool = new ObjectPool<T[]>(() => new T[MaxPooledArraySize]);
+
+            public static T[] GetArray(int size)
+            {
+                if (size <= MaxPooledArraySize)
+                {
+                    var array = s_pool.Allocate();
+                    Array.Clear(array, 0, array.Length);
+                    return array;
+                }
+
+                return new T[size];
+            }
+
+            public static void ReleaseArray(T[] array)
+            {
+                if (array.Length <= MaxPooledArraySize)
+                {
+                    s_pool.Free(array);
+                }
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
@@ -196,23 +196,13 @@ namespace Roslyn.Utilities
 
             // If we've matched all of the 'short' string in the prefix and suffix of 'longString'. then the edit
             // distance is just whatever operations we have to create the remaining longString substring.
+            //
+            // Note: we don't have to check if longLength is 0.  That's because longLength being zero would
+            // necessarily mean that shortLength is 0.
             if (shortLength == 0)
             {
                 return longLength;
             }
-
-#if false
-            // Note: this check is not necessary. Recall that shortLength is always less than 
-            // longLength.  So if longLength was 0 then shortLength would also be zero, and the
-            // above case would hit.
-            //
-            // I'm keeping this in just to help clarify this in case someone wonders why that
-            // check is missing.
-            if (longLength == 0)
-            {
-                return shortLength;
-            }
-#endif
 
             // The is the minimum number of edits we'd have to make.  i.e. if  'shortString' and 
             // 'longString' are the same length, then we might not need to make any edits.  However,

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
@@ -456,18 +456,10 @@ Inner i;
         [Fact]
         public static void FindSourceDeclarationsAsync_Project_Func_Test_NullPredicate()
         {
-            Assert.Throws<AggregateException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
-                try
-                {
-                    var project = GetProject(WorkspaceKind.SingleClass);
-                    var declarations = SymbolFinder.FindSourceDeclarationsAsync(project, null).Result;
-                }
-                catch (AggregateException ex)
-                {
-                    VerifyInnerExceptionArgumentNull(ex, "predicate");
-                    throw;
-                }
+                var project = GetProject(WorkspaceKind.SingleClass);
+                var declarations = SymbolFinder.FindSourceDeclarationsAsync(project, null).Result;
             });
         }
 
@@ -548,18 +540,10 @@ Inner i;
         [Fact]
         public static void FindSourceDeclarationsAsync_Solution_Func_Test_NullPredicate()
         {
-            Assert.Throws<AggregateException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
-                try
-                {
-                    var solution = GetSolution(WorkspaceKind.SingleClass);
-                    var declarations = SymbolFinder.FindSourceDeclarationsAsync(solution, null).Result;
-                }
-                catch (AggregateException ex)
-                {
-                    VerifyInnerExceptionArgumentNull(ex, "predicate");
-                    throw;
-                }
+                var solution = GetSolution(WorkspaceKind.SingleClass);
+                var declarations = SymbolFinder.FindSourceDeclarationsAsync(solution, null).Result;
             });
         }
 

--- a/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
@@ -48,6 +48,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void EditDistance4()
+        {
+            Assert.Equal(EditDistance.GetEditDistance("XlmReade", "XmlReader"), 2);
+        }
+
+        [Fact]
         public void MoreEditDistance()
         {
             Assert.Equal(EditDistance.GetEditDistance("barking", "corkliness"), 6);

--- a/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
@@ -7,56 +7,61 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     public class EditDistanceTests
     {
+        private static int GetEditDistance(string s, string t)
+        {
+            return EditDistance.GetEditDistance(s, t, int.MaxValue);
+        }
+
         [Fact]
         public void EditDistance0()
         {
-            Assert.Equal(EditDistance.GetEditDistance("", ""), 0);
-            Assert.Equal(EditDistance.GetEditDistance("a", "a"), 0);
+            Assert.Equal(GetEditDistance("", ""), 0);
+            Assert.Equal(GetEditDistance("a", "a"), 0);
         }
 
         [Fact]
         public void EditDistance1()
         {
-            Assert.Equal(EditDistance.GetEditDistance("", "a"), 1);
-            Assert.Equal(EditDistance.GetEditDistance("a", ""), 1);
-            Assert.Equal(EditDistance.GetEditDistance("a", "b"), 1);
-            Assert.Equal(EditDistance.GetEditDistance("ab", "a"), 1);
-            Assert.Equal(EditDistance.GetEditDistance("a", "ab"), 1);
-            Assert.Equal(EditDistance.GetEditDistance("aabb", "abab"), 1);
+            Assert.Equal(GetEditDistance("", "a"), 1);
+            Assert.Equal(GetEditDistance("a", ""), 1);
+            Assert.Equal(GetEditDistance("a", "b"), 1);
+            Assert.Equal(GetEditDistance("ab", "a"), 1);
+            Assert.Equal(GetEditDistance("a", "ab"), 1);
+            Assert.Equal(GetEditDistance("aabb", "abab"), 1);
         }
 
         [Fact]
         public void EditDistance2()
         {
-            Assert.Equal(EditDistance.GetEditDistance("", "aa"), 2);
-            Assert.Equal(EditDistance.GetEditDistance("aa", ""), 2);
-            Assert.Equal(EditDistance.GetEditDistance("aa", "bb"), 2);
-            Assert.Equal(EditDistance.GetEditDistance("aab", "a"), 2);
-            Assert.Equal(EditDistance.GetEditDistance("a", "aab"), 2);
-            Assert.Equal(EditDistance.GetEditDistance("aababb", "ababab"), 2);
+            Assert.Equal(GetEditDistance("", "aa"), 2);
+            Assert.Equal(GetEditDistance("aa", ""), 2);
+            Assert.Equal(GetEditDistance("aa", "bb"), 2);
+            Assert.Equal(GetEditDistance("aab", "a"), 2);
+            Assert.Equal(GetEditDistance("a", "aab"), 2);
+            Assert.Equal(GetEditDistance("aababb", "ababab"), 2);
         }
 
         [Fact]
         public void EditDistance3()
         {
-            Assert.Equal(EditDistance.GetEditDistance("", "aaa"), 3);
-            Assert.Equal(EditDistance.GetEditDistance("aaa", ""), 3);
-            Assert.Equal(EditDistance.GetEditDistance("aaa", "bbb"), 3);
-            Assert.Equal(EditDistance.GetEditDistance("aaab", "a"), 3);
-            Assert.Equal(EditDistance.GetEditDistance("a", "aaab"), 3);
-            Assert.Equal(EditDistance.GetEditDistance("aababbab", "abababaa"), 3);
+            Assert.Equal(GetEditDistance("", "aaa"), 3);
+            Assert.Equal(GetEditDistance("aaa", ""), 3);
+            Assert.Equal(GetEditDistance("aaa", "bbb"), 3);
+            Assert.Equal(GetEditDistance("aaab", "a"), 3);
+            Assert.Equal(GetEditDistance("a", "aaab"), 3);
+            Assert.Equal(GetEditDistance("aababbab", "abababaa"), 3);
         }
 
         [Fact]
         public void EditDistance4()
         {
-            Assert.Equal(EditDistance.GetEditDistance("XlmReade", "XmlReader"), 2);
+            Assert.Equal(GetEditDistance("XlmReade", "XmlReader"), 2);
         }
 
         [Fact]
         public void MoreEditDistance()
         {
-            Assert.Equal(EditDistance.GetEditDistance("barking", "corkliness"), 6);
+            Assert.Equal(GetEditDistance("barking", "corkliness"), 6);
         }
 
         [Fact]

--- a/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/EditDistanceTests.cs
@@ -54,31 +54,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void LongestCommonSubstring0()
-        {
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("", ""), 0);
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("a", "b"), 0);
-        }
-
-        [Fact]
-        public void LongestCommonSubstring1()
-        {
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("a", "a"), 1);
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("ab", "a"), 1);
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("a", "ab"), 1);
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("ba", "ab"), 1);
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("foo", "arf"), 1);
-        }
-
-        [Fact]
-        public void MoreLongestCommonSubstring()
-        {
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("aabaaab", "aaa"), 3);
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("kangaroo", "schoolbus"), 2);
-            Assert.Equal(EditDistance.GetLongestCommonSubsequenceLength("inexorable", "exorcism"), 4);
-        }
-
-        [Fact]
         public void TestCloseMatch()
         {
             Assert.True(EditDistance.IsCloseMatch("variabledeclaratorsyntax", "variabledeclaratorsyntaxextensions"));


### PR DESCRIPTION
Note: the initial implementation of this was far too slow. Just doing the search was talking about 2 seconds on my machine (a 3ghz i7). Profiling revealed all the time was spent computing edit distances between candidates.

I've completely overhauled the edit distance code, making it about 20x faster than before. The edit distance algorithm is both smarter than before, and it avoids lots of redundant work. For example, the last algorithm would traverse a candidate string many times, each time going through and obtaining each character of a string and converting it to lower case. In such a hot algorithm, these inefficiencies added up to an enormous amount of overhead.

Fixes: #7036