### PR TITLE
Fix 3290

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7052,5 +7052,21 @@ End Module
 ]]></code>.Value
             Await VerifyItemExistsAsync(text, "Length")
         End Function
+
+        <WorkItem(3290, "https://github.com/dotnet/roslyn/issues/3290")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDotAfterArray() As Task
+            Dim text =
+<code><![CDATA[
+Module Module1
+    Sub Main()
+        Dim x = {1}.$$
+    End Sub
+End Module
+]]></code>.Value
+            Await VerifyItemExistsAsync(text, "Length")
+        End Function
+
+
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
@@ -222,7 +222,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             If container Is Nothing AndAlso TypeOf (leftHandTypeInfo.ConvertedType) Is IArrayTypeSymbol Then
                 container = DirectCast(leftHandTypeInfo.ConvertedType, INamespaceOrTypeSymbol)
             End If
-            If container.IsErrorType AndAlso leftHandSymbolInfo.Symbol IsNot Nothing Then
+            If container.IsErrorType() AndAlso leftHandSymbolInfo.Symbol IsNot Nothing Then
                 ' TODO remove this when 531549 which causes leftHandTypeInfo to be an error type is fixed
                 container = leftHandSymbolInfo.Symbol.GetSymbolType()
             End If

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
@@ -219,7 +219,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             Dim inNameOfExpression = node.IsParentKind(SyntaxKind.NameOfExpression)
 
             Dim container = DirectCast(leftHandTypeInfo.Type, INamespaceOrTypeSymbol)
-            If leftHandTypeInfo.Type.IsErrorType AndAlso leftHandSymbolInfo.Symbol IsNot Nothing Then
+            If container Is Nothing AndAlso TypeOf (leftHandTypeInfo.ConvertedType) Is IArrayTypeSymbol Then
+                container = DirectCast(leftHandTypeInfo.ConvertedType, INamespaceOrTypeSymbol)
+            End If
+            If container.IsErrorType AndAlso leftHandSymbolInfo.Symbol IsNot Nothing Then
                 ' TODO remove this when 531549 which causes leftHandTypeInfo to be an error type is fixed
                 container = leftHandSymbolInfo.Symbol.GetSymbolType()
             End If


### PR DESCRIPTION
When computing completion after a dot, consider a symbol's converted type
if it's an array type.

Tagging @dotnet/roslyn-ide for review