### PR TITLE
Merge TopLevel and MethodBody speculative models

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/MethodBodySemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MethodBodySemanticModel.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Creates an MethodBodySemanticModel that allows asking semantic questions about an attribute node.
         ''' </summary>
-        Friend Shared Function Create(binder As MethodBodyBinder, Optional ignoreAccessibility As Boolean = False) As MethodBodySemanticModel
+        Friend Shared Function Create(binder As SubOrFunctionBodyBinder, Optional ignoreAccessibility As Boolean = False) As MethodBodySemanticModel
             Return New MethodBodySemanticModel(binder.Root, binder, ignoreAccessibility:=ignoreAccessibility)
         End Function
 
@@ -79,30 +79,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             speculativeModel = CreateSpeculative(parentModel, statement, binder, position)
             Return True
-        End Function
-
-        Friend Overrides Function TryGetSpeculativeSemanticModelCore(parentModel As SyntaxTreeSemanticModel, position As Integer, initializer As EqualsValueSyntax, <Out> ByRef speculativeModel As SemanticModel) As Boolean
-            speculativeModel = Nothing
-            Return False
-        End Function
-    End Class
-
-    ' TODO (tomat): merge with MethodBodySemanticModel? C# doesn't have a separate class for top-level. Should it?
-    Friend NotInheritable Class TopLevelCodeSemanticModel
-        Inherits MemberSemanticModel
-
-        Public Sub New(binder As TopLevelCodeBinder, Optional ignoreAccessibility As Boolean = False)
-            MyBase.New(binder.Root, binder, parentSemanticModelOpt:=Nothing, speculatedPosition:=0, ignoreAccessibility:=ignoreAccessibility)
-        End Sub
-
-        Friend Overrides Function TryGetSpeculativeSemanticModelForMethodBodyCore(parentModel As SyntaxTreeSemanticModel, position As Integer, method As MethodBlockBaseSyntax, <Out> ByRef speculativeModel As SemanticModel) As Boolean
-            speculativeModel = Nothing
-            Return False
-        End Function
-
-        Friend Overrides Function TryGetSpeculativeSemanticModelCore(parentModel As SyntaxTreeSemanticModel, position As Integer, statement As ExecutableStatementSyntax, <Out> ByRef speculativeModel As SemanticModel) As Boolean
-            speculativeModel = Nothing
-            Return False
         End Function
 
         Friend Overrides Function TryGetSpeculativeSemanticModelCore(parentModel As SyntaxTreeSemanticModel, position As Integer, initializer As EqualsValueSyntax, <Out> ByRef speculativeModel As SemanticModel) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -134,10 +134,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         ' PERF: These shared variables avoid repeated allocation of Func(Of Binder, MemberSemanticModel) in GetMemberSemanticModel
-        Private Shared ReadOnly s_methodBodySemanticModelCreator As Func(Of Tuple(Of Binder, Boolean), MemberSemanticModel) = Function(key As Tuple(Of Binder, Boolean)) MethodBodySemanticModel.Create(DirectCast(key.Item1, MethodBodyBinder), key.Item2)
+        Private Shared ReadOnly s_methodBodySemanticModelCreator As Func(Of Tuple(Of Binder, Boolean), MemberSemanticModel) = Function(key As Tuple(Of Binder, Boolean)) MethodBodySemanticModel.Create(DirectCast(key.Item1, SubOrFunctionBodyBinder), key.Item2)
         Private Shared ReadOnly s_initializerSemanticModelCreator As Func(Of Tuple(Of Binder, Boolean), MemberSemanticModel) = Function(key As Tuple(Of Binder, Boolean)) InitializerSemanticModel.Create(DirectCast(key.Item1, DeclarationInitializerBinder), key.Item2)
         Private Shared ReadOnly s_attributeSemanticModelCreator As Func(Of Tuple(Of Binder, Boolean), MemberSemanticModel) = Function(key As Tuple(Of Binder, Boolean)) AttributeSemanticModel.Create(DirectCast(key.Item1, AttributeBinder), key.Item2)
-        Private Shared ReadOnly s_topLevelCodeSemanticModelCreator As Func(Of Tuple(Of Binder, Boolean), MemberSemanticModel) = Function(key As Tuple(Of Binder, Boolean)) New TopLevelCodeSemanticModel(DirectCast(key.Item1, TopLevelCodeBinder), key.Item2)
 
         Public Function GetMemberSemanticModel(binder As Binder) As MemberSemanticModel
 
@@ -154,7 +153,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If TypeOf binder Is TopLevelCodeBinder Then
-                Return _semanticModelCache.GetOrAdd(Tuple.Create(binder, IgnoresAccessibility), s_topLevelCodeSemanticModelCreator)
+                Return _semanticModelCache.GetOrAdd(Tuple.Create(binder, IgnoresAccessibility), s_methodBodySemanticModelCreator)
             End If
 
             Return Nothing

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -345,6 +345,15 @@ index:=1)
         index:=0)
         End Function
 
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        Public Async Function TestSimplifyTypeInScriptCode() As Task
+            Await TestAsync(
+        NewLines("Imports System \n [|System.Console.WriteLine(0)|]"),
+        NewLines("Imports System \n Console.WriteLine(0)"),
+        parseOptions:=TestOptions.Script,
+        index:=0)
+        End Function
+
         <WorkItem(542093)>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Async Function TestNoSimplificationOfParenthesizedPredefinedTypes() As Task


### PR DESCRIPTION
Combines top level and method body semantic model classes.
In effect the speculative model for top level code is not null.
This enables top level analysis for top level scope such as type simplifications.