### PR TITLE
Fix/Harden code path hit by Watson dump

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeType.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeType.cs
@@ -165,19 +165,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         public void RemoveMember(object element)
         {
-            var codeElement = ComAggregate.TryGetManagedObject<AbstractCodeElement>(element);
+            // Is this an EnvDTE.CodeElement that we created? If so, try to get the underlying code element object.
+            var abstractCodeElement = ComAggregate.TryGetManagedObject<AbstractCodeElement>(element);
 
-            if (codeElement == null)
+            if (abstractCodeElement == null)
             {
-                codeElement = ComAggregate.TryGetManagedObject<AbstractCodeElement>(this.Members.Item(element));
+                var codeElement = element as EnvDTE.CodeElement;
+                if (codeElement != null)
+                {
+                    // Is at least an EnvDTE.CodeElement? If so, try to retrieve it from the Members collection by name.
+                    // Note: This might throw an ArgumentException if the name isn't found in the collection.
+
+                    abstractCodeElement = ComAggregate.TryGetManagedObject<AbstractCodeElement>(this.Members.Item(codeElement.Name));
+                }
+                else if (element is string || element is int)
+                {
+                    // Is this a string or int? If so, try to retrieve it from the Members collection. Again, this will
+                    // throw an ArgumentException if the name or index isn't found in the collection.
+
+                    abstractCodeElement = ComAggregate.TryGetManagedObject<AbstractCodeElement>(this.Members.Item(element));
+                }
             }
 
-            if (codeElement == null)
+            if (abstractCodeElement == null)
             {
-                throw new ArgumentException(ServicesVSResources.ElementIsNotValid, "element");
+                throw new ArgumentException(ServicesVSResources.ElementIsNotValid, nameof(element));
             }
 
-            codeElement.Delete();
+            abstractCodeElement.Delete();
         }
 
         public EnvDTE.CodeElement AddBase(object @base, object position)


### PR DESCRIPTION
There's a code path being hit in a Watson-reported crash in `CodeClass.RemoveMember(...)`. This method is expected to be passed a Code Model `CodeElement` that we created, a string with the name of a member, or an index to a member. However, it's entirely possible that it could be passed something unexpected, like a `CodeElement` from another language. I wasn't able to determine a repro for the crash, so this is my best effort at hardening that method against further crashes.

Tagging @dotnet/roslyn-ide 