### PR TITLE
Improve analyzer performance for CompilationWithAnalyzers (IDE host)

### DIFF
--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -59,14 +59,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var ns = (NamespaceDeclarationSyntax)node;
                         foreach (var decl in ns.Members) ComputeDeclarations(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken));
+                        var declInfo = GetDeclarationInfo(model, node, getSymbol, cancellationToken);
+                        builder.Add(declInfo);
 
                         NameSyntax name = ns.Name;
+                        INamespaceSymbol nsSymbol = declInfo.DeclaredSymbol as INamespaceSymbol;
                         while (name.Kind() == SyntaxKind.QualifiedName)
                         {
                             name = ((QualifiedNameSyntax)name).Left;
-                            var declaredSymbol = getSymbol ? model.GetSymbolInfo(name, cancellationToken).Symbol : null;
+                            var declaredSymbol = getSymbol ? nsSymbol?.ContainingNamespace : null;
                             builder.Add(new DeclarationInfo(name, ImmutableArray<SyntaxNode>.Empty, declaredSymbol));
+                            nsSymbol = declaredSymbol;
                         }
 
                         return;

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -295,7 +295,8 @@ namespace Microsoft.CodeAnalysis
             }
 
             AttributeData attribute;
-            if (!SuppressMessageAttributeState.IsDiagnosticSuppressed(this, compilation, out attribute))
+            var suppressMessageState = new SuppressMessageAttributeState(compilation);
+            if (!suppressMessageState.IsDiagnosticSuppressed(this, out attribute))
             {
                 attribute = null;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
@@ -19,16 +18,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private readonly object _gate = new object();
             private readonly Dictionary<CompilationEvent, AnalyzerStateData> _pendingEvents = new Dictionary<CompilationEvent, AnalyzerStateData>();
             private readonly Dictionary<ISymbol, AnalyzerStateData> _pendingSymbols = new Dictionary<ISymbol, AnalyzerStateData>();
-            private readonly Dictionary<SyntaxNode, DeclarationAnalyzerStateData> _pendingDeclarations = new Dictionary<SyntaxNode, DeclarationAnalyzerStateData>();
+            private readonly Dictionary<ISymbol, Dictionary<int, DeclarationAnalyzerStateData>> _pendingDeclarations = new Dictionary<ISymbol, Dictionary<int, DeclarationAnalyzerStateData>>();
+
             private Dictionary<SyntaxTree, AnalyzerStateData> _lazyPendingSyntaxAnalysisTrees = null;
 
-            private readonly ObjectPool<AnalyzerStateData> _analyzerStateDataPool = new ObjectPool<AnalyzerStateData>(() => new AnalyzerStateData());
-            private readonly ObjectPool<DeclarationAnalyzerStateData> _declarationAnalyzerStateDataPool = new ObjectPool<DeclarationAnalyzerStateData>(() => new DeclarationAnalyzerStateData());
+            private readonly ObjectPool<AnalyzerStateData> _analyzerStateDataPool;
+            private readonly ObjectPool<DeclarationAnalyzerStateData> _declarationAnalyzerStateDataPool;
+            private readonly ObjectPool<Dictionary<int, DeclarationAnalyzerStateData>> _currentlyAnalyzingDeclarationsMapPool;
 
-            public PerAnalyzerState(ObjectPool<AnalyzerStateData> analyzerStateDataPool, ObjectPool<DeclarationAnalyzerStateData> declarationAnalyzerStateDataPool)
+            public PerAnalyzerState(
+                ObjectPool<AnalyzerStateData> analyzerStateDataPool,
+                ObjectPool<DeclarationAnalyzerStateData> declarationAnalyzerStateDataPool,
+                ObjectPool<Dictionary<int, DeclarationAnalyzerStateData>> currentlyAnalyzingDeclarationsMapPool)
             {
                 _analyzerStateDataPool = analyzerStateDataPool;
                 _declarationAnalyzerStateDataPool = declarationAnalyzerStateDataPool;
+                _currentlyAnalyzingDeclarationsMapPool = currentlyAnalyzingDeclarationsMapPool;
             }
 
             public IEnumerable<CompilationEvent> PendingEvents_NoLock => _pendingEvents.Keys;
@@ -96,11 +101,96 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (pendingEntities.TryGetValue(analysisEntity, out state))
                 {
                     pendingEntities.Remove(analysisEntity);
-                    if (state != null)
+                    FreeState_NoLock(state, pool);
+                }
+            }
+
+            private bool TryStartAnalyzingDeclaration_NoLock(ISymbol symbol, int declarationIndex, out DeclarationAnalyzerStateData state)
+            {
+                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
+                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                {
+                    state = null;
+                    return false;
+                }
+
+                if (declarationDataMap.TryGetValue(declarationIndex, out state))
+                {
+                    if (state.StateKind != StateKind.ReadyToProcess)
                     {
-                        state.Free();
-                        pool.Free(state);
+                        state = null;
+                        return false;
                     }
+                }
+                else
+                {
+                    state = _declarationAnalyzerStateDataPool.Allocate();
+                }
+
+                state.SetStateKind(StateKind.InProcess);
+                Debug.Assert(state.StateKind == StateKind.InProcess);
+                declarationDataMap[declarationIndex] = state;
+                return true;
+            }
+
+            private void MarkDeclarationProcessed(ISymbol symbol, int declarationIndex)
+            {
+                lock (_gate)
+                {
+                    MarkDeclarationProcessed_NoLock(symbol, declarationIndex);
+                }
+            }
+
+            private void MarkDeclarationProcessed_NoLock(ISymbol symbol, int declarationIndex)
+            {
+                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
+                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                {
+                    return;
+                }
+                
+                DeclarationAnalyzerStateData state;
+                if (declarationDataMap.TryGetValue(declarationIndex, out state))
+                {
+                    FreeDeclarationAnalyzerState_NoLock(state);                    
+                }
+
+                declarationDataMap[declarationIndex] = DeclarationAnalyzerStateData.FullyProcessedInstance;
+            }
+
+            private void MarkDeclarationsProcessed_NoLock(ISymbol symbol)
+            {
+                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
+                if (_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                {
+                    FreeDeclarationDataMap_NoLock(declarationDataMap);
+                    _pendingDeclarations.Remove(symbol);
+                }
+            }
+            
+            private void FreeDeclarationDataMap_NoLock(Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap)
+            {
+                declarationDataMap.Clear();
+                _currentlyAnalyzingDeclarationsMapPool.Free(declarationDataMap);
+            }
+
+            private void FreeDeclarationAnalyzerState_NoLock(DeclarationAnalyzerStateData state)
+            {
+                if (ReferenceEquals(state, DeclarationAnalyzerStateData.FullyProcessedInstance))
+                {
+                    return;
+                }
+
+                FreeState_NoLock(state, _declarationAnalyzerStateDataPool);
+            }
+
+            private static void FreeState_NoLock<TAnalyzerStateData>(TAnalyzerStateData state, ObjectPool<TAnalyzerStateData> pool)
+                where TAnalyzerStateData : AnalyzerStateData
+            {
+                if (state != null)
+                {
+                    state.Free();
+                    pool.Free(state);
                 }
             }
 
@@ -116,7 +206,38 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private static bool IsEntityFullyProcessed_NoLock<TAnalysisEntity, TAnalyzerStateData>(TAnalysisEntity analysisEntity, Dictionary<TAnalysisEntity, TAnalyzerStateData> pendingEntities)
                 where TAnalyzerStateData : AnalyzerStateData
             {
-                return !pendingEntities.ContainsKey(analysisEntity);
+                TAnalyzerStateData state;
+                return !pendingEntities.TryGetValue(analysisEntity, out state) ||
+                    state?.StateKind == StateKind.FullyProcessed;
+            }
+
+            private bool IsDeclarationComplete_NoLock(ISymbol symbol, int declarationIndex)
+            {
+                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
+                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                {
+                    return true;
+                }
+
+                DeclarationAnalyzerStateData state;
+                if (!declarationDataMap.TryGetValue(declarationIndex, out state))
+                {
+                    return false;
+                }
+
+                return state.StateKind == StateKind.FullyProcessed;
+            }
+
+            private bool AreDeclarationsProcessed_NoLock(ISymbol symbol, int declarationsCount)
+            {
+                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
+                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                {
+                    return true;
+                }
+
+                return declarationDataMap.Count == declarationsCount &&
+                    declarationDataMap.Values.All(state => state.StateKind == StateKind.FullyProcessed);
             }
 
             public bool TryStartProcessingEvent(CompilationEvent compilationEvent, out AnalyzerStateData state)
@@ -139,19 +260,36 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 MarkEntityProcessed(symbol, _pendingSymbols, _analyzerStateDataPool);
             }
 
-            public bool TryStartAnalyzingDeclaration(SyntaxReference decl, out DeclarationAnalyzerStateData state)
+            public bool TryStartAnalyzingDeclaration(ISymbol symbol, int declarationIndex, out DeclarationAnalyzerStateData state)
             {
-                return TryStartProcessingEntity(decl.GetSyntax(), _pendingDeclarations, _declarationAnalyzerStateDataPool, out state);
+                lock (_gate)
+                {
+                    return TryStartAnalyzingDeclaration_NoLock(symbol, declarationIndex, out state);
+                }
             }
 
-            public bool IsDeclarationComplete(SyntaxNode decl)
+            public bool IsDeclarationComplete(ISymbol symbol, int declarationIndex)
             {
-                return IsEntityFullyProcessed(decl, _pendingDeclarations);
+                lock (_gate)
+                {
+                    return IsDeclarationComplete_NoLock(symbol, declarationIndex);
+                }
             }
 
-            public void MarkDeclarationComplete(SyntaxReference decl)
+            public void MarkDeclarationComplete(ISymbol symbol, int declarationIndex)
             {
-                MarkEntityProcessed(decl.GetSyntax(), _pendingDeclarations, _declarationAnalyzerStateDataPool);
+                lock (_gate)
+                {
+                    MarkDeclarationProcessed_NoLock(symbol, declarationIndex);
+                }
+            }
+
+            public void MarkDeclarationsComplete(ISymbol symbol)
+            {
+                lock (_gate)
+                {
+                    MarkDeclarationsProcessed_NoLock(symbol);
+                }
             }
 
             public bool TryStartSyntaxAnalysis(SyntaxTree tree, out AnalyzerStateData state)
@@ -165,17 +303,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (_lazyPendingSyntaxAnalysisTrees != null)
                 {
                     MarkEntityProcessed(tree, _lazyPendingSyntaxAnalysisTrees, _analyzerStateDataPool);
-                }
-            }
-
-            public void MarkDeclarationsComplete(ImmutableArray<SyntaxReference> declarations)
-            {
-                lock (_gate)
-                {
-                    foreach (var syntaxRef in declarations)
-                    {
-                        MarkEntityProcessed_NoLock(syntaxRef.GetSyntax(), _pendingDeclarations, _declarationAnalyzerStateDataPool);
-                    }
                 }
             }
 
@@ -197,11 +324,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         if (!AnalysisScope.ShouldSkipDeclarationAnalysis(symbol) &&
                             actionCounts.HasAnyExecutableCodeActions)
                         {
-                            foreach (var syntaxRef in symbolEvent.DeclaringSyntaxReferences)
-                            {
-                                needsAnalysis = true;
-                                _pendingDeclarations[syntaxRef.GetSyntax()] = null;
-                            }
+                            needsAnalysis = true;
+                            _pendingDeclarations[symbol] = _currentlyAnalyzingDeclarationsMapPool.Allocate();
                         }
 
                         if (!needsAnalysis)
@@ -257,16 +381,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 // Have the node/code block actions executed for all symbol declarations?
-                foreach (var syntaxRef in symbolDeclaredEvent.DeclaringSyntaxReferences)
+                if (!AreDeclarationsProcessed_NoLock(symbolDeclaredEvent.Symbol, symbolDeclaredEvent.DeclaringSyntaxReferences.Length))
                 {
-                    if (!IsEntityFullyProcessed_NoLock(syntaxRef.GetSyntax(), _pendingDeclarations))
-                    {
-                        return;
-                    }
+                    return;
                 }
 
                 // Mark the symbol event completely processed.
                 MarkEntityProcessed_NoLock(symbolDeclaredEvent, _pendingEvents, _analyzerStateDataPool);
+
+                // Mark declarations completely processed.
+                MarkDeclarationsProcessed_NoLock(symbolDeclaredEvent.Symbol);
             }
         }
     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.StateKind.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.StateKind.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// 1. Completely unprocessed: <see cref="ReadyToProcess"/>
         /// 2. Currently being processed: <see cref="InProcess"/>
         /// 3. Partially processed by one or more older requests that was either completed or cancelled: <see cref="ReadyToProcess"/>
-        /// 4. Fully processed: We don't need a state kind to represent fully processed state as the analysis state object is discarded once fully processed.
+        /// 4. Fully processed: <see cref="FullyProcessed"/>.
         /// </summary>
         internal enum StateKind
         {
@@ -23,7 +23,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// <summary>
             /// Currently being processed.
             /// </summary>
-            InProcess
+            InProcess,
+
+            /// <summary>
+            /// Fully processed.
+            /// </summary>
+            FullyProcessed,
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
@@ -24,11 +24,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// Partial analysis state for operation block actions executed on the declaration.
             /// </summary>
             public OperationBlockAnalyzerStateData OperationBlockAnalysisState { get; }
-            
+
+            public static readonly DeclarationAnalyzerStateData FullyProcessedInstance = CreateFullyProcessedInstance();
+
             public DeclarationAnalyzerStateData()
             {
                 CodeBlockAnalysisState = new CodeBlockAnalyzerStateData();
                 OperationBlockAnalysisState = new OperationBlockAnalyzerStateData();
+            }
+
+            private static DeclarationAnalyzerStateData CreateFullyProcessedInstance()
+            {
+                var instance = new DeclarationAnalyzerStateData();
+                instance.SetStateKind(StateKind.FullyProcessed);
+                return instance;
             }
 
             public override void SetStateKind(StateKind stateKind)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -47,6 +48,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         private ImmutableDictionary<DiagnosticAnalyzer, AnalyzerActionCounts> _lazyAnalyzerActionCountsMap;
 
+        private readonly HashSet<SyntaxTree> _treesWithGeneratedSourceEvents;
+        private readonly HashSet<ISymbol> _partialSymbolsWithGeneratedSourceEvents;
+        private readonly CompilationData _compilationData;
+        private bool _compilationStartGenerated;
+        private bool _compilationEndGenerated;
 
         /// <summary>
         /// Cached semantic model for the compilation trees.
@@ -56,32 +62,37 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private readonly ObjectPool<HashSet<CompilationEvent>> _compilationEventsPool;
         private readonly HashSet<CompilationEvent> _pooledEventsWithAnyActionsSet;
-        private bool _compilationEndAnalyzed;
 
-        public AnalysisState(ImmutableArray<DiagnosticAnalyzer> analyzers)
+        public AnalysisState(ImmutableArray<DiagnosticAnalyzer> analyzers, CompilationData compilationData)
         {
             _gate = new object();
             _analyzerStateMap = CreateAnalyzerStateMap(analyzers, out _analyzerStates);
+            _compilationData = compilationData;
             _pendingSourceEvents = new Dictionary<SyntaxTree, HashSet<CompilationEvent>>();
             _pendingNonSourceEvents = new HashSet<CompilationEvent>();
             _lazyAnalyzerActionCountsMap = null;
             _semanticModelsMap = new ConditionalWeakTable<SyntaxTree, SemanticModel>();
+            _treesWithGeneratedSourceEvents = new HashSet<SyntaxTree>();
+            _partialSymbolsWithGeneratedSourceEvents = new HashSet<ISymbol>();
+            _compilationStartGenerated = false;
+            _compilationEndGenerated = false;
             _compilationEventsPool = new ObjectPool<HashSet<CompilationEvent>>(() => new HashSet<CompilationEvent>());
             _pooledEventsWithAnyActionsSet = new HashSet<CompilationEvent>();
-            _compilationEndAnalyzed = false;
         }
 
         private static ImmutableDictionary<DiagnosticAnalyzer, int> CreateAnalyzerStateMap(ImmutableArray<DiagnosticAnalyzer> analyzers, out ImmutableArray<PerAnalyzerState> analyzerStates)
         {
             var analyzerStateDataPool = new ObjectPool<AnalyzerStateData>(() => new AnalyzerStateData());
             var declarationAnalyzerStateDataPool = new ObjectPool<DeclarationAnalyzerStateData>(() => new DeclarationAnalyzerStateData());
+            var currentlyAnalyzingDeclarationsMapPool = new ObjectPool<Dictionary<int, DeclarationAnalyzerStateData>>(
+                () => new Dictionary<int, DeclarationAnalyzerStateData>());
 
             var statesBuilder = ImmutableArray.CreateBuilder<PerAnalyzerState>();
             var map = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, int>();
             var index = 0;
             foreach (var analyzer in analyzers)
             {
-                statesBuilder.Add(new PerAnalyzerState(analyzerStateDataPool, declarationAnalyzerStateDataPool));
+                statesBuilder.Add(new PerAnalyzerState(analyzerStateDataPool, declarationAnalyzerStateDataPool, currentlyAnalyzingDeclarationsMapPool));
                 map[analyzer] = index;
                 index++;
             }
@@ -96,22 +107,130 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _analyzerStates[index];
         }
 
+        public async Task GenerateSimulatedCompilationEventsAsync(
+            AnalysisScope analysisScope,
+            Compilation compilation,
+            Func<SyntaxTree, Compilation, CancellationToken, SemanticModel> getCachedSemanticModel,
+            AnalyzerDriver driver,
+            CancellationToken cancellationToken)
+        {
+            await EnsureAnalyzerActionCountsInitializedAsync(driver, cancellationToken).ConfigureAwait(false);
+
+            // Compilation started event.
+            GenerateSimulatedCompilatioNonSourceEvent(compilation, driver, started: true, cancellationToken: cancellationToken);
+
+            // Symbol declared and compilation unit completed events.
+            foreach (var tree in analysisScope.SyntaxTrees)
+            {
+                GenerateSimulatedCompilationSourceEvents(tree, compilation, getCachedSemanticModel, driver, cancellationToken);
+            }
+
+            // Compilation ended event.
+            if (analysisScope.FilterTreeOpt == null)
+            {
+                GenerateSimulatedCompilatioNonSourceEvent(compilation, driver, started: false, cancellationToken: cancellationToken);
+            }
+        }
+
+        private void GenerateSimulatedCompilationSourceEvents(
+            SyntaxTree tree,
+            Compilation compilation,
+            Func<SyntaxTree, Compilation, CancellationToken, SemanticModel> getCachedSemanticModel,
+            AnalyzerDriver driver,
+            CancellationToken cancellationToken)
+        {
+            lock (_gate)
+            {
+                if (_treesWithGeneratedSourceEvents.Contains(tree))
+                {
+                    return;
+                }
+            }
+
+            var globalNs = compilation.Assembly.GlobalNamespace;
+            var symbols = GetDeclaredSymbolsInTree(tree, compilation, getCachedSemanticModel, cancellationToken);
+            var compilationEvents = CreateCompilationEventsForTree(symbols.Concat(globalNs), tree, compilation);
+
+            lock (_gate)
+            {
+                if (_treesWithGeneratedSourceEvents.Contains(tree))
+                {
+                    return;
+                }
+
+                OnCompilationEventsGenerated_NoLock(compilationEvents, tree, driver, cancellationToken);
+
+                var added = _treesWithGeneratedSourceEvents.Add(tree);
+                Debug.Assert(added);
+            }
+        }
+
+        private IEnumerable<ISymbol> GetDeclaredSymbolsInTree(
+            SyntaxTree tree,
+            Compilation compilation,
+            Func<SyntaxTree, Compilation, CancellationToken, SemanticModel> getCachedSemanticModel,
+            CancellationToken cancellationToken)
+        {
+            var model = getCachedSemanticModel(tree, compilation, cancellationToken);
+            var fullSpan = tree.GetRoot(cancellationToken).FullSpan;
+            var declarationInfos = new List<DeclarationInfo>();
+            model.ComputeDeclarationsInSpan(fullSpan, getSymbol: true, builder: declarationInfos, cancellationToken: cancellationToken);
+            return declarationInfos.Select(declInfo => declInfo.DeclaredSymbol).WhereNotNull();
+        }
+
+        private static ImmutableArray<CompilationEvent> CreateCompilationEventsForTree(IEnumerable<ISymbol> declaredSymbols, SyntaxTree tree, Compilation compilation)
+        {
+            var builder = ImmutableArray.CreateBuilder<CompilationEvent>();
+            foreach (var symbol in declaredSymbols)
+            {   
+                builder.Add(new SymbolDeclaredCompilationEvent(compilation, symbol));
+            }
+
+            builder.Add(new CompilationUnitCompletedEvent(compilation, tree));
+            return builder.ToImmutable();
+        }
+
+        private void GenerateSimulatedCompilatioNonSourceEvent(Compilation compilation, AnalyzerDriver driver, bool started, CancellationToken cancellationToken)
+        {
+            lock (_gate)
+            {
+                var eventAlreadyGenerated = started ? _compilationStartGenerated : _compilationEndGenerated;
+                if (eventAlreadyGenerated)
+                {
+                    return;
+                }
+
+                var compilationEvent = started ? (CompilationEvent)new CompilationStartedEvent(compilation) : new CompilationCompletedEvent(compilation);
+                var events = ImmutableArray.Create(compilationEvent);
+                OnCompilationEventsGenerated_NoLock(events, filterTreeOpt: null, driver: driver, cancellationToken: cancellationToken);
+
+                if (started)
+                {
+                    _compilationStartGenerated = true;
+                }
+                else
+                {
+                    _compilationEndGenerated = true;
+                }
+            }
+        }
+
         public async Task OnCompilationEventsGeneratedAsync(ImmutableArray<CompilationEvent> compilationEvents, AnalyzerDriver driver, CancellationToken cancellationToken)
         {
             await EnsureAnalyzerActionCountsInitializedAsync(driver, cancellationToken).ConfigureAwait(false);
 
             lock (_gate)
             {
-                OnCompilationEventsGenerated_NoLock(compilationEvents, driver, cancellationToken);
+                OnCompilationEventsGenerated_NoLock(compilationEvents, filterTreeOpt: null, driver: driver, cancellationToken: cancellationToken);
             }
         }
 
-        private void OnCompilationEventsGenerated_NoLock(ImmutableArray<CompilationEvent> compilationEvents, AnalyzerDriver driver, CancellationToken cancellationToken)
+        private void OnCompilationEventsGenerated_NoLock(ImmutableArray<CompilationEvent> compilationEvents, SyntaxTree filterTreeOpt, AnalyzerDriver driver, CancellationToken cancellationToken)
         {
             Debug.Assert(_lazyAnalyzerActionCountsMap != null);
 
             // Add the events to our global pending events map.
-            AddToEventsMap_NoLock(compilationEvents);
+            AddToEventsMap_NoLock(compilationEvents, filterTreeOpt);
 
             // Mark the events for analysis for each analyzer.
             Debug.Assert(_pooledEventsWithAnyActionsSet.Count == 0);
@@ -126,6 +245,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     if (HasActionsForEvent(compilationEvent, actionCounts))
                     {
                         _pooledEventsWithAnyActionsSet.Add(compilationEvent);
+
+                        var symbolDeclaredEvent = compilationEvent as SymbolDeclaredCompilationEvent;
+                        if (symbolDeclaredEvent?.DeclaringSyntaxReferences.Length > 1 &&
+                            !_partialSymbolsWithGeneratedSourceEvents.Add(symbolDeclaredEvent.Symbol))
+                        {
+                            // already processed.
+                            continue;
+                        }
+
                         analyzerState.OnCompilationEventGenerated(compilationEvent, actionCounts);
                     }
                 }
@@ -141,8 +269,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        private void AddToEventsMap_NoLock(ImmutableArray<CompilationEvent> compilationEvents)
+        private void AddToEventsMap_NoLock(ImmutableArray<CompilationEvent> compilationEvents, SyntaxTree filterTreeOpt)
         {
+            if (filterTreeOpt != null)
+            {
+                AddPendingSourceEvents_NoLock(compilationEvents, filterTreeOpt);
+                return;
+            }
+
             foreach (var compilationEvent in compilationEvents)
             {
                 UpdateEventsMap_NoLock(compilationEvent, add: true);
@@ -197,7 +331,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     else
                     {
                         _pendingNonSourceEvents.Remove(compilationEvent);
-                        _compilationEndAnalyzed |= compilationEvent is CompilationCompletedEvent;
                     }
                 }
                 else
@@ -205,12 +338,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     throw new InvalidOperationException("Unexpected compilation event of type " + compilationEvent.GetType().Name);
                 }
             }
+        }
 
-            if (_compilationEndAnalyzed && _pendingSourceEvents.Count == 0)
+        private void AddPendingSourceEvents_NoLock(ImmutableArray<CompilationEvent> compilationEvents, SyntaxTree tree)
+        {
+            HashSet<CompilationEvent> currentEvents;
+            if (!_pendingSourceEvents.TryGetValue(tree, out currentEvents))
             {
-                // Clear the per-compilation data cache if we finished analyzing this compilation.  
-                AnalyzerDriver.RemoveCachedCompilationData(compilationEvent.Compilation);
+                currentEvents = new HashSet<CompilationEvent>(compilationEvents);
+                _pendingSourceEvents[tree] = currentEvents;
+                _compilationData.RemoveCachedSemanticModel(tree);
+                return;
             }
+
+            currentEvents.AddAll(compilationEvents);
         }
 
         private void AddPendingSourceEvent_NoLock(SyntaxTree tree, CompilationEvent compilationEvent)
@@ -218,9 +359,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             HashSet<CompilationEvent> currentEvents;
             if (!_pendingSourceEvents.TryGetValue(tree, out currentEvents))
             {
-                currentEvents = _compilationEventsPool.Allocate();
+                currentEvents = new HashSet<CompilationEvent>();
                 _pendingSourceEvents[tree] = currentEvents;
-                AnalyzerDriver.RemoveCachedSemanticModel(tree, compilationEvent.Compilation);
+                _compilationData.RemoveCachedSemanticModel(tree);
             }
 
             currentEvents.Add(compilationEvent);
@@ -233,8 +374,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (currentEvents.Remove(compilationEvent) && currentEvents.Count == 0)
                 {
-                    _compilationEventsPool.Free(currentEvents);
                     _pendingSourceEvents.Remove(tree);
+                    _compilationData.RemoveCachedSemanticModel(tree);
                 }
             }
         }
@@ -562,19 +703,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Returns false if the declaration has already been processed for the analyzer OR is currently being processed by another task.
         /// If true, then it returns a non-null <paramref name="state"/> representing partial analysis state for the given declaration for the given analyzer.
         /// </returns>
-        public bool TryStartAnalyzingDeclaration(SyntaxReference decl, DiagnosticAnalyzer analyzer, out DeclarationAnalyzerStateData state)
+        public bool TryStartAnalyzingDeclaration(ISymbol symbol, int declarationIndex, DiagnosticAnalyzer analyzer, out DeclarationAnalyzerStateData state)
         {
-            return GetAnalyzerState(analyzer).TryStartAnalyzingDeclaration(decl, out state);
+            return GetAnalyzerState(analyzer).TryStartAnalyzingDeclaration(symbol, declarationIndex, out state);
         }
 
         /// <summary>
         /// True if the given symbol declaration is fully analyzed.
         /// </summary>
-        public bool IsDeclarationComplete(SyntaxNode decl)
+        public bool IsDeclarationComplete(ISymbol symbol, int declarationIndex)
         {
             foreach (var analyzerState in _analyzerStates)
             {
-                if (!analyzerState.IsDeclarationComplete(decl))
+                if (!analyzerState.IsDeclarationComplete(symbol, declarationIndex))
                 {
                     return false;
                 }
@@ -586,30 +727,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// Marks the given symbol declaration as fully analyzed for the given analyzer.
         /// </summary>
-        public void MarkDeclarationComplete(SyntaxReference decl, DiagnosticAnalyzer analyzer)
+        public void MarkDeclarationComplete(ISymbol symbol, int declarationIndex, DiagnosticAnalyzer analyzer)
         {
-            GetAnalyzerState(analyzer).MarkDeclarationComplete(decl);
+            GetAnalyzerState(analyzer).MarkDeclarationComplete(symbol, declarationIndex);
         }
 
         /// <summary>
         /// Marks the given symbol declaration as fully analyzed for the given analyzers.
         /// </summary>
-        public void MarkDeclarationComplete(SyntaxReference decl, IEnumerable<DiagnosticAnalyzer> analyzers)
+        public void MarkDeclarationComplete(ISymbol symbol, int declarationIndex, IEnumerable<DiagnosticAnalyzer> analyzers)
         {
             foreach (var analyzer in analyzers)
             {
-                GetAnalyzerState(analyzer).MarkDeclarationComplete(decl);
+                GetAnalyzerState(analyzer).MarkDeclarationComplete(symbol, declarationIndex);
             }
         }
 
         /// <summary>
         /// Marks all the symbol declarations for the given symbol as fully analyzed for all the given analyzers.
         /// </summary>
-        public void MarkDeclarationsComplete(ImmutableArray<SyntaxReference> declarations, IEnumerable<DiagnosticAnalyzer> analyzers)
+        public void MarkDeclarationsComplete(ISymbol symbol, IEnumerable<DiagnosticAnalyzer> analyzers)
         {
             foreach (var analyzer in analyzers)
             {
-                GetAnalyzerState(analyzer).MarkDeclarationsComplete(declarations);
+                GetAnalyzerState(analyzer).MarkDeclarationsComplete(symbol);
             }
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="symbolActions">Symbol actions to be executed.</param>
         /// <param name="analyzer">Analyzer whose actions are to be executed.</param>
-        /// <param name="symbol">Symbol to be analyzed.</param>
+        /// <param name="symbolDeclaredEvent">Symbol event to be analyzed.</param>
         /// <param name="getTopMostNodeForAnalysis">Delegate to get topmost declaration node for a symbol declaration reference.</param>
         /// <param name="analysisScope">Scope for analyzer execution.</param>
         /// <param name="analysisStateOpt">An optional object to track analysis state.</param>
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void ExecuteSymbolActions(
             ImmutableArray<SymbolAnalyzerAction> symbolActions,
             DiagnosticAnalyzer analyzer,
-            ISymbol symbol,
+            SymbolDeclaredCompilationEvent symbolDeclaredEvent,
             Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
@@ -280,9 +280,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             try
             {
+                var symbol = symbolDeclaredEvent.Symbol;
                 if (TryStartAnalyzingSymbol(symbol, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
                 {
-                    ExecuteSymbolActionsCore(symbolActions, analyzer, symbol, getTopMostNodeForAnalysis, analyzerStateOpt, isGeneratedCodeSymbol);
+                    ExecuteSymbolActionsCore(symbolActions, analyzer, symbolDeclaredEvent, getTopMostNodeForAnalysis, analyzerStateOpt, isGeneratedCodeSymbol);
                     analysisStateOpt?.MarkSymbolComplete(symbol, analyzer);
                 }
             }
@@ -295,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private void ExecuteSymbolActionsCore(
             ImmutableArray<SymbolAnalyzerAction> symbolActions,
             DiagnosticAnalyzer analyzer,
-            ISymbol symbol,
+            SymbolDeclaredCompilationEvent symbolDeclaredEvent,
             Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis,
             AnalyzerStateData analyzerStateOpt,
             bool isGeneratedCodeSymbol)
@@ -307,7 +308,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return;
             }
 
-            var addDiagnostic = GetAddDiagnostic(symbol, analyzer, getTopMostNodeForAnalysis, isGeneratedCodeSymbol);
+            var symbol = symbolDeclaredEvent.Symbol;
+            var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis, isGeneratedCodeSymbol);
 
             foreach (var symbolAction in symbolActions)
             {
@@ -507,6 +509,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             Func<SyntaxNode, TLanguageKindEnum> getKind,
             SyntaxReference declaration,
+            int declarationIndex,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCode)
@@ -521,7 +524,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             try
             {
-                if (TryStartAnalyzingSyntaxRefence(declaration, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
+                if (TryStartAnalyzingSyntaxRefence(declaredSymbol, declarationIndex, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
                 {
                     ExecuteBlockActionsCore<CodeBlockStartAnalyzerAction<TLanguageKindEnum>, CodeBlockAnalyzerAction, SyntaxNodeAnalyzerAction<TLanguageKindEnum>, SyntaxNodeAnalyzerStateData, SyntaxNode, TLanguageKindEnum>(
                         codeBlockStartActions, codeBlockActions, codeBlockEndActions, analyzer,
@@ -546,6 +549,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<IOperation> operations,
             SemanticModel semanticModel,
             SyntaxReference declaration,
+            int declarationIndex,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCode)
@@ -559,7 +563,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             try
             {
-                if (TryStartAnalyzingSyntaxRefence(declaration, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
+                if (TryStartAnalyzingSyntaxRefence(declaredSymbol, declarationIndex, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
                 {
                     ExecuteBlockActionsCore<OperationBlockStartAnalyzerAction, OperationBlockAnalyzerAction, OperationAnalyzerAction, OperationAnalyzerStateData, IOperation, int>(
                         operationBlockStartActions, operationBlockActions, operationBlockEndActions, analyzer,
@@ -778,6 +782,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
            Func<SyntaxNode, TLanguageKindEnum> getKind,
            TextSpan filterSpan,
            SyntaxReference declaration,
+           int declarationIndex,
+           ISymbol declaredSymbol,
            AnalysisScope analysisScope,
            AnalysisState analysisStateOpt,
            bool isGeneratedCode)
@@ -792,7 +798,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             try
             {
-                if (TryStartAnalyzingSyntaxRefence(declaration, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
+                if (TryStartAnalyzingSyntaxRefence(declaredSymbol, declarationIndex, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
                 {
                     ExecuteSyntaxNodeActionsCore(nodesToAnalyze, nodeActionsByKind, analyzer, model, getKind, filterSpan, analyzerStateOpt, isGeneratedCode);
                 }
@@ -900,6 +906,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel model,
             TextSpan filterSpan,
             SyntaxReference declaration,
+            int declarationIndex,
+            ISymbol declaredSymbol,
             AnalysisScope analysisScope,
             AnalysisState analysisStateOpt,
             bool isGeneratedCode)
@@ -913,7 +921,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             try
             {
-                if (TryStartAnalyzingOperationReference(declaration, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
+                if (TryStartAnalyzingOperationReference(declaredSymbol, declarationIndex, analyzer, analysisScope, analysisStateOpt, out analyzerStateOpt))
                 {
                     ExecuteOperationActionsCore(operationsToAnalyze, operationActionsByKind, analyzer, model, filterSpan, analyzerStateOpt, isGeneratedCode);
                 }
@@ -1151,14 +1159,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _analyzerManager.IsSupportedDiagnostic(analyzer, diagnostic, _isCompilerAnalyzer, this);
         }
 
-        private Action<Diagnostic> GetAddDiagnostic(ISymbol contextSymbol, DiagnosticAnalyzer analyzer, Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis, bool isGeneratedCodeSymbol)
+        private Action<Diagnostic> GetAddDiagnostic(ISymbol contextSymbol, ImmutableArray<SyntaxReference> cachedDeclaringReferences, DiagnosticAnalyzer analyzer, Func<ISymbol, SyntaxReference, Compilation, SyntaxNode> getTopMostNodeForAnalysis, bool isGeneratedCodeSymbol)
         {
-            return GetAddDiagnostic(contextSymbol, _compilation, analyzer, isGeneratedCodeSymbol, _addNonCategorizedDiagnosticOpt,
+            return GetAddDiagnostic(contextSymbol, cachedDeclaringReferences, _compilation, analyzer, isGeneratedCodeSymbol, _addNonCategorizedDiagnosticOpt,
                  _addCategorizedLocalDiagnosticOpt, _addCategorizedNonLocalDiagnosticOpt, getTopMostNodeForAnalysis, _shouldSuppressGeneratedCodeDiagnostic, _cancellationToken);
         }
 
         private static Action<Diagnostic> GetAddDiagnostic(
             ISymbol contextSymbol,
+            ImmutableArray<SyntaxReference> cachedDeclaringReferences,
             Compilation compilation,
             DiagnosticAnalyzer analyzer,
             bool isGeneratedCodeSymbol,
@@ -1188,7 +1197,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 if (diagnostic.Location.IsInSource)
                 {
-                    foreach (var syntaxRef in contextSymbol.DeclaringSyntaxReferences)
+                    foreach (var syntaxRef in cachedDeclaringReferences)
                     {
                         if (syntaxRef.SyntaxTree == diagnostic.Location.SourceTree)
                         {
@@ -1334,15 +1343,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return analysisStateOpt == null || analysisStateOpt.TryStartAnalyzingSymbol(symbol, analyzer, out analyzerStateOpt);
         }
 
-        private static bool TryStartAnalyzingSyntaxRefence(SyntaxReference syntaxReference, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out DeclarationAnalyzerStateData analyzerStateOpt)
+        private static bool TryStartAnalyzingSyntaxRefence(ISymbol symbol, int declarationIndex, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out DeclarationAnalyzerStateData analyzerStateOpt)
         {
             Debug.Assert(analysisScope.Analyzers.Contains(analyzer));
 
             analyzerStateOpt = null;
-            return analysisStateOpt == null || analysisStateOpt.TryStartAnalyzingDeclaration(syntaxReference, analyzer, out analyzerStateOpt);
+            return analysisStateOpt == null || analysisStateOpt.TryStartAnalyzingDeclaration(symbol, declarationIndex, analyzer, out analyzerStateOpt);
         }
 
-        private static bool TryStartAnalyzingOperationReference(SyntaxReference syntaxReference, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out OperationAnalyzerStateData analyzerStateOpt)
+        private static bool TryStartAnalyzingOperationReference(ISymbol symbol, int declarationIndex, DiagnosticAnalyzer analyzer, AnalysisScope analysisScope, AnalysisState analysisStateOpt, out OperationAnalyzerStateData analyzerStateOpt)
         {
             Debug.Assert(analysisScope.Analyzers.Contains(analyzer));
 
@@ -1353,7 +1362,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return true;
             }
 
-            if (analysisStateOpt.TryStartAnalyzingDeclaration(syntaxReference, analyzer, out declarationAnalyzerStateOpt))
+            if (analysisStateOpt.TryStartAnalyzingDeclaration(symbol, declarationIndex, analyzer, out declarationAnalyzerStateOpt))
             {
                 analyzerStateOpt = declarationAnalyzerStateOpt.OperationBlockAnalysisState.ExecutableNodesAnalysisState;
                 return true;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _localSuppressionsBySymbol = new ConcurrentDictionary<ISymbol, ImmutableDictionary<string, SuppressMessageInfo>>();
         }
 
-        public static Diagnostic ApplySourceSuppressions(Diagnostic diagnostic, Compilation compilation, ISymbol symbolOpt = null)
+        public Diagnostic ApplySourceSuppressions(Diagnostic diagnostic, ISymbol symbolOpt = null)
         {
             if (diagnostic.IsSuppressed)
             {
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             SuppressMessageInfo info;
-            if (IsDiagnosticSuppressed(diagnostic, compilation, out info))
+            if (IsDiagnosticSuppressed(diagnostic, out info))
             {
                 // Attach the suppression info to the diagnostic.
                 diagnostic = diagnostic.WithIsSuppressed(true);
@@ -95,10 +95,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return diagnostic;
         }
 
-        public static bool IsDiagnosticSuppressed(Diagnostic diagnostic, Compilation compilation, out AttributeData suppressingAttribute)
+        public bool IsDiagnosticSuppressed(Diagnostic diagnostic, out AttributeData suppressingAttribute)
         {
             SuppressMessageInfo info;
-            if (IsDiagnosticSuppressed(diagnostic, compilation, out info))
+            if (IsDiagnosticSuppressed(diagnostic, out info))
             {
                 suppressingAttribute = info.Attribute;
                 return true;
@@ -106,12 +106,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             suppressingAttribute = null;
             return false;
-        }
-
-        private static bool IsDiagnosticSuppressed(Diagnostic diagnostic, Compilation compilation, out SuppressMessageInfo info)
-        {
-            var suppressMessageState = AnalyzerDriver.GetOrCreateCachedCompilationData(compilation).SuppressMessageAttributeState;
-            return suppressMessageState.IsDiagnosticSuppressed(diagnostic, out info);
         }
 
         private bool IsDiagnosticSuppressed(Diagnostic diagnostic, out SuppressMessageInfo info, ISymbol symbolOpt = null)

--- a/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
+++ b/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
@@ -43,13 +43,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     For Each decl In ns.Members
                         ComputeDeclarationsCore(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken)
                     Next
-                    builder.Add(GetDeclarationInfo(model, node, getSymbol, cancellationToken))
+                    Dim declInfo = GetDeclarationInfo(model, node, getSymbol, cancellationToken)
+                    builder.Add(declInfo)
 
                     Dim name = ns.NamespaceStatement.Name
+                    Dim nsSymbol = declInfo.DeclaredSymbol
                     While (name.Kind() = SyntaxKind.QualifiedName)
                         name = (CType(name, QualifiedNameSyntax)).Left
-                        Dim declaredSymbol = If(getSymbol, model.GetSymbolInfo(name, cancellationToken).Symbol, Nothing)
+                        Dim declaredSymbol = If(getSymbol, nsSymbol?.ContainingNamespace, Nothing)
                         builder.Add(New DeclarationInfo(name, ImmutableArray(Of SyntaxNode).Empty, declaredSymbol))
+                        nsSymbol = declaredSymbol
                     End While
 
                     Return


### PR DESCRIPTION
1. Add support for a simulated event queue to generate compilation events by computing declarations in the tree. Invoking GetDiagnostics to populate the event queue is one of the main reason for large allocations/VM in our perf tests. We can get back to using the compilation event queue when the compiler supports attaching an event queue to an existing compilation, without requiring a complete clone.

2. Move the cached compilation data (declarations, suppression state, etc.) out of a conditional weak table and strongly reference it in CompilationWithAnalyzers.

3. Reduce allocations in per-analyzer state maintenance by tracking analyzed declarations instead of pending declarations - latter can be very large for symbols with many declarations (e.g. global namespace).