### PR TITLE
Recognize JoinableTaskSynchronizationContext as a foreground kind

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -44,7 +44,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             base.Initialize();
 
             ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = ForegroundThreadData.CreateDefault();
-            Debug.Assert(ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == ForegroundThreadDataKind.Wpf);
+            Debug.Assert(
+                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == ForegroundThreadDataKind.Wpf ||
+                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == ForegroundThreadDataKind.JoinableTask);
 
             FatalError.Handler = FailFast.OnFatalException;
             FatalError.NonFatalHandler = WatsonReporter.Report;

--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Utilities
     {
         Wpf,
         StaUnitTest,
+        JoinableTask,
         Unknown
     }
 
@@ -28,11 +29,23 @@ namespace Microsoft.CodeAnalysis.Utilities
 
         internal static ForegroundThreadDataKind CreateDefault()
         {
-            var kind = SynchronizationContext.Current?.GetType().FullName == "System.Windows.Threading.DispatcherSynchronizationContext"
-                    ? ForegroundThreadDataKind.Wpf
-                    : ForegroundThreadDataKind.Unknown;
+            var syncConextTypeName = SynchronizationContext.Current?.GetType().FullName;
 
-            return kind;
+            switch (syncConextTypeName)
+            {
+                case "System.Windows.Threading.DispatcherSynchronizationContext":
+
+                    return ForegroundThreadDataKind.Wpf;
+
+                case "Microsoft.VisualStudio.Threading.JoinableTask+JoinableTaskSynchronizationContext":
+
+                    return ForegroundThreadDataKind.JoinableTask;
+
+                default:
+
+                    return ForegroundThreadDataKind.Unknown;
+
+            }
         }
 
         internal static ForegroundThreadDataKind CurrentForegroundThreadDataKind

--- a/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Utilities
         {
 #if DEBUG
             var threadKind = ForegroundThreadDataInfo.CurrentForegroundThreadDataKind;
-            if (threadKind != ForegroundThreadDataKind.Wpf && threadKind != ForegroundThreadDataKind.StaUnitTest)
+            if (threadKind == ForegroundThreadDataKind.Unknown)
             {
                 // If you hit this when running tests then your code is in error.  WaitAndGetResult
                 // should only be called from a foreground thread.  There are a few ways you may 


### PR DESCRIPTION
This is quick fix to prevent throwing asserts if CPS has changed the foreground SynchronizationContext.

Looking at this, I suspect we could probably delete half of our foreground logic with something simpler,
but this unblocks others for now.

Review: @dotnet/roslyn-ide