### PR TITLE
Update Microsoft.DiaSymReader to 1.0.7-beta1

### DIFF
--- a/src/Dependencies/Microsoft.DiaSymReader/Version.targets
+++ b/src/Dependencies/Microsoft.DiaSymReader/Version.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynSemanticVersion>1.0.6</RoslynSemanticVersion>
-    <NuGetVersion>$(RoslynSemanticVersion)</NuGetVersion>
-    <NuGetVersionType>Release</NuGetVersionType>
+    <RoslynSemanticVersion>1.0.7</RoslynSemanticVersion>
+    <NuGetVersion>$(RoslynSemanticVersion)-beta1</NuGetVersion>
+    <NuGetVersionType>PreRelease</NuGetVersionType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Integration test failures are expected. We need to check this change in first in order to kick off signed build that produces a nuget package we can publish. Once it's kicked off we will revert. A follow up change will update all Roslyn to the new nuget package produced by this signed build.