### PR TITLE
Ensure that analyzer driver processes declared namespace symbols whic…

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -1491,5 +1491,19 @@ partial class PartialType
             var diagnostic = Diagnostic(diagnosticId, squiggledText).WithArguments(arguments).WithLocation(line, column);
             builder.Add(diagnostic);
         }
+
+        [Fact]
+        public void TestEnsureNoMergedNamespaceSymbolAnalyzer()
+        {
+            var source = @"namespace N1.N2 { }";
+            
+            var metadataReference = CreateCompilationWithMscorlib(source).ToMetadataReference();
+            var compilation = CreateCompilationWithMscorlib(source, new[] { metadataReference });
+            compilation.VerifyDiagnostics();
+
+            // Analyzer reports a diagnostic if it receives a merged namespace symbol across assemblies in compilation.
+            var analyzers = new DiagnosticAnalyzer[] { new EnsureNoMergedNamespaceSymbolAnalyzer() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers);
+        }
     }
 }

--- a/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
+++ b/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, IEnumerable<SyntaxNode> executableCodeBlocks, CancellationToken cancellationToken)
         {
-            var declaredSymbol = getSymbol ? model.GetDeclaredSymbol(node, cancellationToken) : null;
+            var declaredSymbol = GetDeclaredSymbol(model, node, getSymbol, cancellationToken);
             var codeBlocks = executableCodeBlocks?.Where(c => c != null).AsImmutableOrEmpty() ?? ImmutableArray<SyntaxNode>.Empty;
             return new DeclarationInfo(node, codeBlocks, declaredSymbol);
         }
@@ -24,14 +25,39 @@ namespace Microsoft.CodeAnalysis
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, SyntaxNode executableCodeBlock, CancellationToken cancellationToken)
         {
-            var declaredSymbol = getSymbol ? model.GetDeclaredSymbol(node, cancellationToken) : null;
-            var codeBlock = executableCodeBlock == null ? ImmutableArray<SyntaxNode>.Empty : ImmutableArray.Create(executableCodeBlock);
-            return new DeclarationInfo(node, codeBlock, declaredSymbol);
+            return GetDeclarationInfo(model, node, getSymbol, SpecializedCollections.SingletonEnumerable(executableCodeBlock), cancellationToken);
         }
 
         internal static DeclarationInfo GetDeclarationInfo(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken, params SyntaxNode[] executableCodeBlocks)
         {
             return GetDeclarationInfo(model, node, getSymbol, executableCodeBlocks.AsEnumerable(), cancellationToken);
+        }
+
+        private static ISymbol GetDeclaredSymbol(SemanticModel model, SyntaxNode node, bool getSymbol, CancellationToken cancellationToken)
+        {
+            if (!getSymbol)
+            {
+                return null;
+            }
+
+            var declaredSymbol = model.GetDeclaredSymbol(node, cancellationToken);
+
+            // For namespace declarations, GetDeclaredSymbol returns a compilation scoped namespace symbol,
+            // which includes declarations across the compilation, including those in referenced assemblies.
+            // However, we are only interested in the namespace symbol scoped to the compilation's source assembly.
+            var namespaceSymbol = declaredSymbol as INamespaceSymbol;
+            if (namespaceSymbol != null && namespaceSymbol.ConstituentNamespaces.Length > 1)
+            {
+                var assemblyToScope = model.Compilation.Assembly;
+                var assemblyScopedNamespaceSymbol = namespaceSymbol.ConstituentNamespaces.FirstOrDefault(ns => ns.ContainingAssembly == assemblyToScope);
+                if (assemblyScopedNamespaceSymbol != null)
+                {
+                    Debug.Assert(assemblyScopedNamespaceSymbol.ConstituentNamespaces.Length == 1);
+                    declaredSymbol = assemblyScopedNamespaceSymbol;
+                }
+            }
+
+            return declaredSymbol;
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -182,7 +182,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             var builder = ImmutableArray.CreateBuilder<CompilationEvent>();
             foreach (var symbol in declaredSymbols)
-            {   
+            {
+                Debug.Assert(symbol.ContainingAssembly == compilation.Assembly);
                 builder.Add(new SymbolDeclaredCompilationEvent(compilation, symbol));
             }
 


### PR DESCRIPTION
…h are scoped to source assembly being analyzed, not the merged namespace symbols with declaring references across the compilation (including referenced assemblies).