### PR TITLE
Account for presence of inapplicable extension methods of the same viability when binding arguments for error recovery in presence of single instance method candidate.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2771,7 +2771,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         typeArguments: ImmutableArray<TypeSymbol>.Empty,
                         analyzedArguments: analyzedArguments,
                         invokedAsExtensionMethod: false,
-                        isDelegate: false);
+                        isDelegate: false,
+                        extensionMethodsOfSameViabilityAreAvailable: false);
                     result.WasCompilerGenerated = initializerArgumentListOpt == null;
                     return result;
                 }
@@ -5173,7 +5174,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 OverloadResolution.MethodInvocationOverloadResolution(methodGroup.Methods, methodGroup.TypeArguments, actualArguments, overloadResolutionResult, ref useSiteDiagnostics, isMethodGroupConversion, allowRefOmittedArguments);
                 diagnostics.Add(expression, useSiteDiagnostics);
                 var sealedDiagnostics = diagnostics.ToReadOnlyAndFree();
-                var result = new MethodGroupResolution(methodGroup, null, overloadResolutionResult, actualArguments, methodGroup.ResultKind, sealedDiagnostics);
+                var result = new MethodGroupResolution(methodGroup, null, overloadResolutionResult, actualArguments, methodGroup.ResultKind, sealedDiagnostics,
+                                                       extensionMethodsOfSameViabilityAreAvailable: false);
 
                 // If the search in the current scope resulted in any applicable method (regardless of whether a best 
                 // applicable method could be determined) then our search is complete. Otherwise, store aside the
@@ -6167,7 +6169,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var diagnostics = DiagnosticBag.GetInstance();
                 diagnostics.AddRange(methodResolution.Diagnostics); // Could still have use site warnings.
                 BindMemberAccessReportError(node, diagnostics);
-                return new MethodGroupResolution(methodResolution.MethodGroup, methodResolution.OtherSymbol, methodResolution.OverloadResolutionResult, methodResolution.AnalyzedArguments, methodResolution.ResultKind, diagnostics.ToReadOnlyAndFree());
+                return new MethodGroupResolution(methodResolution.MethodGroup, methodResolution.OtherSymbol, methodResolution.OverloadResolutionResult, methodResolution.AnalyzedArguments, methodResolution.ResultKind, diagnostics.ToReadOnlyAndFree(),
+                                                 methodResolution.ExtensionMethodsOfSameViabilityAreAvailable);
             }
             return methodResolution;
         }
@@ -6196,6 +6199,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var extensionMethodResolution = BindExtensionMethod(expression, methodName, analyzedArguments, methodGroup.ReceiverOpt, methodGroup.TypeArgumentsOpt, isMethodGroupConversion);
 
             bool preferExtensionMethodResolution = false;
+            bool extensionMethodsOfSameViabilityAreAvailable = false;
+
             if (extensionMethodResolution.HasAnyApplicableMethod)
             {
                 preferExtensionMethodResolution = true;
@@ -6220,8 +6225,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 LookupResultKind methodResultKind = methodResolution.ResultKind;
                 LookupResultKind extensionMethodResultKind = extensionMethodResolution.ResultKind;
-                if (methodResultKind != extensionMethodResultKind &&
-                    methodResultKind == extensionMethodResultKind.WorseResultKind(methodResultKind))
+                if (methodResultKind == extensionMethodResultKind)
+                {
+                    // This information allows us to preserve more useful information for SemanticModel.
+                    extensionMethodsOfSameViabilityAreAvailable = true;
+                }
+                else if (methodResultKind == extensionMethodResultKind.WorseResultKind(methodResultKind))
                 {
                     preferExtensionMethodResolution = true;
                 }
@@ -6235,6 +6244,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             extensionMethodResolution.Free();
+
+            if (extensionMethodsOfSameViabilityAreAvailable)
+            {
+                return new MethodGroupResolution(methodResolution.MethodGroup,
+                                                 methodResolution.OtherSymbol,
+                                                 methodResolution.OverloadResolutionResult, 
+                                                 methodResolution.AnalyzedArguments, 
+                                                 methodResolution.ResultKind,
+                                                 methodResolution.Diagnostics,
+                                                 extensionMethodsOfSameViabilityAreAvailable: true);
+            }
+
             return methodResolution;
         }
 
@@ -6293,7 +6314,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     methodGroup.Methods, methodGroup.TypeArguments, analyzedArguments,
                     result, ref useSiteDiagnostics, isMethodGroupConversion, allowRefOmittedArguments,
                     inferWithDynamic: inferWithDynamic, allowUnexpandedForm: allowUnexpandedForm);
-                return new MethodGroupResolution(methodGroup, null, result, analyzedArguments, methodGroup.ResultKind, sealedDiagnostics);
+                return new MethodGroupResolution(methodGroup, null, result, analyzedArguments, methodGroup.ResultKind, sealedDiagnostics,
+                                                 extensionMethodsOfSameViabilityAreAvailable: false);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -415,7 +415,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                result = BindInvocationExpressionContinued(node, expression, methodName, overloadResolutionResult, analyzedArguments, methodGroup, delegateType, diagnostics, queryClause);
+                result = BindInvocationExpressionContinued(node, expression, methodName, overloadResolutionResult, analyzedArguments, methodGroup, delegateType, diagnostics, false, queryClause);
             }
 
             overloadResolutionResult.Free();
@@ -483,7 +483,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     typeArguments,
                     analyzedArguments,
                     invokedAsExtensionMethod: resolution.IsExtensionMethodGroup,
-                    isDelegate: false);
+                    isDelegate: false,
+                    extensionMethodsOfSameViabilityAreAvailable: resolution.ExtensionMethodsOfSameViabilityAreAvailable);
             }
             else if (!resolution.IsEmpty)
             {
@@ -498,7 +499,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // we want to force any unbound lambda arguments to cache an appropriate conversion if possible; see 9448.
                         DiagnosticBag discarded = DiagnosticBag.GetInstance();
-                        result = BindInvocationExpressionContinued(syntax, expression, methodName, resolution.OverloadResolutionResult, resolution.AnalyzedArguments, resolution.MethodGroup, null, discarded, queryClause);
+                        result = BindInvocationExpressionContinued(syntax, expression, methodName, resolution.OverloadResolutionResult, resolution.AnalyzedArguments, resolution.MethodGroup, null, discarded, 
+                                                                   resolution.ExtensionMethodsOfSameViabilityAreAvailable, queryClause);
                         discarded.Free();
                     }
 
@@ -553,7 +555,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         result = BindInvocationExpressionContinued(
                             syntax, expression, methodName, resolution.OverloadResolutionResult, resolution.AnalyzedArguments,
-                            resolution.MethodGroup, null, diagnostics, queryClause);
+                            resolution.MethodGroup, null, diagnostics, resolution.ExtensionMethodsOfSameViabilityAreAvailable, queryClause);
                     }
                 }
             }
@@ -676,6 +678,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="methodGroup">Method group if the invocation represents a potentially overloaded member.</param>
         /// <param name="delegateTypeOpt">Delegate type if method group represents a delegate.</param>
         /// <param name="diagnostics">Diagnostics.</param>
+        /// <param name="extensionMethodsOfSameViabilityAreAvailable">
+        /// Indicates that there are additional extension method candidates of the same lookup viability in cases when 
+        /// none of the instance methods are applicable to the argument list.
+        /// </param>
         /// <param name="queryClause">The syntax for the query clause generating this invocation expression, if any.</param>
         /// <returns>BoundCall or error expression representing the invocation.</returns>
         private BoundCall BindInvocationExpressionContinued(
@@ -687,6 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodGroup methodGroup,
             NamedTypeSymbol delegateTypeOpt,
             DiagnosticBag diagnostics,
+            bool extensionMethodsOfSameViabilityAreAvailable,
             CSharpSyntaxNode queryClause = null)
         {
             Debug.Assert(node != null);
@@ -726,7 +733,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 return CreateBadCall(node, methodGroup.Name, invokedAsExtensionMethod && analyzedArguments.Arguments.Count > 0 && (object)methodGroup.Receiver == (object)analyzedArguments.Arguments[0] ? null : methodGroup.Receiver,
-                    GetOriginalMethods(result), methodGroup.ResultKind, methodGroup.TypeArguments.ToImmutable(), analyzedArguments, invokedAsExtensionMethod: invokedAsExtensionMethod, isDelegate: ((object)delegateTypeOpt != null));
+                    GetOriginalMethods(result), methodGroup.ResultKind, methodGroup.TypeArguments.ToImmutable(), analyzedArguments, invokedAsExtensionMethod: invokedAsExtensionMethod, isDelegate: ((object)delegateTypeOpt != null),
+                    extensionMethodsOfSameViabilityAreAvailable: extensionMethodsOfSameViabilityAreAvailable);
             }
 
             // Otherwise, there were no dynamic arguments and overload resolution found a unique best candidate. 
@@ -950,7 +958,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeSymbol> typeArguments,
             AnalyzedArguments analyzedArguments,
             bool invokedAsExtensionMethod,
-            bool isDelegate)
+            bool isDelegate,
+            bool extensionMethodsOfSameViabilityAreAvailable)
         {
             MethodSymbol method;
             ImmutableArray<BoundExpression> args;
@@ -965,10 +974,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methods = constructedMethods.ToImmutableAndFree();
             }
 
-            if (methods.Length == 1)
+            if (methods.Length == 1 && !extensionMethodsOfSameViabilityAreAvailable)
             {
-                // If there is only one method in the group, we should attempt to bind to it.  That includes
-                // binding any lambdas in the argument list against the method's parameter types.
+                // If there is only one method in the group and no additional extension methods with the same lookup viability,
+                // we should attempt to bind to it.  That includes binding any lambdas in the argument list against
+                // the method's parameter types.
                 method = methods[0];
                 args = BuildArgumentsForErrorRecovery(analyzedArguments, method.Parameters);
             }

--- a/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/MethodGroupResolution.cs
@@ -19,9 +19,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly AnalyzedArguments AnalyzedArguments;
         public readonly ImmutableArray<Diagnostic> Diagnostics;
         public readonly LookupResultKind ResultKind;
+        public readonly bool ExtensionMethodsOfSameViabilityAreAvailable;
 
         public MethodGroupResolution(MethodGroup methodGroup, ImmutableArray<Diagnostic> diagnostics)
-            : this(methodGroup, null, null, null, methodGroup.ResultKind, diagnostics)
+            : this(methodGroup, null, null, null, methodGroup.ResultKind, diagnostics, false)
         {
         }
 
@@ -30,12 +31,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             OverloadResolutionResult<MethodSymbol> overloadResolutionResult,
             AnalyzedArguments analyzedArguments,
             ImmutableArray<Diagnostic> diagnostics)
-            : this(methodGroup, null, overloadResolutionResult, analyzedArguments, methodGroup.ResultKind, diagnostics)
+            : this(methodGroup, null, overloadResolutionResult, analyzedArguments, methodGroup.ResultKind, diagnostics, false)
         {
         }
 
         public MethodGroupResolution(Symbol otherSymbol, LookupResultKind resultKind, ImmutableArray<Diagnostic> diagnostics)
-            : this(null, otherSymbol, null, null, resultKind, diagnostics)
+            : this(null, otherSymbol, null, null, resultKind, diagnostics, false)
         {
         }
 
@@ -45,7 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             OverloadResolutionResult<MethodSymbol> overloadResolutionResult,
             AnalyzedArguments analyzedArguments,
             LookupResultKind resultKind,
-            ImmutableArray<Diagnostic> diagnostics)
+            ImmutableArray<Diagnostic> diagnostics,
+            bool extensionMethodsOfSameViabilityAreAvailable)
         {
             Debug.Assert((methodGroup == null) || (methodGroup.Methods.Count > 0));
             Debug.Assert((methodGroup == null) || ((object)otherSymbol == null));
@@ -53,6 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(((object)otherSymbol == null) || (otherSymbol.Kind != SymbolKind.Method));
             Debug.Assert(resultKind != LookupResultKind.Ambiguous); // HasAnyApplicableMethod is expecting Viable methods.
             Debug.Assert(!diagnostics.IsDefault);
+            Debug.Assert(!extensionMethodsOfSameViabilityAreAvailable || methodGroup == null || !methodGroup.IsExtensionMethodGroup);
 
             this.MethodGroup = methodGroup;
             this.OtherSymbol = otherSymbol;
@@ -60,6 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.AnalyzedArguments = analyzedArguments;
             this.ResultKind = resultKind;
             this.Diagnostics = diagnostics;
+            this.ExtensionMethodsOfSameViabilityAreAvailable = extensionMethodsOfSameViabilityAreAvailable;
         }
 
         public bool IsEmpty


### PR DESCRIPTION
Fixes #5128.

@dotnet/roslyn-compiler Please review.