### PR TITLE
Make captured "this" a constant in expression trees.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -202,7 +202,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.DelegateCreationExpression:
                     return VisitDelegateCreationExpression((BoundDelegateCreationExpression)node);
                 case BoundKind.FieldAccess:
-                    return VisitFieldAccess((BoundFieldAccess)node);
+                    var fieldAccess = (BoundFieldAccess)node;
+                    if (fieldAccess.FieldSymbol.IsCapturedFrame)
+                    {
+                        return Constant(fieldAccess);
+                    }
+                    return VisitFieldAccess(fieldAccess);
                 case BoundKind.IsOperator:
                     return VisitIsOperator((BoundIsOperator)node);
                 case BoundKind.Lambda:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -5861,6 +5861,65 @@ value(ConsoleApplication6.Program)";
                 expectedOutput: expectedOutput);
         }
 
+        [WorkItem(6416, "https://github.com/dotnet/roslyn/issues/6416")]
+        [Fact]
+        public void CapturedThis002()
+        {
+            const string source = @"
+using System;
+using System.Linq.Expressions;
+
+namespace ConsoleApplication6
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var v = new Program();
+            v.test();
+        }
+
+        public int P1
+        {
+            get
+            {
+                return 42;
+            }
+        }
+
+        public void test()
+        {
+            var local = 0;
+
+         Func<Expression<Func<Expression<Func<int>>>>> ff = () =>
+         {
+             Func<Expression<Func<int>>> f =
+                    () =>
+                    {
+                        System.Console.WriteLine(P1 + local);
+                        return () => P1;
+                    };
+
+                return () => f();
+            };
+
+            System.Console.WriteLine((ff().Compile()().Body as MemberExpression).Expression);
+        }
+    }
+}
+";
+
+            const string expectedOutput = @"42
+value(ConsoleApplication6.Program)";
+
+            CompileAndVerify(
+                new[] {
+                    source,
+                },
+                new[] { ExpressionAssemblyRef },
+                expectedOutput: expectedOutput);
+        }
+
         #endregion Regression Tests
 
         #region helpers

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -5808,6 +5808,58 @@ class C //: TestBase
                 expectedOutput: expectedOutput);
         }
 
+        [WorkItem(6416, "https://github.com/dotnet/roslyn/issues/6416")]
+        [Fact]
+        public void CapturedThis001()
+        {
+            const string source = @"
+using System;
+using System.Linq.Expressions;
+
+namespace ConsoleApplication6
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var v = new Program();
+            v.test();
+        }
+
+        public int P1
+        {
+            get
+            {
+                return 42;
+            }
+        }
+
+        public void test()
+        {
+            var local = 0;
+            Func<Expression<Func<int>>> f =
+                () =>
+                {
+                    System.Console.WriteLine(P1 + local);
+                    return () => P1;
+                };
+
+            System.Console.WriteLine((f().Body as MemberExpression).Expression);
+        }
+    }
+}
+";
+
+            const string expectedOutput = @"42
+value(ConsoleApplication6.Program)";
+
+            CompileAndVerify(
+                new[] {
+                    source,
+                },
+                new[] { ExpressionAssemblyRef },
+                expectedOutput: expectedOutput);
+        }
 
         #endregion Regression Tests
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
@@ -217,7 +217,11 @@ lSelect:
                 Case BoundKind.DirectCast
                     Return VisitDirectCast(DirectCast(node, BoundDirectCast))
                 Case BoundKind.FieldAccess
-                    Return VisitFieldAccess(DirectCast(node, BoundFieldAccess))
+                    Dim fieldAccess = DirectCast(node, BoundFieldAccess)
+                    If fieldAccess.FieldSymbol.IsCapturedFrame Then
+                        Return CreateLiteralExpression(node)
+                    End If
+                    Return VisitFieldAccess(fieldAccess)
                 Case BoundKind.Lambda
                     Return VisitLambda(DirectCast(node, BoundLambda))
                 Case BoundKind.NewT

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -8198,5 +8198,55 @@ End Module
 
         End Sub
 
+        <Fact, WorkItem(6416, "https://github.com/dotnet/roslyn/issues/6416")>
+        Public Sub CapturedMe001()
+
+            Dim source = <compilation>
+                             <file name="a.vb"><![CDATA[
+
+Imports System
+Imports System.Linq.Expressions
+
+
+Class Module1
+    Public Shared Sub Main()
+        Dim v = New Module1()
+        v.test()
+    End Sub
+
+    Public ReadOnly Property P1 As Integer
+        Get
+            Return 42
+        End Get
+    End Property
+
+    Public Sub test()
+        Dim local = 0
+        Dim f As Func(Of Expression(Of Func(Of Integer))) =
+                Function()
+                    System.Console.WriteLine(P1 + local)
+                    Return Function() P1
+                End Function
+
+        System.Console.WriteLine(DirectCast(f().Body, MemberExpression).Expression)
+    End Sub
+End Class
+
+
+
+                            ]]></file>
+                         </compilation>
+
+
+            CompileAndVerify(source,
+                 additionalRefs:={SystemCoreRef},
+                 options:=TestOptions.ReleaseExe,
+                 expectedOutput:=<![CDATA[
+42
+value(Module1)
+]]>).VerifyDiagnostics()
+
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
"this" is semantically readonly, so it can be expressed as a constant in expression trees, and that is what native compiler does, and so should do Roslyn.

Fixes #6416