### PR TITLE
Fix publicsign in VB

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1193,6 +1193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                    DeclaringCompilation.Options.CryptoPublicKey.IsEmpty AndAlso
                    Identity.HasPublicKey AndAlso
                    Not IsDelaySigned AndAlso
+                   Not DeclaringCompilation.Options.PublicSign AndAlso
                    Not StrongNameKeys.CanSign Then
 
                     ' Since the container always contains both keys, the problem is that the key file didn't contain private key.

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -1638,12 +1638,11 @@ End Class
     Public Sub PublicSignCore(compilation As Compilation)
         Assert.True(compilation.Options.PublicSign)
         Assert.Null(compilation.Options.DelaySign)
-        compilation.VerifyDiagnostics()
-        compilation.VerifyEmitDiagnostics()
 
         Dim stream As New MemoryStream()
         Dim emitResult = compilation.Emit(stream)
         Assert.True(emitResult.Success)
+        Assert.True(emitResult.Diagnostics.IsEmpty)
         stream.Position = 0
 
         Using reader As New PEReader(stream)

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -1639,9 +1639,11 @@ End Class
         Assert.True(compilation.Options.PublicSign)
         Assert.Null(compilation.Options.DelaySign)
         compilation.VerifyDiagnostics()
+        compilation.VerifyEmitDiagnostics()
 
         Dim stream As New MemoryStream()
-        compilation.Emit(stream)
+        Dim emitResult = compilation.Emit(stream)
+        Assert.True(emitResult.Success)
         stream.Position = 0
 
         Using reader As New PEReader(stream)
@@ -1660,21 +1662,21 @@ End Class
 
     <Fact>
     Public Sub PublicSign_FromPublicKeyFileNoStrongNameProvider()
-        Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey)
+        Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snPublicKey)
         Dim options = TestOptions.ReleaseDll.WithCryptoKeyFile(snk.Path).WithPublicSign(True)
         PublicSignCore(options)
     End Sub
 
     <Fact>
     Public Sub PublicSign_FromKeyFileAndStrongNameProvider()
-        Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey)
+        Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey2)
         Dim options = TestOptions.ReleaseDll.WithCryptoKeyFile(snk.Path).WithPublicSign(True).WithStrongNameProvider(s_defaultProvider)
         PublicSignCore(options)
     End Sub
 
     <Fact>
     Public Sub PublicSign_FromKeyFileAndNoStrongNameProvider()
-        Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey)
+        Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snPublicKey2)
         Dim options = TestOptions.ReleaseDll.WithCryptoKeyFile(snk.Path).WithPublicSign(True)
         PublicSignCore(options)
     End Sub


### PR DESCRIPTION
VB didn't check if publicsign was set before reporting an error
about the keyfile only containing a public key. This also checks
if public sign is set before reporting said error.

@dotnet/roslyn-compiler Please review