### PR TITLE
Handle base keyword for submission class speculation model

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1379,15 +1379,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert((object)container == null);
                 TypeSymbol containingType = binder.ContainingType;
                 TypeSymbol baseType = null;
+
+                // For a script class or a submission class base should have no members.
+                if (containingType != null && containingType.Kind == SymbolKind.NamedType && ((NamedTypeSymbol)containingType).IsScriptClass)
+                {
+                    return ImmutableArray<Symbol>.Empty;
+                }
+
                 if ((object)containingType == null || (object)(baseType = containingType.BaseTypeNoUseSiteDiagnostics) == null)
                 {
-                    // This condition can occur when requesting the base class members of a submission class.
-                    // In this situation simply return no members.
-                    if (baseType != null && baseType.Kind == SymbolKind.NamedType && ((NamedTypeSymbol)baseType).IsSubmissionClass)
-                    {
-                        return ImmutableArray<Symbol>.Empty;
-                    }
-
                     throw new ArgumentException(
                         "Not a valid position for a call to LookupBaseMembers (must be in a type with a base type)",
                         nameof(position));

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1381,7 +1381,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeSymbol baseType = null;
 
                 // For a script class or a submission class base should have no members.
-                if (containingType != null && containingType.Kind == SymbolKind.NamedType && ((NamedTypeSymbol)containingType).IsScriptClass)
+                if ((object)containingType != null && containingType.Kind == SymbolKind.NamedType && ((NamedTypeSymbol)containingType).IsScriptClass)
                 {
                     return ImmutableArray<Symbol>.Empty;
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1378,13 +1378,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert((object)container == null);
                 TypeSymbol containingType = binder.ContainingType;
-                TypeSymbol baseType;
+                TypeSymbol baseType = null;
                 if ((object)containingType == null || (object)(baseType = containingType.BaseTypeNoUseSiteDiagnostics) == null)
                 {
+                    // This condition can occur when requesting the base class members of a submission class.
+                    // In this situation simply return no members.
+                    if (baseType != null && baseType.Kind == SymbolKind.NamedType && ((NamedTypeSymbol)baseType).IsSubmissionClass)
+                    {
+                        return ImmutableArray<Symbol>.Empty;
+                    }
+
                     throw new ArgumentException(
                         "Not a valid position for a call to LookupBaseMembers (must be in a type with a base type)",
                         nameof(position));
                 }
+
                 container = baseType;
             }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -270,9 +270,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(((Cci.ITypeReference)this).AsTypeDefinition(context) != null);
             NamedTypeSymbol baseType = this.BaseTypeNoUseSiteDiagnostics;
 
-            if (this.TypeKind == TypeKind.Submission)
+            if (this.IsScriptClass)
             {
-                // although submission semantically doesn't have a base we need to emit one into metadata:
+                // although submission and scripts semantically doesn't have a base we need to emit one into metadata:
                 Debug.Assert((object)baseType == null);
                 baseType = this.ContainingAssembly.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -48,11 +48,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return NoLocation.Singleton;
         }
 
+        /// <summary>
+        /// Returns null for a submission class.
+        /// This ensures that a submission class does not inherit methods such as ToString or GetHashCode.
+        /// </summary>
         internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
         {
             get
             {
-                // Returns null for a submission class. This ensures that a submission class does not inherit methods such as ToString or GetHashCode.
                 return IsScriptClass ? null : this.DeclaringCompilation.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                // Returns null for a submission class. This ensures that a submission class does not inherit methods such as ToString or GetHashCode.
                 return (this.TypeKind == TypeKind.Submission) ? null : this.DeclaringCompilation.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 // Returns null for a submission class. This ensures that a submission class does not inherit methods such as ToString or GetHashCode.
-                return (this.TypeKind == TypeKind.Submission) ? null : this.DeclaringCompilation.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object);
+                return IsScriptClass ? null : this.DeclaringCompilation.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -54,7 +54,7 @@ void Foo()
             var scriptClass = ((NamedTypeSymbol)c.Assembly.GlobalNamespace.GetMembers().Single());
             Assert.Equal(0, scriptClass.GetAttributes().Length);
             Assert.Equal(0, scriptClass.Interfaces.Length);
-            Assert.Equal(c.ObjectType, scriptClass.BaseType);
+            Assert.Equal(null, scriptClass.BaseType);
             Assert.Equal(0, scriptClass.Arity);
             Assert.True(scriptClass.IsImplicitlyDeclared);
             Assert.Equal(SyntaxKind.CompilationUnit, scriptClass.DeclaringSyntaxReferences.Single().GetSyntax().Kind());

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -46,6 +47,7 @@ namespace N
         public void ScriptClassSymbol()
         {
             var c = CreateCompilationWithMscorlib(@"
+base.ToString();
 void Foo()
 {
 }
@@ -54,12 +56,20 @@ void Foo()
             var scriptClass = ((NamedTypeSymbol)c.Assembly.GlobalNamespace.GetMembers().Single());
             Assert.Equal(0, scriptClass.GetAttributes().Length);
             Assert.Equal(0, scriptClass.Interfaces.Length);
-            Assert.Equal(null, scriptClass.BaseType);
+            Assert.Null(scriptClass.BaseType);
             Assert.Equal(0, scriptClass.Arity);
             Assert.True(scriptClass.IsImplicitlyDeclared);
             Assert.Equal(SyntaxKind.CompilationUnit, scriptClass.DeclaringSyntaxReferences.Single().GetSyntax().Kind());
             Assert.False(scriptClass.IsSubmissionClass);
             Assert.True(scriptClass.IsScriptClass);
+
+            var tree = c.SyntaxTrees.Single();
+            var model = c.GetSemanticModel(tree);
+
+            IEnumerable<IdentifierNameSyntax> identifiers = tree.GetCompilationUnitRoot().DescendantNodes().OfType<IdentifierNameSyntax>();
+            var toStringIdentifier = identifiers.Where(node => node.Identifier.ValueText.Equals("ToString")).Single();
+
+            Assert.Null(model.GetSymbolInfo(toStringIdentifier).Symbol);
         }
 
         [Fact, WorkItem(531535, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531535")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -79,11 +79,11 @@ $$", @"System", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.
         public async Task InactiveRegion()
         {
             await VerifyItemIsAbsentAsync(@"class C {
-#if false 
+#if false
 $$
 #endif", @"String");
             await VerifyItemIsAbsentAsync(@"class C {
-#if false 
+#if false
 $$
 #endif", @"System");
         }
@@ -92,11 +92,11 @@ $$
         public async Task ActiveRegion()
         {
             await VerifyItemIsAbsentAsync(@"class C {
-#if true 
+#if true
 $$
 #endif", @"String");
             await VerifyItemExistsAsync(@"class C {
-#if true 
+#if true
 $$
 #endif", @"System");
         }
@@ -107,13 +107,13 @@ $$
             await VerifyItemIsAbsentAsync(@"using System;
 
 class C {
-#if false 
+#if false
 $$
 #endif", @"String");
             await VerifyItemIsAbsentAsync(@"using System;
 
 class C {
-#if false 
+#if false
 $$
 #endif", @"System");
         }
@@ -124,13 +124,13 @@ $$
             await VerifyItemExistsAsync(@"using System;
 
 class C {
-#if true 
+#if true
 $$
 #endif", @"String");
             await VerifyItemExistsAsync(@"using System;
 
 class C {
-#if true 
+#if true
 $$
 #endif", @"System");
         }
@@ -2569,7 +2569,7 @@ $@"({FeaturesResources.LocalVariable}) 'a a
 class Program {
     string field = 0;
     static void Main()     {
-        var an = new {  new $$  }; 
+        var an = new {  new $$  };
     }
 }
 ";
@@ -2739,7 +2739,7 @@ class A
 {
     public event Func<String, String> E;
 }
- 
+
 class Program
 {
     static void Main(string[] args)
@@ -3090,11 +3090,11 @@ class Program
 using System;
 public class X : Attribute
 { }
- 
+
 public class XAttribute : Attribute
 { }
- 
- 
+
+
 [@X$$]
 class Class3 { }
 ";
@@ -3108,7 +3108,7 @@ class Class3 { }
         {
             await VerifyItemExistsAsync(@"
 using System;
- 
+
 class Program
 {
     static void Main()
@@ -3125,7 +3125,7 @@ class Program
         {
             await VerifyItemExistsAsync(@"
 using System;
- 
+
 class Program
 {
     static void Main()
@@ -3142,7 +3142,7 @@ class Program
         {
             await VerifyItemExistsAsync(@"
 using System;
- 
+
 class Program
 {
     static void Main()
@@ -3159,7 +3159,7 @@ class Program
         {
             await VerifyItemExistsAsync(@"
 using System;
- 
+
 class Program
 {
     static void Main()
@@ -3279,7 +3279,7 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar() 
+    public static void Bar()
     {
     }
 }";
@@ -3310,7 +3310,7 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar() 
+    public static void Bar()
     {
     }
 }";
@@ -3341,7 +3341,7 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
-    public static void Bar() 
+    public static void Bar()
     {
     }
 }";
@@ -3383,12 +3383,12 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar() 
+    public static void Bar()
     {
     }
 
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar(int x) 
+    public static void Bar(int x)
     {
     }
 }";
@@ -3420,12 +3420,12 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar() 
+    public static void Bar()
     {
     }
 
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar(int x) 
+    public static void Bar(int x)
     {
     }
 }";
@@ -3457,12 +3457,12 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar() 
+    public static void Bar()
     {
     }
 
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar(int x) 
+    public static void Bar(int x)
     {
     }
 }";
@@ -3774,14 +3774,14 @@ class Program
             var referencedCode = @"
 public class B
 {
-    public virtual void Foo(int original) 
+    public virtual void Foo(int original)
     {
     }
 }
 
 public class D : B
 {
-    public override void Foo(int derived) 
+    public override void Foo(int derived)
     {
     }
 }";
@@ -3814,7 +3814,7 @@ class Program
 [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
 public class C
 {
-    public void Foo() 
+    public void Foo()
     {
     }
 }";
@@ -3847,7 +3847,7 @@ class Program
 [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
 public class B
 {
-    public void Foo() 
+    public void Foo()
     {
     }
 }
@@ -3886,7 +3886,7 @@ class Program : B
 public class B
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public void Foo() 
+    public void Foo()
     {
     }
 }";
@@ -4727,7 +4727,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -4813,7 +4813,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -4899,7 +4899,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -5018,7 +5018,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -5050,7 +5050,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -5154,7 +5154,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -5323,7 +5323,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -5427,7 +5427,7 @@ class Program
 {
     public void M()
     {
-        $$    
+        $$
     }
 }";
 
@@ -6085,7 +6085,7 @@ class A
 {
     static void Foo() { }
     void Bar() { }
- 
+
     static void Main()
     {
         A A = new A();
@@ -6357,7 +6357,7 @@ class Program
 class Program
 {
     RegistryKey foo;
- 
+
     static void Main(string[] args)
     {
         foo.$$
@@ -6510,6 +6510,13 @@ class C
 }";
 
             await VerifyNoItemsExistAsync(markup);
+        }
+
+        [WorkItem(7788)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NothingAfterBaseDotInScriptContext()
+        {
+            await VerifyItemIsAbsentAsync(@"base.$$", @"ToString", sourceCodeKind: SourceCodeKind.Script);
         }
 
         [WorkItem(858086, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/858086")]
@@ -7276,10 +7283,10 @@ class X
 {
   private int _field;
 
-  public sealed class InnerTest : Test 
+  public sealed class InnerTest : Test
   {
-    
-    public void SomeTest() 
+
+    public void SomeTest()
     {
         $$
     }
@@ -7477,8 +7484,8 @@ class Program
 using IAlias = IFoo;
 ///<summary>summary for interface IFoo</summary>
 interface IFoo {  }
-class C 
-{ 
+class C
+{
     I$$
 }
 ";
@@ -7489,8 +7496,8 @@ class C
         public async Task WithinNameOf()
         {
             var markup = @"
-class C 
-{ 
+class C
+{
     void foo()
     {
         var x = nameof($$)
@@ -7557,7 +7564,7 @@ class C
     class D
     {
         public int x;
-        public static int y;   
+        public static int y;
     }
 
   void foo()
@@ -7581,12 +7588,12 @@ class C
         var x = nameof(T.z.$$)
     }
 }
- 
+
 public class T
 {
-    public U z; 
+    public U z;
 }
- 
+
 public class U
 {
     public int nope;
@@ -7606,12 +7613,12 @@ public class U
         var x = nameof(U.$$)
     }
 }
- 
+
 public class T
 {
-    public U z; 
+    public U z;
 }
- 
+
 public class U
 {
     public int nope;
@@ -8249,7 +8256,7 @@ public static class Test
 ";
             await VerifyItemExistsAsync(markup, "TestA");
         }
-        
+
         [WorkItem(7932, "https://github.com/dotnet/roslyn/issues/7932")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task ExtensionMethodWithinParentClassOfferedForCompletion()

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -79,11 +79,11 @@ $$", @"System", expectedDescriptionOrNull: null, sourceCodeKind: SourceCodeKind.
         public async Task InactiveRegion()
         {
             await VerifyItemIsAbsentAsync(@"class C {
-#if false
+#if false 
 $$
 #endif", @"String");
             await VerifyItemIsAbsentAsync(@"class C {
-#if false
+#if false 
 $$
 #endif", @"System");
         }
@@ -92,11 +92,11 @@ $$
         public async Task ActiveRegion()
         {
             await VerifyItemIsAbsentAsync(@"class C {
-#if true
+#if true 
 $$
 #endif", @"String");
             await VerifyItemExistsAsync(@"class C {
-#if true
+#if true 
 $$
 #endif", @"System");
         }
@@ -107,13 +107,13 @@ $$
             await VerifyItemIsAbsentAsync(@"using System;
 
 class C {
-#if false
+#if false 
 $$
 #endif", @"String");
             await VerifyItemIsAbsentAsync(@"using System;
 
 class C {
-#if false
+#if false 
 $$
 #endif", @"System");
         }
@@ -124,13 +124,13 @@ $$
             await VerifyItemExistsAsync(@"using System;
 
 class C {
-#if true
+#if true 
 $$
 #endif", @"String");
             await VerifyItemExistsAsync(@"using System;
 
 class C {
-#if true
+#if true 
 $$
 #endif", @"System");
         }
@@ -2569,7 +2569,7 @@ $@"({FeaturesResources.LocalVariable}) 'a a
 class Program {
     string field = 0;
     static void Main()     {
-        var an = new {  new $$  };
+        var an = new {  new $$  }; 
     }
 }
 ";
@@ -2739,7 +2739,7 @@ class A
 {
     public event Func<String, String> E;
 }
-
+ 
 class Program
 {
     static void Main(string[] args)
@@ -3090,11 +3090,11 @@ class Program
 using System;
 public class X : Attribute
 { }
-
+ 
 public class XAttribute : Attribute
 { }
-
-
+ 
+ 
 [@X$$]
 class Class3 { }
 ";
@@ -3108,7 +3108,7 @@ class Class3 { }
         {
             await VerifyItemExistsAsync(@"
 using System;
-
+ 
 class Program
 {
     static void Main()
@@ -3125,7 +3125,7 @@ class Program
         {
             await VerifyItemExistsAsync(@"
 using System;
-
+ 
 class Program
 {
     static void Main()
@@ -3142,7 +3142,7 @@ class Program
         {
             await VerifyItemExistsAsync(@"
 using System;
-
+ 
 class Program
 {
     static void Main()
@@ -3159,7 +3159,7 @@ class Program
         {
             await VerifyItemExistsAsync(@"
 using System;
-
+ 
 class Program
 {
     static void Main()
@@ -3279,7 +3279,7 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar()
+    public static void Bar() 
     {
     }
 }";
@@ -3310,7 +3310,7 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar()
+    public static void Bar() 
     {
     }
 }";
@@ -3341,7 +3341,7 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
-    public static void Bar()
+    public static void Bar() 
     {
     }
 }";
@@ -3383,12 +3383,12 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar()
+    public static void Bar() 
     {
     }
 
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar(int x)
+    public static void Bar(int x) 
     {
     }
 }";
@@ -3420,12 +3420,12 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Always)]
-    public static void Bar()
+    public static void Bar() 
     {
     }
 
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar(int x)
+    public static void Bar(int x) 
     {
     }
 }";
@@ -3457,12 +3457,12 @@ class Program
 public class Foo
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar()
+    public static void Bar() 
     {
     }
 
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void Bar(int x)
+    public static void Bar(int x) 
     {
     }
 }";
@@ -3774,14 +3774,14 @@ class Program
             var referencedCode = @"
 public class B
 {
-    public virtual void Foo(int original)
+    public virtual void Foo(int original) 
     {
     }
 }
 
 public class D : B
 {
-    public override void Foo(int derived)
+    public override void Foo(int derived) 
     {
     }
 }";
@@ -3814,7 +3814,7 @@ class Program
 [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
 public class C
 {
-    public void Foo()
+    public void Foo() 
     {
     }
 }";
@@ -3847,7 +3847,7 @@ class Program
 [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
 public class B
 {
-    public void Foo()
+    public void Foo() 
     {
     }
 }
@@ -3886,7 +3886,7 @@ class Program : B
 public class B
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public void Foo()
+    public void Foo() 
     {
     }
 }";
@@ -4727,7 +4727,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -4813,7 +4813,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -4899,7 +4899,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -5018,7 +5018,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -5050,7 +5050,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -5154,7 +5154,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -5323,7 +5323,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -5427,7 +5427,7 @@ class Program
 {
     public void M()
     {
-        $$
+        $$    
     }
 }";
 
@@ -6085,7 +6085,7 @@ class A
 {
     static void Foo() { }
     void Bar() { }
-
+ 
     static void Main()
     {
         A A = new A();
@@ -6357,7 +6357,7 @@ class Program
 class Program
 {
     RegistryKey foo;
-
+ 
     static void Main(string[] args)
     {
         foo.$$
@@ -7283,10 +7283,10 @@ class X
 {
   private int _field;
 
-  public sealed class InnerTest : Test
+  public sealed class InnerTest : Test 
   {
-
-    public void SomeTest()
+    
+    public void SomeTest() 
     {
         $$
     }
@@ -7484,8 +7484,8 @@ class Program
 using IAlias = IFoo;
 ///<summary>summary for interface IFoo</summary>
 interface IFoo {  }
-class C
-{
+class C 
+{ 
     I$$
 }
 ";
@@ -7496,8 +7496,8 @@ class C
         public async Task WithinNameOf()
         {
             var markup = @"
-class C
-{
+class C 
+{ 
     void foo()
     {
         var x = nameof($$)
@@ -7564,7 +7564,7 @@ class C
     class D
     {
         public int x;
-        public static int y;
+        public static int y;   
     }
 
   void foo()
@@ -7588,12 +7588,12 @@ class C
         var x = nameof(T.z.$$)
     }
 }
-
+ 
 public class T
 {
-    public U z;
+    public U z; 
 }
-
+ 
 public class U
 {
     public int nope;
@@ -7613,12 +7613,12 @@ public class U
         var x = nameof(U.$$)
     }
 }
-
+ 
 public class T
 {
-    public U z;
+    public U z; 
 }
-
+ 
 public class U
 {
     public int nope;
@@ -8256,7 +8256,7 @@ public static class Test
 ";
             await VerifyItemExistsAsync(markup, "TestA");
         }
-
+        
         [WorkItem(7932, "https://github.com/dotnet/roslyn/issues/7932")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task ExtensionMethodWithinParentClassOfferedForCompletion()

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -2309,6 +2309,12 @@ End Class
             Await VerifyItemExistsAsync(markup, "Configure")
         End Function
 
+        <WorkItem(7788)>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNothingMyBaseDotInScriptContext() As Task
+            Await VerifyItemIsAbsentAsync("MyBase.$$", "ToString", sourceCodeKind:=SourceCodeKind.Script)
+        End Function
+
         <WorkItem(543580, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543580")>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAfterMyBaseDot2() As Task


### PR DESCRIPTION
Makes the symbol lookup return no symbols when completing `base.` inside
of a REPL.
Fixes #7648