### PR TITLE
Bump the compiler MSBuild task version on every build

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Desktop/MSBuildTask.Desktop.csproj
+++ b/src/Compilers/Core/MSBuildTask/Desktop/MSBuildTask.Desktop.csproj
@@ -14,6 +14,15 @@
     <AssemblyName>Microsoft.Build.Tasks.CodeAnalysis</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+
+  <PropertyGroup Condition="('$(BuildNumber)' != '') and ($(BuildNumber.Split('.').Length) == 2)">
+    <!-- Due to msbuild node reuse, the build task needs to have a different assembly
+         version to be loaded in multiple builds. Since nothing depends on the exact
+         assembly version of the build task we'll append the build number to the assembly
+         version when available (which it always is in official builds) -->
+    <AssemblyVersion>$(RoslynSemanticVersion).$(BuildNumber.Split('.')[0])</AssemblyVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>


### PR DESCRIPTION
Fixes #7185.

/cc @dotnet/roslyn-compiler @dotnet/roslyn-infrastructure @amcasey