### PR TITLE
Fix the Microsoft.Net.Compilers.netcore nuspec

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
@@ -17,7 +17,7 @@
         <tags>$tags$</tags>
         <dependencies>
             <group targetFramework="dnxcore50">
-                <dependency id="Microsoft.CodeAnalysis.Compilers" version="$version$" />
+                <dependency id="Microsoft.CodeAnalysis.Compilers" version="[$version$]" />
                 <dependency id="System.AppContext" version="4.0.1-beta-23504" />
                 <dependency id="System.Collections" version="4.0.11-beta-23504" />
                 <dependency id="System.Collections.Immutable" version="1.1.38-beta-23504" />


### PR DESCRIPTION
The nuspec currently has a >= dependency on the Microsoft.CodeAnalysis.Compilers
package, which contains the compiler DLLs. It's highly unlikely that csc/vbc.exe
will work with mismatched DLL versions, so this dependency should be fixed, not
minimum.

@dotnet/roslyn-compiler Please review