### PR TITLE
Cleanup of ForegroundNotificationServiceTests

### DIFF
--- a/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
+++ b/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
 {
     public class ForegroundNotificationServiceTests
     {
-        private readonly IForegroundNotificationService _service;
+        private readonly ForegroundNotificationService _service;
         private bool _done;
 
         public ForegroundNotificationServiceTests()
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
 
             Assert.True(_done);
             Assert.True(ran);
-            Assert.True(Empty(_service));
+            Assert.True(_service.IsEmpty_TestOnly);
         }
 
         [WpfFact]
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
                 await PumpWait();
 
                 Assert.False(ran);
-                Assert.True(Empty(_service));
+                Assert.True(_service.IsEmpty_TestOnly);
             }
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
 
             Assert.False(watch.IsRunning);
             Assert.True(watch.ElapsedMilliseconds >= 50);
-            Assert.True(Empty(_service));
+            Assert.True(_service.IsEmpty_TestOnly);
         }
 
         [WpfFact]
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
             await PumpWait().ConfigureAwait(false);
             Assert.True(_done);
             Assert.Equal(count, 9000000);
-            Assert.True(Empty(_service));
+            Assert.True(_service.IsEmpty_TestOnly);
         }
 
         private async Task PumpWait()
@@ -144,12 +144,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(1));
             }
-        }
-
-        private static bool Empty(IForegroundNotificationService service)
-        {
-            var temp = (ForegroundNotificationService)service;
-            return temp.IsEmpty_TestOnly;
         }
     }
 }

--- a/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
+++ b/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -69,18 +70,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
         {
             var asyncToken = EmptyAsyncToken.Instance;
 
-            DateTime now = DateTime.UtcNow;
-            DateTime set = DateTime.UtcNow;
+            Stopwatch watch = Stopwatch.StartNew();
 
             _service.RegisterNotification(() =>
             {
-                set = DateTime.UtcNow;
+                watch.Stop();
                 _done = true;
             }, 50, asyncToken, CancellationToken.None);
 
             await PumpWait();
 
-            Assert.True(set.Subtract(now).TotalMilliseconds > 50);
+            Assert.False(watch.IsRunning);
+            Assert.True(watch.ElapsedMilliseconds >= 50);
             Assert.True(Empty(_service));
         }
 


### PR DESCRIPTION
Attempts to fix the issues called out on https://github.com/dotnet/roslyn/issues/7512.

Also simplified IsEmpty checks - to avoid static method indirection.