### PR TITLE
Fix Scripting ref to System.Runtime.Loader

### DIFF
--- a/src/Scripting/Core/Scripting.csproj
+++ b/src/Scripting/Core/Scripting.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Workaround for https://github.com/NuGet/Home/issues/1471 -->
-    <Reference Include="$(NuGetPackageRoot)\System.Runtime.Loader\4.0.0-beta-23401\ref\dotnet\System.Runtime.Loader.dll">
+    <Reference Include="$(NuGetPackageRoot)\System.Runtime.Loader\4.0.0-beta-23504\ref\dotnet5.1\System.Runtime.Loader.dll">
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
The previous NuGet package got upgraded, but the ref was not

/cc @dotnet/roslyn-infrastructure @dotnet/roslyn-interactive @VSadov @amcasey 