### PR TITLE
Add more information to squiggle tests to help diagnose flakeyness

### DIFF
--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Squiggles
 
             using (var workspace = await TestWorkspaceFactory.CreateWorkspaceAsync(workspaceXml))
             {
-                var spans = await GetErrorSpans(workspace);
+                var spans = (await GetDiagnosticsAndErrorSpans(workspace)).Item2;
 
                 Assert.Equal(1, spans.Count());
                 Assert.Equal(PredefinedErrorTypeNames.SyntaxError, spans.First().Tag.ErrorType);
@@ -110,7 +110,7 @@ class Program
                 };
 
                 var spans =
-                    (await GetErrorSpans(workspace, analyzerMap))
+                    (await GetDiagnosticsAndErrorSpans(workspace, analyzerMap)).Item2
                         .OrderBy(s => s.Span.Span.Start).ToImmutableArray();
 
                 Assert.Equal(3, spans.Length);
@@ -293,7 +293,7 @@ class Program
         {
             using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(content))
             {
-                return await GetErrorSpans(workspace);
+                return (await GetDiagnosticsAndErrorSpans(workspace)).Item2;
             }
         }
     }

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
             }
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6968")]
+        [WpfFact]
         public async Task TestPreviewDiagnosticTagger()
         {
             using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class { }"))
@@ -192,8 +192,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
                 //// enable preview diagnostics
                 previewWorkspace.EnableDiagnostic();
 
-                var spans = await SquiggleUtilities.GetErrorSpans(workspace);
-                Assert.Equal(1, spans.Count);
+                var diagnosticsAndErrorsSpans = await SquiggleUtilities.GetDiagnosticsAndErrorSpans(workspace);
+                const string AnalzyerCount = "Analyzer Count: ";
+                Assert.Equal(AnalzyerCount + 1, AnalzyerCount + diagnosticsAndErrorsSpans.Item1.Length);
+
+                const string SquigglesCount = "Squiggles Count: ";
+                Assert.Equal(SquigglesCount + 1, SquigglesCount + diagnosticsAndErrorsSpans.Item2.Count);
             }
         }
 

--- a/src/EditorFeatures/Test/Squiggles/AbstractSquiggleProducerTests.cs
+++ b/src/EditorFeatures/Test/Squiggles/AbstractSquiggleProducerTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
 {
     public static class SquiggleUtilities
     {
-        internal static async Task<List<ITagSpan<IErrorTag>>> GetErrorSpans(
+        internal static async Task<Tuple<ImmutableArray<DiagnosticData>, List<ITagSpan<IErrorTag>>>> GetDiagnosticsAndErrorSpans(
             TestWorkspace workspace,
             Dictionary<string, DiagnosticAnalyzer[]> analyzerMap = null)
         {
@@ -29,10 +29,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
                 {
                     await wrapper.WaitForTags();
 
+                    var analyzerDiagnostics = await wrapper.AnalyzerService.GetDiagnosticsAsync(workspace.CurrentSolution);
+
                     var snapshot = workspace.Documents.First().GetTextBuffer().CurrentSnapshot;
                     var spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToList();
 
-                    return spans;
+                    return Tuple.Create(analyzerDiagnostics,spans);
                 }
             }
         }
@@ -40,11 +42,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
 
     public abstract class AbstractSquiggleProducerTests
     {
-        protected static async Task<IEnumerable<ITagSpan<IErrorTag>>> GetErrorSpans(
+        internal static async Task<Tuple<ImmutableArray<DiagnosticData>, List<ITagSpan<IErrorTag>>>> GetDiagnosticsAndErrorSpans(
             TestWorkspace workspace,
             Dictionary<string, DiagnosticAnalyzer[]> analyzerMap = null)
         {
-            return await SquiggleUtilities.GetErrorSpans(workspace, analyzerMap);
+            return await SquiggleUtilities.GetDiagnosticsAndErrorSpans(workspace, analyzerMap);
         }
 
         internal static async Task<IList<ITagSpan<IErrorTag>>> GetErrorsFromUpdateSource(TestWorkspace workspace, TestHostDocument document, DiagnosticsUpdatedArgs updateArgs)

--- a/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
@@ -17,13 +17,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
 
         Private Async Function ProduceSquiggles(ParamArray lines As String()) As Task(Of IEnumerable(Of ITagSpan(Of IErrorTag)))
             Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines)
-                Return Await GetErrorSpans(workspace)
+                Return (Await GetDiagnosticsAndErrorSpans(workspace)).Item2
             End Using
         End Function
 
         Private Async Function ProduceSquiggles(analyzerMap As Dictionary(Of String, DiagnosticAnalyzer()), ParamArray lines As String()) As Task(Of IEnumerable(Of ITagSpan(Of IErrorTag)))
             Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines)
-                Return Await GetErrorSpans(workspace, analyzerMap)
+                Return (Await GetDiagnosticsAndErrorSpans(workspace, analyzerMap)).Item2
             End Using
         End Function
 


### PR DESCRIPTION
Also add tests to try to help us determine if flekyness is an issue in the squiggle tagger itself, or an issue in the underlying diagnostics engine.

Fixes: https://github.com/dotnet/Roslyn/issues/6968