### PR TITLE
Fix #5373

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8465,5 +8465,33 @@ class Class2
             await VerifyNoItemsExistAsync("#!$$", sourceCodeKind: SourceCodeKind.Script);
             await VerifyNoItemsExistAsync("#! S$$", sourceCodeKind: SourceCodeKind.Script, usePreviousCharAsTrigger: true);
         }
+
+        [WorkItem(5373, "https://github.com/dotnet/roslyn/issues/5373")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task EnumCompletionColorColor()
+        {
+            var markup = @"
+namespace S
+{
+    class C
+    {
+        Fail Fail;
+        Pass Passes;
+
+        void M()
+        {
+            C c = new C();
+            c.Passes = Pass.A; // Completion offers ""Pass"" and then ""A"", as expected.
+            c.Fail = Fail.$; // Completion should only offer enum Fail.A
+        }
+    }
+
+    enum Fail { A };
+    enum Pass { A };
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "CompareTo");
+            await VerifyItemExistsAsync(markup, "A");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -2454,7 +2454,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 1 {FeaturesResources.Overload})");
+            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 1 {FeaturesResources.Overload})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2469,7 +2469,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 2 {FeaturesResources.Overloads})");
+            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 2 {FeaturesResources.Overloads})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2483,7 +2483,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(T i) (+ 1 {FeaturesResources.GenericOverload})");
+            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(T i) (+ 1 {FeaturesResources.GenericOverload})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2498,7 +2498,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(int i) (+ 2 {FeaturesResources.GenericOverloads})");
+            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(int i) (+ 2 {FeaturesResources.GenericOverloads})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -8482,7 +8482,7 @@ namespace S
         {
             C c = new C();
             c.Passes = Pass.A; // Completion offers ""Pass"" and then ""A"", as expected.
-            c.Fail = Fail.$; // Completion should only offer enum Fail.A
+            c.Fail = Fail.$$; // Completion should only offer enum Fail.A
         }
     }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -2454,7 +2454,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 1 {FeaturesResources.Overload})");
+            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 1 {FeaturesResources.Overload})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2469,7 +2469,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 2 {FeaturesResources.Overloads})");
+            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M(int i) (+ 2 {FeaturesResources.Overloads})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2483,7 +2483,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(T i) (+ 1 {FeaturesResources.GenericOverload})");
+            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(T i) (+ 1 {FeaturesResources.GenericOverload})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2498,7 +2498,7 @@ class C
     {
         $$";
 
-            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(int i) (+ 2 {FeaturesResources.GenericOverloads})");
+            await VerifyItemExistsAsync(markup, "M<>", expectedDescriptionOrNull: $"void C.M<T>(int i) (+ 2 {FeaturesResources.GenericOverloads})");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -2703,7 +2703,7 @@ class C
             await VerifyItemExistsAsync(markup, "a");
             await VerifyItemExistsAsync(markup, "b");
             await VerifyItemExistsAsync(markup, "c");
-            await VerifyItemIsAbsentAsync(markup, "Equals");
+            await VerifyItemExistsAsync(markup, "Equals");
         }
 
         [WorkItem(543104, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543104")]
@@ -8490,7 +8490,8 @@ namespace S
     enum Pass { A };
 }
 ";
-            await VerifyItemIsAbsentAsync(markup, "CompareTo");
+            await VerifyItemIsAbsentAsync(markup, "TryParse");
+            await VerifyItemExistsAsync(markup, "CompareTo");
             await VerifyItemExistsAsync(markup, "A");
         }
     }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -2509,7 +2509,7 @@ End Class
             Await VerifyItemExistsAsync(markup, "a")
             Await VerifyItemExistsAsync(markup, "b")
             Await VerifyItemExistsAsync(markup, "c")
-            Await VerifyItemIsAbsentAsync(markup, "Equals")
+            Await VerifyItemExistsAsync(markup, "Equals")
         End Function
 
         <WorkItem(539450, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539450")>

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 isNonAttributeExpressionContext,
                 isConstantExpressionContext,
                 syntaxTree.IsAttributeNameContext(position, cancellationToken),
-                syntaxTree.IsEnumTypeMemberAccessContext(semanticModel, position, cancellationToken),
+                syntaxTree.CouldBeEnumTypeMemberAccessContext(semanticModel, position, cancellationToken),
                 syntaxTree.IsNameOfContext(position, semanticModel, cancellationToken),
                 leftToken.GetAncestor<QueryExpressionSyntax>() != null,
                 IsLeftSideOfUsingAliasDirective(leftToken, cancellationToken),

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2396,7 +2396,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // and bind as as type.
             var speculativeSymbolInfo = semanticModel.GetSpeculativeSymbolInfo(memberAccess.SpanStart, memberAccess.Expression, SpeculativeBindingOption.BindAsTypeOrNamespace);
             var typeSymbol = speculativeSymbolInfo.Symbol as INamedTypeSymbol;
-            if (typeSymbol?.SpecialType == SpecialType.System_Enum)
+            if (typeSymbol?.TypeKind == TypeKind.Enum)
             {
                 return true;
             }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
@@ -88,7 +88,20 @@ namespace Microsoft.CodeAnalysis.Recommendations
 
                 if (_context.IsEnumTypeMemberAccessContext)
                 {
-                    return symbol.Kind == SymbolKind.Field;
+                    // If you have a field and an enum with the same name,
+                    // we want to show instance members (through the field)
+                    // so you can call CompareTo, etc, in addition to the 
+                    // enum fields. However, we don't want to show statics
+                    // from the Enum base type.
+                    if (symbol.Kind == SymbolKind.Field)
+                    {
+                        return true;
+                    }
+
+                    if (symbol.IsStatic && symbol.ContainingType?.SpecialType == SpecialType.System_Enum)
+                    {
+                        return false;
+                    }
                 }
 
                 // In an expression or statement context, we don't want to display instance members declared in outer containing types.


### PR DESCRIPTION
When showing completion after ., detect a "Color color" scenario between
an enum and a field with the same name. In that case, show only enum
members.

Tagging @dotnet/roslyn-ide for review.
