### PR TITLE
Fix NullRef in SemanticClassificationViewTaggerProvider (quick & easy version)

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -94,6 +94,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             var spanToTag = context.SpansToTag.Single();
             var document = spanToTag.Document;
 
+            if (document == null)
+            {
+                return SpecializedTasks.EmptyTask;
+            }
+
             _classificationService = _classificationService ?? document.Project.LanguageServices.GetService<IEditorClassificationService>();
 
             return SemanticClassificationUtilities.ProduceTagsAsync(context, spanToTag, _classificationService, _typeMap);


### PR DESCRIPTION
This null check existed until a refactoring happened back in September that accidentally removed it. A more thorough fix is in progress over at https://github.com/dotnet/roslyn/pull/7539, but we really need to get this fixed immediately.