### PR TITLE
Ensure unit tests close their text views

### DIFF
--- a/src/EditorFeatures/Test/Commands/CommandArgsTests.cs
+++ b/src/EditorFeatures/Test/Commands/CommandArgsTests.cs
@@ -23,10 +23,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Commands
         [WpfFact]
         public void CreateBackspaceCommandArgsWithNullSubjectBuffer()
         {
-            var view = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, "class C { }");
-
-            Assert.Throws<ArgumentNullException>(() =>
-                new BackspaceKeyCommandArgs(view, null));
+            using (var disposableView = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, "class C { }"))
+            {
+                Assert.Throws<ArgumentNullException>(() =>
+    new BackspaceKeyCommandArgs(disposableView.TextView, null));
+            }
         }
 #if false
         [WpfFact]

--- a/src/EditorFeatures/Test/Commands/TypeCharCommandArgsTests.cs
+++ b/src/EditorFeatures/Test/Commands/TypeCharCommandArgsTests.cs
@@ -13,10 +13,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Commands
         [WpfFact]
         public void TestTypedCharProperty()
         {
-            var view = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, "class C { }");
-
-            var args = new TypeCharCommandArgs(view, view.TextBuffer, 'c');
-            Assert.Equal('c', args.TypedChar);
+            using (var disposableView = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, "class C { }"))
+            {
+                var args = new TypeCharCommandArgs(disposableView.TextView, disposableView.TextView.TextBuffer, 'c');
+                Assert.Equal('c', args.TypedChar);
+            }
         }
     }
 }

--- a/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
@@ -168,34 +168,36 @@ class Foo
     void M() { }
 }|end|
 ";
-            var textView = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, code);
-            var selectedSpans = SetupSelection(textView);
-
-            var expectedChanges = new[]
+            using (var disposableView = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, code))
             {
+                var selectedSpans = SetupSelection(disposableView.TextView);
+
+                var expectedChanges = new[]
+                {
                 new TextChange(new TextSpan(0, 0), "//"),
                 new TextChange(new TextSpan(9, 0), "//"),
                 new TextChange(new TextSpan(12, 0), "//"),
                 new TextChange(new TextSpan(30, 0), "//"),
             };
-            CommentSelection(
-                textView,
-                expectedChanges,
-                supportBlockComments: false,
-                expectedSelectedSpans: new[] { new Span(0, 39) });
+                CommentSelection(
+                    disposableView.TextView,
+                    expectedChanges,
+                    supportBlockComments: false,
+                    expectedSelectedSpans: new[] { new Span(0, 39) });
 
-            expectedChanges = new[]
-            {
+                expectedChanges = new[]
+                {
                 new TextChange(new TextSpan(0, 0), "//"),
                 new TextChange(new TextSpan(11, 0), "//"),
                 new TextChange(new TextSpan(16, 0), "//"),
                 new TextChange(new TextSpan(36, 0), "//"),
             };
-            CommentSelection(
-                textView,
-                expectedChanges,
-                supportBlockComments: false,
-                expectedSelectedSpans: new[] { new Span(0, 47) });
+                CommentSelection(
+                    disposableView.TextView,
+                    expectedChanges,
+                    supportBlockComments: false,
+                    expectedSelectedSpans: new[] { new Span(0, 47) });
+            }
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
@@ -538,10 +540,12 @@ class Foo
             bool supportBlockComments,
             CommentUncommentSelectionCommandHandler.Operation operation)
         {
-            var textView = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, code);
-            var selectedSpans = SetupSelection(textView);
+            using (var disposableView = EditorFactory.CreateView(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, code))
+            {
+                var selectedSpans = SetupSelection(disposableView.TextView);
 
-            CommentOrUncommentSelection(textView, expectedChanges, expectedSelectedSpans, supportBlockComments, operation);
+                CommentOrUncommentSelection(disposableView.TextView, expectedChanges, expectedSelectedSpans, supportBlockComments, operation);
+            }
         }
 
         private static void CommentOrUncommentSelection(

--- a/src/EditorFeatures/Test/EditorFactory.cs
+++ b/src/EditorFeatures/Test/EditorFactory.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Test.Utilities;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
 
 namespace Roslyn.Test.EditorUtilities
 {
@@ -33,14 +34,14 @@ namespace Roslyn.Test.EditorUtilities
             return buffer;
         }
 
-        public static IWpfTextView CreateView(
+        public static DisposableTextView CreateView(
             ExportProvider exportProvider,
             params string[] lines)
         {
             return CreateView("text", exportProvider, lines);
         }
 
-        public static IWpfTextView CreateView(
+        public static DisposableTextView CreateView(
             string contentType,
             ExportProvider exportProvider,
             params string[] lines)
@@ -49,7 +50,7 @@ namespace Roslyn.Test.EditorUtilities
             WpfTestCase.RequireWpfFact($"Creates an IWpfTextView through {nameof(EditorFactory)}.{nameof(CreateView)}");
 
             var buffer = CreateBuffer(contentType, exportProvider, lines);
-            return exportProvider.GetExportedValue<ITextEditorFactoryService>().CreateTextView(buffer);
+            return exportProvider.GetExportedValue<ITextEditorFactoryService>().CreateDisposableTextView(buffer);
         }
 
         public static string LinesToFullText(params string[] lines)

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -321,6 +321,7 @@
     <Compile Include="TestExportProvider.cs" />
     <Compile Include="TestExtensionErrorHandler.cs" />
     <Compile Include="TestOptionsServiceFactory.cs" />
+    <Compile Include="TextEditorFactoryExtensions.cs" />
     <Compile Include="TextEditor\TextBufferAssociatedViewServiceTests.cs" />
     <Compile Include="TextEditor\TryGetDocumentTests.cs" />
     <Compile Include="Threading\AsynchronousWorkerTests.cs" />

--- a/src/EditorFeatures/Test/TextEditorFactoryExtensions.cs
+++ b/src/EditorFeatures/Test/TextEditorFactoryExtensions.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.VisualStudio.Text;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
@@ -28,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
             this.TextView = textView;
         }
 
-        public IWpfTextView TextView { get; private set; }
+        public IWpfTextView TextView { get; }
 
         public void Dispose()
         {

--- a/src/EditorFeatures/Test/TextEditorFactoryExtensions.cs
+++ b/src/EditorFeatures/Test/TextEditorFactoryExtensions.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests
+{
+    internal static class TextEditorFactoryExtensions
+    {
+        public static DisposableTextView CreateDisposableTextView(this ITextEditorFactoryService textEditorFactory)
+        {
+            return new DisposableTextView(textEditorFactory.CreateTextView());
+        }
+
+        public static DisposableTextView CreateDisposableTextView(this ITextEditorFactoryService textEditorFactory, ITextBuffer buffer)
+        {
+            return new DisposableTextView(textEditorFactory.CreateTextView(buffer));
+        }
+    }
+
+    public class DisposableTextView : IDisposable
+    {
+        public DisposableTextView(IWpfTextView textView)
+        {
+            this.TextView = textView;
+        }
+
+        public IWpfTextView TextView { get; private set; }
+
+        public void Dispose()
+        {
+            TextView.Close();
+        }
+    }
+}

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1606,17 +1606,14 @@ class C
                 Dim projectionBufferFactory = state.GetExportedValue(Of IProjectionBufferFactoryService)()
                 Dim projection = projectionBufferFactory.CreateProjectionBuffer(Nothing, New Object() {otherExposedSpan, subjectBufferExposedSpan}.ToList(), ProjectionBufferOptions.None)
 
-                Dim view = textViewFactory.CreateTextView(projection)
-                Try
-                    view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, 0))
+                Using disposableView As DisposableTextView = textViewFactory.CreateDisposableTextView(projection)
+                    disposableView.TextView.Caret.MoveTo(New SnapshotPoint(disposableView.TextView.TextBuffer.CurrentSnapshot, 0))
 
-                    Dim editorOperations = editorOperationsFactory.GetEditorOperations(view)
-                    state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, state.SubjectBuffer), Sub() editorOperations.Delete())
+                    Dim editorOperations = editorOperationsFactory.GetEditorOperations(disposableView.TextView)
+                    state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(disposableView.TextView, state.SubjectBuffer), Sub() editorOperations.Delete())
 
                     Await state.AssertNoCompletionSession()
-                Finally
-                    view.Close()
-                End Try
+                End Using
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/Preview/PreviewChangesTests.vb
+++ b/src/VisualStudio/Core/Test/Preview/PreviewChangesTests.vb
@@ -145,18 +145,20 @@ Class C
 
                 WpfTestCase.RequireWpfFact("Test explicitly creates an IWpfTextView")
                 Dim textEditorFactory = componentModel.GetService(Of ITextEditorFactoryService)
-                Dim textView = textEditorFactory.CreateTextView()
+                Using disposableView As DisposableTextView = textEditorFactory.CreateDisposableTextView()
+                    previewEngine.SetTextView(disposableView.TextView)
 
-                previewEngine.SetTextView(textView)
+                    Dim outChangeList As Object = Nothing
+                    previewEngine.GetRootChangesList(outChangeList)
+                    Dim topLevelList = DirectCast(outChangeList, ChangeList)
 
-                Dim outChangeList As Object = Nothing
-                previewEngine.GetRootChangesList(outChangeList)
-                Dim topLevelList = DirectCast(outChangeList, ChangeList)
+                    SetCheckedChildren(New List(Of String)(), topLevelList)
+                    previewEngine.ApplyChanges()
+                    Dim finalText = previewEngine.FinalSolution.GetDocument(documentId).GetTextAsync().Result.ToString()
+                    Assert.Equal(document.GetTextAsync().Result.ToString(), finalText)
+                End Using
 
-                SetCheckedChildren(New List(Of String)(), topLevelList)
-                previewEngine.ApplyChanges()
-                Dim finalText = previewEngine.FinalSolution.GetDocument(documentId).GetTextAsync().Result.ToString()
-                Assert.Equal(document.GetTextAsync().Result.ToString(), finalText)
+
             End Using
         End Function
 
@@ -209,35 +211,35 @@ Class C
 
                 WpfTestCase.RequireWpfFact("Test explicitly creates an IWpfTextView")
                 Dim textEditorFactory = componentModel.GetService(Of ITextEditorFactoryService)
-                Dim textView = textEditorFactory.CreateTextView()
+                Using disposableView As DisposableTextView = textEditorFactory.CreateDisposableTextView()
+                    previewEngine.SetTextView(disposableView.TextView)
 
-                previewEngine.SetTextView(textView)
+                    Dim outChangeList As Object = Nothing
+                    previewEngine.GetRootChangesList(outChangeList)
+                    Dim topLevelList = DirectCast(outChangeList, ChangeList)
 
-                Dim outChangeList As Object = Nothing
-                previewEngine.GetRootChangesList(outChangeList)
-                Dim topLevelList = DirectCast(outChangeList, ChangeList)
+                    Dim checkedItems = New List(Of String) From
+                    {
+                        "test1.cs",
+                        ServicesVSResources.PreviewChangesAddedPrefix + "test4.cs",
+                        ServicesVSResources.PreviewChangesDeletedPrefix + "test2.cs"
+                    }
 
-                Dim checkedItems = New List(Of String) From
-                {
-                    "test1.cs",
-                    ServicesVSResources.PreviewChangesAddedPrefix + "test4.cs",
-                    ServicesVSResources.PreviewChangesDeletedPrefix + "test2.cs"
-                }
+                    SetCheckedChildren(checkedItems, topLevelList)
+                    previewEngine.ApplyChanges()
+                    Dim finalSolution = previewEngine.FinalSolution
+                    Dim finalDocuments = finalSolution.Projects.First().Documents
+                    Assert.Equal(3, finalDocuments.Count)
 
-                SetCheckedChildren(checkedItems, topLevelList)
-                previewEngine.ApplyChanges()
-                Dim finalSolution = previewEngine.FinalSolution
-                Dim finalDocuments = finalSolution.Projects.First().Documents
-                Assert.Equal(3, finalDocuments.Count)
+                    Dim changedDocText = finalSolution.GetDocument(docId).GetTextAsync().Result.ToString()
+                    Assert.Equal(forkedDocument.GetTextAsync().Result.ToString(), changedDocText)
 
-                Dim changedDocText = finalSolution.GetDocument(docId).GetTextAsync().Result.ToString()
-                Assert.Equal(forkedDocument.GetTextAsync().Result.ToString(), changedDocText)
+                    Dim finalAddedDocText = finalSolution.GetDocument(addedDocumentId1).GetTextAsync().Result.ToString()
+                    Assert.Equal(addedDocumentText, finalAddedDocText)
 
-                Dim finalAddedDocText = finalSolution.GetDocument(addedDocumentId1).GetTextAsync().Result.ToString()
-                Assert.Equal(addedDocumentText, finalAddedDocText)
-
-                Dim finalNotRemovedDocText = finalSolution.GetDocument(removedDocumentId2).GetTextAsync().Result.ToString()
-                Assert.Equal("// This file will just escape deletion!", finalNotRemovedDocText)
+                    Dim finalNotRemovedDocText = finalSolution.GetDocument(removedDocumentId2).GetTextAsync().Result.ToString()
+                    Assert.Equal("// This file will just escape deletion!", finalNotRemovedDocText)
+                End Using
             End Using
         End Function
 


### PR DESCRIPTION
Adds a disposable wrapper around ITextView to avoid writing try ...
finally... everywhere. 

Addresses  #5289

@dotnet/roslyn-ide please review.