### PR TITLE
Properly add a using for an extension method when another, incompatible, one is in scope already.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -1896,6 +1896,53 @@ namespace A.C
 @"using lowercase ; namespace A { class A { static void Main ( string [ ] args ) { var a = new b ( ) ; } } } namespace lowercase { class b { } } namespace Uppercase { class B { } } ");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public async Task TestWithExistingIncompatibleExtension()
+        {
+            await TestAsync(
+@"using N;
+
+class C
+{
+    int x()
+    {
+        System.Collections.Generic.IEnumerable<int> x = null;
+        return x.[|Any|]
+    }
+}
+
+namespace N
+{
+    static class Extensions
+    {
+        public static void Any(this string s)
+        {
+        }
+    }
+}",
+@"using System.Linq;
+using N;
+
+class C
+{
+    int x()
+    {
+        System.Collections.Generic.IEnumerable<int> x = null;
+        return x.Any
+    }
+}
+
+namespace N
+{
+    static class Extensions
+    {
+        public static void Any(this string s)
+        {
+        }
+    }
+}");
+        }
+
         [WorkItem(1744, @"https://github.com/dotnet/roslyn/issues/1744")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public async Task TestIncompleteCatchBlockInLambda()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -2089,6 +2089,59 @@ class Test
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public async Task TestExtensionWithIncompatibleInstance()
+        {
+            await TestAsync(
+@"using System.IO;
+
+namespace Namespace1
+{
+    static class StreamExtensions
+    {
+        public static void Write(this Stream stream, byte[] bytes)
+        {
+        }
+    }
+}
+
+namespace Namespace2
+{
+    class Foo
+    {
+        void Bar()
+        {
+            Stream stream = null;
+            stream.[|Write|](new byte[] { 1, 2, 3 });
+        }
+    }
+}",
+@"using System.IO;
+using Namespace1;
+
+namespace Namespace1
+{
+    static class StreamExtensions
+    {
+        public static void Write(this Stream stream, byte[] bytes)
+        {
+        }
+    }
+}
+
+namespace Namespace2
+{
+    class Foo
+    {
+        void Bar()
+        {
+            Stream stream = null;
+            stream.Write(new byte[] { 1, 2, 3 });
+        }
+    }
+}");
+        }
+
         public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -1896,6 +1896,7 @@ namespace A.C
 @"using lowercase ; namespace A { class A { static void Main ( string [ ] args ) { var a = new b ( ) ; } } } namespace lowercase { class b { } } namespace Uppercase { class B { } } ");
         }
 
+        [WorkItem(7443, "https://github.com/dotnet/roslyn/issues/7443")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public async Task TestWithExistingIncompatibleExtension()
         {
@@ -2089,6 +2090,7 @@ class Test
 }");
         }
 
+        [WorkItem(7461, "https://github.com/dotnet/roslyn/issues/7461")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
         public async Task TestExtensionWithIncompatibleInstance()
         {

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -107,6 +107,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
         /// </summary>
         private const string CS1929 = "CS1929";
 
+        /// <summary>
+        /// Cannot convert method group 'X' to non-delegate type 'Y'. Did you intend to invoke the method?
+        /// </summary>
+        private const string CS0428 = "CS0428";
+
         public override ImmutableArray<string> FixableDiagnosticIds
         {
             get
@@ -127,7 +132,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                     CS1580,
                     CS1581,
                     CS1584,
-                    CS1929);
+                    CS1929,
+                    CS0428);
             }
         }
 
@@ -148,6 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
             switch (diagnostic.Id)
             {
+                case CS0428:
                 case CS1061:
                     if (node.IsKind(SyntaxKind.ConditionalAccessExpression))
                     {

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -112,6 +112,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
         /// </summary>
         private const string CS0428 = "CS0428";
 
+        /// <summary>
+        ///  There is no argument given that corresponds to the required formal parameter 'X' of 'Y'
+        /// </summary>
+        private const string CS7036 = "CS7036";
+
         public override ImmutableArray<string> FixableDiagnosticIds
         {
             get
@@ -133,7 +138,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                     CS1581,
                     CS1584,
                     CS1929,
-                    CS0428);
+                    CS0428,
+                    CS7036);
             }
         }
 
@@ -154,6 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
 
             switch (diagnostic.Id)
             {
+                case CS7036:
                 case CS0428:
                 case CS1061:
                     if (node.IsKind(SyntaxKind.ConditionalAccessExpression))


### PR DESCRIPTION
Fixes https://github.com/dotnet/Roslyn/issues/7443 and https://github.com/dotnet/Roslyn/issues/7461