### PR TITLE
Set OfficialBuild=true in DSR Version.proj file

### DIFF
--- a/src/Dependencies/Microsoft.DiaSymReader/Version.targets
+++ b/src/Dependencies/Microsoft.DiaSymReader/Version.targets
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <OfficialBuild>true</OfficialBuild>
     <RoslynSemanticVersion>1.0.6</RoslynSemanticVersion>
     <NuGetVersion>$(RoslynSemanticVersion)</NuGetVersion>
     <NuGetVersionType>Release</NuGetVersionType>


### PR DESCRIPTION
Microsoft.DiaSymReader should never be built with version 42.42.42.42. 
This is just a short term workaround until we move DSR to a separate repo.