### PR TITLE
Do not wait for all members to be completed to emit a compilation event for the container.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -468,6 +468,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             var diagnostics = DiagnosticBag.GetInstance();
                             AfterMembersChecks(diagnostics);
                             AddDeclarationDiagnostics(diagnostics);
+
+                            // We may produce a SymbolDeclaredEvent for the enclosing type before events for its contained members
                             DeclaringCompilation.SymbolDeclaredEvent(this);
                             var thisThreadCompleted = state.NotePartComplete(CompletionPart.FinishMemberChecks);
                             Debug.Assert(thisThreadCompleted);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -468,6 +468,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             var diagnostics = DiagnosticBag.GetInstance();
                             AfterMembersChecks(diagnostics);
                             AddDeclarationDiagnostics(diagnostics);
+                            DeclaringCompilation.SymbolDeclaredEvent(this);
                             var thisThreadCompleted = state.NotePartComplete(CompletionPart.FinishMemberChecks);
                             Debug.Assert(thisThreadCompleted);
                             diagnostics.Free();
@@ -510,10 +511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             // We've completed all members, so we're ready for the PointedAtManagedTypeChecks;
                             // proceed to the next iteration.
-                            if (state.NotePartComplete(CompletionPart.MembersCompleted))
-                            {
-                                DeclaringCompilation.SymbolDeclaredEvent(this);
-                            }
+                            state.NotePartComplete(CompletionPart.MembersCompleted);
                             break;
                         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -390,10 +390,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!this.IsAsync)
             {
-                state.NotePartComplete(CompletionPart.StartAsyncMethodChecks);
-                if (state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks) && IsPartialDefinition)
+                if (state.NotePartComplete(CompletionPart.StartAsyncMethodChecks))
                 {
-                    DeclaringCompilation.SymbolDeclaredEvent(this);
+                    if (IsPartialDefinition) DeclaringCompilation.SymbolDeclaredEvent(this);
+                    state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
+                }
+                else
+                {
+                    state.SpinWaitComplete(CompletionPart.FinishAsyncMethodChecks, cancellationToken);
                 }
 
                 return;
@@ -431,10 +435,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (state.NotePartComplete(CompletionPart.StartAsyncMethodChecks))
             {
                 AddDeclarationDiagnostics(diagnostics);
-                if (state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks) && IsPartialDefinition)
-                {
-                    DeclaringCompilation.SymbolDeclaredEvent(this);
-                }
+                if (IsPartialDefinition) DeclaringCompilation.SymbolDeclaredEvent(this);
+                state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -228,8 +228,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // NOTE: the following is not cancellable.  Once we've set the
                     // members, we *must* do the following to make sure we're in a consistent state.
                     this.DeclaringCompilation.DeclarationDiagnostics.AddRange(diagnostics);
-
                     RegisterDeclaredCorTypes();
+                    DeclaringCompilation.SymbolDeclaredEvent(this);
                     _state.NotePartComplete(CompletionPart.NameToMembersMap);
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -229,6 +229,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // members, we *must* do the following to make sure we're in a consistent state.
                     this.DeclaringCompilation.DeclarationDiagnostics.AddRange(diagnostics);
                     RegisterDeclaredCorTypes();
+
+                    // We may produce a SymbolDeclaredEvent for the enclosing namespace before events for its contained members
                     DeclaringCompilation.SymbolDeclaredEvent(this);
                     _state.NotePartComplete(CompletionPart.NameToMembersMap);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
@@ -76,10 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             if (allCompleted)
                             {
-                                if (_state.NotePartComplete(CompletionPart.MembersCompleted))
-                                {
-                                    DeclaringCompilation.SymbolDeclaredEvent(this);
-                                }
+                                _state.NotePartComplete(CompletionPart.MembersCompleted);
                                 break;
                             }
                             else


### PR DESCRIPTION
Fixes #7446 
@mavasani @dotnet/roslyn-compiler Please review.
