### PR TITLE
fixed flaky squiggle test

### DIFF
--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Squiggles
 {
     public class ErrorSquiggleProducerTests : AbstractSquiggleProducerTests
     {
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task ErrorTagGeneratedForError()
         {
             var spans = await GetErrorSpans("class C {");
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Squiggles
             Assert.Equal(PredefinedErrorTypeNames.SyntaxError, firstSpan.Tag.ErrorType);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task ErrorTagGeneratedForWarning()
         {
             var spans = await GetErrorSpans("class C { long x = 5l; }");
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Squiggles
             Assert.Equal(PredefinedErrorTypeNames.Warning, spans.First().Tag.ErrorType);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task ErrorTagGeneratedForWarningAsError()
         {
             var workspaceXml =
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Squiggles
             }
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task SuggestionTagsForUnnecessaryCode()
         {
             var workspaceXml =
@@ -135,14 +135,14 @@ class Program
             }
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task ErrorDoesNotCrashPastEOF()
         {
             var spans = await GetErrorSpans("class C { int x =");
             Assert.Equal(3, spans.Count());
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task SemanticErrorReported()
         {
             var spans = await GetErrorSpans("class C : Bar { }");
@@ -153,7 +153,7 @@ class Program
             Assert.Contains("Bar", (string)firstSpan.Tag.ToolTipContent, StringComparison.Ordinal);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task TestNoErrorsAfterDocumentRemoved()
         {
             using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class"))
@@ -183,7 +183,7 @@ class Program
             }
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task TestNoErrorsAfterProjectRemoved()
         {
             using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class"))
@@ -214,7 +214,7 @@ class Program
             }
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task BuildErrorZeroLengthSpan()
         {
             var workspaceXml =
@@ -247,7 +247,7 @@ class Program
             }
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task LiveErrorZeroLengthSpan()
         {
             var workspaceXml =

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
@@ -64,11 +64,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
             protected override Task ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition)
             {
-                ProduceTagsAsync(context, spanToTag);
+                ProduceTags(context, spanToTag);
                 return SpecializedTasks.EmptyTask;
             }
 
-            private void ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag)
+            private void ProduceTags(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag)
             {
                 if (!_owner.IsEnabled)
                 {

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
@@ -71,10 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 ValueTuple.Create(FeatureAttribute.DiagnosticService, _asyncListener),
                 ValueTuple.Create(FeatureAttribute.ErrorSquiggles, _asyncListener));
 
-            if (analyzerMap != null)
-            {
-                _analyzerService = CreateDiagnosticAnalyzerService(analyzerMap, new AggregateAsynchronousOperationListener(_listeners, FeatureAttribute.DiagnosticService));
-            }
+            _analyzerService = CreateDiagnosticAnalyzerService(analyzerMap, new AggregateAsynchronousOperationListener(_listeners, FeatureAttribute.DiagnosticService));
 
             if (updateSource == null)
             {

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Dictionary<string, DiagnosticAnalyzer[]> analyzerMap, IAsynchronousOperationListener listener)
         {
             return analyzerMap == null || analyzerMap.Count == 0
-                ? new TestDiagnosticAnalyzerService(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap(), listener: listener)
-                : new TestDiagnosticAnalyzerService(analyzerMap.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()), listener: listener);
+                ? new MyDiagnosticAnalyzerService(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap(), listener: listener)
+                : new MyDiagnosticAnalyzerService(analyzerMap.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()), listener: listener);
         }
 
         private DiagnosticTaggerWrapper(
@@ -133,6 +133,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
 
             await _asyncListener.CreateWaitTask();
+        }
+
+        private class MyDiagnosticAnalyzerService : DiagnosticAnalyzerService
+        {
+            internal MyDiagnosticAnalyzerService(
+                ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzersMap,
+                IAsynchronousOperationListener listener)
+                : base(new HostAnalyzerManager(ImmutableArray.Create<AnalyzerReference>(new TestAnalyzerReferenceByLanguage(analyzersMap)), hostDiagnosticUpdateSource: null),
+                      hostDiagnosticUpdateSource: null,
+                      registrationService: new MockDiagnosticUpdateSourceRegistrationService(),
+                      listener: listener)
+            {
+            }
         }
     }
 

--- a/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -36,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null,
             IDiagnosticUpdateSourceRegistrationService registrationService = null)
-            : this(CreateHostAnalyzerManager(analyzersMap, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException, registrationService, listener)
+            : this(CreateHostAnalyzerManager(analyzersMap, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException, registrationService)
         {
         }
 
@@ -53,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
             IDiagnosticUpdateSourceRegistrationService registrationService = null)
-            : base(hostAnalyzerManager, hostDiagnosticUpdateSource, registrationService ?? new MockDiagnosticUpdateSourceRegistrationService(), listener)
+            : base(hostAnalyzerManager, hostDiagnosticUpdateSource, registrationService ?? new MockDiagnosticUpdateSourceRegistrationService())
         {
             _onAnalyzerException = onAnalyzerException;
         }

--- a/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -26,8 +27,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzersMap,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null,
-            IDiagnosticUpdateSourceRegistrationService registrationService = null)
-            : this(CreateHostAnalyzerManager(analyzersMap, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException, registrationService)
+            IDiagnosticUpdateSourceRegistrationService registrationService = null,
+            IAsynchronousOperationListener listener = null)
+            : this(CreateHostAnalyzerManager(analyzersMap, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException, registrationService, listener)
         {
         }
 
@@ -40,8 +42,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             HostAnalyzerManager hostAnalyzerManager,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
-            IDiagnosticUpdateSourceRegistrationService registrationService = null)
-            : base(hostAnalyzerManager, hostDiagnosticUpdateSource, registrationService ?? new MockDiagnosticUpdateSourceRegistrationService())
+            IDiagnosticUpdateSourceRegistrationService registrationService = null,
+            IAsynchronousOperationListener listener = null)
+            : base(hostAnalyzerManager, hostDiagnosticUpdateSource, registrationService ?? new MockDiagnosticUpdateSourceRegistrationService(), listener)
         {
             _onAnalyzerException = onAnalyzerException;
         }

--- a/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/Diagnostics/TestDiagnosticAnalyzerService.cs
@@ -13,12 +13,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         private readonly Action<Exception, DiagnosticAnalyzer, Diagnostic> _onAnalyzerException;
 
-        internal TestDiagnosticAnalyzerService(string language, DiagnosticAnalyzer analyzer, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null, Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
+        internal TestDiagnosticAnalyzerService(
+            string language,
+            DiagnosticAnalyzer analyzer,
+            AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
+            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
             : this(CreateHostAnalyzerManager(language, analyzer, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException)
         {
         }
 
-        internal TestDiagnosticAnalyzerService(string language, ImmutableArray<DiagnosticAnalyzer> analyzers, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null, Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
+        internal TestDiagnosticAnalyzerService(
+            string language,
+            ImmutableArray<DiagnosticAnalyzer> analyzers,
+            AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
+            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
             : this(CreateHostAnalyzerManager(language, analyzers, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException)
         {
         }
@@ -27,13 +35,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzersMap,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null,
-            IDiagnosticUpdateSourceRegistrationService registrationService = null,
-            IAsynchronousOperationListener listener = null)
+            IDiagnosticUpdateSourceRegistrationService registrationService = null)
             : this(CreateHostAnalyzerManager(analyzersMap, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException, registrationService, listener)
         {
         }
 
-        internal TestDiagnosticAnalyzerService(ImmutableArray<AnalyzerReference> hostAnalyzerReferences, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null, Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
+        internal TestDiagnosticAnalyzerService(
+            ImmutableArray<AnalyzerReference> hostAnalyzerReferences,
+            AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
+            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
             : this(CreateHostAnalyzerManager(hostAnalyzerReferences, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException)
         {
         }
@@ -42,14 +52,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             HostAnalyzerManager hostAnalyzerManager,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
-            IDiagnosticUpdateSourceRegistrationService registrationService = null,
-            IAsynchronousOperationListener listener = null)
+            IDiagnosticUpdateSourceRegistrationService registrationService = null)
             : base(hostAnalyzerManager, hostDiagnosticUpdateSource, registrationService ?? new MockDiagnosticUpdateSourceRegistrationService(), listener)
         {
             _onAnalyzerException = onAnalyzerException;
         }
 
-        internal TestDiagnosticAnalyzerService(AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null, Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
+        internal TestDiagnosticAnalyzerService(
+            AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
+            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
            : base(SpecializedCollections.EmptyEnumerable<HostDiagnosticAnalyzerPackage>(), null, hostDiagnosticUpdateSource, new MockDiagnosticUpdateSourceRegistrationService())
         {
             _onAnalyzerException = onAnalyzerException;

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -532,7 +532,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                     Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
                     project = project.AddAnalyzerReference(analyzerReference)
 
-                    Dim descriptorsMap = DiagnosticService.GetDiagnosticDescriptors(project)
+                    Dim descriptorsMap = diagnosticService.GetDiagnosticDescriptors(project)
                     Assert.Equal(1, descriptorsMap.Count)
 
                     Dim document = project.Documents.Single()
@@ -881,7 +881,7 @@ class AnonymousFunctions
                     Dim document = project.GetDocument(diagnostic.DocumentId)
                     If document.Name = "Test1.cs" Then
                         file1HasDiag = True
-                    ElseIf document.Name = "Test2.cs"
+                    ElseIf document.Name = "Test2.cs" Then
                         file2HasDiag = True
                     End If
                 Next

--- a/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
             End Using
         End Function
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6932"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
         Public Async Sub ErrorTagGeneratedForSimpleError()
             ' Make sure we have errors from the tree
             Dim spans = Await ProduceSquiggles("^")
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
             Assert.Equal(PredefinedErrorTypeNames.SyntaxError, firstSpan.Tag.ErrorType)
         End Sub
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
         Public Async Sub ArgOutOfRangeExceptionBug_904382()
             Dim spans = Await ProduceSquiggles("Class C1", "Sub Foo(", "End Class")
 
@@ -45,7 +45,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
             Dim count = spans.Count
         End Sub
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
         Public Async Sub ErrorDoesNotCrashPastEOF()
             Dim spans = Await ProduceSquiggles("Class C1",
                                          "    Sub Foo()",
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
             Assert.Equal(5, spans.Count())
         End Sub
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
         Public Async Sub SemanticError()
             Dim spans = Await ProduceSquiggles(
 "Class C1",
@@ -69,7 +69,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
             Assert.Contains("Bar", DirectCast(firstSpan.Tag.ToolTipContent, String), StringComparison.Ordinal)
         End Sub
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6866"), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
+        <WpfFact(), Trait(Traits.Feature, Traits.Features.ErrorSquiggles)>
         Public Async Sub SuggestionTagsForUnnecessaryCode()
 
             Dim analyzerMap = New Dictionary(Of String, DiagnosticAnalyzer())

--- a/src/Features/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         {
             TrackActiveTokens = Debugger.IsAttached;
 
-            // TODO: debugging only		
+            // TODO: debugging only
             TrackActiveTokens = true;
         }
 

--- a/src/Features/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -23,6 +23,9 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public AsynchronousOperationListener()
         {
             TrackActiveTokens = Debugger.IsAttached;
+
+            // TODO: debugging only		
+            TrackActiveTokens = true;
         }
 
         public IAsyncToken BeginAsyncOperation(string name, object tag = null, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)

--- a/src/Features/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -23,9 +23,6 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public AsynchronousOperationListener()
         {
             TrackActiveTokens = Debugger.IsAttached;
-
-            // TODO: debugging only
-            TrackActiveTokens = true;
         }
 
         public IAsyncToken BeginAsyncOperation(string name, object tag = null, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)


### PR DESCRIPTION
the reason it became flaky was that diagnostic analyzer events became async events to make sure events are serialized. and this test was written before the change and assumed events are synchronous.

due to layers of test code wrapped around another, this change didn't propagate enough up to find out this squiggle tests.

now we set async listener properly so it should become stable again.