### PR TITLE
add ResultDir to TestResult rather than retrieving it from ResultsFil…

### DIFF
--- a/src/Tools/Source/RunTests/Cache/CachingTestExecutor.cs
+++ b/src/Tools/Source/RunTests/Cache/CachingTestExecutor.cs
@@ -68,6 +68,7 @@ namespace RunTests.Cache
             return new TestResult(
                 exitCode: testResult.ExitCode,
                 assemblyPath: testResult.AssemblyName,
+                resultDir: resultsDir,
                 resultsFilePath: resultsFilePath,
                 commandLine: testResult.CommandLine,
                 elapsed: testResult.Elapsed,

--- a/src/Tools/Source/RunTests/Cache/LocalDataStorage.cs
+++ b/src/Tools/Source/RunTests/Cache/LocalDataStorage.cs
@@ -53,7 +53,9 @@ namespace RunTests.Cache
                 var assemblyPath = Read(checksum, StorageKind.AssemblyPath);
                 var standardOutput = Read(checksum, StorageKind.StandardOutput);
                 var errorOutput = Read(checksum, StorageKind.ErrorOutput);
+
                 var resultsFilePath = GetStoragePath(checksum, StorageKind.ResultsFile);
+                var resultDir = Path.GetDirectoryName(resultsFilePath);
                 if (!File.Exists(resultsFilePath))
                 {
                     resultsFilePath = null;
@@ -62,6 +64,7 @@ namespace RunTests.Cache
                 testResult = new TestResult(
                     exitCode: int.Parse(exitCode),
                     assemblyPath: assemblyPath,
+                    resultDir: resultDir,
                     resultsFilePath: resultsFilePath,
                     commandLine: commandLine,
                     elapsed: TimeSpan.FromSeconds(0),

--- a/src/Tools/Source/RunTests/ITestExecutor.cs
+++ b/src/Tools/Source/RunTests/ITestExecutor.cs
@@ -21,14 +21,17 @@ namespace RunTests
         /// Path to the results file.  Can be null in the case xunit error'd and did not create one. 
         /// </summary>
         internal string ResultsFilePath { get; }
+
+        internal string ResultDir { get; }
         internal bool Succeeded => ExitCode == 0;
 
-        internal TestResult(int exitCode, string assemblyPath, string resultsFilePath, string commandLine, TimeSpan elapsed, string standardOutput, string errorOutput)
+        internal TestResult(int exitCode, string assemblyPath, string resultDir, string resultsFilePath, string commandLine, TimeSpan elapsed, string standardOutput, string errorOutput)
         {
             ExitCode = exitCode;
             AssemblyName = Path.GetFileName(assemblyPath);
             AssemblyPath = assemblyPath;
             CommandLine = commandLine;
+            ResultDir = resultDir;
             ResultsFilePath = resultsFilePath;
             Elapsed = elapsed;
             StandardOutput = standardOutput;

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -23,7 +23,7 @@ namespace RunTests
         public async Task<TestResult> RunTestAsync(string assemblyPath, CancellationToken cancellationToken)
         {
             try
-            { 
+            {
                 var assemblyName = Path.GetFileName(assemblyPath);
                 var resultsDir = Path.Combine(Path.GetDirectoryName(assemblyPath), Constants.ResultsDirectoryName);
                 var resultsFilePath = Path.Combine(resultsDir, $"{assemblyName}.{(_options.UseHtml ? "html" : "xml")}");
@@ -101,6 +101,7 @@ namespace RunTests
                 return new TestResult(
                     exitCode: processOutput.ExitCode,
                     assemblyPath: assemblyPath,
+                    resultDir: resultsDir,
                     resultsFilePath: resultsFilePath,
                     commandLine: commandLine,
                     elapsed: span,

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -101,7 +101,7 @@ namespace RunTests
         private void PrintFailedTestResult(TestResult testResult)
         {
             // Save out the error output for easy artifact inspecting
-            var resultsDir = Path.GetDirectoryName(testResult.ResultsFilePath);
+            var resultsDir = testResult.ResultDir;
             var outputLogPath = Path.Combine(resultsDir, $"{testResult.AssemblyName}.out.log");
             File.WriteAllText(outputLogPath, testResult.StandardOutput);
 


### PR DESCRIPTION
…ePath

ResultsFilePath can be null in cases where xunit failed to save one. so rather than using ResultsFilePath
to figure out ResultDir, we will save the dir in the TestResult along with the filepath.