### PR TITLE
Properly pass along a cancellation token so we don't get an AggregateException

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -727,7 +727,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                     var context = new TaggerContext<TTag>(
                         this.State, spansToTag, caretPoint, this.AccumulatedTextChanges, oldTagTrees, cancellationToken);
-                    ProduceTagsAsync(context).Wait();
+                    ProduceTagsAsync(context).Wait(cancellationToken);
 
                     ProcessContext(spansToTag, oldTagTrees, context);
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/Roslyn/issues/7326