### PR TITLE
Support for Xamarin.iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 # User-specific files
 *.suo
 *.user
+*.userprefs
 *.sln.docstates
 .vs/
+.vscode/
 
 # Build results
 [Bb]inaries/

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -72,6 +72,7 @@
     <Compile Include="InternalUtilities\SetWithInsertionOrder.cs" />
     <Compile Include="InternalUtilities\StackGuard.cs" />
     <Compile Include="InternalUtilities\StreamExtensions.cs" />
+    <Compile Include="Emit\OperandType.cs" />
     <Compile Include="RealParser.cs" />
     <Compile Include="ReferenceManager\MergedAliases.cs" />
     <Compile Include="StrongName\CryptoBlobParser.cs" />

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -73,6 +73,7 @@
     <Compile Include="InternalUtilities\StackGuard.cs" />
     <Compile Include="InternalUtilities\StreamExtensions.cs" />
     <Compile Include="Emit\OperandType.cs" />
+    <Compile Include="Interop\FILETIME.cs" />
     <Compile Include="RealParser.cs" />
     <Compile Include="ReferenceManager\MergedAliases.cs" />
     <Compile Include="StrongName\CryptoBlobParser.cs" />

--- a/src/Compilers/Core/Portable/Emit/OperandType.cs
+++ b/src/Compilers/Core/Portable/Emit/OperandType.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Emit
+{
+
+    using System;
+#pragma warning disable RS0016 // Add public types and members to the declared API
+
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public enum OperandType
+    {
+
+        InlineBrTarget = 0,
+        InlineField = 1,
+        InlineI = 2,
+        InlineI8 = 3,
+        InlineMethod = 4,
+        InlineNone = 5,
+#if !FEATURE_CORECLR
+        /// <internalonly/>
+        [Obsolete("This API has been deprecated. http://go.microsoft.com/fwlink/?linkid=14202")]
+        InlinePhi = 6,
+#endif
+        InlineR = 7,
+        InlineSig = 9,
+        InlineString = 10,
+        InlineSwitch = 11,
+        InlineTok = 12,
+        InlineType = 13,
+        InlineVar = 14,
+        ShortInlineBrTarget = 15,
+        ShortInlineI = 16,
+        ShortInlineR = 17,
+        ShortInlineVar = 18,
+    }
+#pragma warning restore RS0016 // Add public types and members to the declared API
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
@@ -140,62 +140,12 @@ namespace Roslyn.Utilities
 
         public static Action<T> WithCurrentUICulture<T>(Action<T> action)
         {
-            if (s_setCurrentUICulture == null)
-            {
-                return action;
-            }
-
-            var savedCulture = CultureInfo.CurrentUICulture;
-            return param =>
-            {
-                var currentCulture = CultureInfo.CurrentUICulture;
-                if (currentCulture != savedCulture)
-                {
-                    s_setCurrentUICulture(savedCulture);
-                    try
-                    {
-                        action(param);
-                    }
-                    finally
-                    {
-                        s_setCurrentUICulture(currentCulture);
-                    }
-                }
-                else
-                {
-                    action(param);
-                }
-            };
+            return action;
         }
 
         public static Func<T> WithCurrentUICulture<T>(Func<T> func)
         {
-            if (s_setCurrentUICulture == null)
-            {
-                return func;
-            }
-
-            var savedCulture = CultureInfo.CurrentUICulture;
-            return () =>
-            {
-                var currentCulture = CultureInfo.CurrentUICulture;
-                if (currentCulture != savedCulture)
-                {
-                    s_setCurrentUICulture(savedCulture);
-                    try
-                    {
-                        return func();
-                    }
-                    finally
-                    {
-                        s_setCurrentUICulture(currentCulture);
-                    }
-                }
-                else
-                {
-                    return func();
-                }
-            };
+            return func;
         }
     }
 }

--- a/src/Compilers/Core/Portable/Interop/FILETIME.cs
+++ b/src/Compilers/Core/Portable/Interop/FILETIME.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.CodeAnalysis.Interop
+{
+#pragma warning disable RS0016 // Add public types and members to the declared API
+    [StructLayout(LayoutKind.Sequential)]
+
+    public struct FILETIME
+    {
+        public int dwLowDateTime;
+        public int dwHighDateTime;
+    }
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
+}

--- a/src/Compilers/Core/Portable/Interop/IVsSQM.cs
+++ b/src/Compilers/Core/Portable/Interop/IVsSQM.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
     internal interface IVsSqm
     {
         void GetSessionStartTime(
-            [Out] out System.Runtime.InteropServices.ComTypes.FILETIME time
+            [Out] out Microsoft.CodeAnalysis.Interop.FILETIME time
             );
         void GetFlags(
             [Out, MarshalAs(UnmanagedType.U4)] out System.UInt32 flags
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
          );
         void GetSessionStartTime(
             [In, MarshalAs(UnmanagedType.U4)] System.UInt32 sessionHandle,
-            [Out] out System.Runtime.InteropServices.ComTypes.FILETIME time
+            [Out] out Microsoft.CodeAnalysis.Interop.FILETIME time
             );
         Guid GetGlobalSessionGuid();
         [return: MarshalAs(UnmanagedType.U4)]

--- a/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
@@ -73,9 +73,11 @@ namespace Microsoft.Cci
     {
         public static unsafe void DefineConstant2(this ISymUnmanagedWriter2 writer, string name, object value, uint sigToken)
         {
-            VariantStructure variant = new VariantStructure();
-            Marshal.GetNativeVariantForObject(value, new IntPtr(&variant));
-            writer.DefineConstant2(name, variant, sigToken);
+            // Xamarin Bug https://bugzilla.xamarin.com/show_bug.cgi?id=37632
+            throw new NotSupportedException("GetNativeVariantForObject is not available.");
+            //VariantStructure variant = new VariantStructure();
+            //Marshal.GetNativeVariantForObject(value, new IntPtr(&variant));
+            //writer.DefineConstant2(name, variant, sigToken);
         }
     }
 

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbMetadataWrapper.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbMetadataWrapper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Cci
             this.UlOffset = 0;
         }
     }
-
+    /*
     [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("BA3FEE4C-ECB9-4e41-83B7-183FA41CD859"), SuppressUnmanagedCodeSecurity]
     internal unsafe interface IMetaDataEmit
     {
@@ -822,5 +822,5 @@ namespace Microsoft.Cci
             throw new NotImplementedException();
         }
         #endregion
-    }
+    }*/
 }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Cci
         internal const uint DefaultLocalAttributesValue = 0u;
         internal const uint Age = 1;
 
-        private static Type s_lazyCorSymWriterSxSType;
+        //private static Type s_lazyCorSymWriterSxSType;
 
         private readonly string _fileName;
         private readonly Func<object> _symWriterFactory;
@@ -757,13 +757,15 @@ namespace Microsoft.Cci
 
         private static Type GetCorSymWriterSxSType()
         {
-            if (s_lazyCorSymWriterSxSType == null)
+            throw new NotSupportedException("Marshal.GetTypeFromCLSID is not available.");
+
+            /*if (s_lazyCorSymWriterSxSType == null)
             {
-                // If an exception is thrown we propagate it - we want to report it every time. 
+                // If an exception is thrown we propagate it - we want to report it every time.                 
                 s_lazyCorSymWriterSxSType = Marshal.GetTypeFromCLSID(new Guid(SymWriterClsid));
             }
 
-            return s_lazyCorSymWriterSxSType;
+            return s_lazyCorSymWriterSxSType;*/
         }
 
         private static object CreateSymWriterWorker()
@@ -805,7 +807,9 @@ namespace Microsoft.Cci
         {
             try
             {
-                var symWriter = (ISymUnmanagedWriter2)(_symWriterFactory != null ? _symWriterFactory() : CreateSymWriterWorker());
+                throw new NotSupportedException("Native PDB is not supported");
+
+                /*var symWriter = (ISymUnmanagedWriter2)(_symWriterFactory != null ? _symWriterFactory() : CreateSymWriterWorker());
 
                 // Correctness: If the stream is not specified or if it is non-empty the SymWriter appends data to it (provided it contains valid PDB)
                 // and the resulting PDB has Age = existing_age + 1.
@@ -826,7 +830,7 @@ namespace Microsoft.Cci
                 }
 
                 _metadataWriter = metadataWriter;
-                _symWriter = symWriter;
+                _symWriter = symWriter;*/
             }
             catch (Exception ex)
             {

--- a/src/Compilers/Core/Portable/PEWriter/InstructionOperandTypes.cs
+++ b/src/Compilers/Core/Portable/PEWriter/InstructionOperandTypes.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Reflection.Emit;
+using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.Cci
 {

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;

--- a/src/Compilers/Core/Portable/Syntax/AbstractWarningStateMap.cs
+++ b/src/Compilers/Core/Portable/Syntax/AbstractWarningStateMap.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Syntax
         private WarningStateMapEntry GetEntryAtOrBeforePosition(int position)
         {
             Debug.Assert(_warningStateMapEntries != null && _warningStateMapEntries.Length > 0);
-            int r = Array.BinarySearch(_warningStateMapEntries, new WarningStateMapEntry(position));
+            int r = Array.BinarySearch(_warningStateMapEntries, new WarningStateMapEntry(position), new WarningStateMapEntryComparer ());
             return _warningStateMapEntries[r >= 0 ? r : ((~r) - 1)];
         }
 
@@ -85,6 +85,14 @@ namespace Microsoft.CodeAnalysis.Syntax
             public int CompareTo(WarningStateMapEntry other)
             {
                 return this.Position - other.Position;
+            }
+        }
+
+        protected class WarningStateMapEntryComparer : System.Collections.IComparer
+        {
+            public int Compare(object x, object y)
+            {
+                return ((WarningStateMapEntry)x).CompareTo((WarningStateMapEntry)y);
             }
         }
     }

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
@@ -86,5 +86,14 @@ namespace Microsoft.CodeAnalysis
                 return this.UnmappedLine.CompareTo(other.UnmappedLine);
             }
         }
+
+
+        protected class LineMappingEntryComparer : System.Collections.IComparer
+        {
+            public int Compare(object x, object y)
+            {
+                return ((LineMappingEntry)x).CompareTo((LineMappingEntry)y);
+            }
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
         // Find the index of the line mapped entry with the largest unmapped line number <= lineNumber.
         protected int FindEntryIndex(int lineNumber)
         {
-            int r = Array.BinarySearch(this.Entries, new LineMappingEntry(lineNumber));
+            int r = Array.BinarySearch(this.Entries, new LineMappingEntry(lineNumber), new LineMappingEntryComparer ());
             return r >= 0 ? r : ((~r) - 1);
         }
 


### PR DESCRIPTION
Hello,

This PR is just to get the discussion rolling on getting Roslyn working with Xamarin.iOS.

With these patches, I am able to emit CSharpCompilations into MemoryStreams. (I assume the VB compiler works too.)

Workspaces still do not work on iOS due to MEF issues.

I had to make the following changes:
- Create a copy of `OperandType` in `Microsoft.CodeAnalysis.Emit`

Xamarin.iOS does not include any of Reflection.Emit, so I just stuck in a copy from the reference sources in there. This is terrible, I know. I'm open to ideas.
- Create a copy of `FILETIME` in `Microsoft.CodeAnalysis.Interop`

Xamarin.iOS is mysteriously also missing this. I filed a bug.
- Many hacks to disable the native PDB writer

Xamarin is missing two Marshal functions that the writer needs and, oh yeah, it won't work anyway on iOS. :-) I got a little hacky disabling it. I think I heard rumors of a managed PDB writer some day?
- Added AOT helper classes

Xamarin hates structs with comparison interfaces - these sometimes cause the runtime to dynamically create classes that Xam doesn't support. So I added some `IComparer` implementations to make everything work.

Is anyone interested in this?
