### PR TITLE
Throttle async event queues

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
@@ -12,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal partial class DiagnosticAnalyzerService : IDiagnosticUpdateSource
     {
         private const string DiagnosticsUpdatedEventName = "DiagnosticsUpdated";
+
+        private static readonly DiagnosticEventTaskScheduler s_eventScheduler = new DiagnosticEventTaskScheduler(blockingUpperBound: 100);
 
         // use eventMap and taskQueue to serialize events
         private readonly EventMap _eventMap;
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             // use diagnostic event task scheduler so that we never flood async events queue with million of events.
             // queue itself can handle huge number of events but we are seeing OOM due to captured data in pending events.
-            _eventQueue = new SimpleTaskQueue(new DiagnosticEventTaskScheduler(blockingUpperBound: 100));
+            _eventQueue = new SimpleTaskQueue(s_eventScheduler);
 
             registrationService.Register(this);
         }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
@@ -20,7 +20,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private DiagnosticAnalyzerService(IDiagnosticUpdateSourceRegistrationService registrationService) : this()
         {
             _eventMap = new EventMap();
-            _eventQueue = new SimpleTaskQueue(TaskScheduler.Default);
+
+            // use diagnostic event task scheduler so that we never flood async events queue with million of events.
+            // queue itself can handle huge number of events but we are seeing OOM due to captured data in pending events.
+            _eventQueue = new SimpleTaskQueue(new DiagnosticEventTaskScheduler(blockingUpperBound: 100));
 
             registrationService.Register(this);
         }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    /// <summary>
+    /// This task scheduler will block queuing new tasks if upper bound has met.
+    /// </summary>
+    internal class DiagnosticEventTaskScheduler : TaskScheduler
+    {
+        private readonly Task _mainTask;
+        private readonly BlockingCollection<Task> _tasks;
+
+        public DiagnosticEventTaskScheduler(int blockingUpperBound)
+        {
+            _tasks = new BlockingCollection<Task>(blockingUpperBound);
+
+            // portable layer doesnt support explicit thread creation. use long running task to create and hold onto a thread
+            _mainTask = Task.Factory.SafeStartNew(Start, CancellationToken.None,
+                TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        private void Start()
+        {
+            while (true)
+            {
+                var task = _tasks.Take();
+                bool ret = this.TryExecuteTask(task);
+            }
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            _tasks.Add(task);
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            // NOTE: TPL will ensure only one task ever run when running scheduled task. and since this is only used
+            // in diagnostic events, we know task will ever run sequencely. so no worry about reverted order here.
+            return this.TryExecuteTask(task);
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            // debugger will use this method to get scheduled tasks for this scheduler
+            return _tasks.ToArray();
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
             // NOTE: TPL will ensure only one task ever run when running scheduled task. and since this is only used
-            // in diagnostic events, we know task will ever run sequencely. so no worry about reverted order here.
+            // in diagnostic events, we know task will always run sequencely. so no worry about reverted order here.
             return this.TryExecuteTask(task);
         }
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Common;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
@@ -17,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal partial class DiagnosticService : IDiagnosticService
     {
         private const string DiagnosticsUpdatedEventName = "DiagnosticsUpdated";
+
+        private static readonly DiagnosticEventTaskScheduler s_eventScheduler = new DiagnosticEventTaskScheduler(blockingUpperBound: 100);
 
         private readonly IAsynchronousOperationListener _listener;
         private readonly EventMap _eventMap;
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             // use diagnostic event task scheduler so that we never flood async events queue with million of events.
             // queue itself can handle huge number of events but we are seeing OOM due to captured data in pending events.
-            _eventQueue = new SimpleTaskQueue(new DiagnosticEventTaskScheduler(blockingUpperBound: 100));
+            _eventQueue = new SimpleTaskQueue(s_eventScheduler);
 
             _listener = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.DiagnosticService);
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -30,7 +30,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             // queue to serialize events.
             _eventMap = new EventMap();
-            _eventQueue = new SimpleTaskQueue(TaskScheduler.Default);
+
+            // use diagnostic event task scheduler so that we never flood async events queue with million of events.
+            // queue itself can handle huge number of events but we are seeing OOM due to captured data in pending events.
+            _eventQueue = new SimpleTaskQueue(new DiagnosticEventTaskScheduler(blockingUpperBound: 100));
 
             _listener = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.DiagnosticService);
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
@@ -35,12 +35,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 _language = language;
             }
 
-            internal string Name
+            /// <summary>
+            /// Only For Testing
+            /// </summary>
+            internal string Name_TestingOnly
             {
                 get { return _stateName; }
             }
 
-            internal string Language
+            /// <summary>
+            /// Only For Testing
+            /// </summary>
+            internal string Language_TestingOnly
             {
                 get { return _language; }
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     {
                         var state = stateSet.GetState((StateType)i);
 
-                        if (!(set.Add(ValueTuple.Create(state.Language, state.Name))))
+                        if (!(set.Add(ValueTuple.Create(state.Language_TestingOnly, state.Name_TestingOnly))))
                         {
                             Contract.Fail();
                         }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var data = await _executor.GetSyntaxAnalysisDataAsync(userDiagnosticDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticsCreated(StateType.Syntax, document.Id, stateSet, new SolutionArgument(document), data.Items);
+                            RaiseDiagnosticCreatedFromCacheIfNeeded(StateType.Syntax, document, stateSet, data.Items);
                             continue;
                         }
 
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticsCreated(StateType.Document, document.Id, stateSet, new SolutionArgument(document), data.Items);
+                            RaiseDiagnosticCreatedFromCacheIfNeeded(StateType.Document, document, stateSet, data.Items);
                             continue;
                         }
 
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var data = await _executor.GetDocumentAnalysisDataAsync(userDiagnosticDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticsCreated(StateType.Document, document.Id, stateSet, new SolutionArgument(document), data.Items);
+                            RaiseDiagnosticCreatedFromCacheIfNeeded(StateType.Document, document, stateSet, data.Items);
                             continue;
                         }
 
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var data = await _executor.GetProjectAnalysisDataAsync(analyzerDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)
                         {
-                            RaiseProjectDiagnosticsUpdated(project, stateSet, data.Items);
+                            RaiseProjectDiagnosticsUpdatedIfNeeded(project, stateSet, ImmutableArray<DiagnosticData>.Empty, data.Items);
                             continue;
                         }
 
@@ -615,6 +615,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             return VersionStamp.CanReusePersistedVersion(versions.TextVersion, existingData.TextVersion) &&
                    project.CanReusePersistedDependentSemanticVersion(versions.ProjectVersion, versions.DataVersion, existingData.DataVersion);
+        }
+
+        private void RaiseDiagnosticCreatedFromCacheIfNeeded(StateType type, Document document, StateSet stateSet, ImmutableArray<DiagnosticData> items)
+        {
+            RaiseDocumentDiagnosticsUpdatedIfNeeded(type, document, stateSet, ImmutableArray<DiagnosticData>.Empty, items);
         }
 
         private void RaiseDocumentDiagnosticsUpdatedIfNeeded(

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var data = await _executor.GetSyntaxAnalysisDataAsync(userDiagnosticDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticCreatedFromCacheIfNeeded(StateType.Syntax, document, stateSet, data.Items);
+                            RaiseDiagnosticsCreatedFromCacheIfNeeded(StateType.Syntax, document, stateSet, data.Items);
                             continue;
                         }
 
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticCreatedFromCacheIfNeeded(StateType.Document, document, stateSet, data.Items);
+                            RaiseDiagnosticsCreatedFromCacheIfNeeded(StateType.Document, document, stateSet, data.Items);
                             continue;
                         }
 
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         var data = await _executor.GetDocumentAnalysisDataAsync(userDiagnosticDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)
                         {
-                            RaiseDiagnosticCreatedFromCacheIfNeeded(StateType.Document, document, stateSet, data.Items);
+                            RaiseDiagnosticsCreatedFromCacheIfNeeded(StateType.Document, document, stateSet, data.Items);
                             continue;
                         }
 
@@ -617,7 +617,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                    project.CanReusePersistedDependentSemanticVersion(versions.ProjectVersion, versions.DataVersion, existingData.DataVersion);
         }
 
-        private void RaiseDiagnosticCreatedFromCacheIfNeeded(StateType type, Document document, StateSet stateSet, ImmutableArray<DiagnosticData> items)
+        private void RaiseDiagnosticsCreatedFromCacheIfNeeded(StateType type, Document document, StateSet stateSet, ImmutableArray<DiagnosticData> items)
         {
             RaiseDocumentDiagnosticsUpdatedIfNeeded(type, document, stateSet, ImmutableArray<DiagnosticData>.Empty, items);
         }

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Diagnostics\AnalyzerHelper.cs" />
     <Compile Include="Diagnostics\AbstractHostDiagnosticUpdateSource.cs" />
     <Compile Include="Diagnostics\AnalyzerUpdateArgsId.cs" />
+    <Compile Include="Diagnostics\DiagnosticEventTaskScheduler.cs" />
     <Compile Include="Diagnostics\DiagnosticService_UpdateSourceRegistrationService.cs" />
     <Compile Include="Common\UpdatedEventArgs.cs" />
     <Compile Include="Diagnostics\HostDiagnosticAnalyzerPackage.cs" />


### PR DESCRIPTION
we had several reports saying we sometime OOM. investigation shows that we have a lot of async events pending especially around removing documents (ex, close solution, vs shutdown, solution re-analysis and etc).

pending events itself is not that much problem, but data captured for the events sometimes accumulated too much which can cause us to OOM.

this change puts a throttle to async events queue so that we block event producers if too many events are flooded to the queue. queue will be unblocked as pending events are processed by consumers.

...

I also changed some parts of engine not to raise unnecessary events.