### PR TITLE
Fix that unverifiable IL is generated for switch over Nullable<Int64> and Nullable<UInt64>

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -203,9 +203,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 convertedCaseExpression = this.CreateConversion(caseExpression, conversion, switchGoverningType, diagnostics);
             }
 
-            if (switchGoverningType.IsNullableType() && convertedCaseExpression.Kind == BoundKind.Conversion)
+            if (switchGoverningType.IsNullableType()
+                && convertedCaseExpression.Kind == BoundKind.Conversion
+                // Null is a special case here because we want to compare null to the Nullable<T> itself, not to the underlying type.
+                && (convertedCaseExpression.ConstantValue == null || !convertedCaseExpression.ConstantValue.IsNull))
             {
-                constantValueOpt = ((BoundConversion)convertedCaseExpression).Operand.ConstantValue;
+                var operand = ((BoundConversion)convertedCaseExpression).Operand;
+
+                // We are not intested in the diagnostic that get created here
+                var diagnosticBag = DiagnosticBag.GetInstance();
+                constantValueOpt = CreateConversion(operand, switchGoverningType.GetNullableUnderlyingType(), diagnosticBag).ConstantValue;
+                diagnosticBag.Free();
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -1947,7 +1947,7 @@ class Program
 ");
         }
 
-        [Fact]
+        [Fact, WorkItem(7625, "https://github.com/dotnet/roslyn/issues/7625")]
         public void SwitchOnNullableInt64WithInt32Label()
         {
             var text = @"public static class C
@@ -1995,7 +1995,7 @@ class Program
             );
         }
 
-        [Fact]
+        [Fact, WorkItem(7625, "https://github.com/dotnet/roslyn/issues/7625")]
         public void SwitchOnNullableWithNonConstant()
         {
             var text = @"public static class C
@@ -2017,13 +2017,14 @@ class Program
     }
 }";
             var compilation = base.CreateCSharpCompilation(text);
-
+            // (8,13): error CS0150: A constant value is expected
+            //             case i:
             var expected = Diagnostic(ErrorCode.ERR_ConstantExpected, "case i:");
 
             compilation.VerifyDiagnostics(expected);
         }
 
-        [Fact]
+        [Fact, WorkItem(7625, "https://github.com/dotnet/roslyn/issues/7625")]
         public void SwitchOnNullableWithNonCompatibleType()
         {
             var text = @"public static class C
@@ -2045,6 +2046,8 @@ class Program
 }";
             var compilation = base.CreateCSharpCompilation(text);
 
+            // (7,18): error CS0029: Cannot implicitly convert type 'System.DateTime' to 'int?'
+            //             case default(System.DateTime):
             var expected = Diagnostic(ErrorCode.ERR_NoImplicitConv, "default(System.DateTime)").WithArguments("System.DateTime", "int?");
 
             compilation.VerifyDiagnostics(expected);

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSelectCase.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenSelectCase.vb
@@ -3190,6 +3190,65 @@ End Module
             VerifySynthesizedStringHashMethod(compVerifier, expected:=False)
         End Sub
 
+        <Fact>
+        Public Sub SwitchOnNullableInt64WithInt32Label()
+
+            Dim compVerifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Module C
+    Function F(ByVal x As Long?) As Boolean
+        Select Case x
+            Case 1:
+                Return True
+            Case Else
+                Return False
+        End Select
+    End Function
+
+    Sub Main()
+        System.Console.WriteLine(F(1))
+    End Sub
+End Module
+    ]]></file>
+</compilation>, expectedOutput:="True").VerifyIL("C.F(Long?)", <![CDATA[
+{
+  // Code size       56 (0x38)
+  .maxstack  2
+  .locals init (Boolean V_0, //F
+                Long? V_1,
+                Boolean? V_2)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.1
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  call       "Function Long?.get_HasValue() As Boolean"
+  IL_0009:  brtrue.s   IL_0016
+  IL_000b:  ldloca.s   V_2
+  IL_000d:  initobj    "Boolean?"
+  IL_0013:  ldloc.2
+  IL_0014:  br.s       IL_0026
+  IL_0016:  ldloca.s   V_1
+  IL_0018:  call       "Function Long?.GetValueOrDefault() As Long"
+  IL_001d:  ldc.i4.1
+  IL_001e:  conv.i8
+  IL_001f:  ceq
+  IL_0021:  newobj     "Sub Boolean?..ctor(Boolean)"
+  IL_0026:  stloc.2
+  IL_0027:  ldloca.s   V_2
+  IL_0029:  call       "Function Boolean?.GetValueOrDefault() As Boolean"
+  IL_002e:  brfalse.s  IL_0034
+  IL_0030:  ldc.i4.1
+  IL_0031:  stloc.0
+  IL_0032:  br.s       IL_0036
+  IL_0034:  ldc.i4.0
+  IL_0035:  stloc.0
+  IL_0036:  ldloc.0
+  IL_0037:  ret
+}
+]]>)
+            VerifySynthesizedStringHashMethod(compVerifier, expected:=False)
+        End Sub
+
 #Region "Select case string tests"
 
         <Fact, WorkItem(651996, "DevDiv")>


### PR DESCRIPTION
Fixes #7625.