### PR TITLE
Add crossgen script and crossgen xplat Roslyn toolsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ bootstrap: toolset
 	mkdir -p $(BOOTSTRAP_PATH) ; \
 	cp Binaries/$(BUILD_CONFIGURATION)/csccore/* $(BOOTSTRAP_PATH) ; \
 	cp Binaries/$(BUILD_CONFIGURATION)/vbccore/* $(BOOTSTRAP_PATH) ; \
+	./build/scripts/crossgen.sh $(BOOTSTRAP_PATH) ; \
 	rm -rf Binaries/$(BUILD_CONFIGURATION)
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MSBUILD_ADDITIONALARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:Deb
 ifeq ($(OS_NAME),Linux)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=ubuntu.14.04
 	MONO_TOOLSET_NAME = mono.linux.4
-	ROSLYN_TOOLSET_NAME = roslyn.linux.2
+	ROSLYN_TOOLSET_NAME = roslyn.linux.3
 else ifeq ($(OS_NAME),Darwin)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=osx.10.10
 	MONO_TOOLSET_NAME = mono.mac.5

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(OS_NAME),Linux)
 else ifeq ($(OS_NAME),Darwin)
 	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /p:BaseNuGetRuntimeIdentifier=osx.10.10
 	MONO_TOOLSET_NAME = mono.mac.5
-	ROSLYN_TOOLSET_NAME = roslyn.mac.2
+	ROSLYN_TOOLSET_NAME = roslyn.mac.3
 endif
 
 ifneq ($(BUILD_LOG_PATH),)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bootstrap: toolset
 	mkdir -p $(BOOTSTRAP_PATH) ; \
 	cp Binaries/$(BUILD_CONFIGURATION)/csccore/* $(BOOTSTRAP_PATH) ; \
 	cp Binaries/$(BUILD_CONFIGURATION)/vbccore/* $(BOOTSTRAP_PATH) ; \
-	./build/scripts/crossgen.sh $(BOOTSTRAP_PATH) ; \
+	build/scripts/crossgen.sh $(BOOTSTRAP_PATH) ; \
 	rm -rf Binaries/$(BUILD_CONFIGURATION)
 
 test:

--- a/build/scripts/crossgen.sh
+++ b/build/scripts/crossgen.sh
@@ -4,6 +4,8 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+# USAGE: crossgen.sh directory-containing-roslyn
+
 set -e
 
 BIN_DIR="$( cd $1 && pwd )"
@@ -36,6 +38,7 @@ chmod +x crossgen
 
 ./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Reflection.Metadata.dll
 
+# The bootstrap build is currently not copying a dependency. See dotnet/roslyn #7907
 ./crossgen -nologo -MissingDependenciesOK -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
 
 ./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.dll

--- a/build/scripts/crossgen.sh
+++ b/build/scripts/crossgen.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+BIN_DIR="$( cd $1 && pwd )"
+
+UNAME=`uname`
+
+if [ -z "$RID" ]; then
+    if [ "$UNAME" == "Darwin" ]; then
+        RID=osx.10.10-x64
+    elif [ "$UNAME" == "Linux" ]; then
+        RID=ubuntu.14.04-x64
+    else
+        echo "Unknown OS: $UNAME" 1>&2
+        exit 1
+    fi
+fi
+
+# Replace with a robust method for finding the right crossgen.exe
+CROSSGEN_UTIL=$HOME/.nuget/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23504/tools/crossgen
+
+cd $BIN_DIR
+
+# Crossgen currently requires itself to be next to mscorlib
+cp $CROSSGEN_UTIL $BIN_DIR
+chmod +x crossgen
+
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR mscorlib.dll
+
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Collections.Immutable.dll
+
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Reflection.Metadata.dll
+
+./crossgen -nologo -MissingDependenciesOK -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
+
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.dll
+
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.VisualBasic.dll
+
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR csc.exe
+
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR vbc.exe


### PR DESCRIPTION
Adds a crossgen script (`crossgen.sh`) that can be used to crossgen the Roslyn bootstrap toolsets that are used on *nix. A call to the crossgen script is also included after the `bootstrap` Make target. On Linux this seems to result in a ~33% perf improvement in building the compiler and in OS X ~20%.

/cc @dotnet/roslyn-compiler @dotnet/roslyn-infrastructure 