### PR TITLE
Fix incorrect optimization around lifted  0 - x  resulting in just  x

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -341,16 +341,70 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BinaryOperatorKind.PointerAndUIntSubtraction:
                     case BinaryOperatorKind.PointerAndLongSubtraction:
                     case BinaryOperatorKind.PointerAndULongSubtraction:
+                        if (loweredRight.IsDefaultValue())
+                        {
+                            return loweredLeft;
+                        }
                         return RewritePointerNumericOperator(syntax, operatorKind, loweredLeft, loweredRight, type, isPointerElementAccess, isLeftPointer: true);
 
                     case BinaryOperatorKind.IntAndPointerAddition:
                     case BinaryOperatorKind.UIntAndPointerAddition:
                     case BinaryOperatorKind.LongAndPointerAddition:
                     case BinaryOperatorKind.ULongAndPointerAddition:
+                        if (loweredLeft.IsDefaultValue())
+                        {
+                            return loweredRight;
+                        }
                         return RewritePointerNumericOperator(syntax, operatorKind, loweredLeft, loweredRight, type, isPointerElementAccess, isLeftPointer: false);
 
                     case BinaryOperatorKind.PointerSubtraction:
                         return RewritePointerSubtraction(operatorKind, loweredLeft, loweredRight, type);
+
+                    case BinaryOperatorKind.IntAddition:
+                    case BinaryOperatorKind.UIntAddition:
+                    case BinaryOperatorKind.LongAddition:
+                    case BinaryOperatorKind.ULongAddition:
+                        if (loweredLeft.IsDefaultValue())
+                        {
+                            return loweredRight;
+                        }
+                        if (loweredRight.IsDefaultValue())
+                        {
+                            return loweredLeft;
+                        }
+                        goto default;
+
+                    case BinaryOperatorKind.IntSubtraction:
+                    case BinaryOperatorKind.LongSubtraction:
+                    case BinaryOperatorKind.UIntSubtraction:
+                    case BinaryOperatorKind.ULongSubtraction:
+                        if (loweredRight.IsDefaultValue())
+                        {
+                            return loweredLeft;
+                        }
+                        goto default;
+
+                    case BinaryOperatorKind.IntMultiplication:
+                    case BinaryOperatorKind.LongMultiplication:
+                    case BinaryOperatorKind.UIntMultiplication:
+                    case BinaryOperatorKind.ULongMultiplication:
+                        if (loweredLeft.IsDefaultValue())
+                        {
+                            return loweredLeft;
+                        }
+                        if (loweredRight.IsDefaultValue())
+                        {
+                            return loweredRight;
+                        }
+                        if (loweredLeft.ConstantValue?.UInt64Value == 1)
+                        {
+                            return loweredRight;
+                        }
+                        if (loweredRight.ConstantValue?.UInt64Value == 1)
+                        {
+                            return loweredLeft;
+                        }
+                        goto default;
 
                     case BinaryOperatorKind.IntGreaterThan:
                     case BinaryOperatorKind.IntLessThanOrEqual:
@@ -1207,13 +1261,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             //        default(R?);
             //
 
+            var sideeffects = ArrayBuilder<BoundExpression>.GetInstance();
+            var locals = ArrayBuilder<LocalSymbol>.GetInstance();
+
             BoundExpression leftNeverNull = NullableAlwaysHasValue(loweredLeft);
             BoundExpression rightNeverNull = NullableAlwaysHasValue(loweredRight);
 
-            BoundAssignmentOperator tempAssignmentX;
-            BoundLocal boundTempX = _factory.StoreToTemp(leftNeverNull ?? loweredLeft, out tempAssignmentX);
-            BoundAssignmentOperator tempAssignmentY;
-            BoundLocal boundTempY = _factory.StoreToTemp(rightNeverNull ?? loweredRight, out tempAssignmentY);
+            BoundExpression boundTempX = leftNeverNull ?? loweredLeft;
+            boundTempX = CaptureNullableOperandInTempIfNeeded(boundTempX, sideeffects, locals);
+
+            BoundExpression boundTempY = rightNeverNull ?? loweredRight;
+            boundTempY = CaptureNullableOperandInTempIfNeeded(boundTempY, sideeffects, locals);
 
             BoundExpression callX_GetValueOrDefault = MakeOptimizedGetValueOrDefault(syntax, boundTempX);
             BoundExpression callY_GetValueOrDefault = MakeOptimizedGetValueOrDefault(syntax, boundTempY);
@@ -1243,10 +1301,24 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return new BoundSequence(
                 syntax: syntax,
-                locals: ImmutableArray.Create<LocalSymbol>(boundTempX.LocalSymbol, boundTempY.LocalSymbol),
-                sideEffects: ImmutableArray.Create<BoundExpression>(tempAssignmentX, tempAssignmentY),
+                locals: locals.ToImmutableAndFree(),
+                sideEffects: sideeffects.ToImmutableAndFree(),
                 value: conditionalExpression,
                 type: type);
+        }
+
+        private BoundExpression CaptureNullableOperandInTempIfNeeded(BoundExpression operand, ArrayBuilder<BoundExpression> sideeffects, ArrayBuilder<LocalSymbol> locals)
+        {
+            if (CanChangeValueBetweenReads(operand))
+            {
+                BoundAssignmentOperator tempAssignment;
+                var tempAccess = _factory.StoreToTemp(operand, out tempAssignment);
+                sideeffects.Add(tempAssignment);
+                locals.Add(tempAccess.LocalSymbol);
+                operand = tempAccess;
+            }
+
+            return operand;
         }
 
         private BoundExpression OptimizeLiftedBinaryArithmetic(
@@ -1938,14 +2010,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return new BoundBinaryOperator(
-                syntax,
-                kind,
-                loweredLeft,
-                loweredRight,
-                ConstantValue.NotAvailable,
-                null,
-                LookupResultKind.Viable,
-                returnType);
+                            syntax,
+                            kind,
+                            loweredLeft,
+                            loweredRight,
+                            ConstantValue.NotAvailable,
+                            null,
+                            LookupResultKind.Viable,
+                            returnType);
         }
 
         /// <summary>
@@ -1964,9 +2036,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var sizeOfExpression = _factory.Sizeof(pointerType.PointedAtType);
             Debug.Assert(sizeOfExpression.Type.SpecialType == SpecialType.System_Int32);
 
-            // TODO: Generalize this, possibly by moving it to code gen
             // Common case: adding or subtracting one  (e.g. for ++)
-            if (numericOperand.ConstantValue != null && numericOperand.ConstantValue.UInt64Value == 1)
+            if (numericOperand.ConstantValue?.UInt64Value == 1)
             {
                 // We could convert this to a native int (as the unoptimized multiplication would be),
                 // but that would be a no-op (int to native int), so don't bother.
@@ -1975,9 +2046,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var numericSpecialType = numericOperand.Type.SpecialType;
 
-            // TODO: Generalize this, possibly by moving it to code gen
             // Optimization: the size is exactly one byte, then multiplication is unnecessary.
-            if (sizeOfExpression.ConstantValue != null && sizeOfExpression.ConstantValue.Int32Value == 1)
+            if (sizeOfExpression.ConstantValue?.Int32Value == 1)
             {
                 // As in ExpressionBinder::bindPtrAddMul, we apply the following conversions:
                 //   int -> int (add allows int32 operands and will extend to native int if necessary)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOptimizedNullableOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOptimizedNullableOperators.cs
@@ -2166,29 +2166,27 @@ class Program
             // TODO: We will clean this up in a later checkin.
             // TODO: When we do so, add tests for ++ -- +=, etc.
 
-            string expectedIL2 = @"{
-  // Code size       42 (0x2a)
+            string expectedIL2 = @"
+{
+  // Code size       40 (0x28)
   .maxstack  2
-  .locals init (int V_0,
-  int? V_1,
-  int? V_2)
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  call       ""int? Program.N()""
-  IL_0007:  stloc.1
-  IL_0008:  ldloca.s   V_1
-  IL_000a:  call       ""bool int?.HasValue.get""
-  IL_000f:  brtrue.s   IL_001b
-  IL_0011:  ldloca.s   V_2
-  IL_0013:  initobj    ""int?""
-  IL_0019:  ldloc.2
-  IL_001a:  ret
-  IL_001b:  ldloc.0
-  IL_001c:  ldloca.s   V_1
-  IL_001e:  call       ""int int?.GetValueOrDefault()""
-  IL_0023:  add
-  IL_0024:  newobj     ""int?..ctor(int)""
-  IL_0029:  ret
+  .locals init (int? V_0,
+                int? V_1)
+  IL_0000:  call       ""int? Program.N()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       ""bool int?.HasValue.get""
+  IL_000d:  brtrue.s   IL_0019
+  IL_000f:  ldloca.s   V_1
+  IL_0011:  initobj    ""int?""
+  IL_0017:  ldloc.1
+  IL_0018:  ret
+  IL_0019:  ldc.i4.1
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  call       ""int int?.GetValueOrDefault()""
+  IL_0021:  add
+  IL_0022:  newobj     ""int?..ctor(int)""
+  IL_0027:  ret
 }";
 
             var comp = CompileAndVerify(source, expectedOutput: expectedOutput);
@@ -2196,5 +2194,232 @@ class Program
             comp.VerifyIL("Program.M1", expectedIL1);
             comp.VerifyIL("Program.M2", expectedIL2);
         }
+
+        [Fact]
+        public void TestNullableBinOpsOneZero()
+        {
+            // If one side of the nullable binop is non-null then we skip calling HasValue and GetValueOrDefault
+            // on that side.
+
+            string source = @"
+class Program
+{
+    static void Main() 
+    {
+        int? N = 42;
+        System.Console.WriteLine(0 + N);
+        System.Console.WriteLine(N + 0);
+        System.Console.WriteLine(0 - N);
+        System.Console.WriteLine(N - 0);
+        System.Console.WriteLine(0 * N);
+        System.Console.WriteLine(N * 0);
+        System.Console.WriteLine(1 * N);
+        System.Console.WriteLine(N * 1);
+    }
+}
+";
+
+
+            var comp = CompileAndVerify(source, expectedOutput: @"
+42
+42
+-42
+42
+0
+0
+42
+42")
+                .VerifyIL("Program.Main",
+ @"
+{
+  // Code size      349 (0x15d)
+  .maxstack  3
+  .locals init (int? V_0,
+                int? V_1)
+  IL_0000:  ldc.i4.s   42
+  IL_0002:  newobj     ""int?..ctor(int)""
+  IL_0007:  dup
+  IL_0008:  stloc.0
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  call       ""bool int?.HasValue.get""
+  IL_0010:  brtrue.s   IL_001d
+  IL_0012:  ldloca.s   V_1
+  IL_0014:  initobj    ""int?""
+  IL_001a:  ldloc.1
+  IL_001b:  br.s       IL_0029
+  IL_001d:  ldloca.s   V_0
+  IL_001f:  call       ""int int?.GetValueOrDefault()""
+  IL_0024:  newobj     ""int?..ctor(int)""
+  IL_0029:  box        ""int?""
+  IL_002e:  call       ""void System.Console.WriteLine(object)""
+  IL_0033:  dup
+  IL_0034:  stloc.0
+  IL_0035:  ldloca.s   V_0
+  IL_0037:  call       ""bool int?.HasValue.get""
+  IL_003c:  brtrue.s   IL_0049
+  IL_003e:  ldloca.s   V_1
+  IL_0040:  initobj    ""int?""
+  IL_0046:  ldloc.1
+  IL_0047:  br.s       IL_0055
+  IL_0049:  ldloca.s   V_0
+  IL_004b:  call       ""int int?.GetValueOrDefault()""
+  IL_0050:  newobj     ""int?..ctor(int)""
+  IL_0055:  box        ""int?""
+  IL_005a:  call       ""void System.Console.WriteLine(object)""
+  IL_005f:  dup
+  IL_0060:  stloc.0
+  IL_0061:  ldloca.s   V_0
+  IL_0063:  call       ""bool int?.HasValue.get""
+  IL_0068:  brtrue.s   IL_0075
+  IL_006a:  ldloca.s   V_1
+  IL_006c:  initobj    ""int?""
+  IL_0072:  ldloc.1
+  IL_0073:  br.s       IL_0083
+  IL_0075:  ldc.i4.0
+  IL_0076:  ldloca.s   V_0
+  IL_0078:  call       ""int int?.GetValueOrDefault()""
+  IL_007d:  sub
+  IL_007e:  newobj     ""int?..ctor(int)""
+  IL_0083:  box        ""int?""
+  IL_0088:  call       ""void System.Console.WriteLine(object)""
+  IL_008d:  dup
+  IL_008e:  stloc.0
+  IL_008f:  ldloca.s   V_0
+  IL_0091:  call       ""bool int?.HasValue.get""
+  IL_0096:  brtrue.s   IL_00a3
+  IL_0098:  ldloca.s   V_1
+  IL_009a:  initobj    ""int?""
+  IL_00a0:  ldloc.1
+  IL_00a1:  br.s       IL_00af
+  IL_00a3:  ldloca.s   V_0
+  IL_00a5:  call       ""int int?.GetValueOrDefault()""
+  IL_00aa:  newobj     ""int?..ctor(int)""
+  IL_00af:  box        ""int?""
+  IL_00b4:  call       ""void System.Console.WriteLine(object)""
+  IL_00b9:  dup
+  IL_00ba:  stloc.0
+  IL_00bb:  ldloca.s   V_0
+  IL_00bd:  call       ""bool int?.HasValue.get""
+  IL_00c2:  brtrue.s   IL_00cf
+  IL_00c4:  ldloca.s   V_1
+  IL_00c6:  initobj    ""int?""
+  IL_00cc:  ldloc.1
+  IL_00cd:  br.s       IL_00d5
+  IL_00cf:  ldc.i4.0
+  IL_00d0:  newobj     ""int?..ctor(int)""
+  IL_00d5:  box        ""int?""
+  IL_00da:  call       ""void System.Console.WriteLine(object)""
+  IL_00df:  dup
+  IL_00e0:  stloc.0
+  IL_00e1:  ldloca.s   V_0
+  IL_00e3:  call       ""bool int?.HasValue.get""
+  IL_00e8:  brtrue.s   IL_00f5
+  IL_00ea:  ldloca.s   V_1
+  IL_00ec:  initobj    ""int?""
+  IL_00f2:  ldloc.1
+  IL_00f3:  br.s       IL_00fb
+  IL_00f5:  ldc.i4.0
+  IL_00f6:  newobj     ""int?..ctor(int)""
+  IL_00fb:  box        ""int?""
+  IL_0100:  call       ""void System.Console.WriteLine(object)""
+  IL_0105:  dup
+  IL_0106:  stloc.0
+  IL_0107:  ldloca.s   V_0
+  IL_0109:  call       ""bool int?.HasValue.get""
+  IL_010e:  brtrue.s   IL_011b
+  IL_0110:  ldloca.s   V_1
+  IL_0112:  initobj    ""int?""
+  IL_0118:  ldloc.1
+  IL_0119:  br.s       IL_0127
+  IL_011b:  ldloca.s   V_0
+  IL_011d:  call       ""int int?.GetValueOrDefault()""
+  IL_0122:  newobj     ""int?..ctor(int)""
+  IL_0127:  box        ""int?""
+  IL_012c:  call       ""void System.Console.WriteLine(object)""
+  IL_0131:  stloc.0
+  IL_0132:  ldloca.s   V_0
+  IL_0134:  call       ""bool int?.HasValue.get""
+  IL_0139:  brtrue.s   IL_0146
+  IL_013b:  ldloca.s   V_1
+  IL_013d:  initobj    ""int?""
+  IL_0143:  ldloc.1
+  IL_0144:  br.s       IL_0152
+  IL_0146:  ldloca.s   V_0
+  IL_0148:  call       ""int int?.GetValueOrDefault()""
+  IL_014d:  newobj     ""int?..ctor(int)""
+  IL_0152:  box        ""int?""
+  IL_0157:  call       ""void System.Console.WriteLine(object)""
+  IL_015c:  ret
+}");
+        }
+
+        [Fact]
+        public void TestNullableBinOpsOneZero1()
+        {
+            // If one side of the nullable binop is non-null then we skip calling HasValue and GetValueOrDefault
+            // on that side.
+
+            string source = @"
+class Program
+{
+    static void Main() 
+    {
+        System.Console.WriteLine(0 + (int?)42);
+        System.Console.WriteLine((int?)42 + 0);
+        System.Console.WriteLine(0 - (int?)42);
+        System.Console.WriteLine((int?)42 - 0);
+        System.Console.WriteLine(0 * (int?)42);
+        System.Console.WriteLine((int?)42 * 0);
+        System.Console.WriteLine(1 * (int?)42);
+        System.Console.WriteLine((int?)42 * 1);
+    }
+}
+";
+
+
+            var comp = CompileAndVerify(source, expectedOutput: @"
+42
+42
+-42
+42
+0
+0
+42
+42")
+                .VerifyIL("Program.Main",
+ @"
+{
+  // Code size       97 (0x61)
+  .maxstack  2
+  IL_0000:  ldc.i4.s   42
+  IL_0002:  box        ""int""
+  IL_0007:  call       ""void System.Console.WriteLine(object)""
+  IL_000c:  ldc.i4.s   42
+  IL_000e:  box        ""int""
+  IL_0013:  call       ""void System.Console.WriteLine(object)""
+  IL_0018:  ldc.i4.0
+  IL_0019:  ldc.i4.s   42
+  IL_001b:  sub
+  IL_001c:  box        ""int""
+  IL_0021:  call       ""void System.Console.WriteLine(object)""
+  IL_0026:  ldc.i4.s   42
+  IL_0028:  box        ""int""
+  IL_002d:  call       ""void System.Console.WriteLine(object)""
+  IL_0032:  ldc.i4.0
+  IL_0033:  box        ""int""
+  IL_0038:  call       ""void System.Console.WriteLine(object)""
+  IL_003d:  ldc.i4.0
+  IL_003e:  box        ""int""
+  IL_0043:  call       ""void System.Console.WriteLine(object)""
+  IL_0048:  ldc.i4.s   42
+  IL_004a:  box        ""int""
+  IL_004f:  call       ""void System.Console.WriteLine(object)""
+  IL_0054:  ldc.i4.s   42
+  IL_0056:  box        ""int""
+  IL_005b:  call       ""void System.Console.WriteLine(object)""
+  IL_0060:  ret
+}");
+        }
+
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -6689,7 +6689,7 @@ namespace ConsoleApplication1
             compVerifier.VerifyIL("ConsoleApplication1.Program.SwtchTest",
 @"
 {
-  // Code size       96 (0x60)
+  // Code size       94 (0x5e)
   .maxstack  2
   .locals init (int? V_0, //i
                 int V_1,
@@ -6715,22 +6715,20 @@ namespace ConsoleApplication1
   IL_0033:  call       ""void System.Console.WriteLine(string)""
   IL_0038:  ldloc.0
   IL_0039:  stloc.2
-  IL_003a:  ldc.i4.2
-  IL_003b:  stloc.1
-  IL_003c:  ldloca.s   V_2
-  IL_003e:  call       ""bool int?.HasValue.get""
-  IL_0043:  brtrue.s   IL_0050
-  IL_0045:  ldloca.s   V_3
-  IL_0047:  initobj    ""int?""
-  IL_004d:  ldloc.3
-  IL_004e:  br.s       IL_005e
-  IL_0050:  ldloca.s   V_2
-  IL_0052:  call       ""int int?.GetValueOrDefault()""
-  IL_0057:  ldloc.1
-  IL_0058:  add
-  IL_0059:  newobj     ""int?..ctor(int)""
-  IL_005e:  stloc.0
-  IL_005f:  ret
+  IL_003a:  ldloca.s   V_2
+  IL_003c:  call       ""bool int?.HasValue.get""
+  IL_0041:  brtrue.s   IL_004e
+  IL_0043:  ldloca.s   V_3
+  IL_0045:  initobj    ""int?""
+  IL_004b:  ldloc.3
+  IL_004c:  br.s       IL_005c
+  IL_004e:  ldloca.s   V_2
+  IL_0050:  call       ""int int?.GetValueOrDefault()""
+  IL_0055:  ldc.i4.2
+  IL_0056:  add
+  IL_0057:  newobj     ""int?..ctor(int)""
+  IL_005c:  stloc.0
+  IL_005d:  ret
 }
 "
             );

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -2141,6 +2141,74 @@ class C
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
 
+            var baselineIL0 = @"
+{
+  // Code size      147 (0x93)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  box        ""int""
+  IL_0027:  stfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0048:  brfalse.s  IL_004c
+  IL_004a:  br.s       IL_0071
+  IL_004c:  ldc.i4.s   16
+  IL_004e:  ldtoken    ""int""
+  IL_0053:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0058:  ldtoken    ""C""
+  IL_005d:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0062:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0067:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_006c:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0071:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0076:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Target""
+  IL_007b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0080:  ldarg.0
+  IL_0081:  ldfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_0086:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_008b:  call       ""void System.Console.WriteLine(int)""
+  IL_0090:  nop
+  IL_0091:  ldc.i4.0
+  IL_0092:  ret
+}
+";
+            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL0);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
             var baselineIL = @"
 {
   // Code size      149 (0x95)
@@ -2204,12 +2272,7 @@ class C
   IL_0094:  ret
 }
 ";
-            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "0").Replace("<<DYNAMIC_CONTAINER_NAME>>", "<>o__0"));
 
-            var diff1 = compilation1.EmitDifference(
-                generation0,
-                ImmutableArray.Create(
-                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
             diff1.VerifySynthesizedMembers(
                 "C: {<>o__0#1, <F>d__0}",
@@ -3626,6 +3689,61 @@ class C
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
 
+            var baselineIL0 = @"
+{
+  // Code size       87 (0x57)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brfalse.s  IL_0012
+  IL_000a:  br.s       IL_000c
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003d
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldnull
+  IL_0022:  ldc.i4.1
+  IL_0023:  newobj     ""<>f__AnonymousType0<dynamic, int>..ctor(dynamic, int)""
+  IL_0028:  stfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_002d:  ldarg.0
+  IL_002e:  ldc.i4.1
+  IL_002f:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0034:  ldarg.0
+  IL_0035:  ldc.i4.1
+  IL_0036:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003b:  ldc.i4.1
+  IL_003c:  ret
+  IL_003d:  ldarg.0
+  IL_003e:  ldc.i4.m1
+  IL_003f:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0044:  ldarg.0
+  IL_0045:  ldfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_004a:  callvirt   ""int <>f__AnonymousType0<dynamic, int>.B.get""
+  IL_004f:  call       ""void System.Console.WriteLine(int)""
+  IL_0054:  nop
+  IL_0055:  ldc.i4.0
+  IL_0056:  ret
+}
+";
+            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL0);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
             var baselineIL = @"
 {
   // Code size       89 (0x59)
@@ -3676,12 +3794,6 @@ class C
   IL_0058:  ret
 }
 ";
-            v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "0"));
-
-            var diff1 = compilation1.EmitDifference(
-                generation0,
-                ImmutableArray.Create(
-                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
             diff1.VerifySynthesizedMembers(
                 "C: {<F>d__0}",

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -5269,6 +5269,34 @@ class C
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
 
+            var baselineIL0 = @"
+{
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (<>f__AnonymousType0<dynamic, int> V_0) //x
+  IL_0000:  nop
+  IL_0001:  ldnull
+  IL_0002:  ldc.i4.1
+  IL_0003:  newobj     ""<>f__AnonymousType0<dynamic, int>..ctor(dynamic, int)""
+  IL_0008:  stloc.0
+  IL_0009:  ldloc.0
+  IL_000a:  callvirt   ""int <>f__AnonymousType0<dynamic, int>.B.get""
+  IL_000f:  call       ""void System.Console.WriteLine(int)""
+  IL_0014:  nop
+  IL_0015:  ret
+}
+";
+            v0.VerifyIL("C.F", baselineIL0);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "<>f__AnonymousType0<<A>j__TPar, <B>j__TPar>: {Equals, GetHashCode, ToString}");
+
+
             var baselineIL = @"
 {
   // Code size       24 (0x18)
@@ -5288,15 +5316,6 @@ class C
   IL_0017:  ret
 }
 ";
-            v0.VerifyIL("C.F", baselineIL.Replace("<<VALUE>>", "0"));
-
-            var diff1 = compilation1.EmitDifference(
-                generation0,
-                ImmutableArray.Create(
-                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
-
-            diff1.VerifySynthesizedMembers(
-                "<>f__AnonymousType0<<A>j__TPar, <B>j__TPar>: {Equals, GetHashCode, ToString}");
 
             diff1.VerifyIL("C.F", baselineIL.Replace("<<VALUE>>", "1"));
 
@@ -5930,7 +5949,7 @@ class C
 
             v0.VerifyIL("C.F", @"
 {
-  // Code size       84 (0x54)
+  // Code size       82 (0x52)
   .maxstack  3
   .locals init (object V_0) //x
   IL_0000:  nop
@@ -5953,11 +5972,9 @@ class C
   IL_0040:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
   IL_0045:  ldloc.0
   IL_0046:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_004b:  ldc.i4.0
-  IL_004c:  add
-  IL_004d:  call       ""void System.Console.WriteLine(int)""
-  IL_0052:  nop
-  IL_0053:  ret
+  IL_004b:  call       ""void System.Console.WriteLine(int)""
+  IL_0050:  nop
+  IL_0051:  ret
 }
 ");
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
@@ -354,8 +354,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Select Case binaryOpKind
+                Case BinaryOperatorKind.Subtract
+                    If right.IsDefaultValueConstant Then
+                        Return left
+                    End If
+
                 Case BinaryOperatorKind.Add,
-                     BinaryOperatorKind.Subtract,
                      BinaryOperatorKind.Or,
                      BinaryOperatorKind.OrElse
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
@@ -4756,43 +4756,75 @@ Module Module1
     Dim a As Integer? = 1
     Dim b As Integer? = 0 - a
     Console.WriteLine(String.Format("a: {0}, b: {1}", a, b))
+
+    Dim a1 As Integer? = 1
+    Dim b1 As Integer? = a - 0
+    Console.WriteLine(String.Format("a1: {0}, b1: {1}", a1, b1))
+
  End Sub
 End Module
 
     </file>
-</compilation>, expectedOutput:="a: 1, b: -1").
+</compilation>, expectedOutput:="a: 1, b: -1
+a1: 1, b1: 1").
 VerifyIL("Module1.Main",
             <![CDATA[
 {
-  // Code size       71 (0x47)
+  // Code size      144 (0x90)
   .maxstack  3
   .locals init (Integer? V_0, //a
                 Integer? V_1, //b
-                Integer? V_2)
+                Integer? V_2, //a1
+                Integer? V_3, //b1
+                Integer? V_4,
+                Integer? V_5)
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldc.i4.1
   IL_0003:  call       "Sub Integer?..ctor(Integer)"
   IL_0008:  ldloca.s   V_0
   IL_000a:  call       "Function Integer?.get_HasValue() As Boolean"
-  IL_000f:  brtrue.s   IL_001c
-  IL_0011:  ldloca.s   V_2
+  IL_000f:  brtrue.s   IL_001d
+  IL_0011:  ldloca.s   V_4
   IL_0013:  initobj    "Integer?"
-  IL_0019:  ldloc.2
-  IL_001a:  br.s       IL_002a
-  IL_001c:  ldc.i4.0
-  IL_001d:  ldloca.s   V_0
-  IL_001f:  call       "Function Integer?.GetValueOrDefault() As Integer"
-  IL_0024:  sub.ovf
-  IL_0025:  newobj     "Sub Integer?..ctor(Integer)"
-  IL_002a:  stloc.1
-  IL_002b:  ldstr      "a: {0}, b: {1}"
-  IL_0030:  ldloc.0
-  IL_0031:  box        "Integer?"
-  IL_0036:  ldloc.1
-  IL_0037:  box        "Integer?"
-  IL_003c:  call       "Function String.Format(String, Object, Object) As String"
-  IL_0041:  call       "Sub System.Console.WriteLine(String)"
-  IL_0046:  ret
+  IL_0019:  ldloc.s    V_4
+  IL_001b:  br.s       IL_002b
+  IL_001d:  ldc.i4.0
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  call       "Function Integer?.GetValueOrDefault() As Integer"
+  IL_0025:  sub.ovf
+  IL_0026:  newobj     "Sub Integer?..ctor(Integer)"
+  IL_002b:  stloc.1
+  IL_002c:  ldstr      "a: {0}, b: {1}"
+  IL_0031:  ldloc.0
+  IL_0032:  box        "Integer?"
+  IL_0037:  ldloc.1
+  IL_0038:  box        "Integer?"
+  IL_003d:  call       "Function String.Format(String, Object, Object) As String"
+  IL_0042:  call       "Sub System.Console.WriteLine(String)"
+  IL_0047:  ldloca.s   V_2
+  IL_0049:  ldc.i4.1
+  IL_004a:  call       "Sub Integer?..ctor(Integer)"
+  IL_004f:  ldloc.0
+  IL_0050:  stloc.s    V_4
+  IL_0052:  ldloca.s   V_4
+  IL_0054:  call       "Function Integer?.get_HasValue() As Boolean"
+  IL_0059:  brtrue.s   IL_0067
+  IL_005b:  ldloca.s   V_5
+  IL_005d:  initobj    "Integer?"
+  IL_0063:  ldloc.s    V_5
+  IL_0065:  br.s       IL_0073
+  IL_0067:  ldloca.s   V_4
+  IL_0069:  call       "Function Integer?.GetValueOrDefault() As Integer"
+  IL_006e:  newobj     "Sub Integer?..ctor(Integer)"
+  IL_0073:  stloc.3
+  IL_0074:  ldstr      "a1: {0}, b1: {1}"
+  IL_0079:  ldloc.2
+  IL_007a:  box        "Integer?"
+  IL_007f:  ldloc.3
+  IL_0080:  box        "Integer?"
+  IL_0085:  call       "Function String.Format(String, Object, Object) As String"
+  IL_008a:  call       "Sub System.Console.WriteLine(String)"
+  IL_008f:  ret
 }
                 ]]>)
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
@@ -4744,5 +4744,59 @@ End Module
             CompileAndVerify(source, expectedOutput)
         End Sub
 
+        <Fact()>
+        Public Sub SubtractFromZero()
+            CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+
+Module Module1
+  Sub Main()
+    Dim a As Integer? = 1
+    Dim b As Integer? = 0 - a
+    Console.WriteLine(String.Format("a: {0}, b: {1}", a, b))
+ End Sub
+End Module
+
+    </file>
+</compilation>, expectedOutput:="a: 1, b: -1").
+VerifyIL("Module1.Main",
+            <![CDATA[
+{
+  // Code size       71 (0x47)
+  .maxstack  3
+  .locals init (Integer? V_0, //a
+                Integer? V_1, //b
+                Integer? V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  call       "Sub Integer?..ctor(Integer)"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       "Function Integer?.get_HasValue() As Boolean"
+  IL_000f:  brtrue.s   IL_001c
+  IL_0011:  ldloca.s   V_2
+  IL_0013:  initobj    "Integer?"
+  IL_0019:  ldloc.2
+  IL_001a:  br.s       IL_002a
+  IL_001c:  ldc.i4.0
+  IL_001d:  ldloca.s   V_0
+  IL_001f:  call       "Function Integer?.GetValueOrDefault() As Integer"
+  IL_0024:  sub.ovf
+  IL_0025:  newobj     "Sub Integer?..ctor(Integer)"
+  IL_002a:  stloc.1
+  IL_002b:  ldstr      "a: {0}, b: {1}"
+  IL_0030:  ldloc.0
+  IL_0031:  box        "Integer?"
+  IL_0036:  ldloc.1
+  IL_0037:  box        "Integer?"
+  IL_003c:  call       "Function String.Format(String, Object, Object) As String"
+  IL_0041:  call       "Sub System.Console.WriteLine(String)"
+  IL_0046:  ret
+}
+                ]]>)
+
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
That is a valid optimization for many binary operators like  + &  |  , but not for - .

Fixes #7183