### PR TITLE
PDB: Pass method body offset to OpenMethod

### DIFF
--- a/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Cci
 
         #region ISymUnmanagedWriter3
 
-        void OpenMethod2(uint methodToken, int sectionIndex, int offsetRelativeOffset);
+        void OpenMethod2(uint methodToken, int sectionIndex, int sectionRelativeOffset);
         void Commit();
 
         #endregion

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Cci
         private IModule Module => Context.Module;
         private EmitContext Context => _metadataWriter.Context;
 
-        public void SerializeDebugInfo(IMethodBody methodBody, uint localSignatureToken, CustomDebugInfoWriter customDebugInfoWriter)
+        public void SerializeDebugInfo(IMethodBody methodBody, uint localSignatureToken, int methodBodyOffset, CustomDebugInfoWriter customDebugInfoWriter)
         {
             Debug.Assert(_metadataWriter != null);
 
@@ -319,7 +319,7 @@ namespace Microsoft.Cci
 
             int methodToken = _metadataWriter.GetMethodToken(methodBody.MethodDefinition);
 
-            OpenMethod((uint)methodToken, methodBody.MethodDefinition);
+            OpenMethod((uint)methodToken, methodBodyOffset, methodBody.MethodDefinition);
 
             var localScopes = methodBody.LocalScopes;
 
@@ -982,11 +982,11 @@ namespace Microsoft.Cci
             return writer;
         }
 
-        private void OpenMethod(uint methodToken, IMethodDefinition method)
+        private void OpenMethod(uint methodToken, int methodBodyOffset, IMethodDefinition method)
         {
             try
             {
-                _symWriter.OpenMethod(methodToken);
+                _symWriter.OpenMethod2(methodToken, sectionIndex: 1, sectionRelativeOffset: methodBodyOffset);
                 if (_callLogger.LogOperation(OP.OpenMethod))
                 {
                     _callLogger.LogArgument(methodToken);
@@ -994,6 +994,7 @@ namespace Microsoft.Cci
                     // So we log that. Note that this will be the same for overloaded methods.
                     _callLogger.LogArgument(GetOrCreateSerializedTypeName(method.ContainingTypeDefinition));
                     _callLogger.LogArgument(method.Name);
+                    _callLogger.LogArgument(methodBodyOffset);
                 }
 
                 // open outermost scope:

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -4255,7 +4255,7 @@ namespace Microsoft.Cci
                         // TODO: consider parallelizing these (local signature tokens can be piped into IL serialization & debug info generation)
                         rva = this.SerializeMethodBody(body, ilWriter, localSignatureToken);
 
-                        pdbWriterOpt?.SerializeDebugInfo(body, localSignatureToken, customDebugInfoWriter);
+                        pdbWriterOpt?.SerializeDebugInfo(body, localSignatureToken, rva, customDebugInfoWriter);
                     }
                     else
                     {


### PR DESCRIPTION
The PDB includes an offset of the method body for each method with debug information. ISymUnmanagedWriter.OpenMethod synthesizes incorrect value. Use ISymUnmanagedWriter.OpenMethod2 and pass in the correct value.

There is no easy way to validate this, since ISymUnmanagedReader doesn't have API to retrieve the value. We could use DIA directly...
