### PR TITLE
Round-trip notion of nullable reference types through metadata emit/metadata import cycle.

### DIFF
--- a/docs/features/NullableReferenceTypes/ImplementationNotes.md
+++ b/docs/features/NullableReferenceTypes/ImplementationNotes.md
@@ -86,3 +86,32 @@ Array type syntax is extended as follows to allow nullable modifiers:
 
 Warnings are reported when there is a signature mismatch with respect to nullability of reference types during overriding, 
 interface implementing, or partial method implementing. 
+
+
+**NullableAttribute**
+NullableAttribute is applied to a module if it utilizes Nullable Reference Types feature.
+NullableAttribute is applied to other targets in the module to point to specific nullable reference types in type references. 
+The attribute is applied in the same fashion as DynamicAttribute, with the following exceptions:
+- For types of events, it is applied to event declarations (not just to parameters of accessors).
+- Types used as custom modifiers, do not have dedicated transform flags.
+
+Here is the definition of the NullableAttribute required for the successful compilation:
+```
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Event | // The type of the event is nullable, or has a nullable reference type as one of its constituents
+                    AttributeTargets.Field | // The type of the field is a nullable reference type, or has a nullable reference type as one of its constituents
+                    AttributeTargets.GenericParameter | // The generic parameter is a nullable reference type
+                    AttributeTargets.Module | // Nullable reference types in this module are annotated by means of NullableAttribute applied to other targets in it
+                    AttributeTargets.Parameter | // The type of the parameter is a nullable reference type, or has a nullable reference type as one of its constituents
+                    AttributeTargets.ReturnValue, // The return type is a nullable reference type, or has a nullable reference type as one of its constituents
+                   AllowMultiple = false)]
+    public class NullableAttribute : Attribute
+    {
+        public NullableAttribute() { }
+        public NullableAttribute(bool[] transformFlags)
+        {
+        }
+    }
+}
+```

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -562,6 +562,7 @@
     <Compile Include="Symbols\Metadata\PE\DynamicTypeDecoder.cs" />
     <Compile Include="Symbols\Metadata\PE\MemberRefMetadataDecoder.cs" />
     <Compile Include="Symbols\Metadata\PE\MetadataDecoder.cs" />
+    <Compile Include="Symbols\Metadata\PE\NullableTypeDecoder.cs" />
     <Compile Include="Symbols\Metadata\PE\PEAssemblySymbol.cs" />
     <Compile Include="Symbols\Metadata\PE\PEEventSymbol.cs" />
     <Compile Include="Symbols\Metadata\PE\PEFieldSymbol.cs" />

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6533,6 +6533,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Compiler required type &apos;{0}&apos; cannot be found. Are you missing a reference?.
+        /// </summary>
+        internal static string ERR_NullableAttributeMissing {
+            get {
+                return ResourceManager.GetString("ERR_NullableAttributeMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of null is not valid in this context.
         /// </summary>
         internal static string ERR_NullNotValid {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4798,4 +4798,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation_Title" xml:space="preserve">
     <value>Nullability of reference types in type of parameter doesn't match implemented member.</value>
   </data>
+  <data name="ERR_NullableAttributeMissing" xml:space="preserve">
+    <value>Compiler required type '{0}' cannot be found. Are you missing a reference?</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1341,5 +1341,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_NullabilityMismatchInTypeOnExplicitImplementation = 8215,
         WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation = 8216,
         WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation = 8217,
+        ERR_NullableAttributeMissing = 8218,
     }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -2996,10 +2996,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(!(symbol is TypeSymbol));
 
-            // We don't support nullable annotations in metadata yet.
-            // So, we'll ignore them for symbols defined in other modules/assemblies.
-            // This is probably not always accurate when generic instantiations are involved, but is a good starting point.
-            return (object)symbol.ContainingModule == _member.ContainingModule && symbol.IsDefinition; 
+            // TODO: This is probably not always accurate when generic instantiations are involved, but is a good starting point.
+            return symbol.ContainingModule.UtilizesNullableReferenceTypes && symbol.IsDefinition; 
         }
 
         protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method, ParameterSymbol parameter)

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Roslyn.Utilities;
@@ -202,6 +203,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return false;
+        }
+
+        internal override bool ContainsNullableReferenceTypes()
+        {
+            return false;
+        }
+
+        internal override void AddNullableTransforms(ArrayBuilder<bool> transforms)
+        {
+        }
+
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, ref int position, out TypeSymbol result)
+        {
+            result = this;
+            return true;
         }
 
         #region ISymbol Members

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
+{
+    class NullableTypeDecoder
+    {
+        internal static TypeSymbolWithAnnotations TransformType(
+            TypeSymbolWithAnnotations metadataType,
+            EntityHandle targetSymbolToken,
+            PEModuleSymbol containingModule)
+        {
+            Debug.Assert((object)metadataType != null);
+
+            ImmutableArray<bool> nullableTransformFlags;
+            if (containingModule.Module.HasNullableAttribute(targetSymbolToken, out nullableTransformFlags))
+            {
+                int position = 0;
+                TypeSymbolWithAnnotations result;
+
+                if (metadataType.ApplyNullableTransforms(nullableTransformFlags, ref position, out result) && position == nullableTransformFlags.Length)
+                {
+                    return result;
+                }
+            }
+
+            // No NullableAttribute applied to the target symbol, or flags do not line-up, return unchanged metadataType.
+            return metadataType;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -89,7 +89,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             if ((object)_eventType == null)
             {
                 var metadataDecoder = new MetadataDecoder(moduleSymbol, containingType);
-                _eventType = TypeSymbolWithAnnotations.Create(metadataDecoder.GetTypeOfToken(eventType));
+                var type = TypeSymbolWithAnnotations.Create(metadataDecoder.GetTypeOfToken(eventType));
+
+                if (moduleSymbol.UtilizesNullableReferenceTypes)
+                {
+                    type = NullableTypeDecoder.TransformType(type, handle, moduleSymbol);
+                }
+
+                _eventType = type;
             }
 
             // IsWindowsRuntimeEvent checks the signatures, so we just have to check the accessors.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -682,5 +682,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 yield return assemblySymbol.LookupTopLevelMetadataType(ref name, digThroughForwardedTypes: true);
             }
         }
+
+        internal override bool UtilizesNullableReferenceTypes
+        {
+            get
+            {
+                return Module.UtilizesNullableReferenceTypes();
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -431,7 +431,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     if (!token.IsNil)
                     {
                         TypeSymbol decodedType = new MetadataDecoder(moduleSymbol, this).GetTypeOfToken(token);
-                        return (NamedTypeSymbol)DynamicTypeDecoder.TransformType(decodedType, 0, _handle, moduleSymbol);
+                        var result = (NamedTypeSymbol)DynamicTypeDecoder.TransformType(decodedType, 0, _handle, moduleSymbol);
+
+                        if (moduleSymbol.UtilizesNullableReferenceTypes)
+                        {
+                            result = (NamedTypeSymbol)NullableTypeDecoder.TransformType(TypeSymbolWithAnnotations.Create(result), _handle, moduleSymbol).TypeSymbol;
+                        }
+
+                        return result;
                     }
                 }
                 catch (BadImageFormatException mrEx)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -213,7 +213,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
 
                 // CONSIDER: Can we make parameter type computation lazy?
-                _type = type.Update(DynamicTypeDecoder.TransformType(type.TypeSymbol, type.CustomModifiers.Length, handle, moduleSymbol, refKind), type.CustomModifiers);
+                type = type.Update(DynamicTypeDecoder.TransformType(type.TypeSymbol, type.CustomModifiers.Length, handle, moduleSymbol, refKind), type.CustomModifiers);
+
+                if (moduleSymbol.UtilizesNullableReferenceTypes)
+                {
+                    type = NullableTypeDecoder.TransformType(type, handle, moduleSymbol);
+                }
+
+                _type = type;
             }
 
             if (string.IsNullOrEmpty(_name))

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -111,10 +111,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             // CONSIDER: Can we make parameter type computation lazy?
             TypeSymbol originalPropertyType = propertyParams[0].Type;
-            TypeSymbol propertyType = DynamicTypeDecoder.TransformType(originalPropertyType, typeCustomModifiers.Length, handle, moduleSymbol);
+
+            originalPropertyType = DynamicTypeDecoder.TransformType(originalPropertyType, typeCustomModifiers.Length, handle, moduleSymbol);
 
             // Dynamify object type if necessary
-            _propertyType = TypeSymbolWithAnnotations.Create(propertyType.AsDynamicIfNoPia(_containingType), typeCustomModifiers);
+            originalPropertyType = originalPropertyType.AsDynamicIfNoPia(_containingType);
+
+            var propertyType = TypeSymbolWithAnnotations.Create(originalPropertyType, typeCustomModifiers);
+
+            if (moduleSymbol.UtilizesNullableReferenceTypes)
+            {
+                propertyType = NullableTypeDecoder.TransformType(propertyType, handle, moduleSymbol);
+            }
+
+            _propertyType = propertyType;
 
             // A property is bogus and must be accessed by calling its accessors directly if the
             // accessor signatures do not agree, both with each other and with the property,

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -179,6 +179,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
+        internal override bool UtilizesNullableReferenceTypes
+        {
+            get { return false; }
+        }
+
         internal override CharSet? DefaultMarshallingCharSet
         {
             get { return null; }

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -301,6 +301,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasAssemblyRuntimeCompatibilityAttribute { get; }
 
+        internal abstract bool UtilizesNullableReferenceTypes { get; }
+
         /// <summary>
         /// Default char set for contained types, or null if not specified.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Roslyn.Utilities;
@@ -226,6 +227,39 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((object)other == null || !other._pointedAtType.Equals(_pointedAtType, options))
             {
                 return false;
+            }
+
+            return true;
+        }
+
+        internal override bool ContainsNullableReferenceTypes()
+        {
+            return PointedAtType.ContainsNullableReferenceTypes();
+        }
+
+        internal override void AddNullableTransforms(ArrayBuilder<bool> transforms)
+        {
+            PointedAtType.AddNullableTransforms(transforms);
+        }
+
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, ref int position, out TypeSymbol result)
+        {
+            TypeSymbolWithAnnotations oldPointedAtType = PointedAtType;
+            TypeSymbolWithAnnotations newPointedAtType;
+
+            if (!oldPointedAtType.ApplyNullableTransforms(transforms, ref position, out newPointedAtType))
+            {
+                result = this;
+                return false;
+            }
+
+            if ((object)oldPointedAtType == newPointedAtType)
+            {
+                result = this;
+            }
+            else
+            {
+                result = new PointerTypeSymbol(newPointedAtType);
             }
 
             return true;

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -267,6 +268,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             get
             {
                 return _underlyingModule.HasAssemblyRuntimeCompatibilityAttribute;
+            }
+        }
+
+
+        internal override bool UtilizesNullableReferenceTypes
+        {
+            get
+            {
+                return _underlyingModule.UtilizesNullableReferenceTypes;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -628,5 +628,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.CheckModifiersAndType(diagnostics);
             this.Type.CheckAllConstraints(conversions, this.Locations[0], diagnostics);
         }
+
+        internal override void AddSynthesizedAttributes(ModuleCompilationState compilationState, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            base.AddSynthesizedAttributes(compilationState, ref attributes);
+
+            if (this.Type.ContainsNullableReferenceTypes())
+            {
+                var compilation = this.DeclaringCompilation;
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(this.Type));
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -462,6 +462,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var compilation = this.DeclaringCompilation;
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.TypeSymbol, type.CustomModifiers.Length));
             }
+
+            if (type.ContainsNullableReferenceTypes())
+            {
+                var compilation = this.DeclaringCompilation;
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(type));
+            }
         }
 
         internal sealed override bool HasSpecialName

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -951,6 +951,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var compilation = this.DeclaringCompilation;
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(returnType.TypeSymbol, returnType.CustomModifiers.Length));
             }
+
+            if (returnType.ContainsNullableReferenceTypes())
+            {
+                var compilation = this.DeclaringCompilation;
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(returnType));
+            }
         }
 
         internal override CSharpAttributeData EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -526,6 +527,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(
                         WellKnownMember.System_Security_UnverifiableCodeAttribute__ctor));
                 }
+            }
+
+            if (UtilizesNullableReferenceTypes)
+            {
+                AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctor));
+            }
+        }
+
+        internal override bool UtilizesNullableReferenceTypes
+        {
+            get
+            {
+                return ((CSharpParseOptions)_assemblySymbol.DeclaringCompilation.SyntaxTrees.FirstOrDefault()?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1062,9 +1062,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             NamedTypeSymbol baseType = this.BaseTypeNoUseSiteDiagnostics;
-            if ((object)baseType != null && baseType.ContainsDynamic())
+            if ((object)baseType != null)
             {
-                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(baseType, customModifiersCount: 0));
+                if (baseType.ContainsDynamic())
+                {
+                    AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(baseType, customModifiersCount: 0));
+                }
+
+                if (baseType.ContainsNullableReferenceTypes())
+                {
+                    AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(TypeSymbolWithAnnotations.Create(baseType)));
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
@@ -81,6 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(this.Type.TypeSymbol, this.Type.CustomModifiers.Length, this.RefKind));
             }
+
+            if (this.Type.ContainsNullableReferenceTypes())
+            {
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(this.Type));
+            }
         }
 
         internal override ushort CountOfCustomModifiersPrecedingByRef

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1023,6 +1023,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var compilation = this.DeclaringCompilation;
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.TypeSymbol, type.CustomModifiers.Length));
             }
+
+            if (type.ContainsNullableReferenceTypes())
+            {
+                var compilation = this.DeclaringCompilation;
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(type));
+            }
         }
 
         internal override bool HasSpecialName

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
@@ -54,6 +54,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Assume that someone checked earlier that the attribute ctor is available and has no use-site errors.
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(this.Type.TypeSymbol, this.Type.CustomModifiers.Length));
             }
+
+            if (this.Type.ContainsNullableReferenceTypes())
+            {
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(this.Type));
+            }
         }
 
         internal abstract override TypeSymbolWithAnnotations GetFieldType(ConsList<FieldSymbol> fieldsBeingBound);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
@@ -82,6 +82,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var compilation = this.DeclaringCompilation;
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(returnType.TypeSymbol, returnType.CustomModifiers.Length));
             }
+
+            if (returnType.ContainsNullableReferenceTypes())
+            {
+                var compilation = this.DeclaringCompilation;
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(returnType));
+            }
         }
 
         internal sealed override bool GenerateDebugInfo

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -168,6 +168,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(this.Type.TypeSymbol, this.Type.CustomModifiers.Length, this.RefKind));
             }
+
+            if (Type.ContainsNullableReferenceTypes())
+            {
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(Type));
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Roslyn.Utilities;
@@ -522,6 +523,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override int GetHashCode()
         {
             return Hash.Combine(ContainingSymbol, Ordinal);
+        }
+
+        internal override bool ContainsNullableReferenceTypes()
+        {
+            return false;
+        }
+
+        internal override void AddNullableTransforms(ArrayBuilder<bool> transforms)
+        {
+        }
+
+        internal override bool ApplyNullableTransforms(ImmutableArray<bool> transforms, ref int position, out TypeSymbol result)
+        {
+            result = this;
+            return true;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -567,6 +567,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract bool IsManagedType { get; }
 
+        internal abstract bool ContainsNullableReferenceTypes();
+
+        internal abstract void AddNullableTransforms(ArrayBuilder<bool> transforms);
+
+        internal abstract bool ApplyNullableTransforms(ImmutableArray<bool> transforms, ref int position, out TypeSymbol result);
+
         #region ITypeSymbol Members
 
         INamedTypeSymbol ITypeSymbol.BaseType

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -557,6 +557,7 @@ namespace System
                         continue;
                     case WellKnownType.System_FormattableString:
                     case WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory:
+                    case WellKnownType.System_Runtime_CompilerServices_NullableAttribute:
                         // Not yet in the platform.
                         continue;
                 }
@@ -596,6 +597,8 @@ namespace System
                         // C# can't embed VB core.
                         continue;
                     case WellKnownMember.System_Array__Empty:
+                    case WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags:
                         // Not available yet, but will be in upcoming release.
                         continue;
                 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -389,6 +389,8 @@ namespace Microsoft.CodeAnalysis
             s_signature_HasThis_Void_String_DeprecationType_UInt32_Type
         };
 
+        private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
+
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
         internal static readonly AttributeDescription ComImportAttribute = new AttributeDescription("System.Runtime.InteropServices", "ComImportAttribute", s_signaturesOfComImportAttribute);
@@ -494,5 +496,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription AssemblyConfigurationAttribute = new AttributeDescription("System.Reflection", "AssemblyConfigurationAttribute", s_signaturesOfAssemblyConfigurationAttribute);
         internal static readonly AttributeDescription AssemblyAlgorithmIdAttribute = new AttributeDescription("System.Reflection", "AssemblyAlgorithmIdAttribute", s_signaturesOfAssemblyAlgorithmIdAttribute);
         internal static readonly AttributeDescription DeprecatedAttribute = new AttributeDescription("Windows.Foundation.Metadata", "DeprecatedAttribute", s_signaturesOfDeprecatedAttribute);
+        internal static readonly AttributeDescription NullableAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableAttribute", s_signaturesOfNullableAttribute);
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -140,6 +140,8 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_DynamicAttribute__ctorTransformFlags,
         System_Runtime_CompilerServices_CallSite_T__Create,
         System_Runtime_CompilerServices_CallSite_T__Target,
+        System_Runtime_CompilerServices_NullableAttribute__ctor,
+        System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags,
 
         System_Runtime_CompilerServices_RuntimeHelpers__GetObjectValueObject,
         System_Runtime_CompilerServices_RuntimeHelpers__InitializeArrayArrayRuntimeFieldHandle,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -973,6 +973,21 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
 
+                // System_Runtime_CompilerServices_NullableAttribute__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_NullableAttribute,                                       // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+
+                // System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_NullableAttribute,                                       // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
+
                 // System_Runtime_CompilerServices_RuntimeHelpers__GetObjectValueObject
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.System_Runtime_CompilerServices_RuntimeHelpers,                                         // DeclaringTypeId
@@ -2650,6 +2665,8 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_DynamicAttribute__ctorTransformFlags
                 "Create",                                   // System_Runtime_CompilerServices_CallSite_T__Create
                 "Target",                                   // System_Runtime_CompilerServices_CallSite_T__Target
+                ".ctor",                                    // System_Runtime_CompilerServices_NullableAttribute__ctor
+                ".ctor",                                    // System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags
                 "GetObjectValue",                           // System_Runtime_CompilerServices_RuntimeHelpers__GetObjectValueObject
                 "InitializeArray",                          // System_Runtime_CompilerServices_RuntimeHelpers__InitializeArrayArrayRuntimeFieldHandle
                 "get_OffsetToStringData",                   // System_Runtime_CompilerServices_RuntimeHelpers__get_OffsetToStringData

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -163,6 +163,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_CallSiteBinder,
         System_Runtime_CompilerServices_CallSite,
         System_Runtime_CompilerServices_CallSite_T,
+        System_Runtime_CompilerServices_NullableAttribute,
 
         System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken,
         System_Runtime_InteropServices_WindowsRuntime_EventRegistrationTokenTable_T,
@@ -404,6 +405,7 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.CompilerServices.CallSiteBinder",
             "System.Runtime.CompilerServices.CallSite",
             "System.Runtime.CompilerServices.CallSite`1",
+            "System.Runtime.CompilerServices.NullableAttribute",
 
             "System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken",
             "System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable`1",

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -326,6 +326,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 assemblyName);
         }
 
+        public static CSharpCompilation CreateCompilationWithMscorlib45(
+            IEnumerable<string> sources,
+            IEnumerable<MetadataReference> references = null,
+            CSharpCompilationOptions options = null,
+            CSharpParseOptions parseOptions = null,
+            string assemblyName = "")
+        {
+            return CreateCompilationWithMscorlib45(
+                Parse(sources, parseOptions),
+                references,
+                options,
+                assemblyName);
+        }
+
         public static CSharpCompilation CreateCompilationWithMscorlib(
             string text,
             IEnumerable<MetadataReference> references = null,

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -498,7 +498,9 @@ End Namespace
                     Case WellKnownType.Microsoft_VisualBasic_CompilerServices_EmbeddedOperators
                         ' Only present when embedding VB Core.
                         Continue For
-                    Case WellKnownType.System_FormattableString, WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory
+                    Case WellKnownType.System_FormattableString,
+                         WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
+                         WellKnownType.System_Runtime_CompilerServices_NullableAttribute
                         ' Not available on all platforms.
                         Continue For
                 End Select
@@ -526,7 +528,9 @@ End Namespace
                          WellKnownType.Microsoft_VisualBasic_Interaction
                         ' Not embedded, so not available.
                         Continue For
-                    Case WellKnownType.System_FormattableString, WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory
+                    Case WellKnownType.System_FormattableString,
+                         WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
+                         WellKnownType.System_Runtime_CompilerServices_NullableAttribute
                         ' Not available on all platforms.
                         Continue For
                 End Select
@@ -560,7 +564,9 @@ End Namespace
                     Case WellKnownMember.Count
                         ' Not a real value.
                         Continue For
-                    Case WellKnownMember.System_Array__Empty
+                    Case WellKnownMember.System_Array__Empty,
+                         WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                 End Select
@@ -637,7 +643,9 @@ End Namespace
                          WellKnownMember.Microsoft_VisualBasic_Interaction__CallByName
                         ' The type is not embedded, so the member is not available.
                         Continue For
-                    Case WellKnownMember.System_Array__Empty
+                    Case WellKnownMember.System_Array__Empty,
+                         WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_NullableAttribute__ctorTransformFlags
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                 End Select

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -640,6 +640,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(this.ReturnType.TypeSymbol, this.ReturnType.CustomModifiers.Length));
                 }
             }
+
+            if (this.ReturnType.ContainsNullableReferenceTypes())
+            {
+                var compilation = this.DeclaringCompilation;
+
+                if (SourceAssemblySymbol.GetUseSiteDiagnosticForNullableAttribute(compilation)?.Severity != DiagnosticSeverity.Error)
+                {
+                    AddSynthesizedAttribute(ref attributes, compilation.SynthesizeNullableAttribute(this.ReturnType));
+                }
+            }
         }
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)


### PR DESCRIPTION
Apply NullableAttribute to a module if it utilizes Nullable Reference Types feature.
Apply NullableAttribute to other targets in the module to point to nullable reference types in type references. The attribute is applied in the same fashion as DynamicAttribute, with the following exceptions:
- For types of events, it is applied to event declarations (not just to parameters of accessors).
- Types used as custom modifiers, do not have dedicated transform flags.

Here is the definition of the NullableAttribute required for the successful compilation/metadata import :
```
namespace System.Runtime.CompilerServices
{
    [AttributeUsage(AttributeTargets.Event | // The type of the event is nullable, or has a nullable reference type as one of its constituents
                    AttributeTargets.Field | // The type of the field is a nullable reference type, or has a nullable reference type as one of its constituents
                    AttributeTargets.GenericParameter | // The generic parameter is a nullable reference type
                    AttributeTargets.Module | // Nullable reference types in this module are annotated by means of NullableAttribute applied to other targets in it
                    AttributeTargets.Parameter | // The type of the parameter is a nullable reference type, or has a nullable reference type as one of its constituents
                    AttributeTargets.ReturnValue, // The return type is a nullable reference type, or has a nullable reference type as one of its constituents
                   AllowMultiple = false)]
    public class NullableAttribute : Attribute
    {
        public NullableAttribute() { }
        public NullableAttribute(bool[] transformFlags)
        {
        }
    }
}
```

@dotnet/roslyn-compiler  Please review.