### PR TITLE
Change type of IExpression.ConstantValue from object to Optional<object>

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Semantics;
 using Roslyn.Utilities;
 
@@ -15,9 +16,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         OperationKind IOperation.Kind => this.ExpressionKind;
 
         bool IOperation.IsInvalid => this.HasErrors;
-          
-        object IExpression.ConstantValue => this.ConstantValue?.Value;
 
+        Optional<object> IExpression.ConstantValue
+        {
+            get
+            {
+                ConstantValue value = this.ConstantValue;
+                return value != null ? new Optional<object>(value.Value) : default(Optional<object>);
+            }
+        }
         SyntaxNode IOperation.Syntax => this.Syntax;
         
         protected virtual OperationKind ExpressionKind => OperationKind.None;

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/EmptyArrayAnalyzer.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/EmptyArrayAnalyzer.cs
@@ -70,10 +70,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics.SystemLanguage
                             //// Pointer types can't be generic type arguments.
                             && arrayCreation.ElementType.TypeKind != TypeKind.Pointer)
                         {
-                            object arrayLength = arrayCreation.DimensionSizes[0].ConstantValue;
-                            if (arrayLength != null &&
-                                arrayLength is int &&
-                                (int)arrayLength == 0)
+                            Optional<object> arrayLength = arrayCreation.DimensionSizes[0].ConstantValue;
+                            if (arrayLength.HasValue &&
+                                arrayLength.Value is int &&
+                                (int)arrayLength.Value == 0)
                             {
                                 Report(operationContext, arrayCreation.Syntax);
                             }

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/LocalCouldBeConstAnalyzer.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/LocalCouldBeConstAnalyzer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics.SystemLanguage
                                         var localType = local.Type;
                                         if ((!localType.IsReferenceType || localType.SpecialType == SpecialType.System_String) && localType.SpecialType != SpecialType.None)
                                         {
-                                            if (variable.InitialValue != null && variable.InitialValue.ConstantValue != null)
+                                            if (variable.InitialValue != null && variable.InitialValue.ConstantValue.HasValue)
                                             {
                                                 mightBecomeConstLocals.Add(local);
                                             }

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
@@ -108,13 +108,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                              IExpression conditionLeft = condition.Left;
                              IExpression conditionRight = condition.Right;
 
-                             if (conditionRight.ConstantValue != null &&
+                             if (conditionRight.ConstantValue.HasValue &&
                                  conditionRight.ResultType.SpecialType == SpecialType.System_Int32 &&
                                  conditionLeft.Kind == OperationKind.LocalReferenceExpression)
                              {
                                  // Test is known to be a comparison of a local against a constant.
 
-                                 int testValue = (int)conditionRight.ConstantValue;
+                                 int testValue = (int)conditionRight.ConstantValue.Value;
                                  ILocalSymbol testVariable = ((ILocalReferenceExpression)conditionLeft).Local;
 
                                  if (forLoop.Before.Length == 1)
@@ -125,12 +125,12 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                          IAssignmentExpression setupAssignment = (IAssignmentExpression)((IExpressionStatement)setup).Expression;
                                          if (setupAssignment.Target.Kind == OperationKind.LocalReferenceExpression &&
                                              ((ILocalReferenceExpression)setupAssignment.Target).Local == testVariable &&
-                                             setupAssignment.Value.ConstantValue != null &&
+                                             setupAssignment.Value.ConstantValue.HasValue &&
                                              setupAssignment.Value.ResultType.SpecialType == SpecialType.System_Int32)
                                          {
                                              // Setup is known to be an assignment of a constant to the local used in the test.
 
-                                             int initialValue = (int)setupAssignment.Value.ConstantValue;
+                                             int initialValue = (int)setupAssignment.Value.ConstantValue.Value;
 
                                              if (forLoop.AtLoopBottom.Length == 1)
                                              {
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                                              if (!advanceOperation.UsesOperatorMethod &&
                                                                  advanceOperation.Left.Kind == OperationKind.LocalReferenceExpression &&
                                                                  ((ILocalReferenceExpression)advanceOperation.Left).Local == testVariable &&
-                                                                 advanceOperation.Right.ConstantValue != null &&
+                                                                 advanceOperation.Right.ConstantValue.HasValue &&
                                                                  advanceOperation.Right.ResultType.SpecialType == SpecialType.System_Int32)
                                                              {
                                                                  // Advance binary operation is known to involve a reference to the local used in the test and a constant.
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
                                                          if (advanceAssignment.Target.Kind == OperationKind.LocalReferenceExpression &&
                                                              ((ILocalReferenceExpression)advanceAssignment.Target).Local == testVariable &&
-                                                             advanceAssignment.Value.ConstantValue != null &&
+                                                             advanceAssignment.Value.ConstantValue.HasValue &&
                                                              advanceAssignment.Value.ResultType.SpecialType == SpecialType.System_Int32)
                                                          {
                                                              // Advance binary operation is known to involve a reference to the local used in the test and a constant.
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
                                                      if (advanceIncrement != null)
                                                      {
-                                                         int incrementValue = (int)advanceIncrement.ConstantValue;
+                                                         int incrementValue = (int)advanceIncrement.ConstantValue.Value;
                                                          if (advanceOperationCode == BinaryOperationKind.IntegerSubtract)
                                                          {
                                                              advanceOperationCode = BinaryOperationKind.IntegerAdd;
@@ -287,10 +287,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                          hasNonDefault = true;
                                          ISingleValueCaseClause singleValueClause = (ISingleValueCaseClause)clause;
                                          IExpression singleValueExpression = singleValueClause.Value;
-                                         if (singleValueExpression?.ConstantValue != null &&
+                                         if (singleValueExpression != null &&
+                                             singleValueExpression.ConstantValue.HasValue &&
                                              singleValueExpression.ResultType.SpecialType == SpecialType.System_Int32)
                                          {
-                                             int singleValue = (int)singleValueExpression.ConstantValue;
+                                             int singleValue = (int)singleValueExpression.ConstantValue.Value;
                                              caseValueCount += IncludeClause(singleValue, singleValue, ref minCaseValue, ref maxCaseValue);
                                          }
                                          else
@@ -306,13 +307,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                          IRangeCaseClause rangeClause = (IRangeCaseClause)clause;
                                          IExpression rangeMinExpression = rangeClause.MinimumValue;
                                          IExpression rangeMaxExpression = rangeClause.MaximumValue;
-                                         if (rangeMinExpression?.ConstantValue != null &&
+                                         if (rangeMinExpression != null &&
+                                             rangeMinExpression.ConstantValue.HasValue &&
                                              rangeMinExpression.ResultType.SpecialType == SpecialType.System_Int32 &&
-                                             rangeMaxExpression?.ConstantValue != null &&
+                                             rangeMaxExpression != null &&
+                                             rangeMaxExpression.ConstantValue.HasValue &&
                                              rangeMaxExpression.ResultType.SpecialType == SpecialType.System_Int32)
                                          {
-                                             int rangeMinValue = (int)rangeMinExpression.ConstantValue;
-                                             int rangeMaxValue = (int)rangeMaxExpression.ConstantValue;
+                                             int rangeMinValue = (int)rangeMinExpression.ConstantValue.Value;
+                                             int rangeMaxValue = (int)rangeMaxExpression.ConstantValue.Value;
                                              caseValueCount += IncludeClause(rangeMinValue, rangeMaxValue, ref minCaseValue, ref maxCaseValue);
                                          }
                                          else
@@ -327,12 +330,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                                          hasNonDefault = true;
                                          IRelationalCaseClause relationalClause = (IRelationalCaseClause)clause;
                                          IExpression relationalValueExpression = relationalClause.Value;
-                                         if (relationalValueExpression?.ConstantValue != null &&
+                                         if (relationalValueExpression != null &&
+                                             relationalValueExpression.ConstantValue.HasValue &&
                                              relationalValueExpression.ResultType.SpecialType == SpecialType.System_Int32)
                                          {
                                              int rangeMinValue = int.MaxValue;
                                              int rangeMaxValue = int.MinValue;
-                                             int relationalValue = (int)relationalValueExpression.ConstantValue;
+                                             int relationalValue = (int)relationalValueExpression.ConstantValue.Value;
                                              switch (relationalClause.Relation)
                                              {
                                                  case BinaryOperationKind.IntegerEquals:
@@ -489,10 +493,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
         private static void TestAscendingArgument(OperationAnalysisContext operationContext, IExpression argument, ref long priorArgumentValue)
         {
-            object argumentValue = argument.ConstantValue;
-            if (argumentValue != null && argument.ResultType.SpecialType == SpecialType.System_Int32)
+            Optional<object> argumentValue = argument.ConstantValue;
+            if (argumentValue.HasValue && argument.ResultType.SpecialType == SpecialType.System_Int32)
             {
-                int integerArgument = (int)argumentValue;
+                int integerArgument = (int)argumentValue.Value;
                 if (integerArgument < priorArgumentValue)
                 {
                     Report(operationContext, argument.Syntax, OutOfNumericalOrderArgumentsDescriptor);
@@ -535,8 +539,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                  {
                      ILiteralExpression literal = (ILiteralExpression)operationContext.Operation;
                      if (literal.ResultType.SpecialType == SpecialType.System_Int32 &&
-                         literal.ConstantValue != null &&
-                         (int)literal.ConstantValue == 17)
+                         literal.ConstantValue.HasValue &&
+                         (int)literal.ConstantValue.Value == 17)
                      {
                          operationContext.ReportDiagnostic(Diagnostic.Create(SeventeenDescriptor, literal.Syntax.GetLocation()));
                      }

--- a/src/Compilers/Core/Portable/Compilation/Expression.cs
+++ b/src/Compilers/Core/Portable/Compilation/Expression.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Semantics
 
         public bool IsInvalid => Condition == null || Condition.IsInvalid || IfTrue == null || IfTrue.IsInvalid || IfFalse == null || IfFalse.IsInvalid;
 
-        public object ConstantValue => null;
+        public Optional<object> ConstantValue => default(Optional<object>);
     }
 
     public sealed class Assignment : IExpressionStatement
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Semantics
 
             public bool IsInvalid => Target == null || Target.IsInvalid || Value == null || Value.IsInvalid;
 
-            public object ConstantValue => null;
+            public Optional<object> ConstantValue => default(Optional<object>);
         }
     }
 
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Semantics
 
             public bool IsInvalid => Target == null || Target.IsInvalid || Value == null || Value.IsInvalid;
 
-            public object ConstantValue => null;
+            public Optional<object> ConstantValue => default(Optional<object>);
 
             public bool UsesOperatorMethod => this.Operator != null;
         }
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Semantics
 
         public bool IsInvalid => false;
 
-        public object ConstantValue => _value;
+        public Optional<object> ConstantValue => new Optional<object>(_value);
 
         public SyntaxNode Syntax { get; }
     }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Semantics
 
         public bool IsInvalid => false;
 
-        public object ConstantValue => _value.Value;
+        public Optional<object> ConstantValue => new Optional<object>(_value.Value);
 
         public SyntaxNode Syntax { get; }
     }
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.Semantics
 
         public bool IsInvalid => Left == null || Left.IsInvalid || Right == null || Right.IsInvalid;
 
-        public object ConstantValue => null;
+        public Optional<object> ConstantValue => default(Optional<object>);
 
         public SyntaxNode Syntax { get; }
     }
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.Semantics
             return false;
         }
 
-        public object ConstantValue => null;
+        public Optional<object> ConstantValue => default(Optional<object>);
 
         private class DimensionInitializer : IDimensionArrayInitializer
         {

--- a/src/Compilers/Core/Portable/Compilation/IExpression.cs
+++ b/src/Compilers/Core/Portable/Compilation/IExpression.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// </summary>
         ITypeSymbol ResultType { get; }
         /// <summary>
-        /// If the expression evaluates to a constant value, the value of the expression, and otherwise null.
+        /// If the expression evaluates to a constant value, <see cref="Optional{Object}.HasValue"/> is true and <see cref="Optional{Object}.Value"/> is the value of the expression, and otherwise <see cref="Optional{Object}.HasValue"/> is false.
         /// </summary>
-        object ConstantValue { get; }
+        Optional<object> ConstantValue { get; }
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -102,7 +102,7 @@ Microsoft.CodeAnalysis.Semantics.ConditionalChoice.ResultType.get -> Microsoft.C
 Microsoft.CodeAnalysis.Semantics.ConditionalChoice.Syntax.get -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Semantics.ConditionalChoice.Kind.get -> Microsoft.CodeAnalysis.Semantics.OperationKind
 Microsoft.CodeAnalysis.Semantics.ConditionalChoice.IsInvalid.get -> bool
-Microsoft.CodeAnalysis.Semantics.ConditionalChoice.ConstantValue.get -> object
+Microsoft.CodeAnalysis.Semantics.ConditionalChoice.ConstantValue.get -> Microsoft.CodeAnalysis.Optional<object>
 Microsoft.CodeAnalysis.Semantics.Assignment
 Microsoft.CodeAnalysis.Semantics.Assignment.Assignment(Microsoft.CodeAnalysis.Semantics.IReferenceExpression target, Microsoft.CodeAnalysis.Semantics.IExpression value, Microsoft.CodeAnalysis.SyntaxNode syntax) -> void
 Microsoft.CodeAnalysis.Semantics.Assignment.Syntax.get -> Microsoft.CodeAnalysis.SyntaxNode
@@ -121,7 +121,7 @@ Microsoft.CodeAnalysis.Semantics.IntegerLiteral.Spelling.get -> string
 Microsoft.CodeAnalysis.Semantics.IntegerLiteral.ResultType.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.Semantics.IntegerLiteral.Kind.get -> Microsoft.CodeAnalysis.Semantics.OperationKind
 Microsoft.CodeAnalysis.Semantics.IntegerLiteral.IsInvalid.get -> bool
-Microsoft.CodeAnalysis.Semantics.IntegerLiteral.ConstantValue.get -> object
+Microsoft.CodeAnalysis.Semantics.IntegerLiteral.ConstantValue.get -> Microsoft.CodeAnalysis.Optional<object>
 Microsoft.CodeAnalysis.Semantics.IntegerLiteral.Syntax.get -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Semantics.Binary
 Microsoft.CodeAnalysis.Semantics.Binary.Binary(Microsoft.CodeAnalysis.Semantics.BinaryOperationKind binaryKind, Microsoft.CodeAnalysis.Semantics.IExpression left, Microsoft.CodeAnalysis.Semantics.IExpression right, Microsoft.CodeAnalysis.ITypeSymbol resultType, Microsoft.CodeAnalysis.SyntaxNode syntax) -> void
@@ -133,7 +133,7 @@ Microsoft.CodeAnalysis.Semantics.Binary.Operator.get -> Microsoft.CodeAnalysis.I
 Microsoft.CodeAnalysis.Semantics.Binary.ResultType.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.Semantics.Binary.Kind.get -> Microsoft.CodeAnalysis.Semantics.OperationKind
 Microsoft.CodeAnalysis.Semantics.Binary.IsInvalid.get -> bool
-Microsoft.CodeAnalysis.Semantics.Binary.ConstantValue.get -> object
+Microsoft.CodeAnalysis.Semantics.Binary.ConstantValue.get -> Microsoft.CodeAnalysis.Optional<object>
 Microsoft.CodeAnalysis.Semantics.Binary.Syntax.get -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Semantics.ArrayCreation
 Microsoft.CodeAnalysis.Semantics.ArrayCreation.ArrayCreation(Microsoft.CodeAnalysis.IArrayTypeSymbol arrayType, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Semantics.IExpression> elementValues, Microsoft.CodeAnalysis.SyntaxNode syntax) -> void
@@ -143,11 +143,11 @@ Microsoft.CodeAnalysis.Semantics.ArrayCreation.ElementType.get -> Microsoft.Code
 Microsoft.CodeAnalysis.Semantics.ArrayCreation.ResultType.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.Semantics.ArrayCreation.Kind.get -> Microsoft.CodeAnalysis.Semantics.OperationKind
 Microsoft.CodeAnalysis.Semantics.ArrayCreation.IsInvalid.get -> bool
-Microsoft.CodeAnalysis.Semantics.ArrayCreation.ConstantValue.get -> object
+Microsoft.CodeAnalysis.Semantics.ArrayCreation.ConstantValue.get -> Microsoft.CodeAnalysis.Optional<object>
 Microsoft.CodeAnalysis.Semantics.ArrayCreation.Syntax.get -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Semantics.IExpression
 Microsoft.CodeAnalysis.Semantics.IExpression.ResultType.get -> Microsoft.CodeAnalysis.ITypeSymbol
-Microsoft.CodeAnalysis.Semantics.IExpression.ConstantValue.get -> object
+Microsoft.CodeAnalysis.Semantics.IExpression.ConstantValue.get -> Microsoft.CodeAnalysis.Optional<object>
 Microsoft.CodeAnalysis.Semantics.IInvocationExpression
 Microsoft.CodeAnalysis.Semantics.IInvocationExpression.TargetMethod.get -> Microsoft.CodeAnalysis.IMethodSymbol
 Microsoft.CodeAnalysis.Semantics.IInvocationExpression.Instance.get -> Microsoft.CodeAnalysis.Semantics.IExpression

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -44,14 +44,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Class BoundExpression
         Implements IExpression
 
-        Private ReadOnly Property IConstantValue As Object Implements IExpression.ConstantValue
+        Private ReadOnly Property IConstantValue As [Optional](Of Object) Implements IExpression.ConstantValue
             Get
                 Dim value As ConstantValue = Me.ConstantValueOpt
                 If value Is Nothing Then
-                    Return Nothing
+                    Return New [Optional](Of Object)()
                 End If
 
-                Return value.Value
+                Return New [Optional](Of Object)(value.Value)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
@@ -450,9 +450,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Me._capturedValue = capturedValue
             End Sub
 
-            Public ReadOnly Property ConstantValue As Object Implements IExpression.ConstantValue
+            Public ReadOnly Property ConstantValue As [Optional](Of Object) Implements IExpression.ConstantValue
                 Get
-                    Return Nothing
+                    Return New [Optional](Of Object)()
                 End Get
             End Property
 


### PR DESCRIPTION
This change set makes it possible for a client of IExpression to distinguish the conditions of an expression having a constant value of null and of not having a constant value.

The choice of Optional<object> is for consistency with the (shipped) SemanticValue.GetConstantValue API.

Addresses #7295 

This change will break analyzers that have been coded against the existing (unshipped) API, including some in the roslyn-analyzers repository. (What is the process for updating those?)

@lgolding @genlu @srivatsn @mavasani @nguerrera @CyrusNajmabadi might take an interest.