### PR TITLE
Fix Exec targets to work on Mono

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -17,6 +17,7 @@
     <OutputDirectory>Binaries\$(Configuration)</OutputDirectory>
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages</NuGetPackageRoot>
     <XunitVersion>2.1.0</XunitVersion>
+    <ManagedExecutor Condition="'$(OS)' != 'Windows_NT'">mono</ManagedExecutor>
   </PropertyGroup>
 
   <Target Name="Build">
@@ -78,7 +79,7 @@
                       Exclude="$(OutputDirectory)\**\Roslyn.Interactive*;$(OutputDirectory)\**\MakeConst*" />
     </ItemGroup>
 
-    <Exec Command="Binaries\$(Configuration)\RunTests.exe $(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')" />
+    <Exec Command="$(ManagedExecutor) Binaries\$(Configuration)\RunTests.exe $(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')" />
 
   </Target>
 

--- a/build/Targets/GenerateCompilerInternals.targets
+++ b/build/Targets/GenerateCompilerInternals.targets
@@ -33,10 +33,6 @@
       $(CleanDependsOn)
     </CleanDependsOn>
   </PropertyGroup>
-
-  <PropertyGroup>
-	<MonoPrefix Condition="'$(OS)' != 'Windows_NT'">mono </MonoPrefix>
-  </PropertyGroup>
   
   <Target
     Name="GenerateSyntaxModel"
@@ -45,13 +41,13 @@
     Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
-      <SyntaxGenerator Condition="'$(Language)' == 'VB'">$(MonoPrefix) "$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
-      <SyntaxGenerator Condition="'$(Language)' == 'C#'">$(MonoPrefix) "$(CSharpSyntaxGeneratorToolPath)"</SyntaxGenerator>
+      <SyntaxGenerator Condition="'$(Language)' == 'VB'">$(VBSyntaxGeneratorToolPath)</SyntaxGenerator>
+      <SyntaxGenerator Condition="'$(Language)' == 'C#'">$(CSharpSyntaxGeneratorToolPath)</SyntaxGenerator>
       <GeneratedSyntaxModel>@(SyntaxDefinition -> '$(IntermediateOutputPath)%(Filename)%(Extension).Generated$(DefaultLanguageSourceExtension)')</GeneratedSyntaxModel>
     </PropertyGroup>
 
     <Exec
-      Command='$(SyntaxGenerator) "@(SyntaxDefinition)" "$(GeneratedSyntaxModel)"'
+      Command='$(ManagedExecutor) "$(SyntaxGenerator)" "@(SyntaxDefinition)" "$(GeneratedSyntaxModel)"'
       Outputs="$(GeneratedSyntaxModel)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
@@ -81,7 +77,7 @@
     </PropertyGroup>
 
     <Exec
-      Command='$(SyntaxGenerator) &quot;@(SyntaxGetTextDefinition)&quot; &quot;$(GeneratedSyntaxModelGetText)&quot; /gettext'
+      Command='$(ManagedExecutor) "$(SyntaxGenerator)" "@(SyntaxGetTextDefinition)" "$(GeneratedSyntaxModelGetText)" /gettext'
       Outputs="$(GeneratedSyntaxModelGetText)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
@@ -107,13 +103,13 @@
     Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
-      <SyntaxGenerator Condition="'$(Language)' == 'VB'">$(MonoPrefix) "$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
-      <SyntaxGenerator Condition="'$(Language)' == 'C#'">$(MonoPrefix) "$(CSharpSyntaxGeneratorToolPath)"</SyntaxGenerator>
+      <SyntaxGenerator Condition="'$(Language)' == 'VB'">$(VBSyntaxGeneratorToolPath)</SyntaxGenerator>
+      <SyntaxGenerator Condition="'$(Language)' == 'C#'">$(CSharpSyntaxGeneratorToolPath)</SyntaxGenerator>
       <GeneratedSyntaxModelTests>@(SyntaxTestDefinition -> '$(IntermediateOutputPath)\%(FileName)%(Extension).Generated$(DefaultLanguageSourceExtension)')</GeneratedSyntaxModelTests>
     </PropertyGroup>
 
     <Exec
-      Command='$(SyntaxGenerator) &quot;@(SyntaxTestDefinition)&quot; &quot;$(GeneratedSyntaxModelTests)&quot; /test'
+      Command='$(ManagedExecutor) "$(SyntaxGenerator)" "@(SyntaxTestDefinition)" "$(GeneratedSyntaxModelTests)" /test'
       Outputs="$(GeneratedSyntaxModelTests)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
@@ -139,12 +135,12 @@
     Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
-      <BoundTreeGenerator>$(MonoPrefix) "$(BoundTreeGeneratorToolPath)"</BoundTreeGenerator>
+      <BoundTreeGenerator>$(BoundTreeGeneratorToolPath)</BoundTreeGenerator>
       <GeneratedBoundTree>@(BoundTreeDefinition -> '$(IntermediateOutputPath)%(Filename)%(Extension).Generated$(DefaultLanguageSourceExtension)')</GeneratedBoundTree>
     </PropertyGroup>
 
     <Exec
-      Command='$(BoundTreeGenerator) $(Language) "@(BoundTreeDefinition)" "$(GeneratedBoundTree)"'
+      Command='$(ManagedExecutor) "$(BoundTreeGenerator)" $(Language) "@(BoundTreeDefinition)" "$(GeneratedBoundTree)"'
       Outputs="$(GeneratedBoundTree)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
@@ -175,13 +171,13 @@
     Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
-      <ErrorFactsGenerator Condition="'$(Language)' == 'VB'">$(MonoPrefix) "$(VBErrorFactsGeneratorToolPath)"</ErrorFactsGenerator>
-      <ErrorFactsGenerator Condition="'$(Language)' == 'C#'">$(MonoPrefix) "$(CSharpErrorFactsGeneratorToolPath)"</ErrorFactsGenerator>
+      <ErrorFactsGenerator Condition="'$(Language)' == 'VB'">$(VBErrorFactsGeneratorToolPath)</ErrorFactsGenerator>
+      <ErrorFactsGenerator Condition="'$(Language)' == 'C#'">$(CSharpErrorFactsGeneratorToolPath)</ErrorFactsGenerator>
       <GeneratedErrorFacts>@(ErrorCode -> '$(IntermediateOutputPath)ErrorFacts.Generated$(DefaultLanguageSourceExtension)')</GeneratedErrorFacts>
     </PropertyGroup>
 
     <Exec
-      Command='$(ErrorFactsGenerator) "@(ErrorCode)" "$(GeneratedErrorFacts)"'
+      Command='$(ManagedExecutor) "$(ErrorFactsGenerator)" "@(ErrorCode)" "$(GeneratedErrorFacts)"'
       Outputs="$(GeneratedErrorFacts)"
     >
       <Output TaskParameter="Outputs" ItemName="FileWrites" />

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -19,6 +19,8 @@
 
     <!-- Turn on hard-linking on Windows to reduce copy time and disk space -->
     <CreateHardLinksForCopyLocalIfPossible Condition="'$(OS)' == 'Windows_NT'">true</CreateHardLinksForCopyLocalIfPossible>
+
+    <ManagedExecutor Condition="'$(OS)' != 'Windows_NT'">mono</ManagedExecutor>
   </PropertyGroup>
 
   <!-- Import the global NuGet packages -->

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -270,8 +270,7 @@
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
 
-    <Exec Command="&quot;$(FakeSignToolPath)&quot; &quot;@(IntermediateAssembly)&quot;" />
-
+    <Exec Command='$(ManagedExecutor) "$(FakeSignToolPath)" "@(IntermediateAssembly)"' />
   </Target>
 
   <!-- ====================================================================================

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Microsoft.DiaSymReader.PortablePdb.nuget.proj
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Microsoft.DiaSymReader.PortablePdb.nuget.proj
@@ -17,7 +17,7 @@
     <!-- copy any extra content files (like EULAs) that we need to include -->
     <Copy SourceFiles="@(Content)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <!-- package! -->
-    <Exec Command='$(NuGetToolPath) Pack "$(MSBuildProjectDirectory)\%(NuSpec.Identity)" -BasePath $(OutDir) -OutputDirectory $(NuGetOutDir) $(NuGetArguments)' />
+    <Exec Command='$(ManagedExecutor) "$(NuGetToolPath)" Pack "$(MSBuildProjectDirectory)\%(NuSpec.Identity)" -BasePath "$(OutDir)" -OutputDirectory "$(NuGetOutDir)" $(NuGetArguments)' />
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="$(OutDir)NuGet" />

--- a/src/Dependencies/Microsoft.DiaSymReader/Microsoft.DiaSymReader.nuget.proj
+++ b/src/Dependencies/Microsoft.DiaSymReader/Microsoft.DiaSymReader.nuget.proj
@@ -17,7 +17,7 @@
     <!-- copy any extra content files (like EULAs) that we need to include -->
     <Copy SourceFiles="@(Content)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <!-- package! -->
-    <Exec Command='$(NuGetToolPath) Pack "$(MSBuildProjectDirectory)\%(NuSpec.Identity)" -BasePath "$(OutDir)DiaSymReader" -OutputDirectory "$(NuGetOutDir)" $(NuGetArguments)' />
+    <Exec Command='$(ManagedExecutor) "$(NuGetToolPath)" Pack "$(MSBuildProjectDirectory)\%(NuSpec.Identity)" -BasePath "$(OutDir)DiaSymReader" -OutputDirectory "$(NuGetOutDir)" $(NuGetArguments)' />
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="$(OutDir)NuGet" />


### PR DESCRIPTION
This change generalizes approach that was already put in place in GenerateCompilerInternals.targets