### PR TITLE
Use /publicsign instead of FakeSign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
 BUILD_LOG_PATH =
 XUNIT_VERSION = 2.1.0
 
-MSBUILD_ADDITIONALARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:SignAssembly=false /p:DebugSymbols=false /p:Configuration=$(BUILD_CONFIGURATION)
+MSBUILD_ADDITIONALARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:DebugSymbols=false /p:Configuration=$(BUILD_CONFIGURATION)
 
 ifeq ($(OS_NAME),Linux)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=ubuntu.14.04

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash
 OS_NAME = $(shell uname -s)
-NUGET_PACKAGE_NAME = nuget.40
+NUGET_PACKAGE_NAME = nuget.41
 BUILD_CONFIGURATION = Debug
 BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
 BUILD_LOG_PATH =

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -24,7 +24,7 @@
   <!-- Import the global NuGet packages -->
   <PropertyGroup>
     <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
-    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.0-beta-20151211-01\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
+    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.0-beta1-20151231-01\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.RoslynDiagnostics\1.1.1-beta1-20150818-01\build\Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
     <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>
   </PropertyGroup>
@@ -141,12 +141,20 @@
             Condition="Exists('$(RoslynDiagnosticsPropsFilePath)') And ('$(UseRoslynAnalyzers)' == 'true')" />
   </ImportGroup>
 
+  <!-- Otherwise, use the task from the bootstrap location -->
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"
+             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             Condition="'$(BootstrapBuildPath)' != ''" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"
+             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             Condition="'$(BootstrapBuildPath)' != ''" />
+
   <PropertyGroup Condition="'$(BootstrapBuildPath)' != ''">
-    <CscToolPath>$(BootstrapBuildPath)</CscToolPath>
-    <CscToolExe>csc.cmd</CscToolExe>
-    <VbcToolPath>$(BootstrapBuildPath)</VbcToolPath>
-    <VbcToolExe>vbc.cmd</VbcToolExe>
+    <UseSharedCompilation>true</UseSharedCompilation>
+    <CSharpCoreTargetsPath>$(BootstrapBuildPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
+    <VisualBasicCoreTargetsPath>$(BootstrapBuildPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>
+
 
   <!-- Common project settings -->
   <PropertyGroup>

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -53,7 +53,7 @@
        built against the xplat MSBuild references so it can't be loaded properly. Providing
        a response file works around the problem by directly adding the public sign argument
        to all unix compilations. This shouldn't present a problem as it's impossible to
-       fully sign on unix at the moment anyway -->
+       fully sign on unix at the moment anyway. Tracked by #7756. -->
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
       <CompilerResponseFile>$(MSBuildThisFileDirectory)..\scripts\extra_unix_args.rsp</CompilerResponseFile>
   </PropertyGroup>
@@ -141,7 +141,8 @@
             Condition="Exists('$(RoslynDiagnosticsPropsFilePath)') And ('$(UseRoslynAnalyzers)' == 'true')" />
   </ImportGroup>
 
-  <!-- Otherwise, use the task from the bootstrap location -->
+  <!-- Otherwise, use the task from the bootstrap location. This is necessary
+       to support new properties on the build task. -->
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"
              AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
              Condition="'$(BootstrapBuildPath)' != ''" />

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -48,6 +48,16 @@
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\NuGet\Microsoft.NuGet.props"
           Condition="'$(OS)' != 'Windows_NT'" />
 
+  <!-- The /publicsign argument is required for the compiler, but the current MSBuild
+       build task can't be redirected and even if it could the new build task is not
+       built against the xplat MSBuild references so it can't be loaded properly. Providing
+       a response file works around the problem by directly adding the public sign argument
+       to all unix compilations. This shouldn't present a problem as it's impossible to
+       fully sign on unix at the moment anyway -->
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+      <CompilerResponseFile>$(MSBuildThisFileDirectory)..\scripts\extra_unix_args.rsp</CompilerResponseFile>
+  </PropertyGroup>
+
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -45,7 +45,6 @@
             <AssemblyOriginatorKeyFile>$(VSLToolsPath)\Strong Name Keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
             <PublicKey>0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</PublicKey>
             <PublicKeyToken>31BF3856AD364E35</PublicKeyToken>
-            <PublicSign>true</PublicSign>
           </PropertyGroup>
         </When>
 

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -45,6 +45,7 @@
             <AssemblyOriginatorKeyFile>$(VSLToolsPath)\Strong Name Keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
             <PublicKey>0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</PublicKey>
             <PublicKeyToken>31BF3856AD364E35</PublicKeyToken>
+            <PublicSign>true</PublicSign>
           </PropertyGroup>
         </When>
 

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -16,15 +16,33 @@
   </PropertyGroup>
 
   <!-- settings for strong name signing -->
+  <PropertyGroup>
+    <RunningInMicroBuild Condition="Exists('$(TF_BUILD_BUILDDIRECTORY)\MicroBuild\MicroBuild.Signing.dll')">true</RunningInMicroBuild>
+    <ShouldSignBuild Condition="'$(RealSignBuild)' == 'true' OR ('$(RunningInMicroBuild)' == 'true' AND '$(SignType)' == 'real')">true</ShouldSignBuild>
+  </PropertyGroup>
+
   <Choose>
     <When Condition="'$(SignAssembly)' == 'true'">
       <Choose>
         <!-- Shipping binaries in an "official" build are delay-signed with the MS key; later, the signing
              system will finish the strong-name signing. -->
         <When Condition="'$(NonShipping)' != 'true'">
+          <Choose>
+              <!-- DelaySign if we're real signing, otherwise public sign -->
+              <When Condition="'$(ShouldSignBuild)' == 'true'">
+                  <PropertyGroup>
+                      <DelaySign>true</DelaySign>
+                  </PropertyGroup>
+              </When>
+              <Otherwise>
+                  <PropertyGroup>
+                      <PublicSign>true</PublicSign>
+                  </PropertyGroup>
+              </Otherwise>
+          </Choose>
+
           <PropertyGroup>
             <AssemblyOriginatorKeyFile>$(VSLToolsPath)\Strong Name Keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-            <DelaySign>true</DelaySign>
             <PublicKey>0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</PublicKey>
             <PublicKeyToken>31BF3856AD364E35</PublicKeyToken>
           </PropertyGroup>
@@ -214,7 +232,7 @@
 
   <Target Name="PostCompileBinaryModification"
           AfterTargets="CoreCompile"
-          DependsOnTargets="ApplyOptimizations;FakeSign"
+          DependsOnTargets="ApplyOptimizations"
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
 
@@ -248,29 +266,6 @@
 
     <Message Text="Re-signing after merging optimization data" Condition="'$(DelaySign)' != 'true' AND '$(SignAssembly)' == 'true'" />
     <Exec Command="&quot;$(SnToolPath)&quot; -q -R &quot;@(IntermediateAssembly)&quot; &quot;$(AssemblyOriginatorKeyFile)&quot;" Condition="'$(DelaySign)' != 'true' AND '$(SignAssembly)' == 'true'" />
-
-  </Target>
-
-  <!-- ====================================================================================
-
-         Support for signing files that are in VSIXes.
-
-       ==================================================================================== -->
-
-  <PropertyGroup>
-    <RunningInMicroBuild Condition="Exists('$(TF_BUILD_BUILDDIRECTORY)\MicroBuild\MicroBuild.Signing.dll')">true</RunningInMicroBuild>
-    <ShouldSignBuild Condition="'$(RealSignBuild)' == 'true' OR ('$(RunningInMicroBuild)' == 'true' AND '$(SignType)' == 'real')">true</ShouldSignBuild>
-  </PropertyGroup>
-
-  <Target Name="FakeSign"
-          Condition="'$(DelaySign)' == 'true' AND
-                     '$(ShouldSignBuild)' != 'true' AND
-                     ('$(Language)' == 'C#' OR '$(Language)' == 'VB') AND
-                     '$(BuildingProject)' == 'true'"
-          Inputs="@(IntermediateAssembly)"
-          Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
-
-    <Exec Command="&quot;$(FakeSignToolPath)&quot; &quot;@(IntermediateAssembly)&quot;" />
 
   </Target>
 

--- a/build/Toolset.sln
+++ b/build/Toolset.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysis", "..\src\Compilers\Core\Portable\CodeAnalysis.csproj", "{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}"
 EndProject
@@ -49,14 +49,25 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vbc", "..\src\Compilers\Vis
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VBCSCompiler", "..\src\Compilers\Server\VBCSCompiler\VBCSCompiler.csproj", "{9508F118-F62E-4C16-A6F4-7C3B56E166AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuildTask.Desktop", "..\src\Compilers\Core\MSBuildTask\Desktop\MSBuildTask.Desktop.csproj", "{D874349C-8BB3-4BDC-8535-2D52CCCA1198}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "MSBuildTask.Shared", "..\src\Compilers\Core\MSBuildTask\Shared\MSBuildTask.Shared.shproj", "{D87F0E46-DD1B-46EA-8425-9E185D9B602E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\src\Compilers\Core\MSBuildTask\Shared\MSBuildTask.Shared.projitems*{d87f0e46-dd1b-46ea-8425-9e185d9b602e}*SharedItemsImports = 13
 		..\src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
+		..\src\Compilers\Core\CommandLine\CommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 4
+		..\src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
+		..\src\Compilers\Server\ServerShared\ServerShared.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
 		..\src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		..\src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		..\src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
 		..\src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
+		..\src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 4
 		..\src\Compilers\Core\SharedCollections\SharedCollections.projitems*{c1930979-c824-496b-a630-70f5369a636f}*SharedItemsImports = 13
+		..\src\Compilers\Core\CommandLine\CommandLine.projitems*{d874349c-8bb3-4bdc-8535-2d52ccca1198}*SharedItemsImports = 4
+		..\src\Compilers\Core\MSBuildTask\Shared\MSBuildTask.Shared.projitems*{d874349c-8bb3-4bdc-8535-2d52ccca1198}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,16 +118,16 @@ Global
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Debug|ARM.Build.0 = Debug|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Debug|x64.ActiveCfg = Debug|x64
-		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Debug|x64.Build.0 = Debug|x64
+		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Debug|x64.Build.0 = Debug|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|ARM.ActiveCfg = Release|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|ARM.Build.0 = Release|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|x64.ActiveCfg = Release|x64
-		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|x64.Build.0 = Release|x64
+		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|x64.ActiveCfg = Release|Any CPU
+		{2523D0E6-DF32-4A3E-8AE0-A19BFFAE2EF6}.Release|x64.Build.0 = Release|Any CPU
 		{02459936-CD2C-4F61-B671-5C518F2A3DDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{02459936-CD2C-4F61-B671-5C518F2A3DDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02459936-CD2C-4F61-B671-5C518F2A3DDC}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -235,16 +246,16 @@ Global
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Debug|ARM.Build.0 = Debug|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Debug|x64.ActiveCfg = Debug|x64
-		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Debug|x64.Build.0 = Debug|x64
+		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Debug|x64.Build.0 = Debug|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|ARM.ActiveCfg = Release|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|ARM.Build.0 = Release|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|x64.ActiveCfg = Release|x64
-		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|x64.Build.0 = Release|x64
+		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|x64.ActiveCfg = Release|Any CPU
+		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1}.Release|x64.Build.0 = Release|Any CPU
 		{9508F118-F62E-4C16-A6F4-7C3B56E166AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9508F118-F62E-4C16-A6F4-7C3B56E166AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9508F118-F62E-4C16-A6F4-7C3B56E166AD}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -261,6 +272,22 @@ Global
 		{9508F118-F62E-4C16-A6F4-7C3B56E166AD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{9508F118-F62E-4C16-A6F4-7C3B56E166AD}.Release|x64.ActiveCfg = Release|Any CPU
 		{9508F118-F62E-4C16-A6F4-7C3B56E166AD}.Release|x64.Build.0 = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|ARM.Build.0 = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Debug|x64.Build.0 = Debug|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|ARM.ActiveCfg = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|ARM.Build.0 = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|x64.ActiveCfg = Release|Any CPU
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -283,5 +310,7 @@ Global
 		{4B45CA0C-03A0-400F-B454-3D4BCB16AF38} = {32A48625-F0AD-419D-828B-A50BDABA38EA}
 		{E58EE9D7-1239-4961-A0C1-F9EC3952C4C1} = {C65C6143-BED3-46E6-869E-9F0BE6E84C37}
 		{9508F118-F62E-4C16-A6F4-7C3B56E166AD} = {A41D1B99-F489-4C43-BBDF-96D61B19A6B9}
+		{D874349C-8BB3-4BDC-8535-2D52CCCA1198} = {A41D1B99-F489-4C43-BBDF-96D61B19A6B9}
+		{D87F0E46-DD1B-46EA-8425-9E185D9B602E} = {A41D1B99-F489-4C43-BBDF-96D61B19A6B9}
 	EndGlobalSection
 EndGlobal

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -3,7 +3,7 @@
         "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.2.0-beta-20151016-11",
         "Microsoft.Build.Mono.Debug": "14.1.0-prerelease",
         "Microsoft.DiaSymReader.Native": "1.3.3",
-        "Microsoft.Net.Compilers": "1.2.0-beta-20151211-01",
+        "Microsoft.Net.Compilers": "1.2.0-beta1-20151231-01",
         "Microsoft.Net.RoslynDiagnostics": "1.1.1-beta1-20150818-01",
         "FakeSign": "0.9.2",
         "xunit": "2.1.0-beta4-build3109",

--- a/build/scripts/extra_unix_args.rsp
+++ b/build/scripts/extra_unix_args.rsp
@@ -1,0 +1,1 @@
+/publicsign

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -3,7 +3,7 @@
 REM Parse Arguments.
 
 set NugetZipUrlRoot=https://dotnetci.blob.core.windows.net/roslyn
-set NugetZipUrl=%NuGetZipUrlRoot%/nuget.40.zip
+set NugetZipUrl=%NuGetZipUrlRoot%/nuget.41.zip
 set RoslynRoot=%~dp0
 set BuildConfiguration=Debug
 set BuildRestore=false

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -67,7 +67,7 @@ if defined Perf (
   set Target=BuildAndTest
 )
 
-msbuild %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath=%RoslynRoot%Binaries\Bootstrap BuildAndTest.proj /t:%Target% /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /fileloggerparameters:LogFile=%RoslynRoot%Binaries\Build.log || goto :BuildFailed
+msbuild %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath=%RoslynRoot%Binaries\Bootstrap BuildAndTest.proj /t:%Target% /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /fileloggerparameters:LogFile=%RoslynRoot%Binaries\Build.log;verbosity=diagnostic || goto :BuildFailed
 
 call :TerminateCompilerServer
 


### PR DESCRIPTION
Replace usage of FakeSign with /publicsign in Roslyn.

@dotnet/roslyn-compiler @dotnet/roslyn-infrastructure @jaredpar 