### PR TITLE
Avoid async deadlock in InteractiveHost...

### DIFF
--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -826,13 +826,13 @@ namespace Microsoft.CodeAnalysis.Interactive
                         catch (FileLoadException e) when (e.InnerException is InteractiveAssemblyLoaderException)
                         {
                             Console.Error.WriteLine(e.InnerException.Message);
-                            return null;
+                            return Task.FromResult<ScriptState<object>>(null);
                         }
                         catch (Exception e)
                         {
                             // TODO (tomat): format exception
                             Console.Error.WriteLine(e);
-                            return null;
+                            return Task.FromResult<ScriptState<object>>(null);
                         }
                     }))).ConfigureAwait(false);
             }

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -1123,6 +1123,23 @@ new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
             AssertEx.AssertEqualToleratingWhitespaceDifferences("C { P=null }", output);
         }
 
+        [Fact, WorkItem(7280, "https://github.com/dotnet/roslyn/issues/7280")]
+        public void AsyncContinueOnDifferentThread()
+        {
+            Execute(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+Console.Write(Task.Run(() => { Thread.CurrentThread.Join(100); return 42; }).ContinueWith(t => t.Result).Result)");
+            
+            var output = ReadOutputToEnd();
+            var error = ReadErrorOutputToEnd();
+
+            Assert.Equal("42", output);
+            Assert.Empty(error);
+        }
+
         #region Submission result printing - null/void/value.
 
         [Fact]

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -443,7 +443,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
         private async Task<ScriptState<T>> RunSubmissionsAsync(ScriptExecutionState executionState, ImmutableArray<Func<object[], Task>> precedingExecutors, Func<object[], Task> currentExecutor, CancellationToken cancellationToken)
         {
-            var result = await executionState.RunSubmissionsAsync<T>(precedingExecutors, currentExecutor, cancellationToken).ConfigureAwait(continueOnCapturedContext: true);
+            var result = await executionState.RunSubmissionsAsync<T>(precedingExecutors, currentExecutor, cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             return new ScriptState<T>(executionState, result, this);
         }
 


### PR DESCRIPTION
The scheduler returned by TaskScheduler.FromCurrentSynchronizationContext
does not allow concurrency (meaning all Tasks within a submission were being
inlined).  This would nearly always result in a deadlock if you kicked off a
child Task and attempted to continue within the same submission.

We can instead use the Winforms Dispatcher, which will invoke the parent
Task on the "UI" thread but allow child Tasks to use the ThreadPool.

Fixes #7280