### PR TITLE
Fix AssertEx silliness

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -1563,8 +1563,8 @@ class C<T, U, V>
 
             foreach (var p in actualTypeParameters)
             {
-                AssertEx.Throws<Exception>(() => p.GetEffectiveBaseClass(null), allowDerived: true);
-                AssertEx.Throws<Exception>(() => p.GetDeducedBaseType(null), allowDerived: true);
+                Assert.ThrowsAny<Exception>(() => p.GetEffectiveBaseClass(null));
+                Assert.ThrowsAny<Exception>(() => p.GetDeducedBaseType(null));
             }
 
             Assert.Equal(actualTypeParameters[0], actualTypeParameters[1]);

--- a/src/Compilers/Core/CodeAnalysisTest/SimpleAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SimpleAnalyzerAssemblyLoaderTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var loader = new SimpleAnalyzerAssemblyLoader();
 
-            AssertEx.ThrowsArgumentNull("fullPath", () => loader.AddDependencyLocation(null));
+            Assert.Throws<ArgumentNullException>("fullPath", () => loader.AddDependencyLocation(null));
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var loader = new SimpleAnalyzerAssemblyLoader();
 
-            AssertEx.Throws<Exception>(() => loader.LoadFromPath(path), allowDerived: true);
+            Assert.ThrowsAny<Exception>(() => loader.LoadFromPath(path));
         }
 
         [Fact]

--- a/src/EditorFeatures/Test/Extensions/ISymbolExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/ISymbolExtensionsTests.cs
@@ -101,11 +101,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                 SymbolKind.Alias,
                 target: (INamedTypeSymbol)CreateSymbolMock(SymbolKind.NamedType, typeKind: TypeKind.Class));
 
-            AssertEx.Throws<ArgumentException>(() =>
+            Assert.ThrowsAny<ArgumentException>(() =>
                 TestGlyph(
                     StandardGlyphGroup.GlyphGroupClass,
-                    (SymbolKind)1000),
-                allowDerived: true);
+                    (SymbolKind)1000));
 
             TestGlyph(
                 StandardGlyphGroup.GlyphGroupClass,
@@ -136,12 +135,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                 SymbolKind.NamedType,
                 typeKind: TypeKind.Error);
 
-            AssertEx.Throws<Exception>(() =>
+            Assert.ThrowsAny<Exception>(() =>
                 TestGlyph(
                     StandardGlyphGroup.GlyphGroupClass,
                     SymbolKind.NamedType,
-                    typeKind: TypeKind.Unknown),
-                allowDerived: true);
+                    typeKind: TypeKind.Unknown));
         }
 
         [Fact, WorkItem(545015)]

--- a/src/EditorFeatures/Test/Utilities/AsyncLazyTests.cs
+++ b/src/EditorFeatures/Test/Utilities/AsyncLazyTests.cs
@@ -43,12 +43,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 includeSynchronousComputation ? synchronousComputation : null,
                 cacheResult: true);
 
-            var thrownException = Roslyn.Test.Utilities.AssertEx.Throws<Exception>(() =>
+            var thrownException = Assert.ThrowsAny<Exception>(() =>
                 {
                     // Do a first request. Even though we will get a cancellation during the evaluation,
                     // since we handed a result back, that result must be cached.
                     doGetValue(lazy, requestCancellationTokenSource.Token);
-                }, allowDerived: true);
+                });
 
             // Assert it's either cancellation or aggregate exception
             Assert.True(thrownException is OperationCanceledException || ((AggregateException)thrownException).Flatten().InnerException is OperationCanceledException);

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -3406,8 +3406,8 @@ Class C
         <WorkItem(627297)>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameVarNotSupported()
-            AssertEx.Throws(Of ArgumentException)(Sub()
-                                                      Dim result = RenameEngineResult.Create(
+            Assert.ThrowsAny(Of ArgumentException)(Sub()
+                                                       Dim result = RenameEngineResult.Create(
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3427,7 +3427,7 @@ namespace X
                         </Document>
                     </Project>
                 </Workspace>, renameTo:="Int32")
-                                                  End Sub, True)
+                                                   End Sub)
         End Sub
 
         <WorkItem(627297)>
@@ -3465,8 +3465,8 @@ namespace X
         <WorkItem(627297)>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameDynamicNotSupported()
-            AssertEx.Throws(Of ArgumentException)(Sub()
-                                                      Dim result = RenameEngineResult.Create(
+            Assert.ThrowsAny(Of ArgumentException)(Sub()
+                                                       Dim result = RenameEngineResult.Create(
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3486,7 +3486,7 @@ namespace X
                         </Document>
                     </Project>
                 </Workspace>, renameTo:="Int32")
-                                                  End Sub, True)
+                                                   End Sub)
         End Sub
 
         <WorkItem(627297)>

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
@@ -33,9 +33,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
 
             Dim provider = New SmartIndentProvider()
 
-            AssertEx.Throws(Of Exception)(
-                Function() provider.CreateSmartIndent(Nothing),
-                allowDerived:=True)
+            Assert.ThrowsAny(Of ArgumentException)(
+                Function() provider.CreateSmartIndent(Nothing))
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2004,9 +2004,8 @@ End Module</text>.Value
         <Fact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub TestSmartIndenterConstructorThrows1()
-            AssertEx.Throws(Of ArgumentNullException)(
-                Function() New SmartIndent(Nothing),
-                allowDerived:=True)
+            Assert.Throws(Of ArgumentNullException)(
+                Function() New SmartIndent(Nothing))
         End Sub
 
         <WpfFact>

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
             var fn = script.CreateDelegate();
 
             Assert.Equal(3, fn().Result);
-            AssertEx.ThrowsArgumentException("globals", () => fn(new object()));
+            Assert.ThrowsAsync<ArgumentException>("globals", () => fn(new object()));
         }
 
         [Fact]
@@ -55,8 +55,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
             var script = CSharpScript.Create<int>("X + Y", globalsType: typeof(Globals));
             var fn = script.CreateDelegate();
 
-            AssertEx.ThrowsArgumentException("globals", () => fn());
-            AssertEx.ThrowsArgumentException("globals", () => fn(new object()));
+            Assert.ThrowsAsync<ArgumentException>("globals", () => fn());
+            Assert.ThrowsAsync<ArgumentException>("globals", () => fn(new object()));
             Assert.Equal(4, fn(new Globals { X = 1, Y = 3 }).Result);
         }
 
@@ -159,7 +159,7 @@ d.Do()"
             var script = CSharpScript.Create("X + Y");
 
             // Global variables passed to a script without a global type
-            AssertEx.ThrowsArgumentException("globals", () => script.RunAsync(new Globals { X = 1, Y = 2 }));
+            Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new Globals { X = 1, Y = 2 }));
         }
 
         [Fact]
@@ -168,7 +168,7 @@ d.Do()"
             var script = CSharpScript.Create("X + Y", globalsType: typeof(Globals));
 
             //  The script requires access to global variables but none were given
-            AssertEx.ThrowsArgumentException("globals", () => script.RunAsync());
+            Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync());
         }
 
         [Fact]
@@ -177,7 +177,7 @@ d.Do()"
             var script = CSharpScript.Create("X + Y", globalsType: typeof(Globals));
 
             //  The globals of type 'System.Object' is not assignable to 'Microsoft.CodeAnalysis.CSharp.Scripting.Test.ScriptTests+Globals'
-            AssertEx.ThrowsArgumentException("globals", () => script.RunAsync(new object()));
+            Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new object()));
         }
 
         [Fact]
@@ -185,7 +185,7 @@ d.Do()"
         {
             var state = await CSharpScript.RunAsync("X + Y", globals: new Globals());
 
-            AssertEx.ThrowsArgumentNull("previousState", () => state.Script.ContinueAsync(null));
+            await Assert.ThrowsAsync<ArgumentNullException>("previousState", () => state.Script.ContinueAsync(null));
         }
 
         [Fact]
@@ -194,7 +194,7 @@ d.Do()"
             var state1 = await CSharpScript.RunAsync("X + Y + 1", globals: new Globals());
             var state2 = await CSharpScript.RunAsync("X + Y + 2", globals: new Globals());
 
-            AssertEx.ThrowsArgumentException("previousState", () => state1.Script.ContinueAsync(state2));
+            await Assert.ThrowsAsync<ArgumentException>("previousState", () => state1.Script.ContinueAsync(state2));
         }
 
         [Fact]

--- a/src/Scripting/CoreTest/ScriptOptionsTests.cs
+++ b/src/Scripting/CoreTest/ScriptOptionsTests.cs
@@ -49,8 +49,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
 
             AssertEx.ThrowsArgumentNull("references", () => options.AddReferences((IEnumerable<string>)null));
             AssertEx.ThrowsArgumentNull("references[0]", () => options.AddReferences((IEnumerable<string>)new string[] { null }));
-
-            AssertEx.ThrowsArgumentException("references", () => options.AddReferences(moduleRef));
         }
 
         [Fact]
@@ -91,8 +89,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
             AssertEx.ThrowsArgumentNull("references", () => options.WithReferences(default(ImmutableArray<string>)));
             AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(new string[] { null }));
             AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(ImmutableArray.Create((string)null)));
-
-            AssertEx.ThrowsArgumentException("references", () => options.WithReferences(moduleRef));
         }
 
         [Fact]

--- a/src/Scripting/CoreTest/ScriptOptionsTests.cs
+++ b/src/Scripting/CoreTest/ScriptOptionsTests.cs
@@ -32,23 +32,23 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
             var moduleRef = ModuleMetadata.CreateFromImage(TestResources.MetadataTests.NetModule01.ModuleCS00).GetReference();
 
             var options = ScriptOptions.Default;
-            AssertEx.ThrowsArgumentNull("references", () => options.AddReferences((MetadataReference[])null));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.AddReferences(new MetadataReference[] { null }));
+            Assert.Throws<ArgumentNullException>("references", () => options.AddReferences((MetadataReference[])null));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.AddReferences(new MetadataReference[] { null }));
 
-            AssertEx.ThrowsArgumentNull("references", () => options.AddReferences((IEnumerable<MetadataReference>)null));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.AddReferences((IEnumerable<MetadataReference>)new MetadataReference[] { null }));
+            Assert.Throws<ArgumentNullException>("references", () => options.AddReferences((IEnumerable<MetadataReference>)null));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.AddReferences((IEnumerable<MetadataReference>)new MetadataReference[] { null }));
 
-            AssertEx.ThrowsArgumentNull("references", () => options.AddReferences((Assembly[])null));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.AddReferences(new Assembly[] { null }));
+            Assert.Throws<ArgumentNullException>("references", () => options.AddReferences((Assembly[])null));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.AddReferences(new Assembly[] { null }));
 
-            AssertEx.ThrowsArgumentNull("references", () => options.AddReferences((IEnumerable<Assembly>)null));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.AddReferences((IEnumerable<Assembly>)new Assembly[] { null }));
+            Assert.Throws<ArgumentNullException>("references", () => options.AddReferences((IEnumerable<Assembly>)null));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.AddReferences((IEnumerable<Assembly>)new Assembly[] { null }));
 
-            AssertEx.ThrowsArgumentNull("references", () => options.AddReferences((string[])null));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.AddReferences(new string[] { null }));
+            Assert.Throws<ArgumentNullException>("references", () => options.AddReferences((string[])null));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.AddReferences(new string[] { null }));
 
-            AssertEx.ThrowsArgumentNull("references", () => options.AddReferences((IEnumerable<string>)null));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.AddReferences((IEnumerable<string>)new string[] { null }));
+            Assert.Throws<ArgumentNullException>("references", () => options.AddReferences((IEnumerable<string>)null));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.AddReferences((IEnumerable<string>)new string[] { null }));
         }
 
         [Fact]
@@ -72,23 +72,23 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
             var moduleRef = ModuleMetadata.CreateFromImage(TestResources.MetadataTests.NetModule01.ModuleCS00).GetReference();
 
             var options = ScriptOptions.Default;
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences((MetadataReference[])null));
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences((IEnumerable<MetadataReference>)null));
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences(default(ImmutableArray<MetadataReference>)));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(new MetadataReference[] { null }));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(ImmutableArray.Create((MetadataReference)null)));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((MetadataReference[])null));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((IEnumerable<MetadataReference>)null));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences(default(ImmutableArray<MetadataReference>)));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.WithReferences(new MetadataReference[] { null }));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.WithReferences(ImmutableArray.Create((MetadataReference)null)));
 
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences((Assembly[])null));
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences((IEnumerable<Assembly>)null));
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences(default(ImmutableArray<Assembly>)));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(new Assembly[] { null }));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(ImmutableArray.Create((Assembly)null)));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((Assembly[])null));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((IEnumerable<Assembly>)null));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences(default(ImmutableArray<Assembly>)));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.WithReferences(new Assembly[] { null }));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.WithReferences(ImmutableArray.Create((Assembly)null)));
 
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences((string[])null));
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences((IEnumerable<string>)null));
-            AssertEx.ThrowsArgumentNull("references", () => options.WithReferences(default(ImmutableArray<string>)));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(new string[] { null }));
-            AssertEx.ThrowsArgumentNull("references[0]", () => options.WithReferences(ImmutableArray.Create((string)null)));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((string[])null));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((IEnumerable<string>)null));
+            Assert.Throws<ArgumentNullException>("references", () => options.WithReferences(default(ImmutableArray<string>)));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.WithReferences(new string[] { null }));
+            Assert.Throws<ArgumentNullException>("references[0]", () => options.WithReferences(ImmutableArray.Create((string)null)));
         }
 
         [Fact]
@@ -111,14 +111,14 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         {
             var options = ScriptOptions.Default;
            
-            AssertEx.ThrowsArgumentNull("imports", () => options.AddImports((string[])null));
-            AssertEx.ThrowsArgumentNull("imports[0]", () => options.AddImports(new string[] { null } ));
+            Assert.Throws<ArgumentNullException>("imports", () => options.AddImports((string[])null));
+            Assert.Throws<ArgumentNullException>("imports[0]", () => options.AddImports(new string[] { null } ));
 
-            AssertEx.ThrowsArgumentNull("imports", () => options.AddImports((IEnumerable<string>)null));
-            AssertEx.ThrowsArgumentNull("imports[0]", () => options.AddImports((IEnumerable<string>)new string[] { null }));
+            Assert.Throws<ArgumentNullException>("imports", () => options.AddImports((IEnumerable<string>)null));
+            Assert.Throws<ArgumentNullException>("imports[0]", () => options.AddImports((IEnumerable<string>)new string[] { null }));
 
-            AssertEx.ThrowsArgumentNull("imports", () => options.AddImports(default(ImmutableArray<string>)));
-            AssertEx.ThrowsArgumentNull("imports[0]", () => options.AddImports(ImmutableArray.Create((string)null)));
+            Assert.Throws<ArgumentNullException>("imports", () => options.AddImports(default(ImmutableArray<string>)));
+            Assert.Throws<ArgumentNullException>("imports[0]", () => options.AddImports(ImmutableArray.Create((string)null)));
 
             // we only check if the specified name is a valid CLR namespace name, it might not be a valid C#/VB namespace name:
             options.AddImports("");
@@ -132,14 +132,14 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         {
             var options = ScriptOptions.Default;
 
-            AssertEx.ThrowsArgumentNull("imports", () => options.WithImports((string[])null));
-            AssertEx.ThrowsArgumentNull("imports[0]", () => options.WithImports(new string[] { null }));
+            Assert.Throws<ArgumentNullException>("imports", () => options.WithImports((string[])null));
+            Assert.Throws<ArgumentNullException>("imports[0]", () => options.WithImports(new string[] { null }));
 
-            AssertEx.ThrowsArgumentNull("imports", () => options.WithImports((IEnumerable<string>)null));
-            AssertEx.ThrowsArgumentNull("imports[0]", () => options.WithImports((IEnumerable<string>)new string[] { null }));
+            Assert.Throws<ArgumentNullException>("imports", () => options.WithImports((IEnumerable<string>)null));
+            Assert.Throws<ArgumentNullException>("imports[0]", () => options.WithImports((IEnumerable<string>)new string[] { null }));
 
-            AssertEx.ThrowsArgumentNull("imports", () => options.WithImports(default(ImmutableArray<string>)));
-            AssertEx.ThrowsArgumentNull("imports[0]", () => options.WithImports(ImmutableArray.Create((string)null)));
+            Assert.Throws<ArgumentNullException>("imports", () => options.WithImports(default(ImmutableArray<string>)));
+            Assert.Throws<ArgumentNullException>("imports[0]", () => options.WithImports(ImmutableArray.Create((string)null)));
 
             // we only check if the specified name is a valid CLR namespace name, it might not be a valid C#/VB namespace name:
             options.WithImports("");

--- a/src/Test/Utilities/Shared/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Shared/Assert/AssertEx.cs
@@ -324,59 +324,6 @@ namespace Roslyn.Test.Utilities
             Assert.False(AssertEqualityComparer<T>.IsNull(@object), message);
         }
 
-        public static void ThrowsArgumentNull(string parameterName, Action del)
-        {
-            try
-            {
-                del();
-            }
-            catch (ArgumentNullException e)
-            {
-                Assert.Equal(parameterName, e.ParamName);
-            }
-        }
-
-        public static void ThrowsArgumentException(string parameterName, Action del)
-        {
-            try
-            {
-                del();
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(parameterName, e.ParamName);
-            }
-        }
-
-        public static T Throws<T>(Action del, bool allowDerived = false) where T : Exception
-        {
-            try
-            {
-                del();
-            }
-            catch (Exception ex)
-            {
-                var type = ex.GetType();
-                if (type.Equals(typeof(T)))
-                {
-                    // We got exactly the type we wanted
-                    return (T)ex;
-                }
-
-                if (allowDerived && typeof(T).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
-                {
-                    // We got a derived type
-                    return (T)ex;
-                }
-
-                // We got some other type. We know that type != typeof(T), and so we'll use Assert.Equal since Xunit
-                // will give a nice Expected/Actual output for this
-                Assert.Equal(typeof(T), type);
-            }
-
-            throw new Exception("No exception was thrown.");
-        }
-
         // compares against a baseline
         public static void AssertEqualToleratingWhitespaceDifferences(
             string expected,

--- a/src/Test/Utilities/Shared/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Shared/Assert/AssertEx.cs
@@ -319,11 +319,6 @@ namespace Roslyn.Test.Utilities
             Assert.False(true, string.Format(format, args));
         }
 
-        public static void Null<T>(T @object, string message = null)
-        {
-            Assert.True(AssertEqualityComparer<T>.IsNull(@object), message);
-        }
-
         public static void NotNull<T>(T @object, string message = null)
         {
             Assert.False(AssertEqualityComparer<T>.IsNull(@object), message);

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeClassTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeClassTests.cs
@@ -104,7 +104,7 @@ public class Bar
         public async Task GetStartPoint_Attributes()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -136,7 +136,7 @@ public class Bar
         public async Task GetStartPoint_BodyWithDelimiter()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -156,7 +156,7 @@ public class Bar
         public async Task GetStartPoint_HeaderWithAttributes()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -164,7 +164,7 @@ public class Bar
         public async Task GetStartPoint_Name()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -184,7 +184,7 @@ public class Bar
         public async Task GetStartPoint_Whole()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -204,7 +204,7 @@ public class Bar
         public async Task GetEndPoint_Attributes()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -236,7 +236,7 @@ public class Bar
         public async Task GetEndPoint_BodyWithDelimiter()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -245,7 +245,7 @@ public class Bar
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
 
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -253,7 +253,7 @@ public class Bar
         public async Task GetEndPoint_HeaderWithAttributes()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -261,7 +261,7 @@ public class Bar
         public async Task GetEndPoint_Name()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -281,7 +281,7 @@ public class Bar
         public async Task GetEndPoint_Whole()
         {
             CodeClass testObject = await GetCodeClassAsync("Bar");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeFunctionTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeFunctionTests.cs
@@ -282,7 +282,7 @@ public class Ref<T> where T : Entity
         public async Task GetStartPoint_Attributes()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -290,7 +290,7 @@ public class Ref<T> where T : Entity
         public async Task GetStartPoint_AttributesWithDelimiter()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<COMException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
+            Assert.Throws<COMException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -310,7 +310,7 @@ public class Ref<T> where T : Entity
         public async Task GetStartPoint_BodyWithDelimiter()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -330,7 +330,7 @@ public class Ref<T> where T : Entity
         public async Task GetStartPoint_HeaderWithAttributes()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -338,7 +338,7 @@ public class Ref<T> where T : Entity
         public async Task GetStartPoint_Name()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -370,7 +370,7 @@ public class Ref<T> where T : Entity
         public async Task GetStartPoint_Whole()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -390,7 +390,7 @@ public class Ref<T> where T : Entity
         public async Task GetEndPoint_Attributes()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -398,7 +398,7 @@ public class Ref<T> where T : Entity
         public async Task GetEndPoint_AttributesWithDelimiter()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<COMException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
+            Assert.Throws<COMException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -418,7 +418,7 @@ public class Ref<T> where T : Entity
         public async Task GetEndPoint_BodyWithDelimiter()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -426,7 +426,7 @@ public class Ref<T> where T : Entity
         public async Task GetEndPoint_Header()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -434,7 +434,7 @@ public class Ref<T> where T : Entity
         public async Task GetEndPoint_HeaderWithAttributes()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -442,7 +442,7 @@ public class Ref<T> where T : Entity
         public async Task GetEndPoint_Name()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -462,7 +462,7 @@ public class Ref<T> where T : Entity
         public async Task GetEndPoint_Whole()
         {
             CodeFunction testObject = await GetCodeFunctionAsync("A", "MethodA");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeImportTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeImportTests.cs
@@ -29,7 +29,7 @@ using Foo = System.Data;")
         public async Task Name()
         {
             CodeImport import = await GetCodeImportAsync(1);
-            AssertEx.Throws<COMException>(() => { var value = import.Name; });
+            Assert.Throws<COMException>(() => { var value = import.Name; });
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -37,7 +37,7 @@ using Foo = System.Data;")
         public async Task FullName()
         {
             CodeImport import = await GetCodeImportAsync(1);
-            AssertEx.Throws<COMException>(() => { var value = import.FullName; });
+            Assert.Throws<COMException>(() => { var value = import.FullName; });
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -72,7 +72,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_Attributes()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -80,7 +80,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_AttributesWithDelimiter()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<COMException>(() => import.GetStartPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
+            Assert.Throws<COMException>(() => import.GetStartPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -88,7 +88,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_Body()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<COMException>(() => import.GetStartPoint(vsCMPart.vsCMPartBody));
+            Assert.Throws<COMException>(() => import.GetStartPoint(vsCMPart.vsCMPartBody));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -96,7 +96,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_BodyWithDelimiter()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -104,7 +104,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_Header()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -112,7 +112,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_HeaderWithAttributes()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -120,7 +120,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_Name()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -139,7 +139,7 @@ using Foo = System.Data;")
         public async Task GetStartPoint_Whole()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => import.GetStartPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -158,7 +158,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_Attributes()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -166,7 +166,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_AttributesWithDelimiter()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<COMException>(() => import.GetEndPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
+            Assert.Throws<COMException>(() => import.GetEndPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -174,7 +174,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_Body()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<COMException>(() => import.GetEndPoint(vsCMPart.vsCMPartBody));
+            Assert.Throws<COMException>(() => import.GetEndPoint(vsCMPart.vsCMPartBody));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -182,7 +182,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_BodyWithDelimiter()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -190,7 +190,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_Header()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -198,7 +198,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_HeaderWithAttributes()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -206,7 +206,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_Name()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -226,7 +226,7 @@ using Foo = System.Data;")
         public async Task GetEndPoint_Whole()
         {
             CodeImport import = await GetCodeImportAsync(2);
-            AssertEx.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => import.GetEndPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeNamespaceTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeNamespaceTests.cs
@@ -108,7 +108,7 @@ namespace A.B
         public async Task GetStartPoint_Attributes()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -116,7 +116,7 @@ namespace A.B
         public async Task GetStartPoint_AttributesWithDelimiter()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<COMException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
+            Assert.Throws<COMException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -136,7 +136,7 @@ namespace A.B
         public async Task GetStartPoint_BodyWithDelimiter()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -144,7 +144,7 @@ namespace A.B
         public async Task GetStartPoint_Header()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -152,7 +152,7 @@ namespace A.B
         public async Task GetStartPoint_HeaderWithAttributes()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -160,7 +160,7 @@ namespace A.B
         public async Task GetStartPoint_Name()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -180,7 +180,7 @@ namespace A.B
         public async Task GetStartPoint_Whole()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -199,7 +199,7 @@ namespace A.B
         public async Task GetEndPoint_Attributes()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -207,7 +207,7 @@ namespace A.B
         public async Task GetEndPoint_AttributesWithDelimiter()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<COMException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
+            Assert.Throws<COMException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributesWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -227,7 +227,7 @@ namespace A.B
         public async Task GetEndPoint_BodyWithDelimiter()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -235,7 +235,7 @@ namespace A.B
         public async Task GetEndPoint_Header()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -243,7 +243,7 @@ namespace A.B
         public async Task GetEndPoint_HeaderWithAttributes()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -251,7 +251,7 @@ namespace A.B
         public async Task GetEndPoint_Name()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -271,7 +271,7 @@ namespace A.B
         public async Task GetEndPoint_Whole()
         {
             CodeNamespace testObject = await GetCodeNamespaceAsync("A.B");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeVariableTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeVariableTests.cs
@@ -206,7 +206,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetStartPoint_Attributes()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -226,7 +226,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetStartPoint_Body()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<COMException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBody));
+            Assert.Throws<COMException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBody));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -234,7 +234,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetStartPoint_BodyWithDelimiter()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -242,7 +242,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetStartPoint_Header()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -250,7 +250,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetStartPoint_HeaderWithAttributes()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -258,7 +258,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetStartPoint_Name()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -278,7 +278,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetStartPoint_Whole()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetStartPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -298,7 +298,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetEndPoint_Attributes()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -318,7 +318,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetEndPoint_Body()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<COMException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBody));
+            Assert.Throws<COMException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBody));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -326,7 +326,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetEndPoint_BodyWithDelimiter()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartBodyWithDelimiter));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -334,7 +334,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetEndPoint_Header()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeader));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -342,7 +342,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetEndPoint_HeaderWithAttributes()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartHeaderWithAttributes));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -350,7 +350,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetEndPoint_Name()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartName));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartName));
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -370,7 +370,7 @@ unsafe public struct DevDivBugs70194
         public async Task GetEndPoint_Whole()
         {
             CodeVariable testObject = await GetCodeVariableAsync("A", "intC");
-            AssertEx.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
+            Assert.Throws<NotImplementedException>(() => testObject.GetEndPoint(vsCMPart.vsCMPartWhole));
         }
 
         [ConditionalWpfFact(typeof(x86))]

--- a/src/VisualStudio/Core/Test/Venus/CSharpContainedLanguageSupportTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/CSharpContainedLanguageSupportTests.vb
@@ -307,7 +307,7 @@ public class _Default
 
             Using workspace = Await GetWorkspaceAsync(code)
                 Dim document = GetDocument(workspace)
-                AssertEx.Throws(Of InvalidOperationException)(
+                Assert.Throws(Of InvalidOperationException)(
                     Sub()
                         ContainedLanguageCodeSupport.GetCompatibleEventHandlers(
                             document:=document,
@@ -343,7 +343,7 @@ namespace Test
 
             Using workspace = Await GetWorkspaceAsync(code)
                 Dim document = GetDocument(workspace)
-                AssertEx.Throws(Of InvalidOperationException)(
+                Assert.Throws(Of InvalidOperationException)(
                     Sub()
                         ContainedLanguageCodeSupport.GetCompatibleEventHandlers(
                             document:=document,

--- a/src/VisualStudio/Core/Test/Venus/VisualBasicContainedLanguageSupportTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/VisualBasicContainedLanguageSupportTests.vb
@@ -338,7 +338,7 @@ End Class</text>.Value
 
             Using workspace = Await GetWorkspaceAsync(code)
                 Dim document = GetDocument(workspace)
-                AssertEx.Throws(Of InvalidOperationException)(
+                Assert.Throws(Of InvalidOperationException)(
                     Sub()
                         ContainedLanguageCodeSupport.GetCompatibleEventHandlers(
                             document:=document,
@@ -368,7 +368,7 @@ End Class</text>.Value
 
             Using workspace = Await GetWorkspaceAsync(code)
                 Dim document = GetDocument(workspace)
-                AssertEx.Throws(Of InvalidOperationException)(
+                Assert.Throws(Of InvalidOperationException)(
                     Sub()
                         ContainedLanguageCodeSupport.GetCompatibleEventHandlers(
                             document:=document,


### PR DESCRIPTION
The fixing of the AssertEx.ThrowsArgument* helpers is hilarious.

*Reviewers:* @dotnet/roslyn-compiler, @dotnet/roslyn-ide