### PR TITLE
Update toolset to 20160108-01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash
 OS_NAME = $(shell uname -s)
-NUGET_PACKAGE_NAME = nuget.44
+NUGET_PACKAGE_NAME = nuget.45
 BUILD_CONFIGURATION = Debug
 BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
 BUILD_LOG_PATH =

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -24,7 +24,7 @@
   <!-- Import the global NuGet packages -->
   <PropertyGroup>
     <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
-    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.0-beta1-20151231-01\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
+    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.0-beta1-20160108-01\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.RoslynDiagnostics\1.1.1-beta1-20150818-01\build\Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
     <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>
   </PropertyGroup>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -3,7 +3,7 @@
         "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.2.0-beta1-20160105-04",
         "Microsoft.Build.Mono.Debug": "14.1.0-prerelease",
         "Microsoft.DiaSymReader.Native": "1.3.3",
-        "Microsoft.Net.Compilers": "1.2.0-beta1-20151231-01",
+        "Microsoft.Net.Compilers": "1.2.0-beta1-20160108-01",
         "Microsoft.Net.RoslynDiagnostics": "1.1.1-beta1-20150818-01",
         "FakeSign": "0.9.2",
         "xunit": "2.1.0-beta4-build3109",

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -3,7 +3,7 @@
 REM Parse Arguments.
 
 set NugetZipUrlRoot=https://dotnetci.blob.core.windows.net/roslyn
-set NugetZipUrl=%NuGetZipUrlRoot%/nuget.44.zip
+set NugetZipUrl=%NuGetZipUrlRoot%/nuget.45.zip
 set RoslynRoot=%~dp0
 set BuildConfiguration=Debug
 set BuildRestore=false


### PR DESCRIPTION
This should bring in the fixes for the build task issues.

@dotnet/roslyn-infrastructure @amcasey @TyOverby 