### PR TITLE
Add id to open doc list after updating solution

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -408,8 +408,6 @@ namespace Microsoft.CodeAnalysis
                 var oldDocument = oldSolution.GetDocument(documentId);
                 var oldDocumentState = oldDocument.State;
 
-                AddToOpenDocumentMap(documentId);
-
                 var newText = textContainer.CurrentText;
                 var currentSolution = oldSolution;
 
@@ -439,6 +437,11 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 var newSolution = this.SetCurrentSolution(currentSolution);
+
+                // add id to open doc list after updating current solution so document does not claim to be open
+                // until the new text is available.
+                AddToOpenDocumentMap(documentId);
+
                 SignupForTextChanges(documentId, textContainer, isCurrentContext, (w, id, text, mode) => w.OnDocumentTextChanged(id, text, mode));
 
                 var newDoc = newSolution.GetDocument(documentId);


### PR DESCRIPTION
Related to #7566

Moves the call that adds the opened document id to the open document list after the solution has been updated to include the new text for the open document.  There is still a race condition here as these two pieces of state are modified and used independently, but this change should reduce the ability to observe new open documents that don't have corresponding text & buffer changes.