### PR TITLE
Construct submissions with empty file path in VS

### DIFF
--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -202,6 +202,38 @@ class D { }
             }
         }
 
+        [Fact]
+        public async void TestAddedSubmissionParseTreeHasEmptyFilePath()
+        {
+            using (var workspace = CreateWorkspace())
+            {
+                var document1 = new TestHostDocument("var x = 1;", displayName: "Sub1", sourceCodeKind: SourceCodeKind.Script);
+                var project1 = new TestHostProject(workspace, document1, name: "Submission");
+
+                var document2 = new TestHostDocument("var x = 2;", displayName: "Sub2", sourceCodeKind: SourceCodeKind.Script, filePath: "a.csx");
+                var project2 = new TestHostProject(workspace, document2, name: "Script");
+
+                workspace.AddTestProject(project1);
+                workspace.AddTestProject(project2);
+
+                workspace.TryApplyChanges(workspace.CurrentSolution);
+
+                // Check that a parse tree for a submission has an empty file path.
+                SyntaxTree tree1 = await workspace.CurrentSolution
+                    .GetProjectState(project1.Id)
+                    .GetDocumentState(document1.Id)
+                    .GetSyntaxTreeAsync(CancellationToken.None);
+                Assert.Equal("", tree1.FilePath);
+
+                // Check that a parse tree for a script does not have an empty file path.
+                SyntaxTree tree2 = await workspace.CurrentSolution
+                    .GetProjectState(project2.Id)
+                    .GetDocumentState(document2.Id)
+                    .GetSyntaxTreeAsync(CancellationToken.None);
+                Assert.Equal("a.csx", tree2.FilePath);
+            }
+        }
+
         private static async Task VerifyRootTypeNameAsync(TestWorkspace workspaceSnapshotBuilder, string typeName)
         {
             var currentSnapshot = workspaceSnapshotBuilder.CurrentSolution;

--- a/src/EditorFeatures/Test/Workspaces/TestHostDocument.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestHostDocument.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _loader = new TestDocumentLoader(this);
         }
 
-        public TestHostDocument(string text = "", string displayName = "", SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, DocumentId id = null)
+        public TestHostDocument(string text = "", string displayName = "", SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, DocumentId id = null, string filePath = null)
         {
             _exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
             _id = id;
@@ -148,6 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _name = displayName;
             _sourceCodeKind = sourceCodeKind;
             _loader = new TestDocumentLoader(this);
+            _filePath = filePath;
         }
 
         internal void SetProject(TestHostProject project)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -87,10 +87,17 @@ namespace Microsoft.CodeAnalysis
         }
 
         // This is the string used to represent the FilePath property on a SyntaxTree object.
-        // if the document does not yet have a file path, use the document's name instead.
+        // if the document does not yet have a file path, use the document's name instead in regular code
+        // or an empty string in script code.
         private static string GetSyntaxTreeFilePath(DocumentInfo info)
         {
-            return info.FilePath ?? info.Name;
+            if (info.FilePath != null)
+            {
+                return info.FilePath;
+            }
+            return info.SourceCodeKind == SourceCodeKind.Regular
+                ? info.Name
+                : "";
         }
 
         private static ValueSource<TreeAndVersion> CreateLazyFullyParsedTree(


### PR DESCRIPTION
Sets file paths for parsed syntax tree to "" in VS document state.
This is the same path name as set by the scripting API.

Fixes #7645.