### PR TITLE
Fix C# cast simplification issue where removal of a cast can break an implicitly-typed array

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -4824,6 +4824,46 @@ class C
             Await TestAsync(input, expected)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(6966, "https://github.com/dotnet/roslyn/issues/6966")>
+        Public Async Function TestCSharp_DontRemove_NecessaryCastToNullInImplicitlyTypedArray() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    object M()
+    {
+        return new
+        {
+            Something = new[] { {|Simplify:(object)null|}, null, null, null }
+        };
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+class C
+{
+    object M()
+    {
+        return new
+        {
+            Something = new[] { (object)null, null, null, null }
+        };
+    }
+}
+]]>
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
 #End Region
 
 #Region "Visual Basic tests"

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -426,6 +426,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             {
                 return ReplacementBreaksInterpolation((InterpolationSyntax)currentOriginalNode, (InterpolationSyntax)currentReplacedNode);
             }
+            else if (currentOriginalNode.Kind() == SyntaxKind.ImplicitArrayCreationExpression)
+            {
+                return !TypesAreCompatible((ImplicitArrayCreationExpressionSyntax)currentOriginalNode, (ImplicitArrayCreationExpressionSyntax)currentReplacedNode);
+            }
 
             return false;
         }


### PR DESCRIPTION
Fixes #6966

Tagging @dotnet/roslyn-ide 