### PR TITLE
Fix for unverifiable codegen for conditional access when result constrained to class

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2486,15 +2486,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             if (used)
             {
-                var constantValue = type.GetDefaultValue();
-                if (constantValue != null)
+                // default type parameter values must be emitted as 'initobj' regardless of constraints
+                if (!type.IsTypeParameter())
                 {
-                    _builder.EmitConstantValue(constantValue);
+                    var constantValue = type.GetDefaultValue();
+                    if (constantValue != null)
+                    {
+                        _builder.EmitConstantValue(constantValue);
+                        return;
+                    }
                 }
-                else
-                {
-                    EmitInitObj(type, true, syntaxNode);
-                }
+
+                EmitInitObj(type, true, syntaxNode);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // IL gen can generate more compact code for certain conditional accesses 
         // by utilizing stack dup/pop instructions 
-        internal BoundExpression RewriteConditionalAccess(BoundConditionalAccess node, bool used, BoundExpression rewrittenWhenNull = null)
+        internal BoundExpression RewriteConditionalAccess(BoundConditionalAccess node, bool used)
         {
             Debug.Assert(!_inExpressionLambda);
 
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Check trivial case
             if (loweredReceiver.IsDefaultValue())
             {
-                return rewrittenWhenNull ?? _factory.Default(node.Type);
+                return _factory.Default(node.Type);
             }
 
             ConditionalAccessLoweringKind loweringKind;
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                  GetNullableMethod(node.Syntax, loweredReceiver.Type, SpecialMember.System_Nullable_T_get_HasValue) :
                                  null,
                         loweredAccessExpression,
-                        rewrittenWhenNull,
+                        null,
                         currentConditionalAccessID,
                         type);
 
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         result = RewriteConditionalOperator(node.Syntax,
                             condition,
                             consequence,
-                            rewrittenWhenNull ?? _factory.Default(nodeType),
+                            _factory.Default(nodeType),
                             null,
                             nodeType);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -6843,5 +6843,56 @@ class C
 }
 ");
         }
+
+        [WorkItem(7388, "https://github.com/dotnet/roslyn/issues/7388")]
+        [Fact]
+        public void ConditionalClassConstrained001()
+        {
+            var source = @"
+using System;
+
+namespace ConsoleApplication9
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var v = new A<object>();
+            System.Console.WriteLine(A<object>.Test(v));
+        }
+
+        public class A<T> : object where T : class
+        {
+            public T Value { get { return (T)(object)42; }}
+
+            public static T Test(A<T> val)
+            {
+                return val?.Value;
+            }
+        }
+    }
+}
+
+
+";
+            var verifier = CompileAndVerify(source, expectedOutput: @"42");
+
+            verifier.VerifyIL("ConsoleApplication9.Program.A<T>.Test(ConsoleApplication9.Program.A<T>)", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (T V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  brtrue.s   IL_000d
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.0
+  IL_000c:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  call       ""T ConsoleApplication9.Program.A<T>.Value.get""
+  IL_0013:  ret
+}");
+        }
+
     }
 }

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitConversion.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitConversion.vb
@@ -141,7 +141,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Dim typeTo = conversion.Type
 
             If conversion.Operand.IsNothingLiteral Then
-                Debug.Assert(typeTo.IsValueType AndAlso Not typeTo.IsTypeParameter)
+                Debug.Assert(typeTo.IsValueType OrElse typeTo.IsTypeParameter)
 
                 If used Then
                     'TODO: used


### PR DESCRIPTION
Fix for unverifiable codegen for conditional access when result constrained to class

default(T) should not be emitted as "null" even if T is constrained to "class"

FIxes #7388