### PR TITLE
Adjust implementation of NamedTypeSymbol equality to treat generic type, constructed with modified its own type parameters, equal  to its definition when custom modifiers should be ignored.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -652,13 +652,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var thisOriginalDefinition = this.OriginalDefinition;
             var otherOriginalDefinition = other.OriginalDefinition;
 
+            if (((object)this == (object)thisOriginalDefinition || (object)other == (object)otherOriginalDefinition) &&
+                !(ignoreCustomModifiersAndArraySizesAndLowerBounds && (this.HasTypeArgumentsCustomModifiers || other.HasTypeArgumentsCustomModifiers)))
+            {
+                return false;
+            }
+
             // CONSIDER: original definitions are not unique for missing metadata type
             // symbols.  Therefore this code may not behave correctly if 'this' is List<int>
             // where List`1 is a missing metadata type symbol, and other is similarly List<int>
             // but for a reference-distinct List`1.
-            if (((object)this == (object)thisOriginalDefinition) ||
-                ((object)other == (object)otherOriginalDefinition) ||
-                (thisOriginalDefinition != otherOriginalDefinition))
+            if (thisOriginalDefinition != otherOriginalDefinition)
             {
                 return false;
             }
@@ -691,7 +695,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            if (thisIsNotConstructed || otherIsNotConstructed || this.IsUnboundGenericType != other.IsUnboundGenericType)
+            if (((thisIsNotConstructed || otherIsNotConstructed) && 
+                 !(ignoreCustomModifiersAndArraySizesAndLowerBounds && (this.HasTypeArgumentsCustomModifiers || other.HasTypeArgumentsCustomModifiers))) || 
+                this.IsUnboundGenericType != other.IsUnboundGenericType)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -1633,5 +1633,63 @@ namespace ConsoleApplication21
             CompileAndVerify(compilation, expectedOutput: @"Implemented A
 Implemented B");
         }
+
+        [Fact, WorkItem(6372, "https://github.com/dotnet/roslyn/issues/6372")]
+        public void ModifiedTypeParameterAsTypeArgument_01()
+        {
+            var ilSource = @"
+.class public auto ansi beforefieldinit CL1`1<T1>
+       extends[mscorlib] System.Object
+{
+    .method public hidebysig specialname rtspecialname
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000: ldarg.0
+      IL_0001: call instance void[mscorlib] System.Object::.ctor()
+      IL_0006:
+        ret
+    } // end of method CL1`1::.ctor
+
+    .method public hidebysig newslot virtual
+            instance void  Test1(class CL1`1<!T1 modopt([mscorlib]System.Runtime.CompilerServices.IsConst)> t1) cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  0
+      IL_0000:
+        ret
+    } // end of method CL1`1::Test
+
+    .method public hidebysig newslot virtual
+            instance void  Test2(class CL1`1<!T1> t1) cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  0
+      IL_0000:
+        ret
+    } // end of method CL1`1::Test
+} // end of class CL1`1
+";
+            var source = @"";
+            var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseExe);
+
+            var cl1 = compilation.GetTypeByMetadataName("CL1`1");
+            var test1 = cl1.GetMember<MethodSymbol>("Test1");
+            Assert.Equal("void CL1<T1>.Test1(CL1<T1 modopt(System.Runtime.CompilerServices.IsConst)> t1)", test1.ToTestDisplayString());
+
+            var test2 = cl1.GetMember<MethodSymbol>("Test2");
+            Assert.Equal("void CL1<T1>.Test2(CL1<T1> t1)", test2.ToTestDisplayString());
+
+            var t1 = test1.Parameters[0].Type;
+            var t2 = test2.Parameters[0].Type;
+
+            Assert.False(t1.Equals(t2));
+            Assert.False(t2.Equals(t1));
+
+            Assert.True(t1.Equals(t2, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+            Assert.True(t2.Equals(t1, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+        }
+
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -201,11 +201,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim t1IsDefinition = t1.IsDefinition
                 Dim t2IsDefinition = t2.IsDefinition
 
-                If (t1IsDefinition <> t2IsDefinition) Then
+                If (t1IsDefinition <> t2IsDefinition) AndAlso
+                   Not (DirectCast(t1, NamedTypeSymbol).HasTypeArgumentsCustomModifiers OrElse DirectCast(t2, NamedTypeSymbol).HasTypeArgumentsCustomModifiers) Then
                     Return False
                 End If
 
-                If Not t1IsDefinition Then ' This is a generic instantiation
+                If Not (t1IsDefinition AndAlso t2IsDefinition) Then ' This is a generic instantiation case
 
                     If t1.OriginalDefinition <> t2.OriginalDefinition Then
                         Return False ' different definition

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CustomModifiersTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CustomModifiersTests.vb
@@ -1585,5 +1585,68 @@ End Class
 Implemented B")
         End Sub
 
+        <Fact, WorkItem(6372, "https://github.com/dotnet/roslyn/issues/6372")>
+        Public Sub ModifiedTypeParameterAsTypeArgument_01()
+            Dim ilSource = <![CDATA[
+.class public auto ansi beforefieldinit CL1`1<T1>
+       extends[mscorlib] System.Object
+{
+    .method public hidebysig specialname rtspecialname
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      IL_0000: ldarg.0
+      IL_0001: call instance void[mscorlib] System.Object::.ctor()
+      IL_0006:
+        ret
+    } // end of method CL1`1::.ctor
+
+    .method public hidebysig newslot virtual
+            instance void  Test1(class CL1`1<!T1 modopt([mscorlib]System.Runtime.CompilerServices.IsConst)> t1) cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  0
+      IL_0000:
+        ret
+    } // end of method CL1`1::Test
+
+    .method public hidebysig newslot virtual
+            instance void  Test2(class CL1`1<!T1> t1) cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  0
+      IL_0000:
+        ret
+    } // end of method CL1`1::Test
+} // end of class CL1`1
+]]>.Value
+
+            Dim vbSource =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithCustomILSource(vbSource, ilSource, options:=TestOptions.ReleaseExe)
+
+            Dim cl1 = compilation.GetTypeByMetadataName("CL1`1")
+            Dim test1 = cl1.GetMember(Of MethodSymbol)("Test1")
+            Assert.Equal("Sub CL1(Of T1).Test1(t1 As CL1(Of T1 modopt(System.Runtime.CompilerServices.IsConst)))", test1.ToTestDisplayString())
+
+            Dim test2 = cl1.GetMember(Of MethodSymbol)("Test2")
+            Assert.Equal("Sub CL1(Of T1).Test2(t1 As CL1(Of T1))", test2.ToTestDisplayString())
+
+            Dim t1 = test1.Parameters(0).Type
+            Dim t2 = test2.Parameters(0).Type
+
+            Assert.False(t1.Equals(t2))
+            Assert.False(t2.Equals(t1))
+
+            Assert.True(t1.IsSameTypeIgnoringCustomModifiers(t2))
+            Assert.True(t2.IsSameTypeIgnoringCustomModifiers(t1))
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #6372.

@dotnet/roslyn-compiler Please review.