### PR TITLE
Fix a compiler crash when generating debug info for erroneous alias imports

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/BinderBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderBuilder.vb
@@ -106,19 +106,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' Add file-level member imports.
             Dim memberImports = sourceFile.MemberImports
-            If memberImports.Length > 0 Then
+            If Not memberImports.IsEmpty Then
                 sourceFileBinder = New TypesOfImportedNamespacesMembersBinder(sourceFileBinder, memberImports)
                 sourceFileBinder = New ImportedTypesAndNamespacesMembersBinder(sourceFileBinder, memberImports)
             End If
 
             'Add file-level alias imports.
-            Dim aliasImports = sourceFile.AliasImports
+            Dim aliasImports = sourceFile.AliasImportsOpt
             If aliasImports IsNot Nothing Then
                 sourceFileBinder = New ImportAliasesBinder(sourceFileBinder, aliasImports)
             End If
 
             ' Add file-level xmlns imports.
-            Dim xmlNamespaces = sourceFile.XmlNamespaces
+            Dim xmlNamespaces = sourceFile.XmlNamespacesOpt
             If xmlNamespaces IsNot Nothing Then
                 sourceFileBinder = New XmlNamespaceImportsBinder(sourceFileBinder, xmlNamespaces)
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Imports.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Imports.vb
@@ -118,6 +118,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             End If
                         End If
 
+                        ' We create the alias symbol even when the target is erroneous, 
+                        ' so that we can bind to the alias and avoid cascading errors.
+                        ' As a result the further consumers of the aliases have to account for the error case.
                         Dim aliasSymbol = New AliasSymbol(binder.Compilation,
                                                              binder.ContainingNamespaceOrType,
                                                              aliasText,

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
@@ -1422,9 +1422,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend NotInheritable Class XmlNamespaceImportsBinder
         Inherits Binder
 
-        Private ReadOnly _namespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition)
+        Private ReadOnly _namespaces As IReadOnlyDictionary(Of String, XmlNamespaceAndImportsClausePosition)
 
-        Public Sub New(containingBinder As Binder, namespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition))
+        Public Sub New(containingBinder As Binder, namespaces As IReadOnlyDictionary(Of String, XmlNamespaceAndImportsClausePosition))
             MyBase.New(containingBinder)
             Debug.Assert(namespaces IsNot Nothing)
             Debug.Assert(namespaces.Count > 0)

--- a/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
@@ -20,10 +20,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Class ImportAliasesBinder
         Inherits Binder
 
-        Private ReadOnly _importedAliases As Dictionary(Of String, AliasAndImportsClausePosition)
+        Private ReadOnly _importedAliases As IReadOnlyDictionary(Of String, AliasAndImportsClausePosition)
 
-        Public Sub New(containingBinder As Binder, importedAliases As Dictionary(Of String, AliasAndImportsClausePosition))
+        Public Sub New(containingBinder As Binder, importedAliases As IReadOnlyDictionary(Of String, AliasAndImportsClausePosition))
             MyBase.New(containingBinder)
+
+            Debug.Assert(importedAliases IsNot Nothing)
+
             _importedAliases = importedAliases
 
             ' Binder.Lookup relies on the following invariant.

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -1313,7 +1313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Not String.IsNullOrEmpty(aliasName) Then
                 Dim sourceFile = Me._sourceModule.GetSourceFile(Me.SyntaxTree)
 
-                Dim aliasImports As Dictionary(Of String, AliasAndImportsClausePosition) = sourceFile.AliasImports
+                Dim aliasImports As IReadOnlyDictionary(Of String, AliasAndImportsClausePosition) = sourceFile.AliasImportsOpt
                 Dim symbol As AliasAndImportsClausePosition = Nothing
 
                 If aliasImports IsNot Nothing AndAlso aliasImports.TryGetValue(aliasName, symbol) Then

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
@@ -161,8 +161,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim sourceModule = DirectCast(compilation.SourceModule, SourceModuleSymbol)
             Dim sourceFile = sourceModule.GetSourceFile(DirectCast(GetSyntaxTree(DirectCast(semanticModelOpt, SemanticModel)), VisualBasicSyntaxTree))
 
-            If Not sourceFile.AliasImports Is Nothing Then
-                For Each [alias] In sourceFile.AliasImports.Values
+            If Not sourceFile.AliasImportsOpt Is Nothing Then
+                For Each [alias] In sourceFile.AliasImportsOpt.Values
                     If [alias].Alias.Target = DirectCast(symbol, NamespaceOrTypeSymbol) Then
                         Return [alias].Alias
                     End If

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBUsingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBUsingTests.vb
@@ -392,6 +392,34 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub UnusedImports_Nonexisting()
+            Dim source = "
+Imports A.B
+Imports Z = C.D
+
+Class Program
+    Sub Main() 
+    End Sub
+End Class
+"
+            Dim comp = CreateCompilationWithMscorlib(
+                {source},
+                {SystemCoreRef, SystemDataRef},
+                options:=TestOptions.ReleaseDll.WithGlobalImports(GlobalImport.Parse("E.F"), GlobalImport.Parse("Q = G.H")))
+
+            ' only warnings are reported (unlike C# which reports errors):
+            comp.VerifyDiagnostics(
+                Diagnostic(ERRID.WRN_UndefinedOrEmptyProjectNamespaceOrClass1).WithArguments("E.F"),
+                Diagnostic(ERRID.WRN_UndefinedOrEmptyProjectNamespaceOrClass1).WithArguments("Q = G.H"),
+                Diagnostic(ERRID.WRN_UndefinedOrEmptyNamespaceOrClass1, "A.B").WithArguments("A.B"),
+                Diagnostic(ERRID.WRN_UndefinedOrEmptyNamespaceOrClass1, "C.D").WithArguments("C.D"),
+                Diagnostic(ERRID.HDN_UnusedImportStatement, "Imports A.B"),
+                Diagnostic(ERRID.HDN_UnusedImportStatement, "Imports Z = C.D"))
+
+            CompileAndVerify(comp)
+        End Sub
+
+        <Fact>
         Public Sub BadGlobalImports()
             Dim source1 = "
 Namespace N


### PR DESCRIPTION
VB allows alias imports to target erroneous (non-existing) types. It reports a warning, but the compilation continues. Code building debug information for these imports hasn't handled that case and crashed.

Fixes bug #7236.

I reviewed usages of the bound imports to make sure they account for unset collections and error types in other cases as well. To make it easier to understand the invariants I changed some naming and types of ```BoundFileInformation``` fields and added asserts.