### PR TITLE
Adopt .NetFoundation code of conduct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Some of the best ways to contribute are to try things out, file bugs, and join i
 
 Looking for something to work on? The list of [up for grabs issues](https://github.com/dotnet/roslyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+Grabs%22) is a great place to start.
 
+This project has adopted a code of conduct adapted from the [Contributor Covenant](http://contributor-covenant.org/) to clarify expected behavior in our community. This code of conduct has been [adopted by many other projects](http://contributor-covenant.org/adopters/). For more information see the [Code of conduct](http://www.dotnetfoundation.org/code-of-conduct).
+
+
 ### .NET Foundation
 
 This project is part of the [.NET Foundation](http://www.dotnetfoundation.org/projects) along with other


### PR DESCRIPTION
Snipped from the .NetFoundation code of conduct on their website.

The .NET Foundation was created to foster an open, innovative and inclusive community around open source .NET. To clarify expected behaviour in our communities we have adopted the Contributor Covenant. This code of conduct has been adopted by many other open source communities and we feel it expresses our values well. 

We should adopt this CoC for the Roslyn project.  I  suggest that we accept this PR on Tuesday Morning, please offer your suggestions for improvements here.  I urge you all to see the benefits of a code of conduct, adherence to it ensures that working on code which is primarily a fact driven engineering effort, remains a pleasant activity.

Kevin