### PR TITLE
Handle unmatched conditionals in brace matching

### DIFF
--- a/src/EditorFeatures/CSharp/BraceMatching/CSharpDirectiveTriviaBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/CSharpDirectiveTriviaBraceMatcher.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
 {
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
         RegionDirectiveTriviaSyntax, EndRegionDirectiveTriviaSyntax>
     {
         internal override List<DirectiveTriviaSyntax> GetMatchingConditionalDirectives(DirectiveTriviaSyntax directive, CancellationToken cancellationToken)
-                 => directive.GetMatchingConditionalDirectives(cancellationToken).ToList();
+                => directive.GetMatchingConditionalDirectives(cancellationToken)?.ToList();
 
         internal override DirectiveTriviaSyntax GetMatchingDirective(DirectiveTriviaSyntax directive, CancellationToken cancellationToken)
                 => directive.GetMatchingDirective(cancellationToken);

--- a/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
@@ -699,5 +699,53 @@ public class C
 
             await TestAsync(code, expected);
         }
+
+        [WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUnmatchedConditionalDirective()
+        {
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {#if$$
+
+    }
+}";
+            var expected = @"
+class Program
+{
+    static void Main(string[] args)
+    {#if
+
+    }
+}";
+
+            await TestAsync(code, expected);
+        }
+
+        [WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUnmatchedConditionalDirective2()
+        {
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {#else$$
+
+    }
+}";
+            var expected = @"
+class Program
+{
+    static void Main(string[] args)
+    {#else
+
+    }
+}";
+
+            await TestAsync(code, expected);
+        }
     }
 }

--- a/src/EditorFeatures/Core/Extensibility/BraceMatching/AbstractDirectiveTriviaBraceMatcher.cs
+++ b/src/EditorFeatures/Core/Extensibility/BraceMatching/AbstractDirectiveTriviaBraceMatcher.cs
@@ -36,12 +36,15 @@ namespace Microsoft.CodeAnalysis.Editor
                 return null;
             }
 
-            TDirectiveTriviaSyntax matchingDirective;
+            TDirectiveTriviaSyntax matchingDirective = null;
             if (IsConditionalDirective(directive))
             {
                 // #if/#elif/#else/#endif directive cases.
                 var matchingDirectives = GetMatchingConditionalDirectives(directive, cancellationToken);
-                matchingDirective = matchingDirectives[(matchingDirectives.IndexOf(directive) + 1) % matchingDirectives.Count];
+                if (matchingDirectives?.Count > 0)
+                {
+                    matchingDirective = matchingDirectives[(matchingDirectives.IndexOf(directive) + 1) % matchingDirectives.Count];
+                }
             }
             else
             {

--- a/src/EditorFeatures/VisualBasic/BraceMatching/VisualBasicDirectiveTriviaBraceMatcher.vb
+++ b/src/EditorFeatures/VisualBasic/BraceMatching/VisualBasicDirectiveTriviaBraceMatcher.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.BraceMatching
              RegionDirectiveTriviaSyntax, EndRegionDirectiveTriviaSyntax)
 
         Friend Overrides Function GetMatchingConditionalDirectives(directive As DirectiveTriviaSyntax, cancellationToken As CancellationToken) As List(Of DirectiveTriviaSyntax)
-            Return directive.GetMatchingConditionalDirectives(cancellationToken).ToList()
+            Return directive.GetMatchingConditionalDirectives(cancellationToken)?.ToList()
         End Function
 
         Friend Overrides Function GetMatchingDirective(directive As DirectiveTriviaSyntax, cancellationToken As CancellationToken) As DirectiveTriviaSyntax

--- a/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
@@ -590,5 +590,74 @@ End Class
             Await TestAsync(code, expected)
         End Function
 
+        <WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)>
+        Public Async Function TestUnmatchedIncompleteConditionalDirective() As Task
+            Dim code =
+<Text>
+Class C
+    Sub Test()
+#If$$
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+            Dim expected =
+<Text>
+Class C
+    Sub Test()
+[|#If|]
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+
+            Await TestAsync(code, expected)
+        End Function
+
+        <WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)>
+        Public Async Function TestUnmatchedCompleteConditionalDirective() As Task
+            Dim code =
+<Text>
+Class C
+    Sub Test()
+#If$$ CHK Then
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+            Dim expected =
+<Text>
+Class C
+    Sub Test()
+[|#If|] CHK Then
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+
+            Await TestAsync(code, expected)
+        End Function
+
+        <WorkItem(7534, "https://github.com/dotnet/roslyn/issues/7534")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)>
+        Public Async Function TestUnmatchedConditionalDirective() As Task
+            Dim code =
+<Text>
+Class C
+    Sub Test()
+#Else$$
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+            Dim expected =
+<Text>
+Class C
+    Sub Test()
+[|#Else|]
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf)
+
+            Await TestAsync(code, expected)
+        End Function
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #7534 

For unmatched conditionals, C# returns null when asked for a matching
conditional directive, whereas VB returns a list with the single
unmatched directive in it. Incorporate checks for those into the
AbstractDirectiveTriviaBraceMatcher and add tests.