### PR TITLE
Connect cibuild.sh and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ OS_NAME = $(shell uname -s)
 NUGET_PACKAGE_NAME = nuget.40
 BUILD_CONFIGURATION = Debug
 BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
+BUILD_LOG_PATH =
 
-MSBUILD_ADDITIONALARGS = /v:m /fl /fileloggerparameters:Verbosity=normal /p:SignAssembly=false /p:DebugSymbols=false
+MSBUILD_ADDITIONALARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:SignAssembly=false /p:DebugSymbols=false /p:Configuration=$(BUILD_CONFIGURATION)
 
 ifeq ($(OS_NAME),Linux)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=ubuntu.14.04
@@ -14,6 +15,10 @@ else ifeq ($(OS_NAME),Darwin)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=osx.10.10
 	MONO_TOOLSET_NAME = mono.mac.5
 	ROSLYN_TOOLSET_NAME = roslyn.mac.1
+endif
+
+ifneq ($(BUILD_LOG_PATH),)
+	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /fileloggerparameters:LogFile=$(BUILD_LOG_PATH)
 endif
 
 ifeq ($(BOOTSTRAP),true)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ NUGET_PACKAGE_NAME = nuget.40
 BUILD_CONFIGURATION = Debug
 BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
 BUILD_LOG_PATH =
+XUNIT_VERSION = 2.1.0
 
 MSBUILD_ADDITIONALARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:SignAssembly=false /p:DebugSymbols=false /p:Configuration=$(BUILD_CONFIGURATION)
 
@@ -42,6 +43,9 @@ bootstrap: toolset
 	cp Binaries/$(BUILD_CONFIGURATION)/vbccore/* $(BOOTSTRAP_PATH) ; \
 	rm -rf Binaries/$(BUILD_CONFIGURATION)
 
+tests:
+	build/scripts/tests.sh $(MONO_PATH) $(BUILD_CONFIGURATION) $(XUNIT_VERSION)
+
 clean:
 	@rm -rf Binaries
 
@@ -67,4 +71,3 @@ clean_toolset:
 	curl -O https://dotnetci.blob.core.windows.net/roslyn/$(NUGET_PACKAGE_NAME).zip ; \
 	unzip -uoq $(NUGET_PACKAGE_NAME).zip -d ~/ ; \
 	chmod +x ~/.nuget/packages/Microsoft.Build.Mono.Debug/14.1.0-prerelease/lib/MSBuild.exe
-

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MSBUILD_ADDITIONALARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:Sig
 ifeq ($(OS_NAME),Linux)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=ubuntu.14.04
 	MONO_TOOLSET_NAME = mono.linux.4
-	ROSLYN_TOOLSET_NAME = roslyn.linux.1
+	ROSLYN_TOOLSET_NAME = roslyn.linux.2
 else ifeq ($(OS_NAME),Darwin)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=osx.10.10
 	MONO_TOOLSET_NAME = mono.mac.5

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,16 @@ NUGET_PACKAGE_NAME = nuget.40
 BUILD_CONFIGURATION = Debug
 BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
 
-
 MSBUILD_ADDITIONALARGS = /v:m /fl /fileloggerparameters:Verbosity=normal /p:SignAssembly=false /p:DebugSymbols=false
 
 ifeq ($(OS_NAME),Linux)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=ubuntu.14.04
-	MONO_TOOLSET_NAME=mono.linux.4
-	ROSLYN_TOOLSET_NAME=roslyn.linux.1
+	MONO_TOOLSET_NAME = mono.linux.4
+	ROSLYN_TOOLSET_NAME = roslyn.linux.1
 else ifeq ($(OS_NAME),Darwin)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=osx.10.10
-	MONO_TOOLSET_NAME=mono.mac.5
-	ROSLYN_TOOLSET_NAME=roslyn.mac.1
+	MONO_TOOLSET_NAME = mono.mac.5
+	ROSLYN_TOOLSET_NAME = roslyn.mac.1
 endif
 
 ifeq ($(BOOTSTRAP),true)
@@ -24,13 +23,13 @@ else
 endif
 
 MONO_PATH = /tmp/$(MONO_TOOLSET_NAME)/bin/mono
+MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:MonoToolsetPath=$(MONO_PATH)
 TOOLSET_ARGS = $(MSBUILD_ADDITIONALARGS) /p:CscToolPath=$(ROSLYN_TOOLSET_PATH) /p:CscToolExe=csc /p:VbcToolPath=$(ROSLYN_TOOLSET_PATH) /p:VbcToolExe=vbc
 
-all: tools_packages
+all: toolset
 	$(MONO_PATH) ~/.nuget/packages/Microsoft.Build.Mono.Debug/14.1.0-prerelease/lib/MSBuild.exe $(TOOLSET_ARGS) CrossPlatform.sln
 
-
-bootstrap: tools_packages
+bootstrap: toolset
 	$(MONO_PATH) ~/.nuget/packages/Microsoft.Build.Mono.Debug/14.1.0-prerelease/lib/MSBuild.exe $(TOOLSET_ARGS) src/Compilers/CSharp/CscCore/CscCore.csproj ; \
 	$(MONO_PATH) ~/.nuget/packages/Microsoft.Build.Mono.Debug/14.1.0-prerelease/lib/MSBuild.exe $(TOOLSET_ARGS) src/Compilers/VisualBasic/VbcCore/VbcCore.csproj ; \
 	mkdir -p $(BOOTSTRAP_PATH) ; \
@@ -41,7 +40,12 @@ bootstrap: tools_packages
 clean:
 	@rm -rf Binaries
 
-tools_packages: /tmp/$(ROSLYN_TOOLSET_NAME).tar.bz2  /tmp/$(MONO_TOOLSET_NAME).tar.bz2 /tmp/$(NUGET_PACKAGE_NAME).zip
+toolset: /tmp/$(ROSLYN_TOOLSET_NAME).tar.bz2  /tmp/$(MONO_TOOLSET_NAME).tar.bz2 /tmp/$(NUGET_PACKAGE_NAME).zip
+
+clean_toolset:
+	rm /tmp/$(ROSLYN_TOOLSET_NAME).tar.bz2 \
+	rm /tmp/$(MONO_TOOLSET_NAME).tar.bz2 \
+	rm /tmp/$(NUGET_PACKAGE_NAME).tar.bz2 \
 
 /tmp/$(ROSLYN_TOOLSET_NAME).tar.bz2:
 	@pushd /tmp/ ; \

--- a/build/Targets/GenerateCompilerInternals.targets
+++ b/build/Targets/GenerateCompilerInternals.targets
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-	<MonoPrefix Condition="'$(OS)' != 'Windows_NT'">mono </MonoPrefix>
+	<MonoPrefix Condition="'$(OS)' != 'Windows_NT'">$(MonoToolsetPath) </MonoPrefix>
   </PropertyGroup>
   
   <Target

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -3,8 +3,10 @@
 MONO_PATH=$1
 BUILD_CONFIGURATION=$2
 XUNIT_VERSION=$3
+MONO_DIR="$(dirname $MONO_PATH)"
 
 export MONO_THREADS_PER_CPU=50
+export PATH=$MONO_DIR:$PATH
 
 # This function will update the PATH variable to put the desired
 # version of Mono ahead of the system one. 

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+MONO_PATH=$1
+BUILD_CONFIGURATION=$2
+XUNIT_VERSION=$3
+
+export MONO_THREADS_PER_CPU=50
+
+# This function will update the PATH variable to put the desired
+# version of Mono ahead of the system one. 
+
+xunit_runner=~/.nuget/packages/xunit.runner.console/$XUNIT_VERSION/tools/xunit.console.x86.exe
+test_binaries=(
+	Roslyn.Compilers.CSharp.CommandLine.UnitTests
+	Roslyn.Compilers.CSharp.Syntax.UnitTests
+	Roslyn.Compilers.CSharp.Semantic.UnitTests
+	Roslyn.Compilers.CSharp.Symbol.UnitTests
+	Roslyn.Compilers.VisualBasic.Syntax.UnitTests)
+any_failed=false
+
+# Need to copy over the execution dependencies.  This isn't being done correctly
+# by msbuild at the moment. 
+cp ~/.nuget/packages/xunit.extensibility.execution/$XUNIT_VERSION/lib/net45/xunit.execution.desktop.* Binaries/$BUILD_CONFIGURATION
+
+for i in "${test_binaries[@]}"
+do
+	mkdir -p Binaries/$BUILD_CONFIGURATION/xUnitResults/
+	mono $MONO_ARGS $xunit_runner Binaries/$BUILD_CONFIGURATION/$i.dll -xml Binaries/$BUILD_CONFIGURATION/xUnitResults/$i.dll.xml -noshadow
+	if [ $? -ne 0 ]; then
+		any_failed=true
+	fi
+done
+
+if [ "$any_failed" = "true" ]; then
+	echo Unit test failed
+	exit 1
+fi
+

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -296,6 +296,9 @@ if [ "$CLEAN_RUN" == "true" ]; then
     git clean -dxf . 
 fi
 
+# TODO: flow the mono path through to the tools used as a part of the build 
+# TODO: flow the build configuration through 
+
 set_build_info
 restore_nuget
 set_mono_path

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -6,16 +6,14 @@ usage()
     echo "usage: cibuild.sh [options]"
     echo ""
     echo "Options"
-    echo "  --mono-path <path>  Path to the mono installation to use for the run" 
-    echo "  --os <os>           OS to run (Linux / Darwin)"
+    echo "  --debug     Build Debug (default)"
+    echo "  --release   Build Release"
+    echo "  --nocache   Force download of toolsets"
+
 }
 
-XUNIT_VERSION=2.1.0
 BUILD_CONFIGURATION=Debug
-OS_NAME=$(uname -s)
 USE_CACHE=true
-MONO_ARGS='--debug=mdb-optimizations --attach=disable'
-MSBUILD_ADDITIONALARGS='/v:m /consoleloggerparameters:Verbosity=minimal /filelogger /fileloggerparameters:Verbosity=normal'
 
 # LTTNG is the logging infrastructure used by coreclr.  Need this variable set 
 # so it doesn't output warnings to the console.
@@ -35,14 +33,6 @@ do
         usage
         exit 1
         ;;
-        --mono-path)
-        CUSTOM_MONO_PATH=$2
-        shift 2
-        ;;
-        --os)
-        OS_NAME=$2
-        shift 2
-        ;;
         --debug)
         BUILD_CONFIGURATION=Debug
         shift 1
@@ -61,48 +51,6 @@ do
         ;;
     esac
 done
-
-set_build_info()
-{
-    if [ "$OS_NAME" == "Linux" ]; then
-        MSBUILD_ADDITIONALARGS="$MSBUILD_ADDITIONALARGS /p:BaseNuGetRuntimeIdentifier=ubuntu.14.04"
-        MONO_TOOLSET_NAME=mono.linux.4
-        ROSLYN_TOOLSET_NAME=roslyn.linux.1
-    elif [ "$OS_NAME" == "Darwin" ]; then
-        MSBUILD_ADDITIONALARGS="$MSBUILD_ADDITIONALARGS /p:BaseNuGetRuntimeIdentifier=osx.10.10"
-        MONO_TOOLSET_NAME=mono.mac.5
-        ROSLYN_TOOLSET_NAME=roslyn.mac.1
-    else
-        echo Unrecognized OS $OS_NAME
-        exit 1
-    fi
-}
-
-restore_nuget()
-{
-    local package_name="nuget.40.zip"
-    local target="/tmp/$package_name"
-    echo "Installing NuGet Packages $target"
-    if [ -f $target ]; then
-        if [ "$USE_CACHE" = "true" ]; then
-            echo "Nuget already installed"
-            return
-        fi
-    fi
-
-    pushd /tmp/
-
-    rm $package_name 2>/dev/null
-    curl -O https://dotnetci.blob.core.windows.net/roslyn/$package_name
-    unzip -uoq $package_name -d ~/
-    if [ $? -ne 0 ]; then
-        echo "Unable to download NuGet packages"
-        exit 1
-    fi
-
-    popd
-
-}
 
 run_make()
 {
@@ -125,161 +73,21 @@ run_make()
     fi
 }
 
-# NuGet crashes on occasion during restore.  This isn't a fatal action so 
-# we re-run it a number of times.  
-run_nuget()
-{
-    local is_good=false
-    for i in `seq 1 $RETRY_COUNT`
-    do
-        mono $MONO_ARGS .nuget/NuGet.exe "$@"
-        if [ $? -eq 0 ]; then
-            is_good=true
-            break
-        fi
-    done
-
-    if [ "$is_good" != "true" ]; then
-        echo NuGet failed
-        exit 1
-    fi
-}
-
-# Install the Roslyn toolset which is used to build the bootstrap compilers
-install_roslyn_toolset()
-{
-    local package_name=$ROSLYN_TOOLSET_NAME
-    local package_path="/tmp/$ROSLYN_TOOLSET_NAME.tar.bz2"
-
-    local download_package=false
-    if [ ! -f $package_path ]; then
-        download_package=true
-    fi
-
-    if [ "$USE_CACHE" = "true" ]; then
-        download_package=true
-    fi
-
-    if [ "$download_package" = "true" ]; then
-        rm $package_path 2>/dev/null
-        pushd /tmp
-        curl -O https://dotnetci.blob.core.windows.net/roslyn/$package_name.tar.bz2
-        popd
-    fi
-    
-    mkdir -p "Binaries"
-    pushd Binaries > /dev/null
-    tar -jxf $package_path
-    popd > /dev/null
-}
-
-build_bootstrap()
-{
-    echo Compiling the toolset compilers
-    run_make bootstrap 
-}
-
-build_roslyn()
-{    
-    echo Building CrossPlatform.sln
-    run_make all BOOTSTRAP=true BUILD_LOG_PATH=Binaries/Build.log
-}
-
-# Install the specified Mono toolset from our Azure blob storage.
-install_mono_toolset()
-{
-    local target=/tmp/$1
-    echo "Installing Mono toolset $1"
-
-    if [ -d $target ]; then
-        if [ "$USE_CACHE" = "true" ]; then
-            echo "Mono already installed"
-            return
-        fi
-    fi
-
-    pushd /tmp
-
-    rm -r $target 2>/dev/null
-    rm $1.tar.bz2 2>/dev/null
-    curl -O https://dotnetci.blob.core.windows.net/roslyn/$1.tar.bz2
-    tar -jxf $1.tar.bz2
-    if [ $? -ne 0 ]; then
-        echo "Unable to download toolset"
-        exit 1
-    fi
-
-    popd
-}
-
-# This function will update the PATH variable to put the desired
-# version of Mono ahead of the system one. 
-set_mono_path()
-{
-    if [ "$CUSTOM_MONO_PATH" != "" ]; then
-        if [ ! -d "$CUSTOM_MONO_PATH" ]; then
-            echo "Not a valid directory $CUSTOM_MONO_PATH"
-            exit 1
-        fi
-  
-        echo "Using mono path $CUSTOM_MONO_PATH"
-        PATH=$CUSTOM_MONO_PATH:$PATH
-        return
-    fi
-
-
-    install_mono_toolset $MONO_TOOLSET_NAME
-    PATH=/tmp/$MONO_TOOLSET_NAME/bin:$PATH
-}
-
-check_mono()
-{
-    local mono_path=$(which mono)
-    echo "Mono path $mono_path"
-}
-
-test_roslyn()
-{
-    local xunit_runner=~/.nuget/packages/xunit.runner.console/$XUNIT_VERSION/tools/xunit.console.x86.exe
-    local test_binaries=(
-        Roslyn.Compilers.CSharp.CommandLine.UnitTests
-        Roslyn.Compilers.CSharp.Syntax.UnitTests
-        Roslyn.Compilers.CSharp.Semantic.UnitTests
-        Roslyn.Compilers.CSharp.Symbol.UnitTests
-        Roslyn.Compilers.VisualBasic.Syntax.UnitTests)
-    local any_failed=false
-
-    # Need to copy over the execution dependencies.  This isn't being done correctly
-    # by msbuild at the moment. 
-    cp ~/.nuget/packages/xunit.extensibility.execution/$XUNIT_VERSION/lib/net45/xunit.execution.desktop.* Binaries/$BUILD_CONFIGURATION
-
-    for i in "${test_binaries[@]}"
-    do
-        mkdir -p Binaries/$BUILD_CONFIGURATION/xUnitResults/
-        mono $MONO_ARGS $xunit_runner Binaries/$BUILD_CONFIGURATION/$i.dll -xml Binaries/$BUILD_CONFIGURATION/xUnitResults/$i.dll.xml -noshadow
-        if [ $? -ne 0 ]; then
-            any_failed=true
-        fi
-    done
-
-    if [ "$any_failed" = "true" ]; then
-        echo Unit test failed
-        exit 1
-    fi
-}
-
-# TODO: flow through the build log 
-
 if [ "$CLEAN_RUN" == "true" ]; then
     echo Clean out the enlistment
     git clean -dxf . 
 fi
 
-set_build_info
-restore_nuget
-set_mono_path
-check_mono
-build_bootstrap
-build_roslyn
-test_roslyn
+if [ "$USE_CACHE" == "false" ]; then
+    echo Clean out the toolsets
+    make clean_toolset
+fi
+
+echo Building Bootstrap
+run_make bootstrap
+
+echo Building CrossPlatform.sln
+run_make all BOOTSTRAP=true BUILD_LOG_PATH=Binaries/Build.log
+
+make tests
 

--- a/docs/contributing/Building, Debugging, and Testing on Unix.md
+++ b/docs/contributing/Building, Debugging, and Testing on Unix.md
@@ -1,0 +1,13 @@
+# Getting the Code
+
+1. Clone https://github.com/dotnet/roslyn
+1. Run `make toolset` to download the bootstrap compiler, mono and NuGet packages.
+1. Run `make` to build the code.  
+
+# Running Tests
+
+After building run `make tests` in order to run the unit tests.
+
+# Contributing
+
+Please see [Contributing Code](https://github.com/dotnet/roslyn/wiki/Contributing-Code) for details on contributing changes back to the code.

--- a/docs/infrastructure/unix-toolset.md
+++ b/docs/infrastructure/unix-toolset.md
@@ -14,7 +14,7 @@ To build the toolset do the following:
 
 - Run cibuild.sh locally
 - Rename `Binaries/Bootstrap` to the *toolset name* above
-- Bzip the directory: `tar -jcvf <toolset name>.tar.bz2 Binaries/<toolset name>.
+- Bzip the directory: `tar -jcvf <toolset name>.tar.bz2 Binaries/<toolset name>`.
 - Upload the file to the Azure in the dotnetci storage account in the roslyn container.  
 - Send a PR to change [cibuild.sh](https://github.com/dotnet/roslyn/blob/master/cibuild.sh) to use the new toolset.  
 
@@ -24,6 +24,7 @@ This table describes the existing Mono toolsets and the commit they were built f
 | Version | Linux | Mac |
 | --- | --- | --- |
 | 1 | [8dbfd942f07be971f423722891717e2ba9d9bebb](https://github.com/dotnet/roslyn/commit/8dbfd942f07be971f423722891717e2ba9d9bebb) | [8dbfd942f07be971f423722891717e2ba9d9bebb](https://github.com/dotnet/roslyn/commit/8dbfd942f07be971f423722891717e2ba9d9bebb) |
+| 2 | [5486cb18322e9782fccff6741f18933b545be0fa](https://github.com/dotnet/roslyn/commit/5486cb18322e9782fccff6741f18933b545be0fa) | |
 
 ### Building Mono
 The new *toolset name* will be chosen as one of the following:

--- a/src/Compilers/CSharp/CscCore/csc
+++ b/src/Compilers/CSharp/CscCore/csc
@@ -2,5 +2,10 @@
 
 THISDIR=$(dirname $0)
 
+# CoreCLR / CoreFX does not execute reliably with an unlimited 
+# stack.  Make on Linux can execute child processes with an 
+# unlimited stack so force it back to a known good limit
+ulimit -s 8192
+
 chmod +x $THISDIR/corerun 2>/dev/null
 $THISDIR/corerun $THISDIR/csc.exe "$@"

--- a/src/Compilers/VisualBasic/VbcCore/vbc
+++ b/src/Compilers/VisualBasic/VbcCore/vbc
@@ -2,6 +2,11 @@
 
 THISDIR=$(dirname $0)
 
+# CoreCLR / CoreFX does not execute reliably with an unlimited 
+# stack.  Make on Linux can execute child processes with an 
+# unlimited stack so force it back to a known good limit
+ulimit -s 8192
+
 chmod +x $THISDIR/corerun 2>/dev/null
 $THISDIR/corerun $THISDIR/vbc.exe "$@"
 


### PR DESCRIPTION
This changes cibuild.sh to be redefined in terms of our Makefile on Linux / Mac.  This gives us a single way to build, bootstrap and run tests on Unix and hence the two can never get out of sync again. 