### PR TITLE
Constant-folding should not use excess precision.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -756,6 +756,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (conversion.Kind)
             {
                 case ConversionKind.Identity:
+                    // An identity conversion to a floating-point type (for example from a cast in
+                    // source code) changes the internal representation of the constant value
+                    // to precisely the required precision.
+                    switch (destination.SpecialType)
+                    {
+                        case SpecialType.System_Single:
+                            return ConstantValue.Create(sourceConstantValue.SingleValue);
+                        case SpecialType.System_Double:
+                            return ConstantValue.Create(sourceConstantValue.DoubleValue);
+                        default:
+                            return sourceConstantValue;
+                    }
+
                 case ConversionKind.NullLiteral:
                     return sourceConstantValue;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -1577,7 +1577,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(valueLeft != null);
             Debug.Assert(valueRight != null);
 
-            // Note that we do folding on single-precision floats as doubles to preserve precision.
+            // Note that we *cannot* do folding on single-precision floats as doubles to preserve precision,
+            // as that would cause incorrect rounding that would be impossible to correct afterwards.
             switch (kind)
             {
                 case BinaryOperatorKind.ObjectEqual:
@@ -1589,20 +1590,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (valueRight.IsNull) return true;
                     break;
                 case BinaryOperatorKind.DoubleAddition:
-                case BinaryOperatorKind.FloatAddition:
                     return valueLeft.DoubleValue + valueRight.DoubleValue;
+                case BinaryOperatorKind.FloatAddition:
+                    return valueLeft.SingleValue + valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleSubtraction:
-                case BinaryOperatorKind.FloatSubtraction:
                     return valueLeft.DoubleValue - valueRight.DoubleValue;
+                case BinaryOperatorKind.FloatSubtraction:
+                    return valueLeft.SingleValue - valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleMultiplication:
-                case BinaryOperatorKind.FloatMultiplication:
                     return valueLeft.DoubleValue * valueRight.DoubleValue;
+                case BinaryOperatorKind.FloatMultiplication:
+                    return valueLeft.SingleValue * valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleDivision:
-                case BinaryOperatorKind.FloatDivision:
                     return valueLeft.DoubleValue / valueRight.DoubleValue;
+                case BinaryOperatorKind.FloatDivision:
+                    return valueLeft.SingleValue / valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleRemainder:
-                case BinaryOperatorKind.FloatRemainder:
                     return valueLeft.DoubleValue % valueRight.DoubleValue;
+                case BinaryOperatorKind.FloatRemainder:
+                    return valueLeft.SingleValue % valueRight.SingleValue;
                 case BinaryOperatorKind.IntLeftShift:
                     return valueLeft.Int32Value << valueRight.Int32Value;
                 case BinaryOperatorKind.LongLeftShift:
@@ -1660,6 +1666,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.DecimalEqual:
                     return valueLeft.DecimalValue == valueRight.DecimalValue;
                 case BinaryOperatorKind.FloatEqual:
+                    return valueLeft.SingleValue == valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleEqual:
                     return valueLeft.DoubleValue == valueRight.DoubleValue;
                 case BinaryOperatorKind.IntEqual:
@@ -1677,6 +1684,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.DecimalNotEqual:
                     return valueLeft.DecimalValue != valueRight.DecimalValue;
                 case BinaryOperatorKind.FloatNotEqual:
+                    return valueLeft.SingleValue != valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleNotEqual:
                     return valueLeft.DoubleValue != valueRight.DoubleValue;
                 case BinaryOperatorKind.IntNotEqual:
@@ -1690,6 +1698,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.DecimalLessThan:
                     return valueLeft.DecimalValue < valueRight.DecimalValue;
                 case BinaryOperatorKind.FloatLessThan:
+                    return valueLeft.SingleValue < valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleLessThan:
                     return valueLeft.DoubleValue < valueRight.DoubleValue;
                 case BinaryOperatorKind.IntLessThan:
@@ -1703,6 +1712,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.DecimalGreaterThan:
                     return valueLeft.DecimalValue > valueRight.DecimalValue;
                 case BinaryOperatorKind.FloatGreaterThan:
+                    return valueLeft.SingleValue > valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleGreaterThan:
                     return valueLeft.DoubleValue > valueRight.DoubleValue;
                 case BinaryOperatorKind.IntGreaterThan:
@@ -1716,6 +1726,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.DecimalLessThanOrEqual:
                     return valueLeft.DecimalValue <= valueRight.DecimalValue;
                 case BinaryOperatorKind.FloatLessThanOrEqual:
+                    return valueLeft.SingleValue <= valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleLessThanOrEqual:
                     return valueLeft.DoubleValue <= valueRight.DoubleValue;
                 case BinaryOperatorKind.IntLessThanOrEqual:
@@ -1729,6 +1740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.DecimalGreaterThanOrEqual:
                     return valueLeft.DecimalValue >= valueRight.DecimalValue;
                 case BinaryOperatorKind.FloatGreaterThanOrEqual:
+                    return valueLeft.SingleValue >= valueRight.SingleValue;
                 case BinaryOperatorKind.DoubleGreaterThanOrEqual:
                     return valueLeft.DoubleValue >= valueRight.DoubleValue;
                 case BinaryOperatorKind.IntGreaterThanOrEqual:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -4899,5 +4899,30 @@ struct S1
                 );
         }
 
+        [Fact, WorkItem(7262, "https://github.com/dotnet/roslyn/issues/7262")]
+        public void TruncatePrecisionOnCast()
+        {
+            var source =
+@"
+class Test
+{ 
+    static void Main()
+    {
+        float temp1 = (float)(23334800f / 5.5f);
+        System.Console.WriteLine((int)temp1);
+
+        const float temp2 = (float)(23334800f / 5.5f);
+        System.Console.WriteLine((int)temp2);
+
+        System.Console.WriteLine((int)(23334800f / 5.5f));
+}
+}
+";
+            var expectedOutput =
+@"4242691
+4242691
+4242691";
+            var result = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -9620,31 +9620,31 @@ public class MyClass
         }
         if ((double)(d1 - (-d1 * 1.0e-15f)) != d2)
         {
-            ret = ret + 2;
+            ret = ret + 10;
         }
-        if ((double)(d1 * (1.0f + 1.0e-15f)) != d2)
+        if ((double)(d1 * (1.0f + 1.0e-15f)) != d1) // note (1.0f + 1.0e-15f) == 1.0f
         {
-            ret = ret + 4;
+            ret = ret + 100;
         }
-        if ((double)(d1 / (1.0f - 1.0e-15f)) != d2)
+        if ((double)(d1 / (1.0f - 1.0e-15f)) != d1) // note (1.0f - 1.0e-15f) == 1.0f
         {
-            ret = ret + 8;
+            ret = ret + 1000;
         }
         if ((double)(-d1 + (-(d1 * 1.0e-15f))) != d3)
         {
-            ret = ret + 16;
+            ret = ret + 10000;
         }
         if ((double)((-d1 - (d1 * 1.0e-15f))) != d3)
         {
-            ret = ret + 32;
+            ret = ret + 100000;
         }
-        if ((double)(-d1 * (1.0f + 1.0e-15f)) != d3)
+        if ((double)(-d1 * (1.0f + 1.0e-15f)) != -d1) // note (1.0f + 1.0e-15f) == 1.0f
         {
-            ret = ret + 64;
+            ret = ret + 1000000;
         }
-        if ((double)(-d1 / (1.0f - 1.0e-15f)) != d3)
+        if ((double)(-d1 / (1.0f - 1.0e-15f)) != -d1) // note (1.0f - 1.0e-15f) == 1.0f
         {
-            ret = ret + 128;
+            ret = ret + 10000000;
         }
         Console.WriteLine(ret);
         return ret;
@@ -9653,7 +9653,7 @@ public class MyClass
             var compilation = CompileAndVerify(source, expectedOutput: "0").
 VerifyIL("MyClass.Main", @"
 {
-  // Code size      211 (0xd3)
+  // Code size      228 (0xe4)
   .maxstack  3
   .locals init (double V_0, //d1
                 double V_1, //d2
@@ -9685,84 +9685,86 @@ VerifyIL("MyClass.Main", @"
   IL_0040:  sub
   IL_0041:  conv.r8
   IL_0042:  ldloc.1
-  IL_0043:  beq.s      IL_0049
+  IL_0043:  beq.s      IL_004a
   IL_0045:  ldloc.3
-  IL_0046:  ldc.i4.2
-  IL_0047:  add
-  IL_0048:  stloc.3
-  IL_0049:  ldloc.0
-  IL_004a:  ldc.r8     1
-  IL_0053:  mul
-  IL_0054:  conv.r8
-  IL_0055:  ldloc.1
-  IL_0056:  beq.s      IL_005c
-  IL_0058:  ldloc.3
-  IL_0059:  ldc.i4.4
-  IL_005a:  add
-  IL_005b:  stloc.3
-  IL_005c:  ldloc.0
-  IL_005d:  ldc.r8     0.999999999999999
-  IL_0066:  div
-  IL_0067:  conv.r8
-  IL_0068:  ldloc.1
-  IL_0069:  beq.s      IL_006f
-  IL_006b:  ldloc.3
-  IL_006c:  ldc.i4.8
-  IL_006d:  add
-  IL_006e:  stloc.3
-  IL_006f:  ldloc.0
-  IL_0070:  neg
-  IL_0071:  ldloc.0
-  IL_0072:  ldc.r8     1.00000000362749E-15
-  IL_007b:  mul
-  IL_007c:  neg
-  IL_007d:  add
-  IL_007e:  conv.r8
-  IL_007f:  ldloc.2
-  IL_0080:  beq.s      IL_0087
-  IL_0082:  ldloc.3
-  IL_0083:  ldc.i4.s   16
-  IL_0085:  add
-  IL_0086:  stloc.3
-  IL_0087:  ldloc.0
-  IL_0088:  neg
-  IL_0089:  ldloc.0
-  IL_008a:  ldc.r8     1.00000000362749E-15
-  IL_0093:  mul
-  IL_0094:  sub
-  IL_0095:  conv.r8
-  IL_0096:  ldloc.2
-  IL_0097:  beq.s      IL_009e
-  IL_0099:  ldloc.3
-  IL_009a:  ldc.i4.s   32
-  IL_009c:  add
-  IL_009d:  stloc.3
-  IL_009e:  ldloc.0
-  IL_009f:  neg
-  IL_00a0:  ldc.r8     1
-  IL_00a9:  mul
-  IL_00aa:  conv.r8
-  IL_00ab:  ldloc.2
-  IL_00ac:  beq.s      IL_00b3
-  IL_00ae:  ldloc.3
-  IL_00af:  ldc.i4.s   64
-  IL_00b1:  add
-  IL_00b2:  stloc.3
-  IL_00b3:  ldloc.0
-  IL_00b4:  neg
-  IL_00b5:  ldc.r8     0.999999999999999
-  IL_00be:  div
-  IL_00bf:  conv.r8
-  IL_00c0:  ldloc.2
-  IL_00c1:  beq.s      IL_00cb
-  IL_00c3:  ldloc.3
-  IL_00c4:  ldc.i4     0x80
-  IL_00c9:  add
-  IL_00ca:  stloc.3
-  IL_00cb:  ldloc.3
-  IL_00cc:  call       ""void System.Console.WriteLine(int)""
-  IL_00d1:  ldloc.3
-  IL_00d2:  ret
+  IL_0046:  ldc.i4.s   10
+  IL_0048:  add
+  IL_0049:  stloc.3
+  IL_004a:  ldloc.0
+  IL_004b:  ldc.r8     1
+  IL_0054:  mul
+  IL_0055:  conv.r8
+  IL_0056:  ldloc.0
+  IL_0057:  beq.s      IL_005e
+  IL_0059:  ldloc.3
+  IL_005a:  ldc.i4.s   100
+  IL_005c:  add
+  IL_005d:  stloc.3
+  IL_005e:  ldloc.0
+  IL_005f:  ldc.r8     1
+  IL_0068:  div
+  IL_0069:  conv.r8
+  IL_006a:  ldloc.0
+  IL_006b:  beq.s      IL_0075
+  IL_006d:  ldloc.3
+  IL_006e:  ldc.i4     0x3e8
+  IL_0073:  add
+  IL_0074:  stloc.3
+  IL_0075:  ldloc.0
+  IL_0076:  neg
+  IL_0077:  ldloc.0
+  IL_0078:  ldc.r8     1.00000000362749E-15
+  IL_0081:  mul
+  IL_0082:  neg
+  IL_0083:  add
+  IL_0084:  conv.r8
+  IL_0085:  ldloc.2
+  IL_0086:  beq.s      IL_0090
+  IL_0088:  ldloc.3
+  IL_0089:  ldc.i4     0x2710
+  IL_008e:  add
+  IL_008f:  stloc.3
+  IL_0090:  ldloc.0
+  IL_0091:  neg
+  IL_0092:  ldloc.0
+  IL_0093:  ldc.r8     1.00000000362749E-15
+  IL_009c:  mul
+  IL_009d:  sub
+  IL_009e:  conv.r8
+  IL_009f:  ldloc.2
+  IL_00a0:  beq.s      IL_00aa
+  IL_00a2:  ldloc.3
+  IL_00a3:  ldc.i4     0x186a0
+  IL_00a8:  add
+  IL_00a9:  stloc.3
+  IL_00aa:  ldloc.0
+  IL_00ab:  neg
+  IL_00ac:  ldc.r8     1
+  IL_00b5:  mul
+  IL_00b6:  conv.r8
+  IL_00b7:  ldloc.0
+  IL_00b8:  neg
+  IL_00b9:  beq.s      IL_00c3
+  IL_00bb:  ldloc.3
+  IL_00bc:  ldc.i4     0xf4240
+  IL_00c1:  add
+  IL_00c2:  stloc.3
+  IL_00c3:  ldloc.0
+  IL_00c4:  neg
+  IL_00c5:  ldc.r8     1
+  IL_00ce:  div
+  IL_00cf:  conv.r8
+  IL_00d0:  ldloc.0
+  IL_00d1:  neg
+  IL_00d2:  beq.s      IL_00dc
+  IL_00d4:  ldloc.3
+  IL_00d5:  ldc.i4     0x989680
+  IL_00da:  add
+  IL_00db:  stloc.3
+  IL_00dc:  ldloc.3
+  IL_00dd:  call       ""void System.Console.WriteLine(int)""
+  IL_00e2:  ldloc.3
+  IL_00e3:  ret
 }");
         }
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenConstLocal.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenConstLocal.vb
@@ -782,6 +782,37 @@ End Module
 ]]>)
 
         End Sub
+
+        <Fact()>
+        Public Sub TruncatePrecisionFloat()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        const temp1 as single = 23334800f / 5.5f
+        console.WriteLine(Microsoft.VisualBasic.Int(temp1))
+        console.WriteLine(Microsoft.VisualBasic.Int(23334800f / 5.5f))
+        console.WriteLine(temp1 * 5.5)
+
+        const temp2 as double = 23334800.0 / 5.5
+        console.WriteLine(Microsoft.VisualBasic.Int(temp2))
+        console.WriteLine(Microsoft.VisualBasic.Int(23334800.0 / 5.5))
+        console.WriteLine(temp2 * 5.5)
+    End Sub
+End Module
+    </file>
+</compilation>, expectedOutput:=<![CDATA[
+4242691
+4242691
+23334800.5
+4242690
+4242690
+23334800
+            ]]>)
+        End Sub
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #7262 

The Roslyn C# compiler stores constants of type `System.Single` (i.e. `float`) internally as type `double`, but without truncating the value to the required precision. Also, it computes binary constant-folded operators incorrectly, essentially computing the operation in double precision. It also ignores explicit casts to `float`, as those are considered identity conversions, but the language spec required that we truncate precision when we see such a cast.

This change causes floating-point constant-folding operations to be done in precisely the proper precision, and causes casts to truncate precision. With the first change, the latter change may turn out to be a no-op (when the value is already a float, it should already have the correct value with the correct precision), but I'm doing it for completeness.

@dotnet/roslyn-compiler Please review.