### PR TITLE
Use newest language version in scripting compilers

### DIFF
--- a/src/Scripting/CSharp/CSharpScriptCompiler.cs
+++ b/src/Scripting/CSharp/CSharpScriptCompiler.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting
     {
         public static readonly ScriptCompiler Instance = new CSharpScriptCompiler();
 
-        private static readonly CSharpParseOptions s_defaultOptions = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6, kind: SourceCodeKind.Script);
+        private static readonly CSharpParseOptions s_defaultOptions = new CSharpParseOptions(kind: SourceCodeKind.Script);
 
         private CSharpScriptCompiler()
         {

--- a/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
+++ b/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting
 
         Public Shared ReadOnly Instance As ScriptCompiler = New VisualBasicScriptCompiler()
 
-        Private Shared ReadOnly s_defaultOptions As VisualBasicParseOptions = New VisualBasicParseOptions(languageVersion:=LanguageVersion.VisualBasic11, kind:=SourceCodeKind.Script)
+        Private Shared ReadOnly s_defaultOptions As VisualBasicParseOptions = New VisualBasicParseOptions(kind:=SourceCodeKind.Script)
         Private Shared ReadOnly s_vbRuntimeReference As MetadataReference = MetadataReference.CreateFromAssemblyInternal(GetType(CompilerServices.NewLateBinding).GetTypeInfo().Assembly)
 
         Private Sub New()


### PR DESCRIPTION
Makes the vb scripting compiler use the newest compiler version.
This enables features such as multi line string support or interpolated strings in a REPL.