### PR TITLE
Call ICompletionSession.Commit() when committing intellisense

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
@@ -19,5 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor
 
         event EventHandler<CompletionItemEventArgs> ItemSelected;
         event EventHandler<CompletionItemEventArgs> ItemCommitted;
+
+        void Commit();
     }
 }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml
@@ -15,7 +15,7 @@
              Cursor="Arrow"
              Focusable="True"
              AutomationProperties.AutomationId="Rename"
-             UseLayoutRounding="True">
+             UseLayoutRounding="True" >
 
     <UserControl.Resources>
         <ResourceDictionary>

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AbstractController.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AbstractController.cs
@@ -103,11 +103,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             AssertIsForeground();
             if (IsSessionActive)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
         }
 
-        public void StopModelComputation()
+        public void StopComputationAndDismissPresentation()
         {
             AssertIsForeground();
             VerifySessionIsActive();
@@ -116,7 +116,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             // dismiss this again.
             var localSession = sessionOpt;
             sessionOpt = null;
-            localSession.Stop();
+            localSession.StopComputation();
+            localSession.DismissEditorSession();
         }
 
         public bool TryHandleEscapeKey()
@@ -136,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             var handledCommand = sessionOpt.InitialUnfilteredModel != null;
 
             // In the presence of an escape, we always stop what we're doing.
-            this.StopModelComputation();
+            this.StopComputationAndDismissPresentation();
 
             return handledCommand;
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
@@ -64,19 +64,35 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 });
             }
 
+            /// <summary>
+            /// Dismisses the editor completion list.
+            /// 
+            /// NOTE: If calling this, do not call <see cref="CommitEditorSession"/>.
+            /// </summary>
             public override void DismissEditorSession()
             {
                 AssertIsForeground();
-                this.PresenterSession.ItemSelected -= OnPresenterSessionItemSelected;
-                this.PresenterSession.ItemCommitted -= OnPresenterSessionItemCommitted;
+                this.DisconnectFromPresenter();
                 base.DismissEditorSession();
             }
 
+            /// <summary>
+            /// Commits and dismisses the underlying editor completion list.
+            /// 
+            /// NOTE: If calling this, do not call <see cref="DismissEditorSession"/>.
+            /// Committing the editor list will implicitly dismiss it.
+            /// </summary>
             public void CommitEditorSession()
             {
                 AssertIsForeground();
-                this.PresenterSession.ItemCommitted -= OnPresenterSessionItemCommitted;
+                this.DisconnectFromPresenter();
                 this.PresenterSession.Commit();
+            }
+
+            private void DisconnectFromPresenter()
+            {
+                this.PresenterSession.ItemSelected -= OnPresenterSessionItemSelected;
+                this.PresenterSession.ItemCommitted -= OnPresenterSessionItemCommitted;
             }
 
             private SnapshotPoint GetCaretPointInViewBuffer()

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
@@ -64,12 +64,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 });
             }
 
-            public override void Stop()
+            public override void DismissEditorSession()
             {
                 AssertIsForeground();
                 this.PresenterSession.ItemSelected -= OnPresenterSessionItemSelected;
                 this.PresenterSession.ItemCommitted -= OnPresenterSessionItemCommitted;
-                base.Stop();
+                base.DismissEditorSession();
+            }
+
+            public void CommitEditorSession()
+            {
+                AssertIsForeground();
+                this.PresenterSession.ItemCommitted -= OnPresenterSessionItemCommitted;
+                this.PresenterSession.Commit();
             }
 
             private SnapshotPoint GetCaretPointInViewBuffer()

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session.cs
@@ -21,6 +21,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             #endregion
 
+            private bool alreadyCommitted;
+            private bool alreadyDismissed;
+
             public Session(Controller controller, ModelComputation<Model> computation, CompletionRules completionRules, ICompletionPresenterSession presenterSession)
                 : base(controller, computation, presenterSession)
             {
@@ -72,6 +75,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             public override void DismissEditorSession()
             {
                 AssertIsForeground();
+                Contract.ThrowIfTrue(alreadyDismissed, "This session has already been dismissed");
+                Contract.ThrowIfTrue(alreadyCommitted, "This session has already been committed");
+                alreadyDismissed = true;
+
                 this.DisconnectFromPresenter();
                 base.DismissEditorSession();
             }
@@ -85,6 +92,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             public void CommitEditorSession()
             {
                 AssertIsForeground();
+                Contract.ThrowIfTrue(alreadyDismissed, "This session has already been dismissed");
+                Contract.ThrowIfTrue(alreadyCommitted, "This session has already been committed");
+                alreadyCommitted = true;
+
                 this.DisconnectFromPresenter();
                 this.PresenterSession.Commit();
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             AssertIsForeground();
             if (modelOpt == null)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
             else
             {
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // If the selected item is the builder, there's not actually any work to do to commit
             if (item.IsBuilder)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
                 return;
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_AutomaticLineEnder.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_AutomaticLineEnder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // We did not commit based on enter.  So our computation will still be running.  Stop it now.
             if (!committed)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
                 nextHandler();
             }
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     (model != null && GetCompletionService().DismissIfLastFilterCharacterDeleted && AllFilterTextsEmpty(model, GetCaretPointInViewBuffer())))
                 {
                     // If the caret moved out of bounds of our items, then we want to dismiss the list. 
-                    this.StopModelComputation();
+                    this.StopComputationAndDismissPresentation();
                     return;
                 }
                 else if (model != null && model.TriggerInfo.TriggerReason != CompletionTriggerReason.BackspaceOrDeleteCommand)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CaretPositionChanged.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CaretPositionChanged.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             {
                 // Completions hadn't even been computed yet or the caret is out of bounds.  
                 // Just cancel everything we're doing.
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // the event and dismiss the list. This order (buffer edit, event, list dismissmal)
             // matches the behavior under the shims. 
             // Here, we keep a reference to our session as a local to avoid reentrancy when
-            // we ask the session to commit at the end of this method.
+            // we ask the session to commit at the end of this method (which will also dismiss the list).
             var localSession = this.sessionOpt;
             this.sessionOpt = null;
             localSession.StopComputation();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -32,7 +32,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // TODO(cyrusn): We still have a general reentrancy problem where calling into a custom
             // commit provider (or just calling into the editor) may cause something to call back
             // into us.  However, for now, we just hope that no such craziness will occur.
-            this.StopModelComputation();
+            var localSession = this.sessionOpt;
+            this.sessionOpt = null;
+            localSession.StopComputation();
 
             // NOTE(cyrusn): It is intentional that we get the undo history for the
             // surface buffer and not the subject buffer.
@@ -134,6 +136,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     formattingTransaction.Complete();
                 }
             }
+
+            localSession.CommitEditorSession();
+            localSession.DismissEditorSession();
 
             // Let the completion rules know that this item was committed.
             GetCompletionRules().CompletionItemCommitted(item);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CutPaste.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CutPaste.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             AssertIsForeground();
             if (this.sessionOpt != null)
             {
-                StopModelComputation();
+                StopComputationAndDismissPresentation();
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // it.
             if (sessionOpt != null)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
 
             // Next create the session that represents that we now have a potential completion list.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_OnTextViewBufferPostChanged.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_OnTextViewBufferPostChanged.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             if (model != null && this.IsCaretOutsideAllItemBounds(model, this.GetCaretPointInViewBuffer()))
             {
                 // If the caret moved out of bounds of our items, then we want to dismiss the list. 
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
             else
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // We did not commit based on enter.  So our computation will still be running.  Stop it now.
             if (!committed)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
 
             // Enter has different behavior amongst languages, so we need to actually defer to

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SnippetCommands.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SnippetCommands.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             if (sessionOpt != null)
             {
-                StopModelComputation();
+                StopComputationAndDismissPresentation();
             }
 
             nextHandler();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // Also, send the tab through to the editor.
             if (!committed)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
                 nextHandler();
             }
         }
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             if (selectedItem.IsBuilder)
             {
                 committed = true;
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
                 return;
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     {
                         // If we were computing anything, we stop.  We only want to process a typechar
                         // if it was a normal character.
-                        this.StopModelComputation();
+                        this.StopComputationAndDismissPresentation();
                     }
                 }
 
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     else
                     {
                         // Now dismiss the session.
-                        this.StopModelComputation();
+                        this.StopComputationAndDismissPresentation();
                     }
 
                     // The character may commit/dismiss and then trigger completion again. So check

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
@@ -164,6 +164,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
 
         public void Commit()
         {
+            // We've already populated the editor list with CompletionItems
+            // that will call us back when the editor commits (we did this
+            // in order to get notified of commits through double click)/
+            // Set a flag to avoid reentrancy.
             _callingEditorCommit = true;
             if (_editorSessionOpt != null)
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
@@ -166,16 +166,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         {
             // We've already populated the editor list with CompletionItems
             // that will call us back when the editor commits (we did this
-            // in order to get notified of commits through double click)/
+            // in order to get notified of commits through double click).
             // Set a flag to avoid reentrancy.
             _callingEditorCommit = true;
-            if (_editorSessionOpt != null)
+            _isDismissed = true;
+            try
             {
-                _editorSessionOpt.Dismissed -= OnEditorSessionDismissed;
-                _editorSessionOpt.Commit();
+                if (_editorSessionOpt != null)
+                {
+                    _editorSessionOpt.Dismissed -= OnEditorSessionDismissed;
+                    _editorSessionOpt.Commit();
+                    _editorSessionOpt = null;
+                }
             }
-
-            _callingEditorCommit = false;
+            finally
+            {
+                _callingEditorCommit = false;
+            }
         }
 
         private bool ExecuteKeyboardCommand(IntellisenseKeyboardCommand command)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/IController.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/IController.cs
@@ -9,6 +9,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
     {
         void OnModelUpdated(TModel result);
         IAsyncToken BeginAsyncOperation(string name = "", object tag = null, [CallerFilePath] string filePath = "", [CallerLineNumber]int lineNumber = 0);
-        void StopModelComputation();
+        void StopComputationAndDismissPresentation();
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/ISession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/ISession.cs
@@ -6,7 +6,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
     {
         TModel InitialUnfilteredModel { get; }
 
-        void Stop();
+        void StopComputation();
+
+        void DismissEditorSession();
 
         TModel WaitForController();
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             AssertIsForeground();
             if (modelOpt == null || modelOpt.TextVersion != this.SubjectBuffer.CurrentSnapshot.Version)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
             else
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
@@ -36,21 +36,26 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
         {
             AssertIsForeground();
             Contract.ThrowIfFalse(ReferenceEquals(this.PresenterSession, sender));
-            Controller.StopModelComputation();
+            Controller.StopComputationAndDismissPresentation();
         }
 
-        public virtual void Stop()
+        public virtual void StopComputation()
         {
             AssertIsForeground();
             this.Computation.Stop();
-            this.PresenterSession.Dismissed -= OnPresenterSessionDismissed;
-            this.PresenterSession.Dismiss();
         }
 
         public TModel WaitForController()
         {
             AssertIsForeground();
             return Computation.WaitForController();
+        }
+
+        public virtual void DismissEditorSession()
+        {
+            AssertIsForeground();
+            this.PresenterSession.Dismissed -= OnPresenterSessionDismissed;
+            this.PresenterSession.Dismiss();
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                 this.PresenterSession.ItemSelected += OnPresenterSessionItemSelected;
             }
 
-            public override void Stop()
+            public override void StopComputation()
             {
                 AssertIsForeground();
                 this.PresenterSession.ItemSelected -= OnPresenterSessionItemSelected;
-                base.Stop();
+                base.StopComputation();
             }
 
             private void OnPresenterSessionItemSelected(object sender, SignatureHelpItemEventArgs e)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             AssertIsForeground();
             if (modelOpt == null)
             {
-                this.StopModelComputation();
+                this.StopComputationAndDismissPresentation();
             }
             else
             {
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
             if (!this.TextView.GetCaretPoint(this.SubjectBuffer).HasValue)
             {
-                StopModelComputation();
+                StopComputationAndDismissPresentation();
                 return;
             }
 

--- a/src/EditorFeatures/Test2/IntelliSense/SessionTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SessionTests.vb
@@ -30,11 +30,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             presenter.Raise(Sub(p) AddHandler p.Dismissed, Nothing, New EventArgs())
 
-            controller.Verify(Sub(c) c.StopModelComputation())
+            controller.Verify(Sub(c) c.StopComputationAndDismissPresentation())
         End Sub
 
         <WpfFact>
-        Public Sub PresenterIsDismissedWhenSessionIsStopped()
+        Public Sub PresenterIsNotDismissedWhenSessionIsStopped()
             Dim presenter = New Mock(Of IIntelliSensePresenterSession)
             Dim controller = New Mock(Of IController(Of Model))
             Dim session = New Session(Of IController(Of Model), Model, IIntelliSensePresenterSession)(
@@ -42,9 +42,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 New ModelComputation(Of Model)(controller.Object, TaskScheduler.Default),
                 presenter.Object)
 
-            session.Stop()
+            session.StopComputation()
 
-            presenter.Verify(Sub(p) p.Dismiss())
+            presenter.Verify(Sub(p) p.Dismiss(), Times.Never)
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/TestCompletionPresenterSession.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestCompletionPresenterSession.vb
@@ -78,5 +78,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Sub SelectNextPageItem() Implements ICompletionPresenterSession.SelectNextPageItem
             SetSelectedItem(GetFilteredItemAt(CompletionItems.IndexOf(SelectedItem) + s_itemsPerPage))
         End Sub
+
+        Public Sub Commit() Implements ICompletionPresenterSession.Commit
+            _testState.CurrentCompletionPresenterSession = Nothing
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
When committing completion, we dismiss the editor popup (if visible) and then make edits to the buffer. We don't call the Commit method on the editor popup, but it turns out that third party extensions listen for that event. To call it, we split up the actions of stopping our internal model computation and dismissing the editor session when we're done. This allows us to stop computing, make buffer edits, and then call the commit method when we're done.

NB: The VS ShimCompletionController raises the commit event after the text edit; that behavior is preserved in this change.

Tagging @dotnet/roslyn-ide for review
