### PR TITLE
Address infinite cycle issues around generic types constructed with nullable reference types and overriding resolution.

### DIFF
--- a/docs/features/NullableReferenceTypes/ImplementationNotes.md
+++ b/docs/features/NullableReferenceTypes/ImplementationNotes.md
@@ -52,3 +52,26 @@ For the purpose of flow analysis, a trackable expression is considered to be nul
 
 When expression is used as a receiver of a conditional access (?./?[]). 
 For the purpose of flow analysis, a trackable expression is considered to be not null before the access is evaluated. ~~If, according to flow analysis, the expression has a not null value before the receiver is evaluated, a warning is reported that the receiver is never null.~~ Result of the operator is considered to be not null for the purpose of the flow analysis only if both, the receiver and the access are considered to be not null.
+
+Right now, some overriding cases can be ambiguous because constraints are not specified on an overriding method, but rather inherited from the overridden method. For example:
+```
+class A
+{
+    public virtual void M1<T>(T? x) where T : struct 
+    { 
+    }
+
+    public virtual void M1<T>(T? x) where T : class 
+    { 
+    }
+}
+
+class B : A
+{
+    public override void M1<T>(T? x)
+    {
+    }
+} 
+```
+
+Current implementation doesn't detect this ambiguity case and simply grabs the first applicable candidate for overriding, always in in declaration order, I assume.

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -621,6 +621,7 @@
     <Compile Include="Symbols\SignatureOnlyParameterSymbol.cs" />
     <Compile Include="Symbols\SignatureOnlyPropertySymbol.cs" />
     <Compile Include="Symbols\Source\AttributeLocation.cs" />
+    <Compile Include="Symbols\Source\IndexedTypeParameterSymbolForOverriding.cs" />
     <Compile Include="Symbols\Source\ConstantEvaluationHelpers.cs" />
     <Compile Include="Symbols\Source\CrefTypeParameterSymbol.cs" />
     <Compile Include="Symbols\Source\CustomModifierUtils.cs" />

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -489,10 +489,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int minCustomModifierCount = int.MaxValue;
 
             IEqualityComparer<Symbol> exactMatchComparer = memberIsFromSomeCompilation
-                ? MemberSignatureComparer.CSharpCustomModifierOverrideComparer
+                ? (member.IsOverride ? MemberSignatureComparer.CSharpCustomModifierNullableOverrideComparer : MemberSignatureComparer.CSharpCustomModifierOverrideComparer)
                 : MemberSignatureComparer.RuntimePlusRefOutSignatureComparer;
             IEqualityComparer<Symbol> fallbackComparer = memberIsFromSomeCompilation
-                ? MemberSignatureComparer.CSharpOverrideComparer
+                ? (member.IsOverride ? MemberSignatureComparer.CSharpNullableOverrideComparer : MemberSignatureComparer.CSharpOverrideComparer)
                 : MemberSignatureComparer.RuntimeSignatureComparer;
 
             SymbolKind memberKind = member.Kind;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbolForOverriding.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbolForOverriding.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Indexed type parameters are used in place of type parameters for method signatures. 
+    /// 
+    /// They don't have a containing symbol or locations.
+    /// 
+    /// They do not have constraints (except reference type constraint), variance, or attributes. 
+    /// </summary>
+    internal sealed class IndexedTypeParameterSymbolForOverriding : TypeParameterSymbol
+    {
+        private static TypeParameterSymbol[] s_parameterPoolHasReferenceTypeConstraint = SpecializedCollections.EmptyArray<TypeParameterSymbol>();
+        private static TypeParameterSymbol[] s_parameterPoolHasNoReferenceTypeConstraint = SpecializedCollections.EmptyArray<TypeParameterSymbol>();
+
+        private readonly int _index;
+        private readonly bool _hasReferenceTypeConstraint;
+
+        private IndexedTypeParameterSymbolForOverriding(int index, bool hasReferenceTypeConstraint)
+        {
+            _index = index;
+            _hasReferenceTypeConstraint = hasReferenceTypeConstraint;
+        }
+
+        public override TypeParameterKind TypeParameterKind
+        {
+            get
+            {
+                return TypeParameterKind.Method;
+            }
+        }
+
+        internal static TypeParameterSymbol GetTypeParameter(int index, bool hasReferenceTypeConstraint)
+        {
+            TypeParameterSymbol result;
+
+            if (hasReferenceTypeConstraint)
+            {
+                result = GetTypeParameter(ref s_parameterPoolHasReferenceTypeConstraint, index, hasReferenceTypeConstraint);
+            }
+            else
+            {
+                result = GetTypeParameter(ref s_parameterPoolHasNoReferenceTypeConstraint, index, hasReferenceTypeConstraint);
+            }
+
+            Debug.Assert(result.HasReferenceTypeConstraint == hasReferenceTypeConstraint);
+            return result;
+        }
+
+        private static TypeParameterSymbol GetTypeParameter(ref TypeParameterSymbol[] parameterPool, int index, bool hasReferenceTypeConstraint)
+        {
+            if (index >= parameterPool.Length)
+            {
+                GrowPool(ref parameterPool, index + 1, hasReferenceTypeConstraint);
+            }
+
+            return parameterPool[index];
+        }
+
+        private static void GrowPool(ref TypeParameterSymbol[] parameterPool, int count, bool hasReferenceTypeConstraint)
+        {
+            var initialPool = parameterPool;
+            while (count > initialPool.Length)
+            {
+                var newPoolSize = ((count + 0x0F) & ~0xF); // grow in increments of 16
+                var newPool = new TypeParameterSymbol[newPoolSize];
+
+                Array.Copy(initialPool, newPool, initialPool.Length);
+
+                for (int i = initialPool.Length; i < newPool.Length; i++)
+                {
+                    newPool[i] = new IndexedTypeParameterSymbolForOverriding(i, hasReferenceTypeConstraint);
+                }
+
+                Interlocked.CompareExchange(ref parameterPool, newPool, initialPool);
+
+                // repeat if race condition occurred and someone else resized the pool before us
+                // and the new pool is still too small
+                initialPool = parameterPool;
+            }
+        }
+
+        public override int Ordinal
+        {
+            get { return _index; }
+        }
+
+        // These object are unique (per index).
+        internal override bool Equals(TypeSymbol t2, TypeSymbolEqualityOptions options)
+        {
+            return ReferenceEquals(this, t2);
+        }
+
+        public override int GetHashCode()
+        {
+            return _index;
+        }
+
+        public override VarianceKind Variance
+        {
+            get { return VarianceKind.None; }
+        }
+
+        public override bool HasValueTypeConstraint
+        {
+            get { return false; }
+        }
+
+        public override bool HasReferenceTypeConstraint
+        {
+            get { return _hasReferenceTypeConstraint; }
+        }
+
+        public override bool HasConstructorConstraint
+        {
+            get { return false; }
+        }
+
+        public override Symbol ContainingSymbol
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public override ImmutableArray<Location> Locations
+        {
+            get
+            {
+                return ImmutableArray<Location>.Empty;
+            }
+        }
+
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+        {
+            get
+            {
+                return ImmutableArray<SyntaxReference>.Empty;
+            }
+        }
+
+        internal override void EnsureAllConstraintsAreResolved()
+        {
+        }
+
+        internal override ImmutableArray<TypeSymbolWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress)
+        {
+            return ImmutableArray<TypeSymbolWithAnnotations>.Empty;
+        }
+
+        internal override ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress)
+        {
+            return ImmutableArray<NamedTypeSymbol>.Empty;
+        }
+
+        internal override NamedTypeSymbol GetEffectiveBaseClass(ConsList<TypeParameterSymbol> inProgress)
+        {
+            return null;
+        }
+
+        internal override TypeSymbol GetDeducedBaseType(ConsList<TypeParameterSymbol> inProgress)
+        {
+            return null;
+        }
+
+        public override bool IsImplicitlyDeclared
+        {
+            get { return true; }
+        }
+    }
+}


### PR DESCRIPTION
Also simplified implementation of LazyNullableType, by limiting its usage to type parameters only.

CC @dotnet/roslyn-compiler 