### PR TITLE
Fix case where we weren't realizing tabs were used for indentation in broken code.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.Analyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.Analyzer.cs
@@ -59,11 +59,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     // newline.  If so, we keep track of that so we'll appropriately indent later
                     // on. 
 
-                    var previousNonMissingToken = token1.GetPreviousToken();
-                    if (previousNonMissingToken.TrailingTrivia.Count > 0 &&
-                        previousNonMissingToken.TrailingTrivia.Last().Kind() == SyntaxKind.EndOfLineTrivia)
+                    // Keep walking backward until we hit a token whose *full width* is greater than
+                    // 0.  See if this token has an end of line trivia at the end of it.  Note:
+                    // we need to "includeZeroWidth" tokens because we can have zero width tokens
+                    // that still have a full width that is non-zero.  i.e. a missing token that
+                    // still has trailing trivia on it.
+
+                    for (var currentToken = token1; !currentToken.IsKind(SyntaxKind.None); )
                     {
-                        result.LineBreaks = 1;
+                        var previousToken = currentToken.GetPreviousToken(includeSkipped: false, includeZeroWidth: true);
+                        if (previousToken.FullWidth() == 0)
+                        {
+                            currentToken = previousToken;
+                            continue;
+                        }
+
+                        // Finally hit the first previous token with non-zero full width.
+                        if (previousToken.TrailingTrivia.Count > 0 &&
+                            previousToken.TrailingTrivia.Last().Kind() == SyntaxKind.EndOfLineTrivia)
+                        {
+                            result.LineBreaks = 1;
+                        }
+
+                        break;
                     }
                 }
                 else

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6950,6 +6950,29 @@ class Program
 }", changedOptionSet: optionSet);
         }
 
+        [WorkItem(4014, "https://github.com/dotnet/roslyn/issues/4014")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormattingCodeWithBrokenInterpolatedStringShouldRespectFormatTabsOption()
+        {
+            var optionSet = new Dictionary<OptionKey, object> { { new OptionKey(FormattingOptions.UseTabs, LanguageNames.CSharp), true } };
+
+            await AssertFormatAsync(@"class AClass
+{
+	void Main()
+	{
+		Test($""\""_{\"""");
+		Console.WriteLine(args);
+	}
+}", @"class AClass
+{
+	void Main()
+	{
+		Test($""\""_{\"""");
+		Console.WriteLine(args);
+	}
+}", changedOptionSet: optionSet);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(84, "https://github.com/dotnet/roslyn/issues/84")]
         [WorkItem(849870, "DevDiv")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/4014