### PR TITLE
Guard against being passed bad symbols or expressions

### DIFF
--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -644,11 +644,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         protected override bool ConversionsAreCompatible(SemanticModel originalModel, ExpressionSyntax originalExpression, SemanticModel newModel, ExpressionSyntax newExpression)
         {
+            if (originalModel == null || originalExpression == null || newModel == null || newExpression == null)
+            {
+                return false;
+            }
+
             return ConversionsAreCompatible(originalModel.GetConversion(originalExpression), newModel.GetConversion(newExpression));
         }
 
         protected override bool ConversionsAreCompatible(ExpressionSyntax originalExpression, ITypeSymbol originalTargetType, ExpressionSyntax newExpression, ITypeSymbol newTargetType)
         {
+            if (originalExpression == null || originalTargetType == null || newExpression == null || newTargetType == null)
+            {
+                return false;
+            }
+
             var originalConversion = this.OriginalSemanticModel.ClassifyConversion(originalExpression, originalTargetType);
             var newConversion = this.SpeculativeSemanticModel.ClassifyConversion(newExpression, newTargetType);
             return ConversionsAreCompatible(originalConversion, newConversion);

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -519,10 +519,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         End Function
 
         Protected Overrides Function ConversionsAreCompatible(originalModel As SemanticModel, originalExpression As ExpressionSyntax, newModel As SemanticModel, newExpression As ExpressionSyntax) As Boolean
+            If originalExpression Is Nothing OrElse originalModel Is Nothing OrElse newExpression Is Nothing OrElse newModel Is Nothing Then
+                Return False
+            End If
+
             Return ConversionsAreCompatible(originalModel.GetConversion(originalExpression), newModel.GetConversion(newExpression))
         End Function
 
         Protected Overrides Function ConversionsAreCompatible(originalExpression As ExpressionSyntax, originalTargetType As ITypeSymbol, newExpression As ExpressionSyntax, newTargetType As ITypeSymbol) As Boolean
+            If originalExpression Is Nothing OrElse originalTargetType Is Nothing OrElse newExpression Is Nothing OrElse newTargetType Is Nothing Then
+                Return False
+            End If
+
             Dim originalConversion = Me.OriginalSemanticModel.ClassifyConversion(originalExpression, originalTargetType)
             Dim newConversion = Me.SpeculativeSemanticModel.ClassifyConversion(newExpression, newTargetType)
 


### PR DESCRIPTION
No repo case to write tests against, however we do have a callstack.

Fixes https://github.com/dotnet/roslyn/issues/6682