### PR TITLE
Remove *FeaturesResources.Await

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -6306,7 +6306,7 @@ class Program
 
             var description = $@"({CSharpFeaturesResources.Awaitable}) Task Program.foo()
 {WorkspacesResources.Usage}
-  {CSharpFeaturesResources.Await} foo();";
+  {SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)} foo();";
 
             await VerifyItemWithMscorlib45Async(markup, "foo", description, "C#");
         }
@@ -6327,7 +6327,7 @@ class Program
 
             var description = $@"({CSharpFeaturesResources.Awaitable}) Task<int> Program.foo()
 {WorkspacesResources.Usage}
-  int x = {CSharpFeaturesResources.Await} foo();";
+  int x = {SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)} foo();";
 
             await VerifyItemWithMscorlib45Async(markup, "foo", description, "C#");
         }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -3259,7 +3259,7 @@ class C
 
             var documentation = $@"
 {WorkspacesResources.Usage}
-  {CSharpFeaturesResources.Await} Foo();";
+  {SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)} Foo();";
 
             await VerifyWithMscorlib45Async(markup, new[] { MainDescription(description), Usage(documentation) });
         }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -2838,7 +2838,7 @@ End Class</Code>.Value
 $"<{VBFeaturesResources.Awaitable}> Function C.Foo() As Task
 Doc Comment!
 {WorkspacesResources.Usage}
-  {VBFeaturesResources.Await} Foo()"
+  {SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)} Foo()"
 
             Await VerifyItemWithMscorlib45Async(code, "Foo", description, LanguageNames.VisualBasic)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -1437,7 +1437,7 @@ End Class
 
             Dim description = <File>&lt;<%= VBFeaturesResources.Awaitable %>&gt; Function C.foo() As Task</File>.ConvertTestSourceTag()
 
-            Dim doc = StringFromLines("", WorkspacesResources.Usage, $"  {VBFeaturesResources.Await} foo()")
+            Dim doc = StringFromLines("", WorkspacesResources.Usage, $"  {SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)} foo()")
 
             Await TestFromXmlAsync(markup,
                  MainDescription(description), Usage(doc))

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -116,15 +116,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to await.
-        /// </summary>
-        internal static string Await {
-            get {
-                return ResourceManager.GetString("Await", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to awaitable.
         /// </summary>
         internal static string Awaitable {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -237,9 +237,6 @@
   <data name="AwaitableExtension" xml:space="preserve">
     <value>awaitable, extension</value>
   </data>
-  <data name="Await" xml:space="preserve">
-    <value>await</value>
-  </data>
   <data name="OrganizeUsings" xml:space="preserve">
     <value>Organize Usings</value>
   </data>

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
             protected override void AddAwaitableUsageText(IMethodSymbol method, SemanticModel semanticModel, int position)
             {
                 AddToGroup(SymbolDescriptionGroups.AwaitableUsageText,
-                    method.ToAwaitableParts(CSharpFeaturesResources.Await, "x", semanticModel, position));
+                    method.ToAwaitableParts(SyntaxFacts.GetText(SyntaxKind.AwaitKeyword), "x", semanticModel, position));
             }
 
             protected override SymbolDisplayFormat MinimallyQualifiedFormat

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
@@ -106,7 +106,5 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var displayString = displayService.ToMinimalDisplayString(context.SemanticModel, context.Position, symbol);
             return ValueTuple.Create(displayString, displayString);
         }
-
-
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
@@ -106,5 +106,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var displayString = displayService.ToMinimalDisplayString(context.SemanticModel, context.Position, symbol);
             return ValueTuple.Create(displayString, displayString);
         }
+
+
     }
 }

--- a/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
+++ b/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
@@ -150,7 +150,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
 
             Protected Overrides Sub AddAwaitableUsageText(method As IMethodSymbol, semanticModel As SemanticModel, position As Integer)
                 AddToGroup(SymbolDescriptionGroups.AwaitableUsageText,
-                    method.ToAwaitableParts(VBFeaturesResources.Await, "r", semanticModel, position))
+                    method.ToAwaitableParts(SyntaxFacts.GetText(SyntaxKind.AwaitKeyword), "r", semanticModel, position))
             End Sub
 
             Protected Overrides ReadOnly Property MinimallyQualifiedFormat As SymbolDisplayFormat

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
@@ -237,15 +237,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Await.
-        '''</summary>
-        Friend ReadOnly Property Await() As String
-            Get
-                Return ResourceManager.GetString("Await", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Awaitable.
         '''</summary>
         Friend ReadOnly Property Awaitable() As String

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
@@ -303,9 +303,6 @@
   <data name="AwaitableExtension" xml:space="preserve">
     <value>Awaitable, Extension</value>
   </data>
-  <data name="Await" xml:space="preserve">
-    <value>Await</value>
-  </data>
   <data name="NewVariable" xml:space="preserve">
     <value>&lt;new variable&gt;</value>
   </data>


### PR DESCRIPTION
It is only used in the the "await x" sample text for quickinfo of
awaitable methods, where it should not be localized. Replace it with the
text of the await keyword.

Fixes DevDiv internal 152492.

Tagging @dotnet/roslyn-ide for review.