### PR TITLE
This change fixes a few issues for Operation analyzers in lDE live an…

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
@@ -195,9 +195,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         }
 
                         if (!AnalysisScope.ShouldSkipDeclarationAnalysis(symbol) &&
-                            (actionCounts.SyntaxNodeActionsCount > 0 ||
-                            actionCounts.CodeBlockActionsCount > 0 ||
-                            actionCounts.CodeBlockStartActionsCount > 0))
+                            actionCounts.HasAnyExecutableCodeActions)
                         {
                             foreach (var syntaxRef in symbolEvent.DeclaringSyntaxReferences)
                             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -273,10 +273,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
             else if (compilationEvent is SymbolDeclaredCompilationEvent)
             {
-                return actionCounts.CodeBlockActionsCount > 0 ||
-                    actionCounts.CodeBlockStartActionsCount > 0 ||
-                    actionCounts.SymbolActionsCount > 0 ||
-                    actionCounts.SyntaxNodeActionsCount > 0;
+                return actionCounts.SymbolActionsCount > 0 || actionCounts.HasAnyExecutableCodeActions;
             }
             else
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerActionCounts.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerActionCounts.cs
@@ -31,6 +31,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
             CodeBlockStartActionsCount = analyzerActions.CodeBlockStartActionsCount;
             CodeBlockEndActionsCount = analyzerActions.CodeBlockEndActionsCount;
             CodeBlockActionsCount = analyzerActions.CodeBlockActionsCount;
+            OperationActionsCount = analyzerActions.OperationActionsCount;
+            OperationBlockStartActionsCount = analyzerActions.OperationBlockStartActionsCount;
+            OperationBlockEndActionsCount = analyzerActions.OperationBlockEndActionsCount;
+            OperationBlockActionsCount = analyzerActions.OperationBlockActionsCount;
+
+            HasAnyExecutableCodeActions = CodeBlockActionsCount > 0 ||
+                CodeBlockStartActionsCount > 0 ||
+                SyntaxNodeActionsCount > 0 ||
+                OperationActionsCount > 0 ||
+                OperationBlockActionsCount > 0 ||
+                OperationBlockStartActionsCount > 0;
         }
 
         /// <summary>
@@ -82,5 +93,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
         /// Count of code block actions.
         /// </summary>
         public int CodeBlockActionsCount { get; }
+
+        /// <summary>
+        /// Count of Operation actions.
+        /// </summary>
+        public int OperationActionsCount { get; }
+
+        /// <summary>
+        /// Count of Operation block start actions.
+        /// </summary>
+        public int OperationBlockStartActionsCount { get; }
+
+        /// <summary>
+        /// Count of Operation block end actions.
+        /// </summary>
+        public int OperationBlockEndActionsCount { get; }
+
+        /// <summary>
+        /// Count of Operation block actions.
+        /// </summary>
+        public int OperationBlockActionsCount { get; }
+
+        /// <summary>
+        /// Returns true if there are any actions that need to run on executable code.
+        /// </summary>
+        public bool HasAnyExecutableCodeActions { get; }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
@@ -62,6 +62,26 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
         public int CodeBlockActionsCount => _actionCounts.CodeBlockActionsCount;
 
         /// <summary>
+        /// Count of registered operation actions.
+        /// </summary>
+        public int OperationActionsCount => _actionCounts.OperationActionsCount;
+
+        /// <summary>
+        /// Count of registered operation block start actions.
+        /// </summary>
+        public int OperationBlockStartActionsCount => _actionCounts.OperationBlockStartActionsCount;
+
+        /// <summary>
+        /// Count of registered operation block end actions.
+        /// </summary>
+        public int OperationBlockEndActionsCount => _actionCounts.OperationBlockEndActionsCount;
+
+        /// <summary>
+        /// Count of registered operation block actions.
+        /// </summary>
+        public int OperationBlockActionsCount => _actionCounts.OperationBlockActionsCount;
+
+        /// <summary>
         /// Total execution time.
         /// </summary>
         public TimeSpan ExecutionTime { get; }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -642,6 +642,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public int SymbolActionsCount { get { return _symbolActions.Length; } }
         public int SyntaxNodeActionsCount { get { return _syntaxNodeActions.Length; } }
         public int OperationActionsCount { get { return this._operationActions.Length; } }
+        public int OperationBlockStartActionsCount { get { return _operationBlockStartActions.Length; } }
+        public int OperationBlockEndActionsCount { get { return _operationBlockEndActions.Length; } }
+        public int OperationBlockActionsCount { get { return _operationBlockActions.Length; } }
         public int CodeBlockStartActionsCount { get { return _codeBlockStartActions.Length; } }
         public int CodeBlockEndActionsCount { get { return _codeBlockEndActions.Length; } }
         public int CodeBlockActionsCount { get { return _codeBlockActions.Length; } }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -47,6 +47,10 @@ Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.CompilationAc
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.CompilationEndActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.CompilationStartActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.ExecutionTime.get -> System.TimeSpan
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationActionsCount.get -> int
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBlockActionsCount.get -> int
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBlockEndActionsCount.get -> int
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBlockStartActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SemanticModelActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SymbolActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SyntaxNodeActionsCount.get -> int

--- a/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogAggregator.cs
+++ b/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogAggregator.cs
@@ -21,7 +21,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Log
             "Analyzer.SemanticModel",
             "Analyzer.Symbol",
             "Analyzer.SyntaxNode",
-            "Analyzer.SyntaxTree"
+            "Analyzer.SyntaxTree",
+            "Analyzer.Operation",
+            "Analyzer.OperationBlock",
+            "Analyzer.OperationBlockEnd",
+            "Analyzer.OperationBlockStart",
         };
 
         private readonly DiagnosticAnalyzerService _owner;
@@ -63,17 +67,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Log
             {
                 CLRType = analyzer.GetType();
                 Telemetry = telemetry;
-
-                Counts[0] = analyzerTelemetryInfo.CodeBlockActionsCount;
-                Counts[1] = analyzerTelemetryInfo.CodeBlockEndActionsCount;
-                Counts[2] = analyzerTelemetryInfo.CodeBlockStartActionsCount;
-                Counts[3] = analyzerTelemetryInfo.CompilationActionsCount;
-                Counts[4] = analyzerTelemetryInfo.CompilationEndActionsCount;
-                Counts[5] = analyzerTelemetryInfo.CompilationStartActionsCount;
-                Counts[6] = analyzerTelemetryInfo.SemanticModelActionsCount;
-                Counts[7] = analyzerTelemetryInfo.SymbolActionsCount;
-                Counts[8] = analyzerTelemetryInfo.SyntaxNodeActionsCount;
-                Counts[9] = analyzerTelemetryInfo.SyntaxTreeActionsCount;
+                SetAnalyzerTypeCount(analyzerTelemetryInfo);
             }
 
             public void SetAnalyzerTypeCount(AnalyzerTelemetryInfo analyzerTelemetryInfo)
@@ -88,6 +82,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Log
                 Counts[7] = analyzerTelemetryInfo.SymbolActionsCount;
                 Counts[8] = analyzerTelemetryInfo.SyntaxNodeActionsCount;
                 Counts[9] = analyzerTelemetryInfo.SyntaxTreeActionsCount;
+                Counts[10] = analyzerTelemetryInfo.OperationActionsCount;
+                Counts[11] = analyzerTelemetryInfo.OperationBlockActionsCount;
+                Counts[12] = analyzerTelemetryInfo.OperationBlockEndActionsCount;
+                Counts[13] = analyzerTelemetryInfo.OperationBlockStartActionsCount;
             }
         }
     }


### PR DESCRIPTION
…alysis:

1. Ensure that CompilationWithAnalyzers processes symbol declared events for analyzers with just Operation actions (Fixes #7308)

2. Fix the InvalidOperationException from operation action reporting a diagnostic in live analysis (Fixes #7324)

3. Add telemetry for Operation action counts registered per-analyzer. This involves a public API change, basically extending the existing telemetry API for other action counts.