### PR TITLE
Extend array type syntax to allow nullable modifiers on array type and on types of nested arrays within a jagged array.

### DIFF
--- a/docs/features/NullableReferenceTypes/ImplementationNotes.md
+++ b/docs/features/NullableReferenceTypes/ImplementationNotes.md
@@ -75,3 +75,13 @@ class B : A
 ```
 
 Current implementation doesn't detect this ambiguity case and simply grabs the first applicable candidate for overriding, always in in declaration order, I assume.
+
+Array type syntax is extended as follows to allow nullable modifiers:
+-	string?[] x1; // not-nullable one-dimensional array of nullable strings
+-	string?[]? x2; // nullable one-dimensional array of nullable strings
+-	string[]? X3; // nullable one-dimensional array of not-nullable strings
+-	string?[][,] x4; // not-nullable one-dimensional array of not-nullable two-dimensional arrays of nullable strings
+-	string?[][,]? X5; // not-nullable one-dimensional array of nullable two-dimensional arrays of nullable strings
+-	string?[]?[,] x6; // nullable one-dimensional array of not-nullable two-dimensional arrays of nullable strings
+
+

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -371,7 +371,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                         for (int i = node.RankSpecifiers.Count - 1; i >= 0; i--)
                         {
                             var a = node.RankSpecifiers[i];
-                            type = TypeSymbolWithAnnotations.Create(ArrayTypeSymbol.CreateCSharpArray(this.Compilation.Assembly, type, a.Rank));
+                            var array = ArrayTypeSymbol.CreateCSharpArray(this.Compilation.Assembly, type, a.Rank);
+
+                            if (a.QuestionToken.IsKind(SyntaxKind.QuestionToken))
+                            {
+                                type = TypeSymbolWithAnnotations.CreateNullableReferenceType(array);
+                            }
+                            else
+                            {
+                                type = TypeSymbolWithAnnotations.Create(array);
+                            }
                         }
 
                         return type;

--- a/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
@@ -1404,7 +1404,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             // Eat the close brace and we're done.
                             var close = this.EatToken(SyntaxKind.CloseBracketToken);
 
-                            rankList.Add(SyntaxFactory.ArrayRankSpecifier(open, dimensionList, close));
+                            SyntaxToken questionToken = null;
+
+                            if (this.CurrentToken.Kind == SyntaxKind.QuestionToken)
+                            {
+                                questionToken = CheckFeatureAvailability(this.EatToken(), MessageID.IDS_FeatureStaticNullChecking);
+                            }
+
+                            rankList.Add(SyntaxFactory.ArrayRankSpecifier(open, dimensionList, close, questionToken));
                         }
                         finally
                         {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6326,7 +6326,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // Eat the close brace and we're done.
                 var close = this.EatToken(SyntaxKind.CloseBracketToken);
 
-                return _syntaxFactory.ArrayRankSpecifier(open, list, close);
+                SyntaxToken questionToken = null;
+
+                if (this.CurrentToken.Kind == SyntaxKind.QuestionToken)
+                {
+                    questionToken = CheckFeatureAvailability(this.EatToken(), MessageID.IDS_FeatureStaticNullChecking);
+                }
+
+                return _syntaxFactory.ArrayRankSpecifier(open, list, close, questionToken);
             }
             finally
             {

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -14,6 +14,9 @@ Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.WithKind(Microsoft.CodeAnalysis
 Microsoft.CodeAnalysis.CSharp.CSharpScriptCompilationInfo
 Microsoft.CodeAnalysis.CSharp.CSharpScriptCompilationInfo.PreviousScriptCompilation.get -> Microsoft.CodeAnalysis.CSharp.CSharpCompilation
 Microsoft.CodeAnalysis.CSharp.CSharpScriptCompilationInfo.WithPreviousScriptCompilation(Microsoft.CodeAnalysis.CSharp.CSharpCompilation compilation) -> Microsoft.CodeAnalysis.CSharp.CSharpScriptCompilationInfo
+Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax.QuestionToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken openBracketToken, Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax> sizes, Microsoft.CodeAnalysis.SyntaxToken closeBracketToken, Microsoft.CodeAnalysis.SyntaxToken questionToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax.WithQuestionToken(Microsoft.CodeAnalysis.SyntaxToken questionToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax.GetLoadDirectives() -> System.Collections.Generic.IList<Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax>
 Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax.File.get -> Microsoft.CodeAnalysis.SyntaxToken
@@ -81,6 +84,7 @@ static Microsoft.CodeAnalysis.CSharp.SyntaxExtensions.NormalizeWhitespace(this M
 static Microsoft.CodeAnalysis.CSharp.SyntaxExtensions.NormalizeWhitespace(this Microsoft.CodeAnalysis.SyntaxToken token, string indentation, bool elasticTrivia) -> Microsoft.CodeAnalysis.SyntaxToken
 static Microsoft.CodeAnalysis.CSharp.SyntaxExtensions.NormalizeWhitespace(this Microsoft.CodeAnalysis.SyntaxTriviaList list, string indentation = "    ", string eol = "\r\n", bool elasticTrivia = false) -> Microsoft.CodeAnalysis.SyntaxTriviaList
 static Microsoft.CodeAnalysis.CSharp.SyntaxExtensions.NormalizeWhitespace(this Microsoft.CodeAnalysis.SyntaxTriviaList list, string indentation, bool elasticTrivia) -> Microsoft.CodeAnalysis.SyntaxTriviaList
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ArrayRankSpecifier(Microsoft.CodeAnalysis.SyntaxToken openBracketToken, Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax> sizes, Microsoft.CodeAnalysis.SyntaxToken closeBracketToken, Microsoft.CodeAnalysis.SyntaxToken questionToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LoadDirectiveTrivia(Microsoft.CodeAnalysis.SyntaxToken file, bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LoadDirectiveTrivia(Microsoft.CodeAnalysis.SyntaxToken hashToken, Microsoft.CodeAnalysis.SyntaxToken loadKeyword, Microsoft.CodeAnalysis.SyntaxToken file, Microsoft.CodeAnalysis.SyntaxToken endOfDirectiveToken, bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.LoadDirectiveTriviaSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LocalFunctionStatement(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax returnType, Microsoft.CodeAnalysis.SyntaxToken identifier) -> Microsoft.CodeAnalysis.CSharp.Syntax.LocalFunctionStatementSyntax

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -175,6 +175,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return new WithoutCustomModifiers(typeSymbol);
         }
 
+        public static TypeSymbolWithAnnotations CreateNullableReferenceType(TypeSymbol typeSymbol)
+        {
+            // TODO: Consider if it makes sense to cache and reuse instances, at least for definitions.
+            return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
+        }
+
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
         {
             if (customModifiers.IsDefaultOrEmpty)

--- a/src/Compilers/CSharp/Portable/Syntax/ArrayRankSpecifierSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ArrayRankSpecifierSyntax.cs
@@ -15,5 +15,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return this.Sizes.Count;
             }
         }
+
+        public ArrayRankSpecifierSyntax Update(SyntaxToken openBracketToken, SeparatedSyntaxList<ExpressionSyntax> sizes, SyntaxToken closeBracketToken)
+        {
+            return this.Update(openBracketToken, sizes, closeBracketToken, default(SyntaxToken));
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -198,6 +198,12 @@
     <Field Name="CloseBracketToken" Type="SyntaxToken">
       <Kind Name="CloseBracketToken"/>
     </Field>
+    <Field Name="QuestionToken" Type="SyntaxToken" Optional="true">
+      <Kind Name="QuestionToken"/>
+      <PropertyComment>
+        <summary>SyntaxToken representing the question mark.</summary>
+      </PropertyComment>
+    </Field>
   </Node>
   <Node Name="PointerTypeSyntax" Base="TypeSyntax">
     <Kind Name="PointerType"/>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2013,5 +2013,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 name: name,
                 semicolonToken: Token(SyntaxKind.SemicolonToken));
         }
+
+        /// <summary>Creates a new ArrayRankSpecifierSyntax instance.</summary>
+        public static ArrayRankSpecifierSyntax ArrayRankSpecifier(SyntaxToken openBracketToken, SeparatedSyntaxList<ExpressionSyntax> sizes, SyntaxToken closeBracketToken)
+        {
+            return SyntaxFactory.ArrayRankSpecifier(openBracketToken, sizes, closeBracketToken, default(SyntaxToken));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -3722,6 +3722,292 @@ class C
         }
 
         [Fact]
+        public void Array_06()
+        {
+            CSharpCompilation c = CreateCompilationWithMscorlib(@"
+class C
+{
+    static void Main()
+    {
+    }
+
+    object Test1()
+    {
+        object []? u1 = null;
+        return u1;
+    }
+    object Test2()
+    {
+        object [][]? u2 = null;
+        return u2;
+    }
+    object Test3()
+    {
+        object []?[]? u3 = null;
+        return u3;
+    }
+}
+");
+
+            c.VerifyDiagnostics(
+    // (10,18): error CS8058: Feature 'static null checking' is only available in 'experimental' language version.
+    //         object []? u1 = null;
+    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "?").WithArguments("static null checking").WithLocation(10, 18),
+    // (15,20): error CS8058: Feature 'static null checking' is only available in 'experimental' language version.
+    //         object [][]? u2 = null;
+    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "?").WithArguments("static null checking").WithLocation(15, 20),
+    // (20,18): error CS8058: Feature 'static null checking' is only available in 'experimental' language version.
+    //         object []?[]? u3 = null;
+    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "?").WithArguments("static null checking").WithLocation(20, 18),
+    // (20,21): error CS8058: Feature 'static null checking' is only available in 'experimental' language version.
+    //         object []?[]? u3 = null;
+    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "?").WithArguments("static null checking").WithLocation(20, 21)
+                );
+        }
+
+        [Fact]
+        public void Array_07()
+        {
+            CSharpCompilation c = CreateCompilationWithMscorlib(@"
+class C
+{
+    static void Main()
+    {
+    }
+
+    void Test1()
+    {
+        object? [] u1 = new [] { null, new object() };
+        u1 = null;
+    }
+
+    void Test2()
+    {
+        object [] u2 = new [] { null, new object() };
+    }
+
+    void Test3()
+    {
+        var u3 = new object [] { null, new object() };
+    }
+
+    object? Test4()
+    {
+        object []? u4 = null;
+        return u4;
+    }
+
+    object Test5()
+    {
+        object? [] u5 = null;
+        return u5;
+    }
+
+    void Test6()
+    {
+        object [][,]? u6 = null;
+        u6[0] = null;
+        u6[0][0,0] = null;
+        u6[0][0,0].ToString();
+    }
+
+    void Test7()
+    {
+        object [][,] u7 = null;
+        u7[0] = null;
+        u7[0][0,0] = null;
+    }
+
+    void Test8()
+    {
+        object []?[,] u8 = null;
+        u8[0] = null;
+        u8[0][0,0] = null;
+        u8[0][0,0].ToString();
+    }
+
+    void Test9()
+    {
+        object []?[,]? u9 = null;
+        u9[0] = null;
+        u9[0][0,0] = null;
+        u9[0][0,0].ToString();
+    }
+}
+", parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            c.VerifyDiagnostics(
+    // (11,14): warning CS8201: Possible null reference assignment.
+    //         u1 = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(11, 14),
+    // (21,34): warning CS8201: Possible null reference assignment.
+    //         var u3 = new object [] { null, new object() };
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(21, 34),
+    // (32,25): warning CS8201: Possible null reference assignment.
+    //         object? [] u5 = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(32, 25),
+    // (38,28): warning CS8201: Possible null reference assignment.
+    //         object [][,]? u6 = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(38, 28),
+    // (40,9): warning CS8202: Possible dereference of a null reference.
+    //         u6[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(40, 9),
+    // (40,22): warning CS8201: Possible null reference assignment.
+    //         u6[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(40, 22),
+    // (41,9): warning CS8202: Possible dereference of a null reference.
+    //         u6[0][0,0].ToString();
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(41, 9),
+    // (46,27): warning CS8201: Possible null reference assignment.
+    //         object [][,] u7 = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(46, 27),
+    // (47,17): warning CS8201: Possible null reference assignment.
+    //         u7[0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(47, 17),
+    // (48,22): warning CS8201: Possible null reference assignment.
+    //         u7[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(48, 22),
+    // (54,9): warning CS8202: Possible dereference of a null reference.
+    //         u8[0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8").WithLocation(54, 9),
+    // (54,17): warning CS8201: Possible null reference assignment.
+    //         u8[0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(54, 17),
+    // (55,9): warning CS8202: Possible dereference of a null reference.
+    //         u8[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8").WithLocation(55, 9),
+    // (55,22): warning CS8201: Possible null reference assignment.
+    //         u8[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(55, 22),
+    // (56,9): warning CS8202: Possible dereference of a null reference.
+    //         u8[0][0,0].ToString();
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8").WithLocation(56, 9),
+    // (62,9): warning CS8202: Possible dereference of a null reference.
+    //         u9[0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9").WithLocation(62, 9),
+    // (63,9): warning CS8202: Possible dereference of a null reference.
+    //         u9[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9").WithLocation(63, 9),
+    // (63,9): warning CS8202: Possible dereference of a null reference.
+    //         u9[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(63, 9),
+    // (63,22): warning CS8201: Possible null reference assignment.
+    //         u9[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(63, 22),
+    // (64,9): warning CS8202: Possible dereference of a null reference.
+    //         u9[0][0,0].ToString();
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9").WithLocation(64, 9),
+    // (64,9): warning CS8202: Possible dereference of a null reference.
+    //         u9[0][0,0].ToString();
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(64, 9)
+                );
+        }
+
+        [Fact]
+        public void Array_08()
+        {
+            CSharpCompilation c = CreateCompilationWithMscorlib(@"
+class C
+{
+    static void Main()
+    {
+    }
+
+    void Test3()
+    {
+        var u3 = new object? [] { null };
+    }
+
+    void Test6()
+    {
+        var u6 = new object [][,]? {null, 
+                                    new object[,]? {{null}}};
+        u6[0] = null;
+        u6[0][0,0] = null;
+        u6[0][0,0].ToString();
+    }
+
+    void Test7()
+    {
+        var u7 = new object [][,] {null, 
+                                   new object[,] {{null}}};
+        u7[0] = null;
+        u7[0][0,0] = null;
+    }
+
+    void Test8()
+    {
+        var u8 = new object []?[,] {null, 
+                                    new object[,] {{null}}};
+        u8[0] = null;
+        u8[0][0,0] = null;
+        u8[0][0,0].ToString();
+    }
+
+    void Test9()
+    {
+        var u9 = new object []?[,]? {null, 
+                                     new object[,]? {{null}}};
+        u9[0] = null;
+        u9[0][0,0] = null;
+        u9[0][0,0].ToString();
+    }
+}
+", parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            c.VerifyDiagnostics(
+    // (16,54): warning CS8201: Possible null reference assignment.
+    //                                     new object[,]? {{null}}};
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(16, 54),
+    // (18,9): warning CS8202: Possible dereference of a null reference.
+    //         u6[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(18, 9),
+    // (18,22): warning CS8201: Possible null reference assignment.
+    //         u6[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(18, 22),
+    // (19,9): warning CS8202: Possible dereference of a null reference.
+    //         u6[0][0,0].ToString();
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(19, 9),
+    // (24,36): warning CS8201: Possible null reference assignment.
+    //         var u7 = new object [][,] {null, 
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(24, 36),
+    // (25,52): warning CS8201: Possible null reference assignment.
+    //                                    new object[,] {{null}}};
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(25, 52),
+    // (26,17): warning CS8201: Possible null reference assignment.
+    //         u7[0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(26, 17),
+    // (27,22): warning CS8201: Possible null reference assignment.
+    //         u7[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(27, 22),
+    // (32,37): warning CS8201: Possible null reference assignment.
+    //         var u8 = new object []?[,] {null, 
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(32, 37),
+    // (33,53): warning CS8201: Possible null reference assignment.
+    //                                     new object[,] {{null}}};
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(33, 53),
+    // (34,17): warning CS8201: Possible null reference assignment.
+    //         u8[0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(34, 17),
+    // (35,22): warning CS8201: Possible null reference assignment.
+    //         u8[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(35, 22),
+    // (42,55): warning CS8201: Possible null reference assignment.
+    //                                      new object[,]? {{null}}};
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(42, 55),
+    // (44,9): warning CS8202: Possible dereference of a null reference.
+    //         u9[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(44, 9),
+    // (44,22): warning CS8201: Possible null reference assignment.
+    //         u9[0][0,0] = null;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null").WithLocation(44, 22),
+    // (45,9): warning CS8202: Possible dereference of a null reference.
+    //         u9[0][0,0].ToString();
+    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(45, 9)
+                );
+        }
+
+        [Fact]
         public void ObjectInitializer_01()
         {
             CSharpCompilation c = CreateCompilationWithMscorlib(@"


### PR DESCRIPTION

- string?[] x1; // not-nullable one-dimensional array of nullable strings
- string?[]? x2; // nullable one-dimensional array of nullable strings
- string[]? X3; // nullable one-dimensional array of not-nullable strings
- string?[][,] x4; // not-nullable one-dimensional array of not-nullable two-dimensional arrays of nullable strings
- string?[][,]? X5; // not-nullable one-dimensional array of nullable two-dimensional arrays of nullable strings
- string?[]?[,] x6; // nullable one-dimensional array of not-nullable two-dimensional arrays of nullable strings

