### PR TITLE
don't set a tests ResultFilePath to null on crash because its value is used to compute other paths

### DIFF
--- a/src/Tools/Source/RunTests/Cache/CachingTestExecutor.cs
+++ b/src/Tools/Source/RunTests/Cache/CachingTestExecutor.cs
@@ -55,15 +55,19 @@ namespace RunTests.Cache
         /// <returns></returns>
         private static TestResult Migrate(TestResult testResult)
         {
-            if (string.IsNullOrEmpty(testResult.ResultsFilePath))
-            {
-                return testResult;
-            }
-
             var resultsDir = Path.Combine(Path.GetDirectoryName(testResult.AssemblyPath), Constants.ResultsDirectoryName);
             FileUtil.EnsureDirectory(resultsDir);
             var resultsFilePath = Path.Combine(resultsDir, Path.GetFileName(testResult.ResultsFilePath));
-            File.Copy(testResult.ResultsFilePath, resultsFilePath, overwrite: true);
+
+            try
+            {
+                File.Copy(testResult.ResultsFilePath, resultsFilePath, overwrite: true);
+            }
+            catch (FileNotFoundException)
+            {
+                // if the file isn't present (e.g., if xunit crashed and the potentially malformed result file was
+                // deleted) then `File.Copy()` will throw
+            }
 
             return new TestResult(
                 exitCode: testResult.ExitCode,

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -90,7 +90,6 @@ namespace RunTests
                     {
                         // Delete the output file.
                         File.Delete(resultsFilePath);
-                        resultsFilePath = null;
                     }
                 }
 

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -121,9 +122,18 @@ namespace RunTests
             }
 
             // If the results are html, use Process.Start to open in the browser.
-            if (_options.UseHtml && !string.IsNullOrEmpty(testResult.ResultsFilePath))
+            if (_options.UseHtml)
             {
-                Process.Start(testResult.ResultsFilePath);
+                try
+                {
+                    Process.Start(testResult.ResultsFilePath);
+                }
+                catch (Win32Exception e) when ((uint)e.ErrorCode == 0x80004005)
+                {
+                    // if the file isn't present (e.g., if xunit crashed and the potentially malformed result file was
+                    // deleted) then `Process.Start()` will throw:
+                    //     System.ComponentModel.Win32Exception (0x80004005): The system cannot find the file specified
+                }
             }
         }
     }


### PR DESCRIPTION
If xunit crashes then its output file is potentially malformed and deleted (to prevent other tools from crashing when attempting to parse this file) and the test result's `ResultFilePath` was set to `null` [here](https://github.com/dotnet/roslyn/blob/cd36683098ac46d2634e95ed1f30096b67b9f54d/src/Tools/Source/RunTests/ProcessTestExecutor.cs#L93).  That was causing a `NullReferenceException` [here](https://github.com/dotnet/roslyn/blob/cd36683098ac46d2634e95ed1f30096b67b9f54d/src/Tools/Source/RunTests/TestRunner.cs#L105) because `Path.GetDirectoryName(null)` -> `null` (on the previous line).

The fix is to not set `ResultFilePath` to `null` because even if the file isn't present, its value is still used to calculate other useful path information.  Instead locations where `ResultFilePath` is expected to exist are wrapped in a very narrow `try/catch`.  (It's generally a bad idea to rely on code like `if (File.Exists(path)) { doSomething(path); }` because the file could have been deleted/locked/etc. by the OS or another process between the evaluation of the `if` expression and `doSomething`.)

Fixes #7331.

Tagging @dotnet/roslyn-infrastructure for review.