### PR TITLE
Ensure the completion routine is called...

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerDisplayAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerDisplayAttributeTests.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
@@ -615,7 +617,7 @@ class B
         }
 
         [Fact]
-        public void Exception()
+        public void UnhandledException()
         {
             var source =
 @"using System.Diagnostics;
@@ -631,6 +633,42 @@ class A
             var result = FormatResult("a", CreateDkmClrValue(instanceA));
             Verify(result,
                 EvalFailedResult("a", "Unmatched closing brace in 'Value}'", null, null, DkmEvaluationResultFlags.None));
+        }
+
+        [Fact, WorkItem(171123, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv")]
+        public void ExceptionDuringEvaluate()
+        {
+            var source = @"
+using System.Diagnostics;
+[DebuggerDisplay(""Make it throw."")]
+public class Picard { }
+";
+            var assembly = GetAssembly(source);
+            var picard = assembly.GetType("Picard");
+            var jeanLuc = picard.Instantiate();
+            var result = FormatResult("says", CreateDkmClrValue(jeanLuc), declaredType: new BadType(picard));
+            Verify(result,
+                EvalFailedResult("says", BadType.Exception.Message, null, null, DkmEvaluationResultFlags.None));
+        }
+
+        private class BadType : DkmClrType
+        {
+            public static readonly Exception Exception = new TargetInvocationException(new DkmException(DkmExceptionCode.E_PROCESS_DESTROYED));
+
+            public BadType(System.Type innerType)
+                : base((TypeImpl)innerType)
+            {
+            }
+
+            public override VisualStudio.Debugger.Metadata.Type GetLmrType()
+            {
+                if (Environment.StackTrace.Contains("Microsoft.CodeAnalysis.ExpressionEvaluator.ResultProvider.GetTypeName"))
+                {
+                    throw Exception;
+                }
+
+                return base.GetLmrType();
+            }
         }
 
         private IReadOnlyList<DkmEvaluationResult> DepthFirstSearch(DkmEvaluationResult root, int maxDepth)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -609,7 +609,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                             displayType =>
                             {
                                 completionRoutine(GetResult(inspectionContext, dataItem, declaredType, declaredTypeInfo, displayName.Result, displayValue.Result, displayType.Result, parent));
-                                workList.Execute();
                             },
                             onException),
                         onException),
@@ -641,6 +640,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     {
                         onException(e);
                     }
+
+                    workList.Execute();
                 };
             if (str == null)
             {

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
             }
         }
 
-        public Type GetLmrType()
+        public virtual Type GetLmrType()
         {
             return _lmrType;
         }


### PR DESCRIPTION
...when an Exception is thrown during creation of a result that has a DebuggerDisplayAttribute.