### PR TITLE
[Testing - DO NOT REVIEW] Use current TaskScheduler...

### DIFF
--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                             {
                                 var c = new Control();
                                 c.CreateControl();
-                                s_UIThreadScheduler = TaskScheduler.FromCurrentSynchronizationContext();
+                                s_UIThreadScheduler = TaskScheduler.Current;
                                 resetEvent.Set();
                                 Application.Run();
                             });


### PR DESCRIPTION
rather than FromCurrentSynchronizationContext...

The latter appears to schedule ALL Tasks on the same thread (rather than just the initial "kickoff" Task).