### PR TITLE
add options to require this/Me for fields, properties, methods, and events

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.EncapsulateField;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1163,6 +1166,36 @@ class C
 }
 ");
             }
+        }
+
+        [WorkItem(7090, "https://github.com/dotnet/roslyn/issues/7090")]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public async Task ApplyCurrentThisPrefixStyle()
+        {
+            await TestAsync(@"
+class C
+{
+    int [|i|];
+}
+", @"
+class C
+{
+    int i;
+
+    public int I
+    {
+        get
+        {
+            return this.i;
+        }
+        set
+        {
+            this.i = value;
+        }
+    }
+
+}
+", options: new Dictionary<OptionKey, object>() { { new OptionKey(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
@@ -93,7 +93,7 @@ index: 0);
             await TestAsync(
 @"class Z { [|public int A { get ; private set ; } public string B { get ; private set ; }|] } ",
 @"class Z { public Z ( int a , string b ) { this . A = a ; this . B = b ; } public int A { get ; private set ; } public string B { get ; private set ; } } ",
-index: 0, options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+index: 0, options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
             await TestAsync(
 @"class C { void M(int X) { new [|D|](X); } } class D { int X; }",
 @"class C { void M(int X) { new D(X); } } class D { int X; public D(int x) { this.X = x; } }",
-                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WorkItem(539444)]
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
             await TestAsync(
 @"class C { void M(int X) { new [|D|](X); } } class B { protected int X; } class D : B { }",
 @"class C { void M(int X) { new D(X); } } class B { protected int X; } class D : B { public D(int x) { this.X = x; } }",
-                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WorkItem(539444)]
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
             await TestAsync(
 @"class C { void M(int X) { new [|D|](X); } } class D { public int X { get; private set; } }",
 @"class C { void M(int X) { new D(X); } } class D { public D(int x) { this.X = x; } public int X { get; private set; } }",
-                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WorkItem(539444)]
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
             await TestAsync(
 @"class C { void M(int X) { new [|D|](X); } } class B { public int X { get; protected set; } } class D : B { }",
 @"class C { void M(int X) { new D(X); } } class B { public int X { get; protected set; } } class D : B { public D(int x) { this.X = x; } }",
-                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WorkItem(539444)]
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateCon
             await TestAsync(
 @"class C { void M(int X) { new [|D|](X); } } class B { protected int X { get; set; } } class D : B { }",
 @"class C { void M(int X) { new D(X); } } class B { protected int X { get; set; } } class D : B { public D(int x) { this.X = x; } }",
-                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+                options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WorkItem(539444)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -783,7 +783,7 @@ index: 1);
 @"class Class { void M(int i) { Base b = new [|T|](i); } } class Base { protected int I; } ",
 @"class Class { void M(int i) { Base b = new T(i); } } internal class T : Base { public T(int i) { this.I = i; } } class Base { protected int I; }",
 index: 1,
-options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
@@ -838,7 +838,7 @@ index: 1);
 @"class Class { void M(int i) { Base b = new [|T|](i); } } class Base { public int I { get; protected set; } } ",
 @"class Class { void M(int i) { Base b = new T(i); } } internal class T : Base { public T(int i) { this.I = i; } } class Base { public int I { get; protected set; } }",
 index: 1,
-options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
@@ -857,7 +857,7 @@ index: 1);
 @"class Class { void M(int i) { Base b = new [|T|](i); } } class Base { protected int I { get; set; } } ",
 @"class Class { void M(int i) { Base b = new T(i); } } internal class T : Base { public T(int i) { this.I = i; } } class Base { protected int I { get; set; } }",
 index: 1,
-options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+options: new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WorkItem(942568)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -2746,7 +2746,7 @@ class Attribute : System.Attribute
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
-        public async Task ThisQualificationOption()
+        public async Task ThisQualificationOnFieldOption()
         {
             await TestMissingAsync(
 @"
@@ -2758,7 +2758,7 @@ class C
         [|this|].x = 4;
     }
 }
-", new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, "C#"), true } });
+", new Dictionary<OptionKey, object> { { new OptionKey(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, LanguageNames.CSharp), true } });
         }
 
         [WorkItem(942568)]

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
@@ -1,6 +1,8 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.EncapsulateField
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.EncapsulateField
@@ -581,6 +583,30 @@ End Enum
 </File>.ConvertTestSourceTag()
             Await TestMissingAsync(enumField)
 
+        End Function
+
+        <WorkItem(7090, "https://github.com/dotnet/roslyn/issues/7090")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.EncapsulateField)>
+        Public Async Function ApplyCurrentThisPrefixStyle() As Task
+            Await TestAsync("
+Class C
+    Dim [|i|] As Integer
+End Class
+", "
+Class C
+    Dim i As Integer
+
+    Public Property I1 As Integer
+        Get
+            Return Me.i
+        End Get
+        Set(value As Integer)
+            Me.i = value
+        End Set
+    End Property
+End Class
+",
+options:=New Dictionary(Of OptionKey, Object)() From {{New OptionKey(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, LanguageNames.VisualBasic), True}})
         End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add &apos;this&apos; qualification.
+        /// </summary>
+        internal static string AddThisQualification {
+            get {
+                return ResourceManager.GetString("AddThisQualification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to anonymous method.
         /// </summary>
         internal static string AnonymousMethod {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -440,4 +440,7 @@
   <data name="DelegateInvocationCanBeSimplified" xml:space="preserve">
     <value>Delegate invocation can be simplified.</value>
   </data>
+  <data name="AddThisQualification" xml:space="preserve">
+    <value>Add 'this' qualification</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
@@ -28,7 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.SimplifyTypeNames
                 return ImmutableArray.Create(
                     IDEDiagnosticIds.SimplifyNamesDiagnosticId,
                     IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId,
-                    IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId);
+                    IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId,
+                    IDEDiagnosticIds.AddThisOrMeDiagnosticId);
             }
         }
 
@@ -95,6 +96,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.SimplifyTypeNames
 
                 case IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId:
                     return CSharpFeaturesResources.SimplifyThisQualification;
+
+                case IDEDiagnosticIds.AddThisOrMeDiagnosticId:
+                    return CSharpFeaturesResources.AddThisQualification;
 
                 default:
                     throw ExceptionUtilities.Unreachable;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -141,6 +141,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
                         IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId :
                         IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId;
                 }
+                else if (expression.IsKind(SyntaxKind.IdentifierName) && replacementSyntax.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+                {
+                    diagnosticId = IDEDiagnosticIds.AddThisOrMeDiagnosticId;
+                }
             }
 
             return true;

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string SimplifyThisOrMeDiagnosticId = "IDE0003";
         public const string RemoveUnnecessaryCastDiagnosticId = "IDE0004";
         public const string RemoveUnnecessaryImportsDiagnosticId = "IDE0005";
+        public const string AddThisOrMeDiagnosticId = "IDE0006";
 
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -41,13 +41,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
                                                                     isEnabledByDefault: true,
                                                                     customTags: DiagnosticCustomTags.Unnecessary);
 
+        private static readonly LocalizableString s_localizableTitleAddThisOrMe = new LocalizableResourceString(nameof(FeaturesResources.AddThisOrMeQualification), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly DiagnosticDescriptor s_descriptorAddThisOrMe = new DiagnosticDescriptor(IDEDiagnosticIds.AddThisOrMeDiagnosticId,
+                                                                    s_localizableTitleAddThisOrMe,
+                                                                    s_localizableMessage,
+                                                                    DiagnosticCategory.Style,
+                                                                    DiagnosticSeverity.Info,
+                                                                    isEnabledByDefault: true,
+                                                                    customTags: DiagnosticCustomTags.Unnecessary);
+
         private OptionSet _lazyDefaultOptionSet;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
             {
-                return ImmutableArray.Create(s_descriptorSimplifyNames, s_descriptorSimplifyMemberAccess, s_descriptorSimplifyThisOrMe);
+                return ImmutableArray.Create(s_descriptorSimplifyNames, s_descriptorSimplifyMemberAccess, s_descriptorSimplifyThisOrMe, s_descriptorAddThisOrMe);
             }
         }
 
@@ -104,6 +113,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
 
                 case IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId:
                     descriptor = s_descriptorSimplifyThisOrMe;
+                    break;
+
+                case IDEDiagnosticIds.AddThisOrMeDiagnosticId:
+                    descriptor = s_descriptorAddThisOrMe;
                     break;
 
                 default:

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -233,6 +233,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add &apos;this&apos; or &apos;Me&apos; qualification..
+        /// </summary>
+        internal static string AddThisOrMeQualification {
+            get {
+                return ResourceManager.GetString("AddThisOrMeQualification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session..
         /// </summary>
         internal static string AnActiveStatementHasBeenRemoved {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -882,4 +882,7 @@ Do you want to continue?</value>
   <data name="WRN_UnableToLoadAnalyzer" xml:space="preserve">
     <value>Unable to load Analyzer assembly {0}: {1}</value>
   </data>
+  <data name="AddThisOrMeQualification" xml:space="preserve">
+    <value>Add 'this' or 'Me' qualification.</value>
+  </data>
 </root>

--- a/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
@@ -22,7 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             Get
                 Return ImmutableArray.Create(IDEDiagnosticIds.SimplifyNamesDiagnosticId,
                     IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId,
-                    IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId)
+                    IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId,
+                    IDEDiagnosticIds.AddThisOrMeDiagnosticId)
             End Get
         End Property
 
@@ -78,6 +79,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
 
                 Case IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId
                     Return VBFeaturesResources.SimplifyMeQualification
+
+                Case IDEDiagnosticIds.AddThisOrMeDiagnosticId
+                    Return VBFeaturesResources.AddMeQualification
 
                 Case Else
                     Throw ExceptionUtilities.Unreachable

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -79,6 +79,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
                 diagnosticId = If(memberAccess.Expression.Kind = SyntaxKind.MeExpression,
                     IDEDiagnosticIds.SimplifyThisOrMeDiagnosticId,
                     IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId)
+            ElseIf expression.IsKind(SyntaxKind.IdentifierName) AndAlso replacementSyntax.IsKind(SyntaxKind.SimpleMemberAccessExpression) Then
+                diagnosticId = IDEDiagnosticIds.AddThisOrMeDiagnosticId
             End If
 
             Return True

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
@@ -71,6 +71,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Add &apos;Me&apos; qualification.
+        '''</summary>
+        Friend ReadOnly Property AddMeQualification() As String
+            Get
+                Return ResourceManager.GetString("AddMeQualification", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Add Overloads.
         '''</summary>
         Friend ReadOnly Property AddOverloadsKeyword() As String

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
@@ -1201,4 +1201,7 @@ Sub(&lt;parameterList&gt;) &lt;statement&gt;</value>
   <data name="AddOverloadsKeyword" xml:space="preserve">
     <value>Add Overloads</value>
   </data>
+  <data name="AddMeQualification" xml:space="preserve">
+    <value>Add 'Me' qualification</value>
+  </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -637,6 +637,42 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Qualify member event access with &apos;this&apos;.
+        /// </summary>
+        internal static string QualifyMemberEventAccessWithThis {
+            get {
+                return ResourceManager.GetString("QualifyMemberEventAccessWithThis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Qualify member field access with &apos;this&apos;.
+        /// </summary>
+        internal static string QualifyMemberFieldAccessWithThis {
+            get {
+                return ResourceManager.GetString("QualifyMemberFieldAccessWithThis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Qualify member method access with &apos;this&apos;.
+        /// </summary>
+        internal static string QualifyMemberMethodAccessWithThis {
+            get {
+                return ResourceManager.GetString("QualifyMemberMethodAccessWithThis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Qualify member property access with &apos;this&apos;.
+        /// </summary>
+        internal static string QualifyMemberPropertyAccessWithThis {
+            get {
+                return ResourceManager.GetString("QualifyMemberPropertyAccessWithThis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Set other spacing options.
         /// </summary>
         internal static string SetOtherSpacingOptions {

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -408,4 +408,16 @@
   <data name="NewLinesForBracesProperty" xml:space="preserve">
     <value>Place open brace on new line for properties, indexers, and events</value>
   </data>
+  <data name="QualifyMemberEventAccessWithThis" xml:space="preserve">
+    <value>Qualify member event access with 'this'</value>
+  </data>
+  <data name="QualifyMemberFieldAccessWithThis" xml:space="preserve">
+    <value>Qualify member field access with 'this'</value>
+  </data>
+  <data name="QualifyMemberMethodAccessWithThis" xml:space="preserve">
+    <value>Qualify member method access with 'this'</value>
+  </data>
+  <data name="QualifyMemberPropertyAccessWithThis" xml:space="preserve">
+    <value>Qualify member property access with 'this'</value>
+  </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -445,10 +445,28 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set { SetBooleanOption(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, value); }
         }
 
-        public int Style_QualifyMemberAccessWithThisOrMe
+        public int Style_QualifyMemberFieldAccessWithThisOrMe
         {
-            get { return GetBooleanOption(SimplificationOptions.QualifyMemberAccessWithThisOrMe); }
-            set { SetBooleanOption(SimplificationOptions.QualifyMemberAccessWithThisOrMe, value); }
+            get { return GetBooleanOption(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe); }
+            set { SetBooleanOption(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, value); }
+        }
+
+        public int Style_QualifyMemberPropertyAccessWithThisOrMe
+        {
+            get { return GetBooleanOption(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe); }
+            set { SetBooleanOption(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, value); }
+        }
+
+        public int Style_QualifyMemberMethodAccessWithThisOrMe
+        {
+            get { return GetBooleanOption(SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe); }
+            set { SetBooleanOption(SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe, value); }
+        }
+
+        public int Style_QualifyMemberEventAccessWithThisOrMe
+        {
+            get { return GetBooleanOption(SimplificationOptions.QualifyMemberEventAccessWithThisOrMe); }
+            set { SetBooleanOption(SimplificationOptions.QualifyMemberEventAccessWithThisOrMe, value); }
         }
 
         public int Style_UseVarWhenDeclaringLocals

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -108,7 +108,10 @@ class Program
 
         internal StyleViewModel(OptionSet optionSet, IServiceProvider serviceProvider) : base(optionSet, serviceProvider, LanguageNames.CSharp)
         {
-            Items.Add(new CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberAccessWithThisOrMe, CSharpVSResources.QualifyMemberAccessWithThis, s_declarationPreviewTrue, s_declarationPreviewFalse, this, optionSet));
+            Items.Add(new CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, CSharpVSResources.QualifyMemberFieldAccessWithThis, s_declarationPreviewTrue, s_declarationPreviewFalse, this, optionSet));
+            Items.Add(new CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, CSharpVSResources.QualifyMemberPropertyAccessWithThis, s_declarationPreviewTrue, s_declarationPreviewFalse, this, optionSet));
+            Items.Add(new CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe, CSharpVSResources.QualifyMemberPropertyAccessWithThis, s_declarationPreviewTrue, s_declarationPreviewFalse, this, optionSet));
+            Items.Add(new CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberEventAccessWithThisOrMe, CSharpVSResources.QualifyMemberEventAccessWithThis, s_declarationPreviewTrue, s_declarationPreviewFalse, this, optionSet));
             Items.Add(new CheckBoxOptionViewModel(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, CSharpVSResources.PreferIntrinsicPredefinedTypeKeywordInDeclaration, s_intrinsicPreviewDeclarationTrue, s_intrinsicPreviewDeclarationFalse, this, optionSet));
             Items.Add(new CheckBoxOptionViewModel(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, CSharpVSResources.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, s_intrinsicPreviewMemberAccessTrue, s_intrinsicPreviewMemberAccessFalse, this, optionSet));
             Items.Add(new CheckBoxOptionViewModel(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals, CSharpVSResources.UseVarWhenGeneratingLocals, s_varPreviewTrue, s_varPreviewFalse, this, optionSet));

--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.Designer.vb
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.Designer.vb
@@ -324,5 +324,41 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 Return ResourceManager.GetString("QualifyMemberAccessWithMe", resourceCulture)
             End Get
         End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Qualify member event access with &apos;Me&apos;.
+        '''</summary>
+        Friend Shared ReadOnly Property QualifyMemberEventAccessWithMe() As String
+            Get
+                Return ResourceManager.GetString("QualifyMemberEventAccessWithMe", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Qualify member field access with &apos;Me&apos;.
+        '''</summary>
+        Friend Shared ReadOnly Property QualifyMemberFieldAccessWithMe() As String
+            Get
+                Return ResourceManager.GetString("QualifyMemberFieldAccessWithMe", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Qualify member method access with &apos;Me&apos;.
+        '''</summary>
+        Friend Shared ReadOnly Property QualifyMemberMethodAccessWithMe() As String
+            Get
+                Return ResourceManager.GetString("QualifyMemberMethodAccessWithMe", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Qualify member property access with &apos;Me&apos;.
+        '''</summary>
+        Friend Shared ReadOnly Property QualifyMemberPropertyAccessWithMe() As String
+            Get
+                Return ResourceManager.GetString("QualifyMemberPropertyAccessWithMe", resourceCulture)
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
@@ -204,4 +204,16 @@
   <data name="Option_GoToDefinition" xml:space="preserve">
     <value>Go to Definition</value>
   </data>
+  <data name="QualifyMemberEventAccessWithMe" xml:space="preserve">
+    <value>Qualify member event access with 'Me'</value>
+  </data>
+  <data name="QualifyMemberFieldAccessWithMe" xml:space="preserve">
+    <value>Qualify member field access with 'Me'</value>
+  </data>
+  <data name="QualifyMemberMethodAccessWithMe" xml:space="preserve">
+    <value>Qualify member method access with 'Me'</value>
+  </data>
+  <data name="QualifyMemberPropertyAccessWithMe" xml:space="preserve">
+    <value>Qualify member property access with 'Me'</value>
+  </data>
 </root>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -143,12 +143,39 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             End Set
         End Property
 
-        Public Property Style_QualifyMemberAccessWithThisOrMe As Boolean
+        Public Property Style_QualifyMemberFieldAccessWithThisOrMe As Boolean
             Get
-                Return GetBooleanOption(SimplificationOptions.QualifyMemberAccessWithThisOrMe)
+                Return GetBooleanOption(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(SimplificationOptions.QualifyMemberAccessWithThisOrMe, value)
+                SetBooleanOption(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, value)
+            End Set
+        End Property
+
+        Public Property Style_QualifyMemberPropertyAccessWithThisOrMe As Boolean
+            Get
+                Return GetBooleanOption(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe)
+            End Get
+            Set(value As Boolean)
+                SetBooleanOption(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, value)
+            End Set
+        End Property
+
+        Public Property Style_QualifyMemberMethodAccessWithThisOrMe As Boolean
+            Get
+                Return GetBooleanOption(SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe)
+            End Get
+            Set(value As Boolean)
+                SetBooleanOption(SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe, value)
+            End Set
+        End Property
+
+        Public Property Style_QualifyMemberEventAccessWithThisOrMe As Boolean
+            Get
+                Return GetBooleanOption(SimplificationOptions.QualifyMemberEventAccessWithThisOrMe)
+            End Get
+            Set(value As Boolean)
+                SetBooleanOption(SimplificationOptions.QualifyMemberEventAccessWithThisOrMe, value)
             End Set
         End Property
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
@@ -80,7 +80,10 @@ End Class
         Public Sub New(optionSet As OptionSet, serviceProvider As IServiceProvider)
             MyBase.New(optionSet, serviceProvider, LanguageNames.VisualBasic)
 
-            Me.Items.Add(New CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberAccessWithThisOrMe, BasicVSResources.QualifyMemberAccessWithMe, _mePreviewTrue, _mePreviewFalse, Me, optionSet))
+            Me.Items.Add(New CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe, BasicVSResources.QualifyMemberFieldAccessWithMe, _mePreviewTrue, _mePreviewFalse, Me, optionSet))
+            Me.Items.Add(New CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe, BasicVSResources.QualifyMemberPropertyAccessWithMe, _mePreviewTrue, _mePreviewFalse, Me, optionSet))
+            Me.Items.Add(New CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe, BasicVSResources.QualifyMemberPropertyAccessWithMe, _mePreviewTrue, _mePreviewFalse, Me, optionSet))
+            Me.Items.Add(New CheckBoxOptionViewModel(SimplificationOptions.QualifyMemberEventAccessWithThisOrMe, BasicVSResources.QualifyMemberEventAccessWithMe, _mePreviewTrue, _mePreviewFalse, Me, optionSet))
             Me.Items.Add(New CheckBoxOptionViewModel(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, BasicVSResources.PreferIntrinsicPredefinedTypeKeywordInDeclaration, _intrinsicDeclarationPreviewTrue, _intrinsicDeclarationPreviewFalse, Me, optionSet))
             Me.Items.Add(New CheckBoxOptionViewModel(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, BasicVSResources.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, _intrinsicMemberAccessPreviewTrue, _intrinsicMemberAccessPreviewFalse, Me, optionSet))
         End Sub

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpNameReducer.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpNameReducer.Rewriter.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
@@ -19,160 +19,72 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             {
             }
 
-            public override SyntaxNode VisitPredefinedType(PredefinedTypeSyntax node)
+            private SyntaxNode SimplifyVisit<TExpression>(
+                TExpression node,
+                Func<TExpression, SyntaxNode> baseVisit)
+                where TExpression : SyntaxNode
             {
                 bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
+                this.alwaysSimplify |= node.HasAnnotation(Simplifier.Annotation);
 
-                var result = SimplifyExpression(
-                    node,
-                    newNode: base.VisitPredefinedType(node),
-                    simplifier: SimplifyName);
+                var result = baseVisit(node);
 
                 this.alwaysSimplify = oldAlwaysSimplify;
 
                 return result;
+            }
+
+            private SyntaxNode SimplifyExpression<TExpression>(
+                TExpression node,
+                Func<TExpression, SyntaxNode> baseVisit)
+                where TExpression : SyntaxNode
+            {
+                return SimplifyVisit(node, n => SimplifyExpression(n, newNode: baseVisit(n), simplifier: SimplifyName));
+            }
+
+            public override SyntaxNode VisitPredefinedType(PredefinedTypeSyntax node)
+            {
+                return SimplifyExpression(node, base.VisitPredefinedType);
             }
 
             public override SyntaxNode VisitAliasQualifiedName(AliasQualifiedNameSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = SimplifyExpression(
-                    node,
-                    newNode: base.VisitAliasQualifiedName(node),
-                    simplifier: SimplifyName);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyExpression(node, base.VisitAliasQualifiedName);
             }
 
             public override SyntaxNode VisitQualifiedName(QualifiedNameSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = SimplifyExpression(
-                    node,
-                    newNode: base.VisitQualifiedName(node),
-                    simplifier: SimplifyName);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyExpression(node, base.VisitQualifiedName);
             }
 
             public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = SimplifyExpression(
-                    node,
-                    newNode: base.VisitMemberAccessExpression(node),
-                    simplifier: SimplifyName);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyExpression(node, base.VisitMemberAccessExpression);
             }
 
             public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = SimplifyExpression(
-                    node,
-                    newNode: base.VisitIdentifierName(node),
-                    simplifier: SimplifyName);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyExpression(node, base.VisitIdentifierName);
             }
 
             public override SyntaxNode VisitGenericName(GenericNameSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = SimplifyExpression(
-                    node,
-                    newNode: base.VisitGenericName(node),
-                    simplifier: SimplifyName);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyExpression(node, base.VisitGenericName);
             }
 
             public override SyntaxNode VisitQualifiedCref(QualifiedCrefSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = SimplifyExpression(
-                    node,
-                    newNode: base.VisitQualifiedCref(node),
-                    simplifier: SimplifyName);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyExpression(node, base.VisitQualifiedCref);
             }
 
             public override SyntaxNode VisitArrayType(ArrayTypeSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = base.VisitArrayType(node);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyVisit(node, base.VisitArrayType);
             }
 
             public override SyntaxNode VisitNullableType(NullableTypeSyntax node)
             {
-                bool oldAlwaysSimplify = this.alwaysSimplify;
-                if (!this.alwaysSimplify)
-                {
-                    this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);
-                }
-
-                var result = base.VisitNullableType(node);
-
-                this.alwaysSimplify = oldAlwaysSimplify;
-
-                return result;
+                return SimplifyVisit(node, base.VisitNullableType);
             }
 
             public override SyntaxNode VisitBinaryExpression(BinaryExpressionSyntax node)

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -4,4 +4,8 @@ Microsoft.CodeAnalysis.Workspace.UpdateReferencesAfterAdd() -> void
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ArrayCreationExpression(Microsoft.CodeAnalysis.SyntaxNode elementType, Microsoft.CodeAnalysis.SyntaxNode size) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ArrayCreationExpression(Microsoft.CodeAnalysis.SyntaxNode elementType, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> elements) -> Microsoft.CodeAnalysis.SyntaxNode
 static Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetGenerator(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Editing.SyntaxGenerator
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyMemberEventAccessWithThisOrMe.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
 virtual Microsoft.CodeAnalysis.Editing.SyntaxGenerator.RemoveNode(Microsoft.CodeAnalysis.SyntaxNode root, Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.SyntaxRemoveOptions options) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOption.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOption.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Simplification
@@ -45,9 +46,30 @@ namespace Microsoft.CodeAnalysis.Simplification
         public static Option<bool> AllowSimplificationToBaseType { get; } = new Option<bool>(NonPerLanguageFeatureName, "AllowSimplificationToBaseType", true);
 
         /// <summary>
-        /// This option says if we should simplify away the this. or Me. in member access expression
+        /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in member access expressions.
         /// </summary>
-        public static PerLanguageOption<bool> QualifyMemberAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberAccessWithThisOrMe", defaultValue: false);
+        [Obsolete]
+        public static PerLanguageOption<bool> QualifyMemberAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberAccessWithThisOrMe", false);
+
+        /// <summary>
+        /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in member field access expressions.
+        /// </summary>
+        public static PerLanguageOption<bool> QualifyMemberFieldAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberFieldAccessWithThisOrMe", defaultValue: false);
+
+        /// <summary>
+        /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in member property access expressions.
+        /// </summary>
+        public static PerLanguageOption<bool> QualifyMemberPropertyAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberPropertyAccessWithThisOrMe", defaultValue: false);
+
+        /// <summary>
+        /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in member method access expressions.
+        /// </summary>
+        public static PerLanguageOption<bool> QualifyMemberMethodAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberMethodAccessWithThisOrMe", defaultValue: false);
+
+        /// <summary>
+        /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in member event access expressions.
+        /// </summary>
+        public static PerLanguageOption<bool> QualifyMemberEventAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(PerLanguageFeatureName, "QualifyMemberEventAccessWithThisOrMe", defaultValue: false);
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Declarations

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOptionProvider.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOptionProvider.cs
@@ -19,7 +19,10 @@ namespace Microsoft.CodeAnalysis.Simplification
                 SimplificationOptions.PreferImplicitTypeInLocalDeclaration,
                 SimplificationOptions.AllowSimplificationToGenericType,
                 SimplificationOptions.AllowSimplificationToBaseType,
-                SimplificationOptions.QualifyMemberAccessWithThisOrMe,
+                SimplificationOptions.QualifyMemberFieldAccessWithThisOrMe,
+                SimplificationOptions.QualifyMemberPropertyAccessWithThisOrMe,
+                SimplificationOptions.QualifyMemberMethodAccessWithThisOrMe,
+                SimplificationOptions.QualifyMemberEventAccessWithThisOrMe,
                 SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration,
                 SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess
             }.ToImmutableArray();

--- a/src/Workspaces/Core/Portable/Simplification/SimplifyTypeNameCodeAction.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplifyTypeNameCodeAction.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicNameReducer.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicNameReducer.Rewriter.vb
@@ -14,100 +14,51 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 MyBase.New(optionSet, cancellationToken)
             End Sub
 
-            Public Overrides Function VisitGenericName(node As GenericNameSyntax) As SyntaxNode
-                Dim oldAlwaysSimplify = Me._alwaysSimplify
-                If Not Me._alwaysSimplify Then
-                    Me._alwaysSimplify = node.HasAnnotation(Simplifier.Annotation)
-                End If
+            Private Function SimplifyVisit(Of TExpression As SyntaxNode)(
+                node As TExpression,
+                baseVisit As Func(Of TExpression, SyntaxNode)) As SyntaxNode
 
-                Dim result = SimplifyExpression(
-                    node,
-                    newNode:=MyBase.VisitGenericName(node),
-                    simplifier:=AddressOf SimplifyName)
+                Dim oldAlwaysSimplify = Me._alwaysSimplify
+                Me._alwaysSimplify = Me._alwaysSimplify OrElse node.HasAnnotation(Simplifier.Annotation)
+
+                Dim result = baseVisit(node)
 
                 Me._alwaysSimplify = oldAlwaysSimplify
 
                 Return result
+            End Function
+
+            Private Function DoSimplifyExpression(Of TExpression As ExpressionSyntax)(
+                node As TExpression,
+                baseVisit As Func(Of TExpression, SyntaxNode)) As SyntaxNode
+
+                Return SimplifyVisit(node, Function(n)
+                                               Return SimplifyExpression(n, newNode:=baseVisit(n), simplifier:=AddressOf SimplifyName)
+                                           End Function)
+            End Function
+
+            Public Overrides Function VisitGenericName(node As GenericNameSyntax) As SyntaxNode
+                Return DoSimplifyExpression(node, AddressOf MyBase.VisitGenericName)
             End Function
 
             Public Overrides Function VisitIdentifierName(node As IdentifierNameSyntax) As SyntaxNode
-                Dim oldAlwaysSimplify = Me._alwaysSimplify
-                If Not Me._alwaysSimplify Then
-                    Me._alwaysSimplify = node.HasAnnotation(Simplifier.Annotation)
-                End If
-
-                Dim result = SimplifyExpression(
-                    node,
-                    newNode:=MyBase.VisitIdentifierName(node),
-                    simplifier:=AddressOf SimplifyName)
-
-                Me._alwaysSimplify = oldAlwaysSimplify
-
-                Return result
+                Return DoSimplifyExpression(node, AddressOf MyBase.VisitIdentifierName)
             End Function
 
             Public Overrides Function VisitQualifiedName(node As QualifiedNameSyntax) As SyntaxNode
-                Dim oldAlwaysSimplify = Me._alwaysSimplify
-                If Not Me._alwaysSimplify Then
-                    Me._alwaysSimplify = node.HasAnnotation(Simplifier.Annotation)
-                End If
-
-                Dim result = SimplifyExpression(
-                    node,
-                    newNode:=MyBase.VisitQualifiedName(node),
-                    simplifier:=AddressOf SimplifyName)
-
-                Me._alwaysSimplify = oldAlwaysSimplify
-
-                Return result
+                Return DoSimplifyExpression(node, AddressOf MyBase.VisitQualifiedName)
             End Function
 
             Public Overrides Function VisitMemberAccessExpression(node As MemberAccessExpressionSyntax) As SyntaxNode
-                Dim oldAlwaysSimplify = Me._alwaysSimplify
-                If Not Me._alwaysSimplify Then
-                    Me._alwaysSimplify = node.HasAnnotation(Simplifier.Annotation)
-                End If
-
-                Dim result = SimplifyExpression(
-                    node,
-                    newNode:=MyBase.VisitMemberAccessExpression(node),
-                    simplifier:=AddressOf SimplifyName)
-
-                Me._alwaysSimplify = oldAlwaysSimplify
-
-                Return result
+                Return DoSimplifyExpression(node, AddressOf MyBase.VisitMemberAccessExpression)
             End Function
 
             Public Overrides Function VisitNullableType(node As NullableTypeSyntax) As SyntaxNode
-                Dim oldAlwaysSimplify = Me._alwaysSimplify
-                If Not Me._alwaysSimplify Then
-                    Me._alwaysSimplify = node.HasAnnotation(Simplifier.Annotation)
-                End If
-
-                Dim result = SimplifyExpression(
-                    node,
-                    newNode:=MyBase.VisitNullableType(node),
-                    simplifier:=AddressOf SimplifyName)
-
-                Me._alwaysSimplify = oldAlwaysSimplify
-
-                Return result
+                Return DoSimplifyExpression(node, AddressOf MyBase.VisitNullableType)
             End Function
 
             Public Overrides Function VisitArrayType(node As ArrayTypeSyntax) As SyntaxNode
-                Dim oldAlwaysSimplify = Me._alwaysSimplify
-                If Not Me._alwaysSimplify Then
-                    Me._alwaysSimplify = node.HasAnnotation(Simplifier.Annotation)
-                End If
-
-                Dim result = SimplifyExpression(
-                    node,
-                    newNode:=MyBase.VisitArrayType(node),
-                    simplifier:=AddressOf SimplifyName)
-
-                Me._alwaysSimplify = oldAlwaysSimplify
-
-                Return result
+                Return DoSimplifyExpression(node, AddressOf MyBase.VisitArrayType)
             End Function
 
         End Class


### PR DESCRIPTION
### Description
This PR splits the option "Qualify member access with '`this`' or '`Me`'" into four separate options (and marks the former as `[Obsolete]`):

- Qualify member **field** access with '`this`' or '`Me`'.

- Qualify member **property** access with '`this`' or '`Me`'.

- Qualify member **method** access with '`this`' or '`Me`'.

- Qualify member **event** access with '`this`' or '`Me`'.

### Implementation/Rationale
I opted to make all changes in the reducer, including potentially expanding `someField` to `this.someField`/`Me.someField`.  My reasons for doing this are twofold:
1.  The reducer already has to handle the reduction or non-reduction of `this.`/`Me.` and it seemed to make sense to do this work in the same location.
2.  It is a well-known pattern that third-party code fixers should add the `Simplifier.Annotation` annotation to their generated code but they won't necessarily expand (adding `this.`/`Me.`) before adding the annotation, and we want all code fixers (first- and third-party) to have the same nice experience of "I add the `Simplifier.Annotation` annotation and the user's code gets automatically corrected to their specified style."

### Errata
The vast majority of the tests added are in `TypeNameSimplifierTest.vb` but for whatever reason, git classifies this as a huge change, when in reality I just updated 2 tests, then added a bunch of others.  To see the added tests, view the raw file and look for all tests with the `"Qualify"` prefix (e.g., `QualifyFieldAccessWithThis_AsLHS_CSharp`).  They were added in two batches; near the middle of the file for C# and near the end of the file for VB.  There are about 10 or 12 tests for each language.

Most of this was simple plumbing work with the most significant changes occurring in `ExpressionSyntaxExtensions.cs/.vb`.  The changes in `CSharpNameReducer.Rewriter.cs` and `VisualBasicNameReducer.Rewriter.vb` are purely refactorings to make the file shorter and (I think) easier to read.  E.g., the C# file changed a bunch of methods that looked like this:

``` C#
VisitAliasQualifiedName()
{
    bool oldAlwaysSimplify = this.alwaysSimplify;  
    if (!this.alwaysSimplify)  
    {  
        this.alwaysSimplify = node.HasAnnotation(Simplifier.Annotation);  
    }  

    var result = SimplifyExpression(  
        node,  
        newNode: base.VisitAliasQualifiedName(node),  
        simplifier: SimplifyName);

    this.alwaysSimplify = oldAlwaysSimplify;

    return result;
}
```

to this:

``` C#
VisitAliasQualifiedName()
{
    return SimplifyVisit(node, n => SimplifyExpression(n, newNode: baseVisit(n), simplifier: SimplifyName)); 
}
```

### Known Issues
1.  We've discussed giving the user a dial in how and when these properties should be applied, e.g., "only apply this style on newly generated code" all the way up to "flag misuses of this style as a build break" and various steps in between.  That has not been addressed in this PR as it is still an open discussion item that I filed as #7289.
2.  If a user currently has "Qualify member access with '`this`' or '`Me`'" set to true, we need some way to upgrade/migrate that setting to the 4 new separate settings.

Fixes #7065 and #7090.