### PR TITLE
make SyntaxFactory.AreEquivalent ignore => bodies if topLevel:true

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxEquivalence.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxEquivalence.cs
@@ -110,11 +110,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
             if (topLevel)
             {
-                // Once we get down to the block level we don't need to go any further and we can
+                // Once we get down to the body level we don't need to go any further and we can
                 // consider these trees equivalent.
-                if ((SyntaxKind)before.RawKind == SyntaxKind.Block)
+                switch ((SyntaxKind)before.RawKind)
                 {
-                    return true;
+                    case SyntaxKind.Block:
+                    case SyntaxKind.ArrowExpressionClause:
+                        return true;
                 }
 
                 // If we're only checking top level equivalence, then we don't have to go down into

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxEquivalenceTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxEquivalenceTests.cs
@@ -437,5 +437,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             VerifyEquivalent(tree1, tree2, topLevel: true);
             VerifyNotEquivalent(tree1, tree2, topLevel: false);
         }
+
+        [Fact(DisplayName = "https://github.com/dotnet/roslyn/issues/7380")]
+        public void TestExpressionBodiedMethod()
+        {
+            var tree1 = SyntaxFactory.ParseSyntaxTree("class C { void M() => 1; }");
+            var tree2 = SyntaxFactory.ParseSyntaxTree("class C { void M() => 2; }");
+
+            VerifyEquivalent(tree1, tree2, topLevel: true);
+            VerifyNotEquivalent(tree1, tree2, topLevel: false);
+        }
     }
 }


### PR DESCRIPTION
Fixes #7380 
@dotnet/roslyn-compiler Please review this tiny change