### PR TITLE
Only allow one client to produce a symbol tree info at a time.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public abstract MetadataId MetadataId { get; }
+        public abstract AssemblyMetadata GetMetadata();
 
         INamedTypeSymbol IAssemblySymbol.ResolveForwardedType(string fullyQualifiedMetadataName)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -973,6 +973,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public abstract MetadataId MetadataId { get; }
+
         INamedTypeSymbol IAssemblySymbol.ResolveForwardedType(string fullyQualifiedMetadataName)
         {
             return ResolveForwardedType(fullyQualifiedMetadataName);

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -973,6 +973,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        /// <summary>
+        /// If this symbol represents a metadata assembly returns the underlying <see cref="AssemblyMetadata"/>.
+        /// 
+        /// Otherwise, this returns <code>null</code>.
+        /// </summary>
         public abstract AssemblyMetadata GetMetadata();
 
         INamedTypeSymbol IAssemblySymbol.ResolveForwardedType(string fullyQualifiedMetadataName)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using Roslyn.Utilities;
 using System.Diagnostics;
 using System.Linq;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
@@ -248,5 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get { return null; }
         }
+
+        public override MetadataId MetadataId => _assembly.MetadataId;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using Roslyn.Utilities;
 using System.Diagnostics;
 using System.Linq;
-using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
@@ -249,6 +249,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get { return null; }
         }
 
-        public override AssemblyMetadata GetMetadata() => _assembly.GetMetadataCopy();
+        public override AssemblyMetadata GetMetadata() => _assembly.GetNonDisposableMetadata();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
@@ -250,6 +250,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get { return null; }
         }
 
-        public override MetadataId MetadataId => _assembly.MetadataId;
+        public override AssemblyMetadata GetMetadata() => _assembly.GetMetadataCopy();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -682,5 +682,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 yield return assemblySymbol.LookupTopLevelMetadataType(ref name, digThroughForwardedTypes: true);
             }
         }
+
+        public override ModuleMetadata GetMetadata() => _module.GetMetadataCopy();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -683,6 +683,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        public override ModuleMetadata GetMetadata() => _module.GetMetadataCopy();
+        public override ModuleMetadata GetMetadata() => _module.GetNonDisposableMetadata();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
@@ -184,5 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
         }
+
+        public override MetadataId MetadataId => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
@@ -185,6 +185,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override MetadataId MetadataId => null;
+        public override AssemblyMetadata GetMetadata() => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -183,6 +183,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { return null; }
         }
+
+        public override ModuleMetadata GetMetadata() => null;
     }
 
     internal class MissingModuleSymbolWithName : MissingModuleSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -377,6 +377,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitModule(this);
         }
 
+        public abstract ModuleMetadata GetMetadata();
+
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -377,6 +377,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitModule(this);
         }
 
+        /// <summary>
+        /// If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
+        /// 
+        /// Otherwise, this returns <code>null</code>.
+        /// </summary>
         public abstract ModuleMetadata GetMetadata();
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
@@ -284,5 +284,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
             return this.RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName);
         }
+
+        public override MetadataId MetadataId => _underlyingAssembly.MetadataId;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
@@ -285,6 +285,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return this.RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName);
         }
 
-        public override MetadataId MetadataId => _underlyingAssembly.MetadataId;
+        public override AssemblyMetadata GetMetadata() => _underlyingAssembly.GetMetadata();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -282,5 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get { return null; }
         }
+
+        public override ModuleMetadata GetMetadata() => _underlyingModule.GetMetadata();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2557,5 +2557,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return null;
         }
+
+        public override MetadataId MetadataId => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2558,6 +2558,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        public override MetadataId MetadataId => null;
+        public override AssemblyMetadata GetMetadata() => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -555,5 +556,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return data != null && data.HasDefaultCharSetAttribute ? data.DefaultCharacterSet : (CharSet?)null;
             }
         }
+
+        public override ModuleMetadata GetMetadata() => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -8,7 +7,6 @@ using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
@@ -105,6 +105,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return null;
         }
 
-        public override MetadataId MetadataId => null;
+        public override AssemblyMetadata GetMetadata() => null;
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
@@ -104,5 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             return null;
         }
+
+        public override MetadataId MetadataId => null;
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
@@ -174,5 +174,7 @@ namespace Microsoft.CodeAnalysis
                 return _lazyDeclaresTheObjectClass == ThreeState.True;
             }
         }
+
+        public MetadataId MetadataId => _owner.Id;
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
@@ -175,6 +175,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public AssemblyMetadata GetMetadataCopy() => _owner.Copy();
+        public AssemblyMetadata GetNonDisposableMetadata() => _owner.Copy();
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
@@ -40,7 +40,10 @@ namespace Microsoft.CodeAnalysis
 
         private ThreeState _lazyDeclaresTheObjectClass;
 
-        // We need to store reference for to keep the metadata alive while symbols have reference to PEAssembly.
+        /// <summary>
+        /// We need to store reference to the assembly metadata to keep the metadata alive while 
+        /// symbols have reference to PEAssembly.
+        /// </summary>
         private readonly AssemblyMetadata _owner;
 
         //Maps from simple name to list of public keys. If an IVT attribute specifies no public

--- a/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEAssembly.cs
@@ -175,6 +175,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public MetadataId MetadataId => _owner.Id;
+        public AssemblyMetadata GetMetadataCopy() => _owner.Copy();
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -24,7 +24,10 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal sealed class PEModule : IDisposable
     {
-        // We need to store reference for to keep the metadata alive while symbols have reference to PEModule.
+        /// <summary>
+        /// We need to store reference to the module metadata to keep the metadata alive while 
+        /// symbols have reference to PEModule.
+        /// </summary>
         private readonly ModuleMetadata _owner;
 
         // Either we have PEReader or we have pointer and size of the metadata blob:

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -2971,6 +2971,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public ModuleMetadata GetMetadataCopy() => _owner.Copy();
+        public ModuleMetadata GetNonDisposableMetadata() => _owner.Copy();
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis
 
         // creates a copy
         private AssemblyMetadata(AssemblyMetadata other)
-            : base(isImageOwner: false)
+            : base(isImageOwner: false, id: other.Id)
         {
             this.CachedSymbols = other.CachedSymbols;
             _lazyData = other._lazyData;
@@ -81,14 +81,14 @@ namespace Microsoft.CodeAnalysis
         }
 
         internal AssemblyMetadata(ImmutableArray<ModuleMetadata> modules)
-            : base(isImageOwner: true)
+            : base(isImageOwner: true, id: new MetadataId())
         {
             Debug.Assert(!modules.IsDefaultOrEmpty);
             _initialModules = modules;
         }
 
         internal AssemblyMetadata(ModuleMetadata manifestModule, Func<string, ModuleMetadata> moduleFactory)
-            : base(isImageOwner: true)
+            : base(isImageOwner: true, id: new MetadataId())
         {
             Debug.Assert(manifestModule != null);
             Debug.Assert(moduleFactory != null);

--- a/src/Compilers/Core/Portable/MetadataReference/Metadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/Metadata.cs
@@ -6,15 +6,34 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
+    /// An Id that can be used to identify a metadata instance.  If two metadata instances 
+    /// have the same id then they are guaranteed to have the same content.  If two metadata
+    /// instances have different ids, then the contents may or may not be the same.  As such,
+    /// the id is useful as a key in a cache when a client wants to share data for a metadata
+    /// reference as long as it has not changed.
+    /// </summary>
+    public sealed class MetadataId
+    {
+    }
+
+    /// <summary>
     /// Represents immutable assembly or module CLI metadata.
     /// </summary>
     public abstract class Metadata : IDisposable
     {
         internal readonly bool IsImageOwner;
 
-        internal Metadata(bool isImageOwner)
+        /// <summary>
+        /// The id for this metadata instance.  If two metadata instances have the same id, then 
+        /// they have the same content.  If they have different ids they may or may not have the
+        /// same content.
+        /// </summary>
+        public MetadataId Id { get; }
+
+        internal Metadata(bool isImageOwner, MetadataId id)
         {
             this.IsImageOwner = isImageOwner;
+            this.Id = id;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
@@ -24,13 +24,13 @@ namespace Microsoft.CodeAnalysis
         private ModuleMetadata(PEReader peReader)
             : base(isImageOwner: true, id: new MetadataId())
         {
-            _module = new PEModule(peReader: peReader, metadataOpt: IntPtr.Zero, metadataSizeOpt: 0);
+            _module = new PEModule(this, peReader: peReader, metadataOpt: IntPtr.Zero, metadataSizeOpt: 0);
         }
 
         private ModuleMetadata(IntPtr metadata, int size, bool includeEmbeddedInteropTypes)
             : base(isImageOwner: true, id: new MetadataId())
         {
-            _module = new PEModule(peReader: null, metadataOpt: metadata, metadataSizeOpt: size, includeEmbeddedInteropTypes: includeEmbeddedInteropTypes);
+            _module = new PEModule(this, peReader: null, metadataOpt: metadata, metadataSizeOpt: size, includeEmbeddedInteropTypes: includeEmbeddedInteropTypes);
         }
 
         // creates a copy

--- a/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
@@ -22,20 +22,20 @@ namespace Microsoft.CodeAnalysis
         private readonly PEModule _module;
 
         private ModuleMetadata(PEReader peReader)
-            : base(isImageOwner: true)
+            : base(isImageOwner: true, id: new MetadataId())
         {
             _module = new PEModule(peReader: peReader, metadataOpt: IntPtr.Zero, metadataSizeOpt: 0);
         }
 
         private ModuleMetadata(IntPtr metadata, int size, bool includeEmbeddedInteropTypes)
-            : base(isImageOwner: true)
+            : base(isImageOwner: true, id: new MetadataId())
         {
             _module = new PEModule(peReader: null, metadataOpt: metadata, metadataSizeOpt: size, includeEmbeddedInteropTypes: includeEmbeddedInteropTypes);
         }
 
         // creates a copy
         private ModuleMetadata(ModuleMetadata metadata)
-            : base(isImageOwner: false)
+            : base(isImageOwner: false, id: metadata.Id)
         {
             _module = metadata.Module;
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -84,7 +84,7 @@ Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SyntaxNodeAct
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SyntaxTreeActionsCount.get -> int
 Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Embedded = 3 -> Microsoft.CodeAnalysis.Emit.DebugInformationFormat
 Microsoft.CodeAnalysis.Emit.DebugInformationFormat.PortablePdb = 2 -> Microsoft.CodeAnalysis.Emit.DebugInformationFormat
-Microsoft.CodeAnalysis.IAssemblySymbol.MetadataId.get -> Microsoft.CodeAnalysis.MetadataId
+Microsoft.CodeAnalysis.IAssemblySymbol.GetMetadata() -> Microsoft.CodeAnalysis.AssemblyMetadata
 Microsoft.CodeAnalysis.ICompilationUnitSyntax
 Microsoft.CodeAnalysis.ICompilationUnitSyntax.EndOfFileToken.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.Metadata.Id.get -> Microsoft.CodeAnalysis.MetadataId

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -84,8 +84,11 @@ Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SyntaxNodeAct
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SyntaxTreeActionsCount.get -> int
 Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Embedded = 3 -> Microsoft.CodeAnalysis.Emit.DebugInformationFormat
 Microsoft.CodeAnalysis.Emit.DebugInformationFormat.PortablePdb = 2 -> Microsoft.CodeAnalysis.Emit.DebugInformationFormat
+Microsoft.CodeAnalysis.IAssemblySymbol.MetadataId.get -> Microsoft.CodeAnalysis.MetadataId
 Microsoft.CodeAnalysis.ICompilationUnitSyntax
 Microsoft.CodeAnalysis.ICompilationUnitSyntax.EndOfFileToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.Metadata.Id.get -> Microsoft.CodeAnalysis.MetadataId
+Microsoft.CodeAnalysis.MetadataId
 Microsoft.CodeAnalysis.MetadataReference.MetadataReference(Microsoft.CodeAnalysis.MetadataReferenceProperties properties) -> void
 Microsoft.CodeAnalysis.ParseOptions.WithKind(Microsoft.CodeAnalysis.SourceCodeKind kind) -> Microsoft.CodeAnalysis.ParseOptions
 Microsoft.CodeAnalysis.ScriptCompilationInfo

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -87,6 +87,7 @@ Microsoft.CodeAnalysis.Emit.DebugInformationFormat.PortablePdb = 2 -> Microsoft.
 Microsoft.CodeAnalysis.IAssemblySymbol.GetMetadata() -> Microsoft.CodeAnalysis.AssemblyMetadata
 Microsoft.CodeAnalysis.ICompilationUnitSyntax
 Microsoft.CodeAnalysis.ICompilationUnitSyntax.EndOfFileToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.IModuleSymbol.GetMetadata() -> Microsoft.CodeAnalysis.ModuleMetadata
 Microsoft.CodeAnalysis.Metadata.Id.get -> Microsoft.CodeAnalysis.MetadataId
 Microsoft.CodeAnalysis.MetadataId
 Microsoft.CodeAnalysis.MetadataReference.MetadataReference(Microsoft.CodeAnalysis.MetadataReferenceProperties properties) -> void

--- a/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
@@ -74,13 +74,10 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// If this is an <see cref="IAssemblySymbol"/> for an <see cref="AssemblyMetadata"/>,
-        /// this returns the <see cref="Metadata.Id"/> for that <see cref="AssemblyMetadata"/>.
+        /// this returns that <see cref="AssemblyMetadata"/>.
         /// 
         /// Otherwise, this returns <code>null</code>.
-        /// 
-        /// If two assembly symbols are created from the same underlying <see cref="AssemblyMetadata"/>
-        /// object, then they will have the same Id.
         /// </summary>
-        MetadataId MetadataId { get; }
+        AssemblyMetadata GetMetadata();
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
@@ -71,5 +71,16 @@ namespace Microsoft.CodeAnalysis
         /// null is returned.
         /// </summary>
         INamedTypeSymbol ResolveForwardedType(string fullyQualifiedMetadataName);
+
+        /// <summary>
+        /// If this is an <see cref="IAssemblySymbol"/> for an <see cref="AssemblyMetadata"/>,
+        /// this returns the <see cref="Metadata.Id"/> for that <see cref="AssemblyMetadata"/>.
+        /// 
+        /// Otherwise, this returns <code>null</code>.
+        /// 
+        /// If two assembly symbols are created from the same underlying <see cref="AssemblyMetadata"/>
+        /// object, then they will have the same Id.
+        /// </summary>
+        MetadataId MetadataId { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IAssemblySymbol.cs
@@ -73,8 +73,7 @@ namespace Microsoft.CodeAnalysis
         INamedTypeSymbol ResolveForwardedType(string fullyQualifiedMetadataName);
 
         /// <summary>
-        /// If this is an <see cref="IAssemblySymbol"/> for an <see cref="AssemblyMetadata"/>,
-        /// this returns that <see cref="AssemblyMetadata"/>.
+        /// If this symbol represents a metadata assembly returns the underlying <see cref="AssemblyMetadata"/>.
         /// 
         /// Otherwise, this returns <code>null</code>.
         /// </summary>

--- a/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
@@ -38,5 +38,13 @@ namespace Microsoft.CodeAnalysis
         /// from ReferencedAssemblySymbols correspond to each other.
         /// </summary>
         ImmutableArray<IAssemblySymbol> ReferencedAssemblySymbols { get; }
+
+        /// <summary>
+        /// If this is an <see cref="IModuleSymbol"/> for an <see cref="ModuleMetadata"/>,
+        /// this returns that <see cref="ModuleMetadata"/>.
+        /// 
+        /// Otherwise, this returns <code>null</code>.
+        /// </summary>
+        ModuleMetadata GetMetadata();
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IModuleSymbol.cs
@@ -40,8 +40,7 @@ namespace Microsoft.CodeAnalysis
         ImmutableArray<IAssemblySymbol> ReferencedAssemblySymbols { get; }
 
         /// <summary>
-        /// If this is an <see cref="IModuleSymbol"/> for an <see cref="ModuleMetadata"/>,
-        /// this returns that <see cref="ModuleMetadata"/>.
+        /// If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
         /// 
         /// Otherwise, this returns <code>null</code>.
         /// </summary>

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -803,9 +803,7 @@ Friend Class MockAssemblySymbol
         Return Nothing
     End Function
 
-    Public Overrides ReadOnly Property MetadataId As MetadataId
-        Get
-            Return Nothing
-        End Get
-    End Property
+    Public Overrides Function GetMetadata() As AssemblyMetadata
+        Return Nothing
+    End Function
 End Class

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -706,6 +706,10 @@ Friend Class MockModuleSymbol
             Return Nothing
         End Get
     End Property
+
+    Public Overrides Function GetMetadata() As ModuleMetadata
+        Return Nothing
+    End Function
 End Class
 
 Friend Class MockAssemblySymbol

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -802,4 +802,10 @@ Friend Class MockAssemblySymbol
     Friend Overrides Function TryLookupForwardedMetadataTypeWithCycleDetection(ByRef emittedName As MetadataTypeName, visitedAssemblies As ConsList(Of AssemblySymbol), ignoreCase As Boolean) As NamedTypeSymbol
         Return Nothing
     End Function
+
+    Public Overrides ReadOnly Property MetadataId As MetadataId
+        Get
+            Return Nothing
+        End Get
+    End Property
 End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -81,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' If this symbol represents a metadata assembly returns the underlying <see cref="AssemblyMetadata"/>.
         ''' 
-        ''' Otherwise, this returns <code>null</code>.
+        ''' Otherwise, this returns <code>nothing</code>.
         ''' </summary>
         Public MustOverride Function GetMetadata() As AssemblyMetadata Implements IAssemblySymbol.GetMetadata
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -78,6 +78,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        ''' <summary>
+        ''' If this symbol represents a metadata assembly returns the underlying <see cref="AssemblyMetadata"/>.
+        ''' 
+        ''' Otherwise, this returns <code>null</code>.
+        ''' </summary>
         Public MustOverride Function GetMetadata() As AssemblyMetadata Implements IAssemblySymbol.GetMetadata
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -78,6 +78,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Public MustOverride ReadOnly Property MetadataId As MetadataId Implements IAssemblySymbol.MetadataId
+
         ''' <summary>
         ''' Get the name of this assembly.
         ''' </summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public MustOverride ReadOnly Property MetadataId As MetadataId Implements IAssemblySymbol.MetadataId
+        Public MustOverride Function GetMetadata() As AssemblyMetadata Implements IAssemblySymbol.GetMetadata
 
         ''' <summary>
         ''' Get the name of this assembly.

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
@@ -229,7 +229,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Property
 
         Public Overrides Function GetMetadata() As AssemblyMetadata
-            Return _assembly.GetMetadataCopy()
+            Return _assembly.GetNonDisposableMetadata()
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
@@ -227,6 +227,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 Return Nothing
             End Get
         End Property
+
+        Public Overrides ReadOnly Property MetadataId As MetadataId
+            Get
+                Return _assembly.MetadataId
+            End Get
+        End Property
     End Class
 End Namespace
-

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
@@ -228,10 +228,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Get
         End Property
 
-        Public Overrides ReadOnly Property MetadataId As MetadataId
-            Get
-                Return _assembly.MetadataId
-            End Get
-        End Property
+        Public Overrides Function GetMetadata() As AssemblyMetadata
+            Return _assembly.GetMetadataCopy()
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
@@ -457,5 +457,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Next
         End Function
 
+        Public Overrides Function GetMetadata() As ModuleMetadata
+            Return _module.GetMetadataCopy()
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
@@ -458,7 +458,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Public Overrides Function GetMetadata() As ModuleMetadata
-            Return _module.GetMetadataCopy()
+            Return _module.GetNonDisposableMetadata()
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
@@ -143,6 +143,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return False
             End Get
         End Property
+
+        Public Overrides ReadOnly Property MetadataId As MetadataId
+            Get
+                Return Nothing
+            End Get
+        End Property
     End Class
 
     ''' <summary>
@@ -192,5 +198,4 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         End Function
     End Class
-
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
@@ -144,11 +144,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Overrides ReadOnly Property MetadataId As MetadataId
-            Get
-                Return Nothing
-            End Get
-        End Property
+        Public Overrides Function GetMetadata() As AssemblyMetadata
+            Return Nothing
+        End Function
     End Class
 
     ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingModuleSymbol.vb
@@ -165,6 +165,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Nothing
             End Get
         End Property
+
+        Public Overrides Function GetMetadata() As ModuleMetadata
+            Return Nothing
+        End Function
     End Class
 
     Friend Class MissingModuleSymbolWithName
@@ -200,5 +204,4 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return other IsNot Nothing AndAlso m_Assembly.Equals(other.m_Assembly) AndAlso String.Equals(_name, other._name, StringComparison.OrdinalIgnoreCase)
         End Function
     End Class
-
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -126,7 +126,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
         ''' 
-        ''' Otherwise, this returns <code>null</code>.
+        ''' Otherwise, this returns <code>nothing</code>.
         ''' </summary>
         Public MustOverride Function GetMetadata() As ModuleMetadata Implements IModuleSymbol.GetMetadata
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -123,6 +123,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        ''' <summary>
+        ''' If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
+        ''' 
+        ''' Otherwise, this returns <code>null</code>.
+        ''' </summary>
         Public MustOverride Function GetMetadata() As ModuleMetadata Implements IModuleSymbol.GetMetadata
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -123,6 +123,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Public MustOverride Function GetMetadata() As ModuleMetadata Implements IModuleSymbol.GetMetadata
+
         ''' <summary>
         ''' Returns an array of assembly identities for assemblies referenced by this module.
         ''' Items at the same position from GetReferencedAssemblies and from GetReferencedAssemblySymbols 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.vb
@@ -246,5 +246,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
             Return Me.RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName)
         End Function
+
+        Public Overrides ReadOnly Property MetadataId As MetadataId
+            Get
+                Return _underlyingAssembly.MetadataId
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.vb
@@ -247,10 +247,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Return Me.RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName)
         End Function
 
-        Public Overrides ReadOnly Property MetadataId As MetadataId
-            Get
-                Return _underlyingAssembly.MetadataId
-            End Get
-        End Property
+        Public Overrides Function GetMetadata() As AssemblyMetadata
+            Return _underlyingAssembly.GetMetadata()
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingModuleSymbol.vb
@@ -273,5 +273,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         Public Overrides Function GetDocumentationCommentXml(Optional preferredCulture As CultureInfo = Nothing, Optional expandIncludes As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As String
             Return _underlyingModule.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken)
         End Function
+
+        Public Overrides Function GetMetadata() As ModuleMetadata
+            Return _underlyingModule.GetMetadata()
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1683,5 +1683,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
+        Public Overrides ReadOnly Property MetadataId As MetadataId
+            Get
+                Return Nothing
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1683,10 +1683,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        Public Overrides ReadOnly Property MetadataId As MetadataId
-            Get
-                Return Nothing
-            End Get
-        End Property
+        Public Overrides Function GetMetadata() As AssemblyMetadata
+            Return Nothing
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -1163,5 +1163,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Select
             Next
         End Sub
+
+        Public Overrides Function GetMetadata() As ModuleMetadata
+            Return Nothing
+        End Function
     End Class
 End Namespace

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -249,8 +249,9 @@ namespace D
                     compilation.Emit(exebits, pdbbits);
 
                     exebits.Position = 0;
-                    using (var module = new PEModule(new PEReader(exebits, PEStreamOptions.LeaveOpen), metadataOpt: IntPtr.Zero, metadataSizeOpt: 0))
+                    using (var metadata = ModuleMetadata.CreateFromStream(exebits, leaveOpen: true))
                     {
+                        var module = metadata.Module;
                         var metadataReader = module.MetadataReader;
                         MethodDefinitionHandle methodHandle = metadataReader.MethodDefinitions.Single(mh => metadataReader.GetString(metadataReader.GetMethodDefinition(mh).Name) == methodName);
                         int methodToken = metadataReader.GetToken(methodHandle);

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -376,8 +376,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 throw new NotImplementedException();
             }
 
-            using (var module = new PEModule(new PEReader(assembly), metadataOpt: IntPtr.Zero, metadataSizeOpt: 0))
+            using (var metadata = ModuleMetadata.CreateFromImage(assembly))
             {
+                var module = metadata.Module;
                 var reader = module.MetadataReader;
                 var typeDef = reader.GetTypeDef(parts[0]);
                 var methodName = parts[1];

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
@@ -97,10 +97,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return 0;
             }
 
-            using (var module = new PEModule(new PEReader(ImmutableArray.CreateRange(this.FullImage)), metadataOpt: IntPtr.Zero, metadataSizeOpt: 0))
+            using (var metadata = ModuleMetadata.CreateFromImage(this.FullImage))
             {
-                var reader = module.MetadataReader;
-                var methodIL = module.GetMethodBodyOrThrow(methodHandle);
+                var reader = metadata.MetadataReader;
+                var methodIL = metadata.Module.GetMethodBodyOrThrow(methodHandle);
                 var localSignatureHandle = methodIL.LocalSignature;
                 return reader.GetToken(localSignatureHandle);
             }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
@@ -124,7 +124,8 @@ End Namespace
                     compilation.Emit(exebits, pdbbits)
 
                     exebits.Position = 0
-                    Using [module] As New PEModule(New PEReader(exebits, PEStreamOptions.LeaveOpen), metadataOpt:=Nothing, metadataSizeOpt:=0)
+                    Using metadata = modulemetadata.CreateFromStream(exebits, leaveOpen:=True)
+                        Dim [module] = metadata.module
                         Dim metadataReader = [module].MetadataReader
                         Dim methodHandle = metadataReader.MethodDefinitions.Single(Function(mh) metadataReader.GetString(metadataReader.GetMethodDefinition(mh).Name) = methodName)
                         Dim methodToken = metadataReader.GetToken(methodHandle)

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.SearchScope.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
             protected override Task<IEnumerable<ISymbol>> FindDeclarationsAsync(string name, SymbolFilter filter, SearchQuery searchQuery)
             {
                 return SymbolFinder.FindDeclarationsAsync(
-                    _solution, _assembly, _metadataReference.FilePath, searchQuery, filter, cancellationToken);
+                    _solution, _assembly, _metadataReference, searchQuery, filter, cancellationToken);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     else
                     {
                         await AddDeclarationsAsync(
-                            project.Solution, assembly, GetMetadataReferenceFilePath(compilation.GetMetadataReference(assembly)),
+                            project.Solution, assembly, compilation.GetMetadataReference(assembly) as PortableExecutableReference,
                             query, criteria, list, cancellationToken).ConfigureAwait(false);
                     }
                 }
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         internal static async Task<IEnumerable<ISymbol>> FindDeclarationsAsync(
-            Solution solution, IAssemblySymbol assembly, string filePath, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
+            Solution solution, IAssemblySymbol assembly, PortableExecutableReference reference, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
             {
@@ -280,18 +280,23 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
 
             var result = new List<ISymbol>();
-            await AddDeclarationsAsync(solution, assembly, filePath, query, filter, result, cancellationToken).ConfigureAwait(false);
+            await AddDeclarationsAsync(solution, assembly, reference, query, filter, result, cancellationToken).ConfigureAwait(false);
             return result;
         }
 
         private static async Task AddDeclarationsAsync(
-            Solution solution, IAssemblySymbol assembly, string filePath, SearchQuery query, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
+            Solution solution, IAssemblySymbol assembly, PortableExecutableReference reference, SearchQuery query, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.SymbolFinder_Assembly_AddDeclarationsAsync, cancellationToken))
             {
-                var info = await SymbolTreeInfo.GetInfoForAssemblyAsync(solution, assembly, filePath, cancellationToken).ConfigureAwait(false);
-
-                list.AddRange(FilterByCriteria(Find(query, info, assembly, cancellationToken), filter));
+                if (reference != null)
+                {
+                    var info = await SymbolTreeInfo.TryGetInfoForAssemblyAsync(solution, assembly, reference, cancellationToken).ConfigureAwait(false);
+                    if (info != null)
+                    {
+                        list.AddRange(FilterByCriteria(Find(query, info, assembly, cancellationToken), filter));
+                    }
+                }
             }
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
@@ -285,13 +285,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         private static async Task AddDeclarationsAsync(
-            Solution solution, IAssemblySymbol assembly, PortableExecutableReference reference, SearchQuery query, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
+            Solution solution, IAssemblySymbol assembly, PortableExecutableReference referenceOpt, SearchQuery query, SymbolFilter filter, List<ISymbol> list, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.SymbolFinder_Assembly_AddDeclarationsAsync, cancellationToken))
             {
-                if (reference != null)
+                if (referenceOpt != null)
                 {
-                    var info = await SymbolTreeInfo.TryGetInfoForAssemblyAsync(solution, assembly, reference, cancellationToken).ConfigureAwait(false);
+                    var info = await SymbolTreeInfo.TryGetInfoForAssemblyAsync(solution, assembly, referenceOpt, cancellationToken).ConfigureAwait(false);
                     if (info != null)
                     {
                         list.AddRange(FilterByCriteria(Find(query, info, assembly, cancellationToken), filter));

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -2,13 +2,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Utilities;
-using static Roslyn.Utilities.PortableShim;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             using (await s_assemblyInfosGate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                var metadataId = assembly.MetadataId;
+                var metadataId = assembly.GetMetadata()?.Id;
                 if (metadataId == null)
                 {
                     return null;

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -192,20 +192,20 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             using (await s_assemblyInfosGate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                var metadataId = assembly.GetMetadata()?.Id;
-                if (metadataId == null)
+                var metadata = assembly.GetMetadata();
+                if (metadata == null)
                 {
                     return null;
                 }
 
                 SymbolTreeInfo info;
-                if (s_assemblyInfos.TryGetValue(metadataId, out info))
+                if (s_assemblyInfos.TryGetValue(metadata.Id, out info))
                 {
                     return info;
                 }
 
                 info = await LoadOrCreateAsync(solution, assembly, reference.FilePath, cancellationToken).ConfigureAwait(false);
-                return s_assemblyInfos.GetValue(metadataId, _ => info);
+                return s_assemblyInfos.GetValue(metadata.Id, _ => info);
             }
         }
 

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -180,9 +180,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 Assert.NotNull(mdp2Sys3);
 
                 // all references to System.dll share the same metadata bytes
-                Assert.Same(mdp1Sys1, mdp1Sys2);
-                Assert.Same(mdp1Sys1, mdp2Sys1);
-                Assert.Same(mdp1Sys1, mdp2Sys3);
+                Assert.Same(mdp1Sys1.Id, mdp1Sys2.Id);
+                Assert.Same(mdp1Sys1.Id, mdp2Sys1.Id);
+                Assert.Same(mdp1Sys1.Id, mdp2Sys3.Id);
             }
         }
 


### PR DESCRIPTION
Refresher:  SymbolTreeInfo is the type we keep around that acts as an index (by name) of all the top level symbols in a source compilation or dll.  It is used by numerous IDE features to quickly go from Name-to-Symbol (for example with features like Add-Using).  SymbolTreeInfo keeps both exact indices (i.e. the searched name must exactly match the symbol name) as well as fuzzy indices (i.e. the searched name needs to be 'close enough' to the symbol name).  

This change addresses two problems we were having with the current system around SymbolTreeInfo.

First:
The current implementation of SymbolTreeInfo does no synchronization when clients call in to create one.  This means if we have N threads trying to get the same SymbolTreeInfo we'll perform the computation for it N times, keeping only the last result.  This is pretty wasteful.  And, in my own personal testing, was happening a lot.

Now, we only allow a single SymbolTreeInfo to be created at a time, so that we don't waste any CPU producing and then throwing away work.

--

Second:
We were caching SymbolTreeInfos in a way that was causing them to be created and thrown out far more often than we would have liked.  For metadata dlls we want the lifetime of the SymbolTreeInfo to be as long as the metadata we've loaded for them.  In the IDE we load this metadata once and keep it around as long as the file hasn't changed on disk.  The introduction of the Metadata ID works to allow us to represent that lifetime, and associate our indices appropriately.  i.e. as long as a MetadataReference is still producing and caching (in the IDE case) Metadata with the same ID, then our indices for that dll will stay alive.  When the IDE dumps this metadata, then we'll dump the index as well.