### PR TITLE
fix pr instructions

### DIFF
--- a/src/Tools/Github/GitMergeBot/Program.cs
+++ b/src/Tools/Github/GitMergeBot/Program.cs
@@ -160,11 +160,10 @@ This is an automatically generated pull request from {_options.SourceBranch} int
 git remote add {remoteName} ""https://github.com/{_options.SourceUser}/{_options.RepoName}.git""
 git fetch {remoteName}
 git checkout {newBranchName}
-git reset --hard upstream/{_options.DestinationBranch}
-git merge upstream/{_options.SourceBranch}
+git merge upstream/{_options.DestinationBranch}
 # Fix merge conflicts
 git commit
-git push {remoteName} {newBranchName} --force
+git push {remoteName} {newBranchName}
 ```
 
 Once the merge can be made and all the tests pass, you are free to merge the pull request.

--- a/src/Tools/Github/GitMergeBot/Program.cs
+++ b/src/Tools/Github/GitMergeBot/Program.cs
@@ -158,6 +158,7 @@ This is an automatically generated pull request from {_options.SourceBranch} int
 
 ``` bash
 git remote add {remoteName} ""https://github.com/{_options.SourceUser}/{_options.RepoName}.git""
+# git remote add {remoteName} ""git@github.com:{_options.SourceUser}/{_options.RepoName}.git""
 git fetch {remoteName}
 git checkout {newBranchName}
 git merge upstream/{_options.DestinationBranch}


### PR DESCRIPTION
I have no idea what the [original author](https://github.com/TyOverby/) was thinking when he wrote the instructions for the merge bot to put in the automated pull requests.

This method is much cleaner, doesn't generate false conflicts, and doesn't require force pushing.