### PR TITLE
Make /delaysign and /publicsign used together an error

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -565,6 +565,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     builder.Add(Diagnostic.Create(MessageProvider.Instance, (int)ErrorCode.ERR_MutuallyExclusiveOptions, nameof(CryptoPublicKey), nameof(CryptoKeyContainer)));
                 }
             }
+
+            if (PublicSign && DelaySign.HasValue)
+            {
+                builder.Add(Diagnostic.Create(MessageProvider.Instance, (int)ErrorCode.ERR_MutuallyExclusiveOptions, nameof(PublicSign), nameof(DelaySign)));
+            }
         }
 
         public bool Equals(CSharpCompilationOptions other)

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7217,15 +7217,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Public sign was specified and requires a public key, but no public key was specified.
-        /// </summary>
-        internal static string ERR_PublicSignNoKey {
-            get {
-                return ResourceManager.GetString("ERR_PublicSignNoKey", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The range variable &apos;{0}&apos; has already been declared.
         /// </summary>
         internal static string ERR_QueryDuplicateRangeVariable {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7217,6 +7217,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Public sign was specified and requires a public key, but no public key was specified.
+        /// </summary>
+        internal static string ERR_PublicSignNoKey {
+            get {
+                return ResourceManager.GetString("ERR_PublicSignNoKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The range variable &apos;{0}&apos; has already been declared.
         /// </summary>
         internal static string ERR_QueryDuplicateRangeVariable {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3794,6 +3794,9 @@ You should consider suppressing the warning only if you're sure that you don't w
   <data name="ERR_SignButNoPrivateKey" xml:space="preserve">
     <value>Key file '{0}' is missing the private key needed for signing</value>
   </data>
+  <data name="ERR_PublicSignNoKey" xml:space="preserve">
+    <value>Public sign was specified and requires a public key, but no public key was specified</value>
+  </data>
   <data name="WRN_DelaySignButNoKey" xml:space="preserve">
     <value>Delay signing was specified and requires a public key, but no public key was specified</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3794,8 +3794,8 @@ You should consider suppressing the warning only if you're sure that you don't w
   <data name="ERR_SignButNoPrivateKey" xml:space="preserve">
     <value>Key file '{0}' is missing the private key needed for signing</value>
   </data>
-  <data name="ERR_PublicSignNoKey" xml:space="preserve">
-    <value>Public sign was specified and requires a public key, but no public key was specified</value>
+  <data name="ERR_PublicSignButNoKey" xml:space="preserve">
+    <value>Public signing was specified and requires a public key, but no public key was specified.</value>
   </data>
   <data name="WRN_DelaySignButNoKey" xml:space="preserve">
     <value>Delay signing was specified and requires a public key, but no public key was specified</value>
@@ -4665,9 +4665,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_InvalidPathMap" xml:space="preserve">
     <value>The pathmap option was incorrectly formatted.</value>
-  </data>
-  <data name="ERR_PublicSignButNoKey" xml:space="preserve">
-    <value>Public signing was specified and requires a public key, but no public key was specified.</value>
   </data>
   <data name="ERR_InvalidReal" xml:space="preserve">
     <value>Invalid real literal.</value>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -812,6 +812,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return _compilation.Options.DelaySign.Value;
                 }
 
+                // The public sign argument should also override the attribute
+                if (_compilation.Options.PublicSign)
+                {
+                    return false;
+                }
+
                 return (this.AssemblyDelaySignAttributeSetting == ThreeState.True);
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -420,6 +420,24 @@ public class C {}
             Assert.Equal(CorFlags.ILOnly | CorFlags.StrongNameSigned, metadata.Module.PEReaderOpt.PEHeaders.CorHeader.Flags);
         }
 
+        private void VerifySignedBitSetAfterEmit(Compilation comp)
+        {
+            var outStrm = new MemoryStream();
+            var emitResult = comp.Emit(outStrm);
+            Assert.True(emitResult.Success);
+
+            outStrm.Position = 0;
+
+            // Verify that the sign bit is set
+            using (var reader = new PEReader(outStrm))
+            {
+                Assert.True(reader.HasMetadata);
+
+                var flags = reader.PEHeaders.CorHeader.Flags;
+                Assert.True(flags.HasFlag(CorFlags.StrongNameSigned));
+            }
+        }
+
         [Fact]
         public void SnkFile_PublicSign()
         {
@@ -437,20 +455,7 @@ public class C {}
             Assert.False(comp.IsRealSigned);
             Assert.NotNull(comp.Options.CryptoKeyFile);
 
-            var outStrm = new MemoryStream();
-            var emitResult = comp.Emit(outStrm);
-            Assert.True(emitResult.Success);
-
-            outStrm.Position = 0;
-
-            // Verify that the sign bit is set
-            using (var reader = new PEReader(outStrm))
-            {
-                Assert.True(reader.HasMetadata);
-
-                var flags = reader.PEHeaders.CorHeader.Flags;
-                Assert.True(flags.HasFlag(CorFlags.StrongNameSigned));
-            }
+            VerifySignedBitSetAfterEmit(comp);
         }
 
         [Fact]
@@ -470,20 +475,7 @@ public class C {}
             Assert.False(comp.IsRealSigned);
             Assert.NotNull(comp.Options.CryptoKeyFile);
 
-            var outStrm = new MemoryStream();
-            var emitResult = comp.Emit(outStrm);
-            Assert.True(emitResult.Success);
-
-            outStrm.Position = 0;
-
-            // Verify that the sign bit is set
-            using (var reader = new PEReader(outStrm))
-            {
-                Assert.True(reader.HasMetadata);
-
-                var flags = reader.PEHeaders.CorHeader.Flags;
-                Assert.True(flags.HasFlag(CorFlags.StrongNameSigned));
-            }
+            VerifySignedBitSetAfterEmit(comp);
         }
 
         [Fact]
@@ -507,22 +499,8 @@ public class C {}",
             Assert.False(comp.IsRealSigned);
             Assert.NotNull(comp.Options.CryptoKeyFile);
 
-            var outStrm = new MemoryStream();
-            var emitResult = comp.Emit(outStrm);
-            Assert.True(emitResult.Success);
-
-            outStrm.Position = 0;
-
-            // Verify that the sign bit is set
-            using (var reader = new PEReader(outStrm))
-            {
-                Assert.True(reader.HasMetadata);
-
-                var flags = reader.PEHeaders.CorHeader.Flags;
-                Assert.True(flags.HasFlag(CorFlags.StrongNameSigned));
-            }
+            VerifySignedBitSetAfterEmit(comp);
         }
-
 
         [Fact]
         public void KeyContainerNoSNProvider_PublicSign()
@@ -555,20 +533,7 @@ public class C {}",
             Assert.False(comp.IsRealSigned);
             Assert.NotNull(comp.Options.CryptoKeyContainer);
 
-            var outStrm = new MemoryStream();
-            var emitResult = comp.Emit(outStrm);
-            Assert.True(emitResult.Success);
-
-            outStrm.Position = 0;
-
-            // Verify that the sign bit is set
-            using (var reader = new PEReader(outStrm))
-            {
-                Assert.True(reader.HasMetadata);
-
-                var flags = reader.PEHeaders.CorHeader.Flags;
-                Assert.True(flags.HasFlag(CorFlags.StrongNameSigned));
-            }
+            VerifySignedBitSetAfterEmit(comp);
         }
 
         [Fact]
@@ -585,8 +550,24 @@ public class C {}",
             comp.VerifyDiagnostics(
     // error CS7102: Compilation options 'PublicSign' and 'DelaySign' can't both be specified at the same time.
     Diagnostic(ErrorCode.ERR_MutuallyExclusiveOptions).WithArguments("PublicSign", "DelaySign").WithLocation(1, 1));
+
+            Assert.True(comp.Options.PublicSign);
+            Assert.True(comp.Options.DelaySign);
         }
 
+        [Fact]
+        public void PublicSignNoKey()
+        {
+            var comp = CreateCompilationWithMscorlib("public class C {}",
+                options: TestOptions.ReleaseDll
+                    .WithPublicSign(true));
+
+            comp.VerifyDiagnostics(
+    // error CS8102: Public signing was specified and requires a public key, but no public key was specified.
+    Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1) );
+            Assert.True(comp.Options.PublicSign);
+            Assert.True(comp.Assembly.PublicKey.IsDefaultOrEmpty);
+        }
 
         [Fact]
         public void PublicKeyFromOptions_InvalidCompilationOptions()

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1680,6 +1680,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_InterpolatedStringFactoryError = 37251
         ERR_DebugEntryPointNotSourceMethodDefinition = 37252
         ERR_InvalidPathMap = 37253
+        ERR_PublicSignNoKey = 37254
 
         ERR_LastPlusOne
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1184,6 +1184,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     diagnostics.Add(ERRID.WRN_DelaySignButNoKey, NoLocation.Singleton)
                 End If
 
+                If DeclaringCompilation.Options.PublicSign AndAlso Not Identity.HasPublicKey Then
+                    diagnostics.Add(ERRID.ERR_PublicSignNoKey, NoLocation.Singleton)
+                End If
+
                 ' If the options and attributes applied on the compilation imply real signing,
                 ' but we have no private key to sign it with report an error.
                 ' Note that if public key is set and delay sign is off we do OSS signing, which doesn't require private key.

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -9145,6 +9145,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Public sign was specified and requires a public key, but no public key was specified.
+        '''</summary>
+        Friend ReadOnly Property ERR_PublicSignNoKey() As String
+            Get
+                Return ResourceManager.GetString("ERR_PublicSignNoKey", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to &apos;:&apos; is not allowed. XML qualified names cannot be used in this context..
         '''</summary>
         Friend ReadOnly Property ERR_QualifiedNameNotAllowed() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -4295,6 +4295,9 @@
   <data name="ERR_FriendRefSigningMismatch" xml:space="preserve">
     <value>Friend access was granted by '{0}', but the strong name signing state of the output assembly does not match that of the granting assembly.</value>
   </data>
+  <data name="ERR_PublicSignNoKey" xml:space="preserve">
+    <value>Public sign was specified and requires a public key, but no public key was specified</value>
+  </data>
   <data name="WRN_DelaySignButNoKey" xml:space="preserve">
     <value>Delay signing was specified and requires a public key, but no public key was specified.</value>
   </data>

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -932,6 +932,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_MutuallyExclusiveOptions, NameOf(CryptoPublicKey), NameOf(CryptoKeyContainer)))
                 End If
             End If
+
+            If PublicSign AndAlso DelaySign.HasValue Then
+                builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_MutuallyExclusiveOptions, NameOf(PublicSign), NameOf(DelaySign)))
+            End If
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -1664,7 +1664,11 @@ End Class
                 </file>
             </compilation>, options:=options
         )
-        comp.VerifyDiagnostics(Diagnostic(ERRID.ERR_PublicSignNoKey).WithLocation(1, 1))
+
+        AssertTheseDiagnostics(comp,
+<errors>
+BC37254: Public sign was specified and requires a public key, but no public key was specified
+</errors>)
         Assert.True(comp.Options.PublicSign)
         Assert.True(comp.Assembly.PublicKey.IsDefaultOrEmpty)
     End Sub
@@ -1731,8 +1735,11 @@ End Class
         Dim options = TestOptions.ReleaseDll.WithCryptoKeyFile(snk.Path).WithPublicSign(True)
         Dim comp = CreateCompilationWithMscorlib(source, options:=options)
 
-        comp.VerifyDiagnostics(
-            Diagnostic(ERRID.ERR_CmdOptionConflictsSource).WithArguments("System.Reflection.AssemblyDelaySignAttribute", "PublicSign").WithLocation(1, 1))
+        AssertTheseDiagnostics(comp,
+<errors>
+BC37207: Attribute 'System.Reflection.AssemblyDelaySignAttribute' given in a source file conflicts with option 'PublicSign'.
+</errors>)
+        Assert.True(comp.Options.PublicSign)
     End Sub
 
     <Fact>
@@ -1751,9 +1758,13 @@ End Class
             options:=options
         )
 
-        comp.VerifyDiagnostics(
-            Diagnostic(ERRID.ERR_MutuallyExclusiveOptions).WithArguments("PublicSign", "DelaySign").WithLocation(1, 1))
+        AssertTheseDiagnostics(comp,
+<errors>
+BC2046: Compilation options 'PublicSign' and 'DelaySign' can't both be specified at the same time.
+</errors>)
 
+        Assert.True(comp.Options.PublicSign)
+        Assert.True(comp.Options.DelaySign)
     End Sub
 
     <Fact, WorkItem(769840, "DevDiv")>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -1664,7 +1664,9 @@ End Class
                 </file>
             </compilation>, options:=options
         )
-        comp.VerifyDiagnostics()
+        comp.VerifyDiagnostics(Diagnostic(ERRID.ERR_PublicSignNoKey).WithLocation(1, 1))
+        Assert.True(comp.Options.PublicSign)
+        Assert.True(comp.Assembly.PublicKey.IsDefaultOrEmpty)
     End Sub
 
     <Fact>


### PR DESCRIPTION
Also adds tests for this case. Right now /delaysign silently wins.

Fixes bug #7734.

/cc @dotnet/roslyn-compiler @jaredpar 