### PR TITLE
[TEST ONLY - Do not review] Avoid async deadlock in InteractiveHost...

### DIFF
--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -443,7 +443,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
         private async Task<ScriptState<T>> RunSubmissionsAsync(ScriptExecutionState executionState, ImmutableArray<Func<object[], Task>> precedingExecutors, Func<object[], Task> currentExecutor, CancellationToken cancellationToken)
         {
-            var result = await executionState.RunSubmissionsAsync<T>(precedingExecutors, currentExecutor, cancellationToken).ConfigureAwait(continueOnCapturedContext: true);
+            var result = await executionState.RunSubmissionsAsync<T>(precedingExecutors, currentExecutor, cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             return new ScriptState<T>(executionState, result, this);
         }
 


### PR DESCRIPTION
The scheduler returned by TaskScheduler.FromCurrentSynchronizationContext
does not allow concurrency (meaning all Tasks within a submission were being
inlined).  This would nearly always result in a deadlock if you kicked off a
child Task and called Task.Wait within the same submission.

We can instead use the Winforms Dispatcher, which will invoke the parent
Task on the "UI" thread but allow child Tasks to use the ThreadPool.