### PR TITLE
Remove ibcmerge re-sign

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -264,9 +264,6 @@
     <Message Text="Adding optimization data to @(IntermediateAssembly)"/>
     <Exec Command="&quot;$(IbcMergePath)&quot; -q -f -partialNGEN -minify -mo &quot;@(IntermediateAssembly)&quot; -incremental &quot;$(OptimizationDataFile)&quot;" />
 
-    <Message Text="Re-signing after merging optimization data" Condition="'$(DelaySign)' != 'true' AND '$(SignAssembly)' == 'true'" />
-    <Exec Command="&quot;$(SnToolPath)&quot; -q -R &quot;@(IntermediateAssembly)&quot; &quot;$(AssemblyOriginatorKeyFile)&quot;" Condition="'$(DelaySign)' != 'true' AND '$(SignAssembly)' == 'true'" />
-
   </Target>
 
   <!-- ====================================================================================


### PR DESCRIPTION
We currently attempt to 're-sign' after merging IBC data, but
since we don't re-sign delay-signed bits and IBC merge happened
before we ran FakeSign, this line should have been a no-op.