### PR TITLE
Include byte order marks from explicit Encoding in checksum

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Text
@@ -11,7 +13,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
     public class SourceTextTests
     {
         private static readonly Encoding s_utf8 = Encoding.UTF8;
-        private static readonly Encoding s_utf8Bom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
         private static readonly Encoding s_unicode = Encoding.Unicode;
         private const string HelloWorld = "Hello, World!";
 
@@ -34,24 +35,32 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
         [Fact]
         public void Encoding1()
         {
+            var utf8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
             Assert.Same(s_utf8, SourceText.From(HelloWorld, s_utf8).Encoding);
             Assert.Same(s_unicode, SourceText.From(HelloWorld, s_unicode).Encoding);
 
             var bytes = s_unicode.GetBytes(HelloWorld);
             Assert.Same(s_unicode, SourceText.From(bytes, bytes.Length, s_unicode).Encoding);
+            Assert.Equal(utf8NoBOM, SourceText.From(bytes, bytes.Length, null).Encoding);
 
             var stream = new MemoryStream(bytes);
             Assert.Same(s_unicode, SourceText.From(stream, s_unicode).Encoding);
+            Assert.Equal(utf8NoBOM, SourceText.From(stream, null).Encoding);
         }
 
         [Fact]
         public void EncodingBOM()
         {
-            var bytes = s_utf8Bom.GetPreamble().Concat(s_utf8Bom.GetBytes("abc")).ToArray();
-            Assert.Equal(s_utf8.EncodingName, SourceText.From(bytes, bytes.Length, s_unicode).Encoding.EncodingName);
+            var utf8BOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+
+            var bytes = utf8BOM.GetPreamble().Concat(utf8BOM.GetBytes("abc")).ToArray();
+            Assert.Equal(utf8BOM, SourceText.From(bytes, bytes.Length, s_unicode).Encoding);
+            Assert.Equal(utf8BOM, SourceText.From(bytes, bytes.Length, null).Encoding);
 
             var stream = new MemoryStream(bytes);
-            Assert.Equal(s_utf8.EncodingName, SourceText.From(stream, s_unicode).Encoding.EncodingName);
+            Assert.Equal(utf8BOM, SourceText.From(stream, s_unicode).Encoding);
+            Assert.Equal(utf8BOM, SourceText.From(stream, null).Encoding);
         }
 
         [Fact]
@@ -70,6 +79,63 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
             Assert.Equal(SourceHashAlgorithm.Sha1, SourceText.From(stream).ChecksumAlgorithm);
             Assert.Equal(SourceHashAlgorithm.Sha1, SourceText.From(stream, checksumAlgorithm: SourceHashAlgorithm.Sha1).ChecksumAlgorithm);
             Assert.Equal(SourceHashAlgorithm.Sha256, SourceText.From(stream, checksumAlgorithm: SourceHashAlgorithm.Sha256).ChecksumAlgorithm);
+        }
+
+        [WorkItem(7225)]
+        [Fact]
+        public void ChecksumAndBOM()
+        {
+            const string source = "Hello, World!";
+            var checksumAlgorigthm = SourceHashAlgorithm.Sha1;
+            var encodingNoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            var encodingBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+
+            var checksumNoBOM = ImmutableArray.Create<byte>(0xa, 0xa, 0x9f, 0x2a, 0x67, 0x72, 0x94, 0x25, 0x57, 0xab, 0x53, 0x55, 0xd7, 0x6a, 0xf4, 0x42, 0xf8, 0xf6, 0x5e, 0x1);
+            var checksumBOM = ImmutableArray.Create<byte>(0xb2, 0x19, 0x0, 0x9b, 0x61, 0xce, 0xcd, 0x50, 0x7b, 0x2e, 0x56, 0x3c, 0xc0, 0xeb, 0x96, 0xe2, 0xa1, 0xd9, 0x3f, 0xfc);
+
+            // SourceText from string.
+            VerifyChecksum(SourceText.From(source, encodingNoBOM, checksumAlgorigthm), checksumNoBOM);
+            VerifyChecksum(SourceText.From(source, encodingBOM, checksumAlgorigthm), checksumBOM);
+
+            var bytesNoBOM = new byte[] { 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21 };
+            var bytesBOM = new byte[] { 0xef, 0xbb, 0xbf, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21 };
+
+            var streamNoBOM = new MemoryStream(bytesNoBOM);
+            var streamBOM = new MemoryStream(bytesBOM);
+
+            // SourceText from bytes no BOM.
+            VerifyChecksum(SourceText.From(bytesNoBOM, bytesNoBOM.Length, null, checksumAlgorigthm), checksumNoBOM);
+            VerifyChecksum(SourceText.From(bytesNoBOM, bytesNoBOM.Length, encodingNoBOM, checksumAlgorigthm), checksumNoBOM);
+            VerifyChecksum(SourceText.From(bytesNoBOM, bytesNoBOM.Length, encodingBOM, checksumAlgorigthm), checksumBOM);
+
+            // SourceText from bytes with BOM.
+            VerifyChecksum(SourceText.From(bytesBOM, bytesBOM.Length, null, checksumAlgorigthm), checksumBOM);
+            VerifyChecksum(SourceText.From(bytesBOM, bytesBOM.Length, encodingNoBOM, checksumAlgorigthm), checksumBOM);
+            VerifyChecksum(SourceText.From(bytesBOM, bytesBOM.Length, encodingBOM, checksumAlgorigthm), checksumBOM);
+
+            // SourceText from stream no BOM.
+            VerifyChecksum(SourceText.From(streamNoBOM, null, checksumAlgorigthm), checksumNoBOM);
+            VerifyChecksum(SourceText.From(streamNoBOM, encodingNoBOM, checksumAlgorigthm), checksumNoBOM);
+            VerifyChecksum(SourceText.From(streamNoBOM, encodingBOM, checksumAlgorigthm), checksumBOM);
+
+            // SourceText from stream with BOM.
+            VerifyChecksum(SourceText.From(streamBOM, null, checksumAlgorigthm), checksumBOM);
+            VerifyChecksum(SourceText.From(streamBOM, encodingNoBOM, checksumAlgorigthm), checksumBOM);
+            VerifyChecksum(SourceText.From(streamBOM, encodingBOM, checksumAlgorigthm), checksumBOM);
+
+            // SourceText from stream no BOM.
+            VerifyChecksum(LargeText.Decode(streamNoBOM, encodingNoBOM, checksumAlgorigthm, throwIfBinaryDetected: false), checksumNoBOM);
+            VerifyChecksum(LargeText.Decode(streamNoBOM, encodingBOM, checksumAlgorigthm, throwIfBinaryDetected: false), checksumBOM);
+
+            // SourceText from stream with BOM.
+            VerifyChecksum(LargeText.Decode(streamBOM, encodingNoBOM, checksumAlgorigthm, throwIfBinaryDetected: false), checksumBOM);
+            VerifyChecksum(LargeText.Decode(streamBOM, encodingBOM, checksumAlgorigthm, throwIfBinaryDetected: false), checksumBOM);
+        }
+
+        private static void VerifyChecksum(SourceText text, ImmutableArray<byte> expectedChecksum)
+        {
+            var actualChecksum = text.GetChecksum();
+            Assert.Equal<byte>(expectedChecksum, actualChecksum);
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTest.cs
@@ -236,16 +236,17 @@ bar baz";
         [Fact]
         public void FromStream_CheckSum_NoBOM()
         {
-            // Note: The 0x95 is outside the ASCII range, so a question mark will
-            // be substituted in decoded text. Note, however, that the checksum
-            // should be derived from the original input.
+            // Note: The 0x95 is outside the ASCII range, so a question mark 0x3f will
+            // be substituted in decoded text. The checksum is derived from the
+            // decoded text since that is the text exposed by the SourceText.
             var bytes = new byte[] { 0x61, 0x62, 0x95 };
+            var bytesForChecksum = new byte[] { 0x61, 0x62, 0x3f };
 
             var source = SourceText.From(new MemoryStream(bytes), Encoding.ASCII);
             Assert.Equal("ab?", source.ToString());
 
             var checksum = source.GetChecksum();
-            AssertEx.Equal(CryptographicHashProvider.ComputeSha1(bytes), checksum);
+            AssertEx.Equal(CryptographicHashProvider.ComputeSha1(bytesForChecksum), checksum);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -127,8 +127,8 @@ namespace Microsoft.CodeAnalysis.Text
                 throw new InvalidDataException();
             }
 
-            var checksum = CalculateChecksum(stream, checksumAlgorithm);
-            return new StringText(text, encoding, checksum, checksumAlgorithm);
+            Debug.Assert(encoding != null);
+            return new StringText(text, encoding, checksumAlgorithm: checksumAlgorithm);
         }
 
         /// <summary>
@@ -171,9 +171,8 @@ namespace Microsoft.CodeAnalysis.Text
                 throw new InvalidDataException();
             }
 
-            // Since we have the bytes in hand, it's easy to compute the checksum.
-            var checksum = CalculateChecksum(buffer, 0, length, checksumAlgorithm);
-            return new StringText(text, encoding, checksum, checksumAlgorithm);
+            Debug.Assert(encoding != null);
+            return new StringText(text, encoding, checksumAlgorithm: checksumAlgorithm);
         }
 
         /// <summary>
@@ -441,15 +440,6 @@ namespace Microsoft.CodeAnalysis.Text
                     stream.Seek(0, SeekOrigin.Begin);
                 }
                 return ImmutableArray.Create(algorithm.ComputeHash(stream));
-            }
-        }
-
-        private static ImmutableArray<byte> CalculateChecksum(byte[] buffer, int offset, int count, SourceHashAlgorithm algorithmId)
-        {
-            using (var algorithm = CryptographicHashProvider.TryGetAlgorithm(algorithmId))
-            {
-                Debug.Assert(algorithm != null);
-                return ImmutableArray.Create(algorithm.ComputeHash(buffer, offset, count));
             }
         }
 

--- a/src/Compilers/Core/Portable/Text/StringText.cs
+++ b/src/Compilers/Core/Portable/Text/StringText.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Text
     /// <summary>
     /// Implementation of SourceText based on a <see cref="String"/> input
     /// </summary>
-    internal sealed partial class StringText : SourceText
+    internal sealed class StringText : SourceText
     {
         private readonly string _source;
         private readonly Encoding _encodingOpt;


### PR DESCRIPTION
```SourceText.From(Stream, Encoding, ...)``` included the byte order preamble in the stream
written to disk but the BOM was not included in the checksum for shorter files.
(The BOM was included in the checksum from ```SourceText.From(string, Encoding, ...)```
and from ```SourceText.From(Stream, Encoding, ...)``` for large files.)