### PR TITLE
Address FixAll performance regression in Update1

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
@@ -36,7 +36,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 _currentlyAnalyzingDeclarationsMapPool = currentlyAnalyzingDeclarationsMapPool;
             }
 
-            public IEnumerable<CompilationEvent> PendingEvents_NoLock => _pendingEvents.Keys;
+            public void AddPendingEvents(HashSet<CompilationEvent> uniqueEvents)
+            {
+                lock (_gate)
+                {
+                    foreach (var pendingEvent in _pendingEvents.Keys)
+                    {
+                        uniqueEvents.Add(pendingEvent);
+                    }
+                }
+            }
 
             public bool HasPendingSyntaxAnalysis(SyntaxTree treeOpt)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -478,10 +478,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             foreach (var analyzer in analyzers)
             {
                 var analyzerState = GetAnalyzerState(analyzer);
-                foreach (var pendingEvent in analyzerState.PendingEvents_NoLock)
-                {
-                    uniqueEvents.Add(pendingEvent);
-                }
+                analyzerState.AddPendingEvents(uniqueEvents);
             }
 
             return uniqueEvents;

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -25,8 +25,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private readonly TextSpan? _span;
         private readonly Project _project;
         private readonly DiagnosticIncrementalAnalyzer _owner;
+        private readonly bool _concurrentAnalysis;
+        private readonly bool _reportSuppressedDiagnostics;
         private readonly CancellationToken _cancellationToken;
-        private readonly CompilationWithAnalyzersOptions _analysisOptions;
 
         private CompilationWithAnalyzers _lazyCompilationWithAnalyzers;
 
@@ -35,8 +36,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             TextSpan? span,
             SyntaxNode root,
             DiagnosticIncrementalAnalyzer owner,
+            bool concurrentAnalysis,
+            bool reportSuppressedDiagnostics,
             CancellationToken cancellationToken)
-            : this(document.Project, owner, cancellationToken)
+            : this(document, span, root, owner, concurrentAnalysis, reportSuppressedDiagnostics, cachedCompilationWithAnalyzersOpt: null, cancellationToken: cancellationToken)
+        {
+        }
+
+        public DiagnosticAnalyzerDriver(
+            Document document,
+            TextSpan? span,
+            SyntaxNode root,
+            DiagnosticIncrementalAnalyzer owner,
+            bool concurrentAnalysis,
+            bool reportSuppressedDiagnostics,
+            CompilationWithAnalyzers cachedCompilationWithAnalyzersOpt,
+            CancellationToken cancellationToken)
+            : this(document.Project, owner, concurrentAnalysis, reportSuppressedDiagnostics, cachedCompilationWithAnalyzersOpt, cancellationToken)
         {
             _document = document;
             _span = span;
@@ -46,18 +62,27 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         public DiagnosticAnalyzerDriver(
             Project project,
             DiagnosticIncrementalAnalyzer owner,
+            bool concurrentAnalysis,
+            bool reportSuppressedDiagnostics,
+            CancellationToken cancellationToken)
+            : this (project, owner, concurrentAnalysis, reportSuppressedDiagnostics, cachedCompilationWithAnalyzersOpt: null, cancellationToken: cancellationToken)
+        {
+        }
+
+        public DiagnosticAnalyzerDriver(
+            Project project,
+            DiagnosticIncrementalAnalyzer owner,
+            bool concurrentAnalysis,
+            bool reportSuppressedDiagnostics,
+            CompilationWithAnalyzers cachedCompilationWithAnalyzersOpt,
             CancellationToken cancellationToken)
         {
             _project = project;
             _owner = owner;
+            _concurrentAnalysis = concurrentAnalysis;
+            _reportSuppressedDiagnostics = reportSuppressedDiagnostics;
             _cancellationToken = cancellationToken;
-            _analysisOptions = new CompilationWithAnalyzersOptions(
-                new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Workspace),
-                owner.GetOnAnalyzerException(project.Id),
-                concurrentAnalysis: false,
-                logAnalyzerExecutionTime: true,
-                reportSuppressedDiagnostics: true);
-            _lazyCompilationWithAnalyzers = null;
+            _lazyCompilationWithAnalyzers = cachedCompilationWithAnalyzersOpt;
         }
 
         public Document Document
@@ -101,12 +126,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             if (_lazyCompilationWithAnalyzers == null)
             {
-                var analyzers = _owner
-                        .GetAnalyzers(_project)
-                        .Where(a => !CompilationWithAnalyzers.IsDiagnosticAnalyzerSuppressed(a, compilation.Options, _analysisOptions.OnAnalyzerException))
-                        .ToImmutableArray()
-                        .Distinct();
-                Interlocked.CompareExchange(ref _lazyCompilationWithAnalyzers, new CompilationWithAnalyzers(compilation, analyzers, _analysisOptions), null);
+                Interlocked.CompareExchange(
+                    ref _lazyCompilationWithAnalyzers,
+                    _owner.GetCompilationWithAnalyzers(_project, compilation, _concurrentAnalysis, _reportSuppressedDiagnostics),
+                    null);
             }
 
             return _lazyCompilationWithAnalyzers;
@@ -187,7 +210,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 exceptionDiagnostic = CompilationWithAnalyzers.GetEffectiveDiagnostics(ImmutableArray.Create(exceptionDiagnostic), compilation).SingleOrDefault();
             }
 
-            _analysisOptions.OnAnalyzerException(ex, analyzer, exceptionDiagnostic);
+            var onAnalyzerException = _owner.GetOnAnalyzerException(_project.Id);
+            onAnalyzerException(ex, analyzer, exceptionDiagnostic);
         }
 
         public async Task<ImmutableArray<Diagnostic>> GetSemanticDiagnosticsAsync(DiagnosticAnalyzer analyzer)

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             private void ValidateMemberDiagnostics(DiagnosticAnalyzer analyzer, Document document, SyntaxNode root, ImmutableArray<DiagnosticData> diagnostics)
             {
 #if RANGE
-                var documentBasedDriver = new DiagnosticAnalyzerDriver(document, root.FullSpan, root, this, CancellationToken.None);
+                var documentBasedDriver = new DiagnosticAnalyzerDriver(document, root.FullSpan, root, this, ConcurrentAnalysis, ReportSuppressedDiagnostics, CancellationToken.None);
                 var expected = GetSemanticDiagnosticsAsync(documentBasedDriver, analyzer).WaitAndGetResult(documentBasedDriver.CancellationToken) ?? SpecializedCollections.EmptyEnumerable<DiagnosticData>();
                 Contract.Requires(diagnostics.SetEquals(expected));
 #endif

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetLatestDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetLatestDiagnosticsForSpan.cs
@@ -55,10 +55,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                 // Share the diagnostic analyzer driver across all analyzers.
                 var fullSpan = root?.FullSpan;
+                
+                // We are computing diagnostics for a single document/span, so we don't need to enable concurrent analysis.
+                const bool concurrentAnalysis = false;
+                const bool reportSuppressedDiagnostics = true;
 
-                _spanBasedDriver = new DiagnosticAnalyzerDriver(_document, _range, root, _owner, _cancellationToken);
-                _documentBasedDriver = new DiagnosticAnalyzerDriver(_document, fullSpan, root, _owner, _cancellationToken);
-                _projectDriver = new DiagnosticAnalyzerDriver(_document.Project, _owner, _cancellationToken);
+                _spanBasedDriver = new DiagnosticAnalyzerDriver(_document, _range, root, _owner, concurrentAnalysis, reportSuppressedDiagnostics, _cancellationToken);
+                _documentBasedDriver = new DiagnosticAnalyzerDriver(_document, fullSpan, root, _owner, concurrentAnalysis, reportSuppressedDiagnostics, _cancellationToken);
+                _projectDriver = new DiagnosticAnalyzerDriver(_document.Project, _owner, concurrentAnalysis, reportSuppressedDiagnostics, _cancellationToken);
             }
 
             public List<DiagnosticData> Diagnostics { get; }


### PR DESCRIPTION
Ensure that we use a single CompilationWithAnalyzers instance for computing diagnostics with the LatestDiagnosticsGetter (FixAll code path and other explicit GetDiagnostics requests to the diagnostic service). This avoids us cloning the compilation and re-running analyzer compilation start actions once per each document for which we need to compute diagnostics.

Background analysis based off the solution crawler still creates a new CompilationWithAnalyzers instance per document analysis request as caching it in memory causes high VM usage.

This change addresses the FixAll performance regression in VS2015 Update1 reported in https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/1979#issuecomment-166656002. 