### PR TITLE
Revert "Update Microsoft.DiaSymReader to 1.0.7-beta1"

### DIFF
--- a/src/Dependencies/Microsoft.DiaSymReader/Version.targets
+++ b/src/Dependencies/Microsoft.DiaSymReader/Version.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynSemanticVersion>1.0.7</RoslynSemanticVersion>
-    <NuGetVersion>$(RoslynSemanticVersion)-beta1</NuGetVersion>
-    <NuGetVersionType>PreRelease</NuGetVersionType>
+    <RoslynSemanticVersion>1.0.6</RoslynSemanticVersion>
+    <NuGetVersion>$(RoslynSemanticVersion)</NuGetVersion>
+    <NuGetVersionType>Release</NuGetVersionType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Reverts dotnet/roslyn#7343

Now that we have a signed nuget package, we can revert this until we move all of roslyn to depend on this package