### PR TITLE
Revert "Merge pull request #7480 from gafter/fix7446"

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -468,9 +468,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             var diagnostics = DiagnosticBag.GetInstance();
                             AfterMembersChecks(diagnostics);
                             AddDeclarationDiagnostics(diagnostics);
-
-                            // We may produce a SymbolDeclaredEvent for the enclosing type before events for its contained members
-                            DeclaringCompilation.SymbolDeclaredEvent(this);
                             var thisThreadCompleted = state.NotePartComplete(CompletionPart.FinishMemberChecks);
                             Debug.Assert(thisThreadCompleted);
                             diagnostics.Free();
@@ -513,7 +510,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             // We've completed all members, so we're ready for the PointedAtManagedTypeChecks;
                             // proceed to the next iteration.
-                            state.NotePartComplete(CompletionPart.MembersCompleted);
+                            if (state.NotePartComplete(CompletionPart.MembersCompleted))
+                            {
+                                DeclaringCompilation.SymbolDeclaredEvent(this);
+                            }
                             break;
                         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -390,14 +390,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!this.IsAsync)
             {
-                if (state.NotePartComplete(CompletionPart.StartAsyncMethodChecks))
+                state.NotePartComplete(CompletionPart.StartAsyncMethodChecks);
+                if (state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks) && IsPartialDefinition)
                 {
-                    if (IsPartialDefinition) DeclaringCompilation.SymbolDeclaredEvent(this);
-                    state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
-                }
-                else
-                {
-                    state.SpinWaitComplete(CompletionPart.FinishAsyncMethodChecks, cancellationToken);
+                    DeclaringCompilation.SymbolDeclaredEvent(this);
                 }
 
                 return;
@@ -435,8 +431,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (state.NotePartComplete(CompletionPart.StartAsyncMethodChecks))
             {
                 AddDeclarationDiagnostics(diagnostics);
-                if (IsPartialDefinition) DeclaringCompilation.SymbolDeclaredEvent(this);
-                state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
+                if (state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks) && IsPartialDefinition)
+                {
+                    DeclaringCompilation.SymbolDeclaredEvent(this);
+                }
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -228,10 +228,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // NOTE: the following is not cancellable.  Once we've set the
                     // members, we *must* do the following to make sure we're in a consistent state.
                     this.DeclaringCompilation.DeclarationDiagnostics.AddRange(diagnostics);
-                    RegisterDeclaredCorTypes();
 
-                    // We may produce a SymbolDeclaredEvent for the enclosing namespace before events for its contained members
-                    DeclaringCompilation.SymbolDeclaredEvent(this);
+                    RegisterDeclaredCorTypes();
                     _state.NotePartComplete(CompletionPart.NameToMembersMap);
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
@@ -76,7 +76,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             if (allCompleted)
                             {
-                                _state.NotePartComplete(CompletionPart.MembersCompleted);
+                                if (_state.NotePartComplete(CompletionPart.MembersCompleted))
+                                {
+                                    DeclaringCompilation.SymbolDeclaredEvent(this);
+                                }
                                 break;
                             }
                             else

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -127,7 +127,7 @@ class C
             Assert.Equal(4, info.WarningLevel);
         }
 
-        [Fact, WorkItem(7446, "https://github.com/dotnet/roslyn/issues/7446")]
+        [Fact(Skip ="7446"), WorkItem(7446, "https://github.com/dotnet/roslyn/issues/7446")]
         public void TestCompilationEventQueueWithSemanticModelGetDiagnostics()
         {
             var source1 = @"
@@ -155,8 +155,10 @@ namespace N1
             var compilation = CreateCompilationWithMscorlib45(new[] { tree1, tree2 }).WithEventQueue(eventQueue);
             
             // Invoke SemanticModel.GetDiagnostics to force populate the event queue for symbols in the first source file.
-            var model = compilation.GetSemanticModel(tree1);
-            model.GetDiagnostics(tree1.GetRoot().FullSpan);
+            var tree = compilation.SyntaxTrees.Single(t => t == tree1);
+            var root = tree.GetRoot();
+            var model = compilation.GetSemanticModel(tree);
+            model.GetDiagnostics(root.FullSpan);
 
             Assert.True(eventQueue.Count > 0);
             bool compilationStartedFired;
@@ -169,10 +171,10 @@ namespace N1
             Assert.True(declaredSymbolNames.Contains("N1"));
             Assert.True(declaredSymbolNames.Contains("Class"));
             Assert.True(declaredSymbolNames.Contains("NonPartialMethod1"));
-            Assert.True(completedCompilationUnits.Contains(tree1.FilePath));
+            Assert.True(completedCompilationUnits.Contains(tree.FilePath));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7477"), WorkItem(7477, "https://github.com/dotnet/roslyn/issues/7477")]
+        [Fact(Skip = "7446"), WorkItem(7446, "https://github.com/dotnet/roslyn/issues/7446")]
         public void TestCompilationEventsForPartialMethod()
         {
             var source1 = @"
@@ -202,8 +204,10 @@ namespace N1
             var compilation = CreateCompilationWithMscorlib45(new[] { tree1, tree2 }).WithEventQueue(eventQueue);
 
             // Invoke SemanticModel.GetDiagnostics to force populate the event queue for symbols in the first source file.
-            var model = compilation.GetSemanticModel(tree1);
-            model.GetDiagnostics(tree1.GetRoot().FullSpan);
+            var tree = compilation.SyntaxTrees.Single(t => t == tree1);
+            var root = tree.GetRoot();
+            var model = compilation.GetSemanticModel(tree);
+            model.GetDiagnostics(root.FullSpan);
 
             Assert.True(eventQueue.Count > 0);
             bool compilationStartedFired;
@@ -217,7 +221,7 @@ namespace N1
             Assert.True(declaredSymbolNames.Contains("Class"));
             Assert.True(declaredSymbolNames.Contains("NonPartialMethod1"));
             Assert.True(declaredSymbolNames.Contains("PartialMethod"));
-            Assert.True(completedCompilationUnits.Contains(tree1.FilePath));
+            Assert.True(completedCompilationUnits.Contains(tree.FilePath));
         }
 
         private static bool DequeueCompilationEvents(AsyncQueue<CompilationEvent> eventQueue, out bool compilationStartedFired, out HashSet<string> declaredSymbolNames, out HashSet<string> completedCompilationUnits)
@@ -243,8 +247,7 @@ namespace N1
                     var symbolDeclaredEvent = compEvent as SymbolDeclaredCompilationEvent;
                     if (symbolDeclaredEvent != null)
                     {
-                        var added = declaredSymbolNames.Add(symbolDeclaredEvent.Symbol.Name);
-                        Assert.True(added, "Unexpected multiple symbol declared events for symbol " + symbolDeclaredEvent.Symbol);
+                        Assert.True(declaredSymbolNames.Add(symbolDeclaredEvent.Symbol.Name), "Unexpected multiple symbol declared events for same symbol");
                     }
                     else
                     {


### PR DESCRIPTION
This reverts commit 357eb029c49187dc87c25154bed72a48be19b563, reversing
changes made to b91400c457de95e878c075af54192c2cf057173f.

(until additional allocations are understood)

This change is resulting in ~340MB of extra allocations during the Picasso RPS test.  I'd like to revert this change and re-open the original issue until we can understand/mitigate that cost.