### PR TITLE
Trivial fix for 6805.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var arg = node.Indices[0];
                 var index = Visit(arg);
-                if (node.Type != _int32Type)
+                if (index.Type != _int32Type)
                 {
                     index = ConvertIndex(index, arg.Type, _int32Type);
                 }
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var arg in expressions)
             {
                 var index = Visit(arg);
-                if (arg.Type != _int32Type)
+                if (index.Type != _int32Type)
                 {
                     index = ConvertIndex(index, arg.Type, _int32Type);
                 }


### PR DESCRIPTION
Just fixing the easy-out check that verifies if index conversion is needed at all. Currently the condition is always true - likely a typo.
Otherwise, the part that creates conversion does the right thing regardless, so the end result should be the same.

Fixes #6805