### PR TITLE
Introduce ObjectDisplayOptions.EscapeNonPrintableStringCharacters

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -255,8 +255,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var useQuotes = options.IncludesOption(ObjectDisplayOptions.UseQuotes);
+            var escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
             var quote = useQuotes ? '"' : '\0';
-            if (!useQuotes && !ReplaceAny(value, quote))
+            if (!useQuotes && !(escapeNonPrintable && ReplaceAny(value, quote)))
             {
                 return value;
             }
@@ -267,9 +268,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 builder.Append(quote);
             }
-            foreach (var c in value)
+            if (escapeNonPrintable)
             {
-                FormatStringChar(builder, c, quote);
+                foreach (var c in value)
+                {
+                    FormatStringChar(builder, c, quote);
+                }
+            }
+            else
+            {
+                builder.Append(value);
             }
             if (useQuotes)
             {

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public static string FormatPrimitive(object obj, bool quoteStrings, bool useHexadecimalNumbers)
         {
-            var options = ObjectDisplayOptions.None;
+            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters;
             if (quoteStrings)
             {
                 options |= ObjectDisplayOptions.UseQuotes;
@@ -168,7 +168,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public static string FormatLiteral(string value, bool quote)
         {
-            return ObjectDisplay.FormatLiteral(value, quote ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None);
+            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters | 
+                (quote ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None);
+            return ObjectDisplay.FormatLiteral(value, options);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -261,21 +261,33 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("12.5M", FormatPrimitiveIncludingTypeSuffix(decimalValue, useHexadecimalNumbers: true));
         }
 
+        [Fact]
+        public void StringEscaping()
+        {
+            const string value = "a\tb";
+
+            Assert.Equal("a\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.None));
+            Assert.Equal("\"a\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes));
+            Assert.Equal("a\\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
+            Assert.Equal("\"a\\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
+        }
+
         private string FormatPrimitive(object obj, bool quoteStrings = false)
         {
-            return ObjectDisplay.FormatPrimitive(obj, quoteStrings ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None);
+            var options = quoteStrings ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None;
+            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
         }
 
         private string FormatPrimitiveUsingHexadecimalNumbers(object obj, bool quoteStrings = false)
         {
             var options = quoteStrings ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None;
-            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.UseHexadecimalNumbers);
+            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.UseHexadecimalNumbers | ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
         }
 
         private string FormatPrimitiveIncludingTypeSuffix(object obj, bool useHexadecimalNumbers = false)
         {
             var options = useHexadecimalNumbers ? ObjectDisplayOptions.UseHexadecimalNumbers : ObjectDisplayOptions.None;
-            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.IncludeTypeSuffix);
+            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.IncludeTypeSuffix | ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
@@ -31,8 +31,14 @@ namespace Microsoft.CodeAnalysis
         UseHexadecimalNumbers = 1 << 2,
 
         /// <summary>
-        /// Whether or not to quote character and string literals. In Visual Basic, this also enables pretty-listing of non-printable characters using ChrW function and vb* constants.
+        /// Whether or not to quote character and string literals.
         /// </summary>
         UseQuotes = 1 << 3,
+
+        /// <summary>
+        /// In C#, replace non-printable (e.g. control) characters with dedicated (e.g. \t) or unicode (\u0001) escape sequences.
+        /// In Visual Basic, replace non-printable characters with calls to ChrW and vb* constants.
+        /// </summary>
+        EscapeNonPrintableStringCharacters = 1 << 4,
     }
 }

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
@@ -122,7 +122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function FormatPrimitive(obj As Object, quoteStrings As Boolean, useHexadecimalNumbers As Boolean) As String
             Dim options = ObjectDisplayOptions.None
             If quoteStrings Then
-                options = options Or ObjectDisplayOptions.UseQuotes
+                options = options Or ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters
             End If
             If useHexadecimalNumbers Then
                 options = options Or ObjectDisplayOptions.UseHexadecimalNumbers
@@ -135,7 +135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim sb = pooledBuilder.Builder
 
             Dim lastKind = -1
-            For Each token As Integer In ObjectDisplay.TokenizeString(str, quote:=True, useHexadecimalNumbers:=True)
+            For Each token As Integer In ObjectDisplay.TokenizeString(str, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.UseHexadecimalNumbers Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
                 Dim kind = token >> 16
 
                 ' merge contiguous tokens of the same kind into a single part

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -370,7 +370,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary> Creates a token with kind StringLiteralToken from a string value. </summary>
         ''' <param name="value">The string value to be represented by the returned token.</param>
         Public Shared Function Literal(value As String) As SyntaxToken
-            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes), value)
+            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters), value)
         End Function
 
         ''' <summary> Creates a token with kind StringLiteralToken from the text and corresponding string value. </summary>
@@ -393,7 +393,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary> Creates a token with kind CharacterLiteralToken from a character value. </summary>
         ''' <param name="value">The character value to be represented by the returned token.</param>
         Public Shared Function Literal(value As Char) As SyntaxToken
-            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes), value)
+            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters), value)
         End Function
 
         ''' <summary> Creates a token with kind CharacterLiteralToken from the text and corresponding character value. </summary>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
@@ -147,7 +147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             ' non-printable characters are unchanged if quoting is disabled
             Assert.Equal(s, FormatPrimitiveUsingHexadecimalNumbers(s, quoteStrings:=False))
             Assert.Equal(s, ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.None))
-            Assert.Equal("""a"" & ChrW(&HFFFF) & ChrW(&HFFFE) & vbCrLf & ""b""", ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.UseHexadecimalNumbers))
+            Assert.Equal("""a"" & ChrW(&HFFFF) & ChrW(&HFFFE) & vbCrLf & ""b""", ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters Or ObjectDisplayOptions.UseHexadecimalNumbers))
 
             ' "well-known" characters:
             Assert.Equal("""a"" & vbBack", FormatPrimitiveUsingHexadecimalNumbers("a" & vbBack, quoteStrings:=True))
@@ -225,12 +225,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal("12.5D", FormatPrimitiveIncludingTypeSuffix(decimalValue, useHexadecimalNumbers:=True))
         End Sub
 
+        <Fact>
+        Public Sub StringEscaping()
+            Const value = "a" & vbTab & "b"
+
+            Assert.Equal("a" & vbTab & "b", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.None))
+            Assert.Equal("""a" & vbTab & "b""", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes))
+            ' Not allowed in VB: ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
+            Assert.Equal("""a"" & vbTab & ""b""", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters))
+        End Sub
+
         Private Function FormatPrimitive(obj As Object, Optional quoteStrings As Boolean = False) As String
-            Return ObjectDisplay.FormatPrimitive(obj, If(quoteStrings, ObjectDisplayOptions.UseQuotes, ObjectDisplayOptions.None))
+            Return ObjectDisplay.FormatPrimitive(obj, If(quoteStrings, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters, ObjectDisplayOptions.None))
         End Function
 
         Private Function FormatPrimitiveUsingHexadecimalNumbers(obj As Object, Optional quoteStrings As Boolean = False) As String
-            Dim options = If(quoteStrings, ObjectDisplayOptions.UseQuotes, ObjectDisplayOptions.None)
+            Dim options = If(quoteStrings, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters, ObjectDisplayOptions.None)
             Return ObjectDisplay.FormatPrimitive(obj, options Or ObjectDisplayOptions.UseHexadecimalNumbers)
         End Function
 

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override string FormatLiteral(int value, ObjectDisplayOptions options)
         {
-            return ObjectDisplay.FormatLiteral(value, options & ~ObjectDisplayOptions.UseQuotes);
+            return ObjectDisplay.FormatLiteral(value, options & ~(ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
         }
 
         internal override string FormatPrimitiveObject(object value, ObjectDisplayOptions options)
@@ -217,5 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             return ObjectDisplay.FormatString(str, useQuotes: options.IncludesOption(ObjectDisplayOptions.UseQuotes));
         }
+
+        internal override ObjectDisplayOptions QuotedStringOptions => ObjectDisplayOptions.UseQuotes;
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -42,6 +42,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return SyntaxFacts.IsWhitespace(c);
         }
 
+        internal override ObjectDisplayOptions GetValueStringOptions(bool useQuotes)
+        {
+            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters;
+            if (useQuotes)
+            {
+                options |= ObjectDisplayOptions.UseQuotes;
+            }
+
+            return options;
+        }
+
         internal override string TrimAndGetFormatSpecifiers(string expression, out ReadOnlyCollection<string> formatSpecifiers)
         {
             expression = RemoveComments(expression);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     return IncludeObjectId(
                         value,
-                        FormatPrimitive(value, options & ~ObjectDisplayOptions.UseQuotes, inspectionContext),
+                        FormatPrimitive(value, options & ~(ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters), inspectionContext),
                         flags);
                 }
             }
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 if (!value.IsNull)
                 {
-                    return this.GetValueString(value, inspectionContext, ObjectDisplayOptions.UseQuotes, GetValueFlags.None);
+                    return this.GetValueString(value, inspectionContext, QuotedStringOptions, GetValueFlags.None);
                 }
             }
             else if (type.IsCharacter())
@@ -409,6 +409,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal abstract string FormatPrimitiveObject(object value, ObjectDisplayOptions options);
 
         internal abstract string FormatString(string str, ObjectDisplayOptions options);
+
+        internal abstract ObjectDisplayOptions QuotedStringOptions { get; }
 
         #endregion
     }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Text;
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -30,9 +29,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         string IDkmClrFormatter.GetValueString(DkmClrValue value, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers)
         {
-            var options = ((inspectionContext.EvaluationFlags & DkmEvaluationFlags.NoQuotes) == 0) ?
-                ObjectDisplayOptions.UseQuotes :
-                ObjectDisplayOptions.None;
+            ObjectDisplayOptions options = GetValueStringOptions((inspectionContext.EvaluationFlags & DkmEvaluationFlags.NoQuotes) == 0);
             return GetValueString(value, inspectionContext, options, GetValueFlags.IncludeObjectId);
         }
 
@@ -66,6 +63,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal abstract bool IsPredefinedType(Type type);
 
         internal abstract bool IsWhitespace(char c);
+
+        internal abstract ObjectDisplayOptions GetValueStringOptions(bool useQuotes);
 
         // Note: We could be less conservative (e.g. "new C()").
         internal bool NeedsParentheses(string expr)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
@@ -171,6 +171,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return ObjectDisplay.FormatLiteral(str, options)
         End Function
 
+        Friend Overrides ReadOnly Property QuotedStringOptions As ObjectDisplayOptions
+            Get
+                Return ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters
+            End Get
+        End Property
+
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -2,9 +2,6 @@
 
 Imports System.Collections.ObjectModel
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.VisualStudio.Debugger.Clr
-Imports Microsoft.VisualStudio.Debugger.ComponentInterfaces
-Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Microsoft.VisualStudio.Debugger.Metadata
 
@@ -13,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     ''' <summary>
     ''' Computes string representations of <see cref="DkmClrValue"/> instances.
     ''' </summary>
-    Partial Friend NotInheritable Class VisualBasicFormatter : Inherits Formatter : Implements IDkmClrFormatter
+    Partial Friend NotInheritable Class VisualBasicFormatter : Inherits Formatter
 
         ''' <summary>
         ''' Singleton instance of VisualBasicFormatter (created using default constructor).
@@ -25,25 +22,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                        nullString:="Nothing",
                        staticMembersString:=Resources.SharedMembers)
         End Sub
-
-        Private Function IDkmClrFormatter_GetTypeName(inspectionContext As DkmInspectionContext, clrType As DkmClrType, clrTypeInfo As DkmClrCustomTypeInfo, formatSpecifiers As ReadOnlyCollection(Of String)) As String Implements IDkmClrFormatter.GetTypeName
-            Return GetTypeName(New TypeAndCustomInfo(clrType.GetLmrType(), clrTypeInfo), escapeKeywordIdentifiers:=False, sawInvalidIdentifier:=Nothing)
-        End Function
-
-        Private Function IDkmClrFormatter_GetUnderlyingString(clrValue As DkmClrValue, inspectionContext As DkmInspectionContext) As String Implements IDkmClrFormatter.GetUnderlyingString
-            Return GetUnderlyingString(clrValue, inspectionContext)
-        End Function
-
-        Private Function IDkmClrFormatter_GetValueString(clrValue As DkmClrValue, inspectionContext As DkmInspectionContext, formatSpecifiers As ReadOnlyCollection(Of String)) As String Implements IDkmClrFormatter.GetValueString
-            Dim options = If((inspectionContext.EvaluationFlags And DkmEvaluationFlags.NoQuotes) = 0,
-                ObjectDisplayOptions.UseQuotes,
-                ObjectDisplayOptions.None)
-            Return GetValueString(clrValue, inspectionContext, options, GetValueFlags.IncludeObjectId)
-        End Function
-
-        Private Function IDkmClrFormatter_HasUnderlyingString(clrValue As DkmClrValue, inspectionContext As DkmInspectionContext) As Boolean Implements IDkmClrFormatter.HasUnderlyingString
-            Return HasUnderlyingString(clrValue, inspectionContext)
-        End Function
 
         Friend Overrides Function IsValidIdentifier(name As String) As Boolean
             Return SyntaxFacts.IsValidIdentifier(name)
@@ -59,6 +37,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Friend Overrides Function IsWhitespace(c As Char) As Boolean
             Return SyntaxFacts.IsWhitespace(c)
+        End Function
+
+        Friend Overrides Function GetValueStringOptions(useQuotes As Boolean) As ObjectDisplayOptions
+            Return If(useQuotes,
+                ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters,
+                ObjectDisplayOptions.None)
         End Function
 
         Friend Overrides Function TrimAndGetFormatSpecifiers(expression As String, ByRef formatSpecifiers As ReadOnlyCollection(Of String)) As String

--- a/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
+++ b/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string FormatLiteral(string value, bool quote, bool useHexadecimalNumbers = false)
         {
-            var options = ObjectDisplayOptions.None;
+            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters;
             if (quote)
             {
                 options |= ObjectDisplayOptions.UseQuotes;


### PR DESCRIPTION
It used to be always on in C# and implied by UseQuotes in VB.  Now it can
be manipulated separately.  This will allow us to print unescaped strings
in the C# interactive window.