### PR TITLE
don't show `(Awaitable)` for dynamic objects

### DIFF
--- a/src/EditorFeatures/CSharp/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
 
         protected IList<SymbolDisplayPart> GetAwaitableUsage(IMethodSymbol method, SemanticModel semanticModel, int position)
         {
-            if (method.IsAwaitable(semanticModel, position))
+            if (method.IsAwaitableNonDynamic(semanticModel, position))
             {
                 return method.ToAwaitableParts(SyntaxFacts.GetText(SyntaxKind.AwaitKeyword), "x", semanticModel, position);
             }

--- a/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider_Method.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/GenericNameSignatureHelpProvider_Method.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
         {
             var result = new List<SymbolDisplayPart>();
 
-            var awaitable = method.GetOriginalUnreducedDefinition().IsAwaitable(semanticModel, position);
+            var awaitable = method.GetOriginalUnreducedDefinition().IsAwaitableNonDynamic(semanticModel, position);
             var extension = method.GetOriginalUnreducedDefinition().IsExtensionMethod();
 
             if (awaitable && extension)

--- a/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
+++ b/src/EditorFeatures/CSharp/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SignatureHelp
         {
             var result = new List<SymbolDisplayPart>();
 
-            var awaitable = method.GetOriginalUnreducedDefinition().IsAwaitable(semanticModel, position);
+            var awaitable = method.GetOriginalUnreducedDefinition().IsAwaitableNonDynamic(semanticModel, position);
             var extension = method.GetOriginalUnreducedDefinition().IsExtensionMethod();
 
             if (awaitable && extension)

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -1266,6 +1266,23 @@ class C
                          TypeParameterMap($"\r\nTResult {FeaturesResources.Is} int"));
         }
 
+        [WorkItem(7100, "https://github.com/dotnet/roslyn/issues/7100")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestDynamicIsntAwaitable()
+        {
+            var markup = @"
+class C
+{
+    dynamic D() { return null; }
+    void M()
+    {
+        D$$();
+    }
+}
+";
+            await TestAsync(markup, MainDescription("dynamic C.D()"));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestStringLiteral()
         {

--- a/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
+++ b/src/EditorFeatures/VisualBasic/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.SignatureHelp
         End Function
 
         Private Function GetAwaitableDescription(member As ISymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
-            If member.IsAwaitable(semanticModel, position) Then
+            If member.IsAwaitableNonDynamic(semanticModel, position) Then
                 Return member.ToAwaitableParts(SyntaxFacts.GetText(SyntaxKind.AwaitKeyword), "r", semanticModel, position)
             End If
 

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -1443,6 +1443,23 @@ End Class
                  MainDescription(description), Usage(doc))
         End Function
 
+        <WorkItem(7100, "https://github.com/dotnet/roslyn/issues/7100")>
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Async Function TestObjectWithOptionStrictOffIsntAwaitable() As Task
+            Dim markup = "
+Option Strict Off
+Class C
+    Function D() As Object
+        Return Nothing
+    End Function
+    Sub M()
+        D$$()
+    End Sub
+End Class
+"
+            Await TestAsync(markup, MainDescription("Function C.D() As Object"))
+        End Function
+
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Async Function TestObsoleteItem() As Task
             Await TestAsync(<Text><![CDATA[

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
             private void AddDescriptionForNamedType(INamedTypeSymbol symbol)
             {
-                if (symbol.IsAwaitable(_semanticModel, _position))
+                if (symbol.IsAwaitableNonDynamic(_semanticModel, _position))
                 {
                     AddAwaitablePrefix();
                 }
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             private void AddDescriptionForMethod(IMethodSymbol method)
             {
                 // TODO : show duplicated member case
-                var awaitable = method.IsAwaitable(_semanticModel, _position);
+                var awaitable = method.IsAwaitableNonDynamic(_semanticModel, _position);
                 var extension = method.IsExtensionMethod || method.MethodKind == MethodKind.ReducedExtension;
                 if (awaitable && extension)
                 {

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -480,7 +480,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             private void AddDescriptionForMethod(IMethodSymbol method)
             {
                 // TODO : show duplicated member case
-                // TODO : a way to check whether it is a member call off dynamic type?
                 var awaitable = method.IsAwaitable(_semanticModel, _position);
                 var extension = method.IsExtensionMethod || method.MethodKind == MethodKind.ReducedExtension;
                 if (awaitable && extension)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -875,11 +875,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         /// <summary>
-        /// If the <paramref name="symbol"/> is a method symbol, returns True if the method's return type is "awaitable".
-        /// If the <paramref name="symbol"/> is a type symbol, returns True if that type is "awaitable".
+        /// If the <paramref name="symbol"/> is a method symbol, returns <see langword="true"/> if the method's return type is "awaitable", but not if it's <see langword="dynamic"/>.
+        /// If the <paramref name="symbol"/> is a type symbol, returns <see langword="true"/> if that type is "awaitable".
         /// An "awaitable" is any type that exposes a GetAwaiter method which returns a valid "awaiter". This GetAwaiter method may be an instance method or an extension method.
         /// </summary>
-        public static bool IsAwaitable(this ISymbol symbol, SemanticModel semanticModel, int position)
+        public static bool IsAwaitableNonDynamic(this ISymbol symbol, SemanticModel semanticModel, int position)
         {
             IMethodSymbol methodSymbol = symbol as IMethodSymbol;
             ITypeSymbol typeSymbol = null;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -898,13 +898,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 {
                     return false;
                 }
-
-                // dynamic
-                if (methodSymbol.ReturnType.TypeKind == TypeKind.Dynamic &&
-                    methodSymbol.MethodKind != MethodKind.BuiltinOperator)
-                {
-                    return true;
-                }
             }
 
             // otherwise: needs valid GetAwaiter


### PR DESCRIPTION
The extension method [`ISymbol.IsAwaitable()`](http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/ISymbolExtensions.cs,906) flags `dynamic` objects as awaitable because they could potentially have a `GetAwaiter()` method, but this should not be exposed in the quick info tool tip because that can't be verified at design time.

VB doesn't have the same bug since the closest it comes to C#'s `dynamic` is `Object` with `Option Strict Off`, but I added a test anyways to make sure it never shows up.

Fixes #7100.