### PR TITLE
Don't create an index for symbols that are private, or can't be referenced by name

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -322,19 +322,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         private static Func<ISymbol, IEnumerable<ISymbol>> GetMembers = symbol =>
         {
-            var nt = symbol as INamedTypeSymbol;
-            if (nt != null)
-            {
-                return nt.GetMembers().Where(UseSymbol);
-            }
-
-            var ns = symbol as INamespaceSymbol;
-            if (ns != null)
-            {
-                return ns.GetMembers().Where(UseSymbol);
-            }
-
-            return SpecializedCollections.EmptyEnumerable<ISymbol>();
+            var nt = symbol as INamespaceOrTypeSymbol;
+            return nt != null 
+                ? nt.GetMembers().Where(UseSymbol)
+                : SpecializedCollections.EmptyEnumerable<ISymbol>();
         };
 
         #endregion

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -303,13 +303,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
+        private static readonly Func<ISymbol, bool> IgnoreSymbol = 
+            s => !s.CanBeReferencedByName || s.DeclaredAccessibility == Accessibility.Private;
+
         // generate nodes for symbols that share the same name, and all their descendants
         private static void GenerateNodes(string name, int parentIndex, IEnumerable<INamespaceOrTypeSymbol> symbolsWithSameName, List<Node> list)
         {
             // Don't bother adding entries for names that can't even be referenced in code.
             // Also, don't bother if all the symbols with this name are private.
-            if (!symbolsWithSameName.Any(s => s.CanBeReferencedByName) || 
-                symbolsWithSameName.All(s => s.DeclaredAccessibility == Accessibility.Private))
+            if (symbolsWithSameName.All(IgnoreSymbol))
             {
                 return;
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
-        private static IEnumerable<ISymbol> GetMembers(ISymbol symbol)
+        private static Func<ISymbol, IEnumerable<ISymbol>> GetMembers = symbol =>
         {
             var nt = symbol as INamedTypeSymbol;
             if (nt != null)
@@ -335,7 +335,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
 
             return SpecializedCollections.EmptyEnumerable<ISymbol>();
-        }
+        };
+
         #endregion
 
         #region Binding 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -306,6 +306,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         // generate nodes for symbols that share the same name, and all their descendants
         private static void GenerateNodes(string name, int parentIndex, IEnumerable<INamespaceOrTypeSymbol> symbolsWithSameName, List<Node> list)
         {
+            // Don't bother adding entries for names that can't even be referenced in code.
+            // Also, don't bother if all the symbols with this name are private.
+            if (!symbolsWithSameName.Any(s => s.CanBeReferencedByName) || 
+                symbolsWithSameName.All(s => s.DeclaredAccessibility == Accessibility.Private))
+            {
+                return;
+            }
+
             var node = new Node(name, parentIndex);
             var nodeIndex = list.Count;
             list.Add(node);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class SymbolTreeInfo : IObjectWritable
     {
         private const string PrefixMetadataSymbolTreeInfo = "<MetadataSymbolTreeInfoPersistence>_";
-        private const string SerializationFormat = "2";
+        private const string SerializationFormat = "3";
 
         /// <summary>
         /// this is for a metadata reference in a solution


### PR DESCRIPTION
This reduces the size of our symbol tree by about 50%