### PR TITLE
Add `CopyCode` operation to InteractiveWindow

### DIFF
--- a/src/InteractiveWindow/Editor/IInteractiveWindowOperations2.cs
+++ b/src/InteractiveWindow/Editor/IInteractiveWindowOperations2.cs
@@ -10,6 +10,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         void Copy();
 
         /// <summary>
+        /// Copies only user inputs to clipboard. 
+        /// If selection is empty, then copy from current line, otherwise copy from selected lines.
+        /// </summary>
+        void CopyInputs();
+
+        /// <summary>
         /// Delete Line; Delete all selected lines, or the current line if no selection.  
         /// </summary>
         void DeleteLine();

--- a/src/InteractiveWindow/Editor/IInteractiveWindowOperations2.cs
+++ b/src/InteractiveWindow/Editor/IInteractiveWindowOperations2.cs
@@ -10,10 +10,10 @@ namespace Microsoft.VisualStudio.InteractiveWindow
         void Copy();
 
         /// <summary>
-        /// Copies only user inputs to clipboard. 
+        /// Copies code from user inputs to clipboard. 
         /// If selection is empty, then copy from current line, otherwise copy from selected lines.
         /// </summary>
-        void CopyInputs();
+        void CopyCode();
 
         /// <summary>
         /// Delete Line; Delete all selected lines, or the current line if no selection.  

--- a/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
@@ -2790,8 +2790,8 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                 }
             }
 
-            /// <summary>Implements <see cref="IInteractiveWindowOperations2.CopyInputs"/>.</summary>
-            public void CopyInputs()
+            /// <summary>Implements <see cref="IInteractiveWindowOperations2.CopyCode"/>.</summary>
+            public void CopyCode()
             {
                 var selection = TextView.Selection;
                 NormalizedSnapshotSpanCollection spans;

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -382,9 +382,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             UIThread(uiOnly => uiOnly.Copy());
         }
 
-        void IInteractiveWindowOperations2.CopyInputs()
+        void IInteractiveWindowOperations2.CopyCode()
         {
-            UIThread(uiOnly => uiOnly.CopyInputs());
+            UIThread(uiOnly => uiOnly.CopyCode());
         }
 
         bool IInteractiveWindowOperations.Backspace()

--- a/src/InteractiveWindow/Editor/InteractiveWindow.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.cs
@@ -382,6 +382,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow
             UIThread(uiOnly => uiOnly.Copy());
         }
 
+        void IInteractiveWindowOperations2.CopyInputs()
+        {
+            UIThread(uiOnly => uiOnly.CopyInputs());
+        }
+
         bool IInteractiveWindowOperations.Backspace()
         {
             return UIThread(uiOnly => uiOnly.Backspace());

--- a/src/InteractiveWindow/Editor/PublicAPI.Unshipped.txt
+++ b/src/InteractiveWindow/Editor/PublicAPI.Unshipped.txt
@@ -85,6 +85,7 @@ Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations.SelectAll(
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations.TrySubmitStandardInput() -> bool
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.Copy() -> void
+Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.CopyInputs() -> void
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.CutLine() -> void
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.DeleteLine() -> void
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.TypeChar(char typedChar) -> void

--- a/src/InteractiveWindow/Editor/PublicAPI.Unshipped.txt
+++ b/src/InteractiveWindow/Editor/PublicAPI.Unshipped.txt
@@ -85,7 +85,7 @@ Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations.SelectAll(
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations.TrySubmitStandardInput() -> bool
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.Copy() -> void
-Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.CopyInputs() -> void
+Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.CopyCode() -> void
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.CutLine() -> void
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.DeleteLine() -> void
 Microsoft.VisualStudio.InteractiveWindow.IInteractiveWindowOperations2.TypeChar(char typedChar) -> void

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -1141,9 +1141,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             ((IInteractiveWindowOperations2)operations).Copy();
         }
 
-        internal static void CopyInputs(this IInteractiveWindowOperations operations)
+        internal static void CopyCode(this IInteractiveWindowOperations operations)
         {
-            ((IInteractiveWindowOperations2)operations).CopyInputs();
+            ((IInteractiveWindowOperations2)operations).CopyCode();
         }
 
         internal static void DeleteLine(this IInteractiveWindowOperations operations)

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -1141,6 +1141,11 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             ((IInteractiveWindowOperations2)operations).Copy();
         }
 
+        internal static void CopyInputs(this IInteractiveWindowOperations operations)
+        {
+            ((IInteractiveWindowOperations2)operations).CopyInputs();
+        }
+
         internal static void DeleteLine(this IInteractiveWindowOperations operations)
         {
             ((IInteractiveWindowOperations2)operations).DeleteLine();

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests_ClipboardTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests_ClipboardTests.cs
@@ -1518,10 +1518,28 @@ System.Console.WriteLine();",
             Window.Operations.SelectAll();
             Window.Operations.SelectAll();
             Window.Operations.CopyInputs();
-            VerifyClipboardData("111\r\n\r\n222\r\n",
-                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par \\par 222}",
-                "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4},{\"content\":\"222\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4}]",
-                expectedToBeLineCopy: true);
+            VerifyClipboardData("111\r\n222",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par 222}",
+                "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2},{\"content\":\"222\",\"kind\":2}]");
+
+
+            _testClipboard.Clear();
+            Window.Operations.ClearView();
+
+            Window.InsertCode("111");
+            Window.Operations.BreakLine();
+            Window.InsertCode("222");
+            
+            // Make a selection as follows:
+            // |> 111
+            // > 222|
+            Window.Operations.SelectAll();
+            Window.Operations.SelectAll();
+            Window.Operations.CopyInputs();
+
+            VerifyClipboardData("111\r\n222",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par 222}",
+                "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2},{\"content\":\"222\",\"kind\":2}]");
 
             _testClipboard.Clear();
             Window.TextView.Selection.Clear();
@@ -1540,13 +1558,12 @@ System.Console.WriteLine();",
             selection.Select(anchor, active);
             Window.Operations.CopyInputs();
 
-            VerifyClipboardData("111\r\n\r\n222\r\n",
-                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par \\par 222}",
-                "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4},{\"content\":\"222\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4}]",
-                 expectedToBeLineCopy: true);
+            VerifyClipboardData("1\r\n2\r\n",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 1\\par 2}",
+                "[{\"content\":\"1\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4},{\"content\":\"2\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4}]",
+                 expectedToBeBoxCopy: true);
 
             _testClipboard.Clear();
-            Window.TextView.Selection.Clear();
             Window.Operations.ClearView();
 
             await Submit(
@@ -1559,7 +1576,7 @@ System.Console.WriteLine();",
             // > 111
             // 1|11
             // > 22|2
-            MoveCaretToNextPosition(1);
+            MoveCaretToPreviousPosition(1);
             anchor = caret.Position.VirtualBufferPosition;
             MoveCaretToPreviousPosition(7);
             active = caret.Position.VirtualBufferPosition;
@@ -1567,16 +1584,11 @@ System.Console.WriteLine();",
             selection.Select(anchor, active);
             Window.Operations.CopyInputs();
 
-            VerifyClipboardData("222",
-                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 222}",
-                "[{\"content\":\"222\",\"kind\":2}]",
-                expectedToBeLineCopy: true);
+            VerifyClipboardData("22",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 22}",
+                "[{\"content\":\"22\",\"kind\":2}]");
 
             _testClipboard.Clear();
-            Window.TextView.Selection.Clear();
-
-            _testClipboard.Clear();
-            Window.TextView.Selection.Clear();
             Window.Operations.ClearView();
 
             await Submit(

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests_ClipboardTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests_ClipboardTests.cs
@@ -1455,6 +1455,151 @@ System.Console.WriteLine();",
             Assert.Equal("> ", GetTextFromCurrentSnapshot());
         }
 
+        [WpfFact]
+        public async Task CopyInputsFromCurrentLine()
+        {
+            _testClipboard.Clear();
+
+            Window.InsertCode("111");
+            Window.Operations.BreakLine();
+            Window.InsertCode("222");
+
+            Window.Operations.CopyInputs();
+            VerifyClipboardData("222",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 222}",
+                "[{\"content\":\"222\",\"kind\":2}]",
+                expectedToBeLineCopy: true);
+
+
+            // Move caret to:
+            // > 1|11
+            // > 222
+            MoveCaretToPreviousPosition(7);
+            Window.Operations.CopyInputs();
+            VerifyClipboardData("111\r\n",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par }",
+                "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2}]",
+                expectedToBeLineCopy: true);
+
+            _testClipboard.Clear();
+            Window.Operations.ClearView();
+            
+            await Submit(
+@"111",
+@"111
+").ConfigureAwait(true);
+
+            Window.InsertCode("222");
+
+            // Move caret to:
+            // > 111
+            // 1|11
+            // > 222
+            MoveCaretToPreviousPosition(7);
+            Window.Operations.CopyInputs();
+            VerifyClipboardData(null, null, null);
+        }
+
+        [WpfFact]
+        public async Task CopyInputsFromSelection()
+        {
+            _testClipboard.Clear();
+
+            await Submit(
+@"111",
+@"111
+").ConfigureAwait(true);
+            Window.InsertCode("222");
+
+            // Make following stream selection:
+            // |> 111
+            // 111
+            // > 222|
+            Window.Operations.SelectAll();
+            Window.Operations.SelectAll();
+            Window.Operations.CopyInputs();
+            VerifyClipboardData("111\r\n\r\n222\r\n",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par \\par 222}",
+                "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4},{\"content\":\"222\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4}]",
+                expectedToBeLineCopy: true);
+
+            _testClipboard.Clear();
+            Window.TextView.Selection.Clear();
+
+            var caret = Window.TextView.Caret;
+            // Make a box selection as follows:
+            // |> 1|11
+            // |111|
+            // |> 2|22
+            MoveCaretToPreviousPosition(2);
+            var selection = Window.TextView.Selection;
+            var anchor = caret.Position.VirtualBufferPosition;
+            MoveCaretToPreviousPosition(13);
+            var active = caret.Position.VirtualBufferPosition;
+            selection.Mode = Text.Editor.TextSelectionMode.Box;
+            selection.Select(anchor, active);
+            Window.Operations.CopyInputs();
+
+            VerifyClipboardData("111\r\n\r\n222\r\n",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par \\par 222}",
+                "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4},{\"content\":\"222\",\"kind\":2},{\"content\":\"\\u000d\\u000a\",\"kind\":4}]",
+                 expectedToBeLineCopy: true);
+
+            _testClipboard.Clear();
+            Window.TextView.Selection.Clear();
+            Window.Operations.ClearView();
+
+            await Submit(
+@"111",
+@"111
+").ConfigureAwait(true);
+            Window.InsertCode("222");
+
+            // Make a stream selection as follows:
+            // > 111
+            // 1|11
+            // > 22|2
+            MoveCaretToNextPosition(1);
+            anchor = caret.Position.VirtualBufferPosition;
+            MoveCaretToPreviousPosition(7);
+            active = caret.Position.VirtualBufferPosition;
+            selection.Mode = Text.Editor.TextSelectionMode.Stream;
+            selection.Select(anchor, active);
+            Window.Operations.CopyInputs();
+
+            VerifyClipboardData("222",
+                "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 222}",
+                "[{\"content\":\"222\",\"kind\":2}]",
+                expectedToBeLineCopy: true);
+
+            _testClipboard.Clear();
+            Window.TextView.Selection.Clear();
+
+            _testClipboard.Clear();
+            Window.TextView.Selection.Clear();
+            Window.Operations.ClearView();
+
+            await Submit(
+@"111",
+@"111
+").ConfigureAwait(true);
+            Window.InsertCode("222");
+
+            // Make a stream selection as follows:
+            // > 111
+            // 1|11|
+            // > 222
+            MoveCaretToPreviousPosition(6);
+            anchor = caret.Position.VirtualBufferPosition;
+            MoveCaretToPreviousPosition(2);
+            active = caret.Position.VirtualBufferPosition;
+            selection.Mode = Text.Editor.TextSelectionMode.Stream;
+            selection.Select(anchor, active);
+            Window.Operations.CopyInputs();
+
+            VerifyClipboardData(null, null, null);
+        }
+
         /// <summary>
         /// Put text equivalent to copying from following selection to clipboard:
         /// |> TextCopiedFromStreamSelection| 
@@ -1557,8 +1702,8 @@ System.Console.WriteLine();",
                 Assert.Equal(expectedRtf, actualRtf);
             }
 
-            Assert.Equal(expectedToBeLineCopy, data.GetDataPresent(InteractiveWindow.ClipboardLineBasedCutCopyTag));
-            Assert.Equal(expectedToBeBoxCopy, data.GetDataPresent(InteractiveWindow.BoxSelectionCutCopyTag));
+            Assert.Equal(expectedToBeLineCopy, data?.GetDataPresent(InteractiveWindow.ClipboardLineBasedCutCopyTag) ?? false);
+            Assert.Equal(expectedToBeBoxCopy, data?.GetDataPresent(InteractiveWindow.BoxSelectionCutCopyTag) ?? false);
             Assert.False(expectedToBeLineCopy && expectedToBeBoxCopy);
         }
 

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests_ClipboardTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests_ClipboardTests.cs
@@ -1464,7 +1464,7 @@ System.Console.WriteLine();",
             Window.Operations.BreakLine();
             Window.InsertCode("222");
 
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
             VerifyClipboardData("222",
                 "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 222}",
                 "[{\"content\":\"222\",\"kind\":2}]",
@@ -1475,7 +1475,7 @@ System.Console.WriteLine();",
             // > 1|11
             // > 222
             MoveCaretToPreviousPosition(7);
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
             VerifyClipboardData("111\r\n",
                 "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par }",
                 "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2}]",
@@ -1496,7 +1496,7 @@ System.Console.WriteLine();",
             // 1|11
             // > 222
             MoveCaretToPreviousPosition(7);
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
             VerifyClipboardData(null, null, null);
         }
 
@@ -1517,7 +1517,7 @@ System.Console.WriteLine();",
             // > 222|
             Window.Operations.SelectAll();
             Window.Operations.SelectAll();
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
             VerifyClipboardData("111\r\n222",
                 "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par 222}",
                 "[{\"content\":\"111\\u000d\\u000a\",\"kind\":2},{\"content\":\"222\",\"kind\":2}]");
@@ -1535,7 +1535,7 @@ System.Console.WriteLine();",
             // > 222|
             Window.Operations.SelectAll();
             Window.Operations.SelectAll();
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
 
             VerifyClipboardData("111\r\n222",
                 "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 111\\par 222}",
@@ -1556,7 +1556,7 @@ System.Console.WriteLine();",
             var active = caret.Position.VirtualBufferPosition;
             selection.Mode = Text.Editor.TextSelectionMode.Box;
             selection.Select(anchor, active);
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
 
             VerifyClipboardData("1\r\n2\r\n",
                 "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 1\\par 2}",
@@ -1582,7 +1582,7 @@ System.Console.WriteLine();",
             active = caret.Position.VirtualBufferPosition;
             selection.Mode = Text.Editor.TextSelectionMode.Stream;
             selection.Select(anchor, active);
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
 
             VerifyClipboardData("22",
                 "{\\rtf\\ansi{\\fonttbl{\\f0 Consolas;}}{\\colortbl;\\red0\\green0\\blue0;\\red255\\green255\\blue255;}\\f0 \\fs24 \\cf1 \\cb2 \\highlight2 22}",
@@ -1607,7 +1607,7 @@ System.Console.WriteLine();",
             active = caret.Position.VirtualBufferPosition;
             selection.Mode = Text.Editor.TextSelectionMode.Stream;
             selection.Select(anchor, active);
-            Window.Operations.CopyInputs();
+            Window.Operations.CopyCode();
 
             VerifyClipboardData(null, null, null);
         }

--- a/src/InteractiveWindow/VisualStudio/CommandIds.cs
+++ b/src/InteractiveWindow/VisualStudio/CommandIds.cs
@@ -16,5 +16,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
         SearchHistoryPrevious = 0x010B,
         ExecuteInInteractiveWindow = 0x010C,
         CopyToInteractiveWindow = 0x010D,
+        CopyInputs = 0x010E,
     }
 }

--- a/src/InteractiveWindow/VisualStudio/CommandIds.cs
+++ b/src/InteractiveWindow/VisualStudio/CommandIds.cs
@@ -16,6 +16,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
         SearchHistoryPrevious = 0x010B,
         ExecuteInInteractiveWindow = 0x010C,
         CopyToInteractiveWindow = 0x010D,
-        CopyInputs = 0x010E,
+        CopyCode = 0x010E,
     }
 }

--- a/src/InteractiveWindow/VisualStudio/InteractiveWindow.vsct
+++ b/src/InteractiveWindow/VisualStudio/InteractiveWindow.vsct
@@ -202,6 +202,19 @@
         </Strings>
       </Button>
 
+      <Button guid="guidInteractiveWindowCmdSet" id="cmdidCopyInputs" priority="0x0300" type="Button">
+        <Parent guid="guidInteractiveWindowCmdSet" id="ConsoleMenuEditGroup"/>
+        <Icon guid="ImageCatalogGuid" id="CopyItem" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <Strings>
+          <ButtonText>Copy Inputs</ButtonText>
+          <CanonicalName>.InteractiveConsole.CopyInputs</CanonicalName>
+          <LocCanonicalName>.InteractiveConsole.CopyInputs</LocCanonicalName>
+        </Strings>
+      </Button>
+
       <!-- Toolbar Buttons -->
 
       <!--<Button guid="guidInteractiveWindowCmdSet" id="cmdidAbortExecution" priority="0x0300" type="Button">
@@ -281,6 +294,7 @@
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidBreakLine" key1="VK_RETURN" mod1="Shift" editor="guidInteractiveWindow" />
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidSearchHistoryNext" key1="VK_DOWN" mod1="Control Alt" editor="guidInteractiveWindow" />
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidSearchHistoryPrevious" key1="VK_UP" mod1="Control Alt" editor="guidInteractiveWindow" />
+    <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidCopyInputs" key1="C" mod1="Control Shift" editor="guidInteractiveWindow" />
 
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidExecuteInInteractiveWindow" editor="GUID_TextEditorFactory" mod1="Control" key1="E" mod2="Control" key2="VK_RETURN"  />
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidCopyToInteractiveWindow" editor="GUID_TextEditorFactory" mod1="Control" key1="K" mod2="Control" key2="VK_RETURN" />
@@ -314,6 +328,7 @@
       <IDSymbol name="cmdidSearchHistoryPrevious" value="0x010B"/>
       <IDSymbol name="cmdidExecuteInInteractiveWindow" value="0x010C"/>
       <IDSymbol name="cmdidCopyToInteractiveWindow" value="0x010D"/>
+      <IDSymbol name="cmdidCopyInputs" value="0x010E"/>
 
       <!-- Groups -->
       <IDSymbol name="ConsoleMenuGroup" value="0x1050" />

--- a/src/InteractiveWindow/VisualStudio/InteractiveWindow.vsct
+++ b/src/InteractiveWindow/VisualStudio/InteractiveWindow.vsct
@@ -202,16 +202,16 @@
         </Strings>
       </Button>
 
-      <Button guid="guidInteractiveWindowCmdSet" id="cmdidCopyInputs" priority="0x0300" type="Button">
+      <Button guid="guidInteractiveWindowCmdSet" id="cmdidCopyCode" priority="0x0300" type="Button">
         <Parent guid="guidInteractiveWindowCmdSet" id="ConsoleMenuEditGroup"/>
         <Icon guid="ImageCatalogGuid" id="CopyItem" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
-          <ButtonText>Copy Inputs</ButtonText>
-          <CanonicalName>.InteractiveConsole.CopyInputs</CanonicalName>
-          <LocCanonicalName>.InteractiveConsole.CopyInputs</LocCanonicalName>
+          <ButtonText>Copy Code</ButtonText>
+          <CanonicalName>.InteractiveConsole.CopyCode</CanonicalName>
+          <LocCanonicalName>.InteractiveConsole.CopyCode</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -294,7 +294,7 @@
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidBreakLine" key1="VK_RETURN" mod1="Shift" editor="guidInteractiveWindow" />
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidSearchHistoryNext" key1="VK_DOWN" mod1="Control Alt" editor="guidInteractiveWindow" />
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidSearchHistoryPrevious" key1="VK_UP" mod1="Control Alt" editor="guidInteractiveWindow" />
-    <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidCopyInputs" key1="C" mod1="Control Shift" editor="guidInteractiveWindow" />
+    <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidCopyCode" key1="C" mod1="Control Shift" editor="guidInteractiveWindow" />
 
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidExecuteInInteractiveWindow" editor="GUID_TextEditorFactory" mod1="Control" key1="E" mod2="Control" key2="VK_RETURN"  />
     <KeyBinding guid="guidInteractiveWindowCmdSet" id="cmdidCopyToInteractiveWindow" editor="GUID_TextEditorFactory" mod1="Control" key1="K" mod2="Control" key2="VK_RETURN" />
@@ -328,7 +328,7 @@
       <IDSymbol name="cmdidSearchHistoryPrevious" value="0x010B"/>
       <IDSymbol name="cmdidExecuteInInteractiveWindow" value="0x010C"/>
       <IDSymbol name="cmdidCopyToInteractiveWindow" value="0x010D"/>
-      <IDSymbol name="cmdidCopyInputs" value="0x010E"/>
+      <IDSymbol name="cmdidCopyCode" value="0x010E"/>
 
       <!-- Groups -->
       <IDSymbol name="ConsoleMenuGroup" value="0x1050" />

--- a/src/InteractiveWindow/VisualStudio/InteractiveWindowPackage.cs
+++ b/src/InteractiveWindow/VisualStudio/InteractiveWindowPackage.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [Description("Visual Studio Interactive Window")]
     [ProvideKeyBindingTable(Guids.InteractiveToolWindowIdString, 200)] // Resource ID: "Interactive Window"
-    [ProvideMenuResource("Menus.ctmenu", 3)]
+    [ProvideMenuResource("Menus.ctmenu", 4)]
     [Guid(Guids.InteractiveWindowPackageIdString)]
     [ProvideBindingPath]  // make sure our DLLs are loadable from other packages
     public sealed class InteractiveWindowPackage : Package

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -374,6 +374,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                         prgCmds[0].cmdf = !_window.IsResetting ? CommandEnabled : CommandDisabled;
                         prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
                         return VSConstants.S_OK;
+                    case CommandIds.CopyInputs:
+                        prgCmds[0].cmdf = _window.Operations is IInteractiveWindowOperations2 ? CommandEnabled : CommandDisabled;
+                        return VSConstants.S_OK;
                     default:
                         prgCmds[0].cmdf = CommandEnabled;
                         break;
@@ -420,6 +423,15 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                     case CommandIds.HistoryNext: _window.Operations.HistoryNext(); return VSConstants.S_OK;
                     case CommandIds.HistoryPrevious: _window.Operations.HistoryPrevious(); return VSConstants.S_OK;
                     case CommandIds.ClearScreen: _window.Operations.ClearView(); return VSConstants.S_OK;
+                    case CommandIds.CopyInputs:
+                        {
+                            var operation = _window.Operations as IInteractiveWindowOperations2;
+                            if (operation != null)
+                            {
+                                operation.CopyInputs();
+                            }
+                            return VSConstants.S_OK;
+                        }
                     case CommandIds.SearchHistoryNext:
                         _window.Operations.HistorySearchNext();
                         return VSConstants.S_OK;

--- a/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
+++ b/src/InteractiveWindow/VisualStudio/VsInteractiveWindowCommandFilter.cs
@@ -374,7 +374,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                         prgCmds[0].cmdf = !_window.IsResetting ? CommandEnabled : CommandDisabled;
                         prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
                         return VSConstants.S_OK;
-                    case CommandIds.CopyInputs:
+                    case CommandIds.CopyCode:
                         prgCmds[0].cmdf = _window.Operations is IInteractiveWindowOperations2 ? CommandEnabled : CommandDisabled;
                         return VSConstants.S_OK;
                     default:
@@ -423,12 +423,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
                     case CommandIds.HistoryNext: _window.Operations.HistoryNext(); return VSConstants.S_OK;
                     case CommandIds.HistoryPrevious: _window.Operations.HistoryPrevious(); return VSConstants.S_OK;
                     case CommandIds.ClearScreen: _window.Operations.ClearView(); return VSConstants.S_OK;
-                    case CommandIds.CopyInputs:
+                    case CommandIds.CopyCode:
                         {
                             var operation = _window.Operations as IInteractiveWindowOperations2;
                             if (operation != null)
                             {
-                                operation.CopyInputs();
+                                operation.CopyCode();
                             }
                             return VSConstants.S_OK;
                         }


### PR DESCRIPTION
`CopyCode` copies code from user inputs (if any) to clipboard, standard-input is not considered code here: If selection is empty, then copy code from user inputs in current line, otherwise copy code from user inputs in all selected text.

A button for this operation is added to VS with a shortcut "ctrl + shift + c" in Interactive Window scope. The only other command that uses the same shortcut is `View.ClassView` in global scope.

![copyinputs](https://cloud.githubusercontent.com/assets/788783/11827852/2cd8a176-a344-11e5-9557-c8b635d43d44.png)


This provides (a renamed) "copy inputs" command as described in #5212

@dotnet/roslyn-interactive 