### PR TITLE
Consume asynchronous snippet enumeration API

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetInfoService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetInfoService.cs
@@ -2,49 +2,60 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Snippets;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 {
+    /// <summary>
+    /// This service is created on the UI thread during package initialization, but it must not
+    /// block the initialization process. If the expansion manager is an <see cref="IExpansionManager"/>,
+    /// then we can use the asynchronous population mechanism it provides. Otherwise, getting
+    /// snippet information from the <see cref="IVsExpansionManager"/> must be done synchronously
+    /// through on the UI thread, which we do after package initialization at a lower priority.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IExpansionManager"/> was introduced in Visual Studio 2015 Update 1, but
+    /// will be enabled by default for the first time in Visual Studio 2015 Update 2. However,
+    /// the platform still supports returning the <see cref="IVsExpansionManager"/> if a major
+    /// problem in the <see cref="IExpansionManager"/> is discovered, so we must continue 
+    /// supporting the fallback.
+    /// </remarks>
     internal abstract class AbstractSnippetInfoService : ForegroundThreadAffinitizedObject, ISnippetInfoService, IVsExpansionEvents
     {
         private readonly Guid _languageGuidForSnippets;
         private readonly IVsExpansionManager _expansionManager;
 
         /// <summary>
-        /// This service is created on the UI thread during package initialization, but it must not
-        /// block the initialization process. Getting snippet information from the <see cref="IVsExpansionManager"/>
-        /// must be done on the UI thread, so do this work in a task that will run on the UI thread
-        /// with lower priority.
+        /// Initialize these to empty values. When returning from <see cref="GetSnippetsIfAvailable "/> 
+        /// and <see cref="SnippetShortcutExists_NonBlocking"/>, we return the current set of known 
+        /// snippets rather than waiting for initial results.
         /// </summary>
-        protected readonly Task InitialCachePopulationTask;
-
-        protected object cacheGuard = new object();
-
-        // Initialize these to empty values. When returning from GetSnippetsIfAvailable and
-        // SnippetShortcutExists_NonBlocking, we can return without checking the status
-        // of InitialCachePopulationTask.
         protected IList<SnippetInfo> snippets = SpecializedCollections.EmptyList<SnippetInfo>();
         protected ISet<string> snippetShortcuts = SpecializedCollections.EmptySet<string>();
 
-        public bool InsertSnippetCommandBound { get; private set; }
+        // Guard the snippets and snippetShortcut fields so that returned result sets are always
+        // complete.
+        protected object cacheGuard = new object();
+
+        private readonly AggregateAsynchronousOperationListener _waiter;
 
         public AbstractSnippetInfoService(
             Shell.SVsServiceProvider serviceProvider,
             Guid languageGuidForSnippets,
             IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {
-            _languageGuidForSnippets = languageGuidForSnippets;
+            AssertIsForeground();
 
             if (serviceProvider != null)
             {
@@ -52,38 +63,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 if (textManager.GetExpansionManager(out _expansionManager) == VSConstants.S_OK)
                 {
                     ComEventSink.Advise<IVsExpansionEvents>(_expansionManager, this);
+                    _waiter = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.Snippets);
+                    _languageGuidForSnippets = languageGuidForSnippets;
+                    PopulateSnippetCaches();
                 }
             }
-
-            IAsynchronousOperationListener waiter = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.Snippets);
-            var token = waiter.BeginAsyncOperation(GetType().Name + ".Start");
-
-            InitialCachePopulationTask = Task.Factory.StartNew(() => PopulateSnippetCaches(),
-                CancellationToken.None,
-                TaskCreationOptions.None,
-                ForegroundTaskScheduler).CompletesAsyncOperation(token);
         }
 
         public int OnAfterSnippetsUpdate()
         {
-            PopulateSnippetCaches();
+            AssertIsForeground();
+
+            if (_expansionManager != null)
+            {
+                PopulateSnippetCaches();
+            }
+
             return VSConstants.S_OK;
         }
 
         public int OnAfterSnippetsKeyBindingChange([ComAliasName("Microsoft.VisualStudio.OLE.Interop.DWORD")]uint dwCmdGuid, [ComAliasName("Microsoft.VisualStudio.OLE.Interop.DWORD")]uint dwCmdId, [ComAliasName("Microsoft.VisualStudio.OLE.Interop.BOOL")]int fBound)
         {
-            InsertSnippetCommandBound = fBound != 0;
             return VSConstants.S_OK;
         }
 
         public IEnumerable<SnippetInfo> GetSnippetsIfAvailable()
         {
-            // This function used to be async and wait for the cache population task.
-            // Since the cache population task must run on the UI thread, this could
-            // deadlock if completion blocked on the UI thread before the 
-            // population task started. We now simply return whatever snippets were
-            // there. When we're told to update snippets, we'll return stale data
-            // until that process is complete, which is fine.
+            // Immediately return the known set of snippets, even if we're still in the process
+            // of calculating a more up-to-date list.
             lock (cacheGuard)
             {
                 return snippets;
@@ -92,12 +99,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
         public bool SnippetShortcutExists_NonBlocking(string shortcut)
         {
-            // This function used to be async and wait for the cache population task.
-            // Since the cache population task must run on the UI thread, this could
-            // deadlock if completion blocked on the UI thread before the 
-            // population task started. We now simply return whatever snippets were
-            // there. When we're told to update snippets, we'll return stale data
-            // until that process is complete, which is fine.
+            // Check against the known set of snippets, even if we're still in the process of
+            // calculating a more up-to-date list.
             lock (cacheGuard)
             {
                 return snippetShortcuts.Contains(shortcut);
@@ -111,7 +114,101 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
         private void PopulateSnippetCaches()
         {
-            var updatedSnippets = GetSnippetInfoList();
+            Debug.Assert(_expansionManager != null);
+
+            var token = _waiter.BeginAsyncOperation(GetType().Name + ".Start");
+            if (_expansionManager is IExpansionManager)
+            {
+                // Call the asynchronous snippet population API on a background thread
+                Task.Factory.StartNew(async () => await PopulateSnippetCacheAsync().ConfigureAwait(false),
+                            CancellationToken.None,
+                            TaskCreationOptions.None,
+                            TaskScheduler.Default).CompletesAsyncOperation(token);
+        }
+
+        private async Task PopulateSnippetCacheOnBackgroundWithForegroundFallback()
+        {
+            AssertIsBackground();
+
+            try
+            {
+                IVsExpansionEnumeration expansionEnumerator = await ((dynamic)_expansionManager).EnumerateExpansionsAsync(
+                    _languageGuidForSnippets,
+                    0, // shortCutOnly
+                    Array.Empty<string>(), // types
+                    0, // countTypes
+                    1, // includeNULLTypes
+                    1 // includeDulicates: Allows snippets with the same title but different shortcuts
+                    ).ConfigureAwait(false);
+
+                // The rest of the process requires being on the UI thread, see the explanation on 
+                // PopulateSnippetCacheFromExpansionEnumeration for details
+                await Task.Factory.StartNew(() => PopulateSnippetCacheFromExpansionEnumeration(expansionEnumerator),
+                    CancellationToken.None,
+                    TaskCreationOptions.None,
+                    ForegroundTaskScheduler).ConfigureAwait(false);
+            }
+            catch (RuntimeBinderException)
+            {
+                // The IExpansionManager.EnumerateExpansionsAsync could not be found. Use 
+                // IVsExpansionManager.EnumerateExpansions instead, but from the UI thread.
+                await Task.Factory.StartNew(() => PopulateSnippetCacheOnForeground(),
+                            CancellationToken.None,
+                            TaskCreationOptions.None,
+                            ForegroundTaskScheduler).ConfigureAwait(false);
+            }
+        }
+
+        /// <remarks>
+        /// Changes to the <see cref="IVsExpansionManager.EnumerateExpansions"/> invocation
+        /// should also be made to the <see cref="IExpansionManager.EnumerateExpansionsAsync"/>
+        /// invocation in <see cref="PopulateSnippetCacheAsync"/>.
+        /// </remarks>
+        private void PopulateSnippetCacheOnForeground()
+        {
+            AssertIsForeground();
+
+            IVsExpansionEnumeration expansionEnumerator = null;
+            _expansionManager.EnumerateExpansions(
+                _languageGuidForSnippets,
+                fShortCutOnly: 0,
+                bstrTypes: null,
+                iCountTypes: 0,
+                fIncludeNULLType: 1,
+                fIncludeDuplicates: 1, // Allows snippets with the same title but different shortcuts
+                pEnum: out expansionEnumerator);
+
+            PopulateSnippetCacheFromExpansionEnumeration(expansionEnumerator);
+        }
+
+        /// <remarks>
+        /// This method must be called on the UI thread because it eventually calls into
+        /// IVsExpansionEnumeration.Next, which must be called on the UI thread due to an issue
+        /// with how the call is marshalled.
+        /// 
+        /// The second parameter for IVsExpansionEnumeration.Next is defined like this:
+        ///    [ComAliasName("Microsoft.VisualStudio.TextManager.Interop.VsExpansion")] IntPtr[] rgelt
+        ///
+        /// We pass a pointer for rgelt that we expect to be populated as the result. This
+        /// eventually calls into the native CExpansionEnumeratorShim::Next method, which has the
+        /// same contract of expecting a non-null rgelt that it can drop expansion data into. When
+        /// we call from the UI thread, this transition from managed code to the
+        /// CExpansionEnumeratorShim` goes smoothly and everything works.
+        ///
+        /// When we call from a background thread, the COM marshaller has to move execution to the
+        /// UI thread, and as part of this process it uses the interface as defined in the idl to
+        /// set up the appropriate arguments to pass. The same parameter from the idl is defined as
+        ///    [out, size_is(celt), length_is(*pceltFetched)] VsExpansion **rgelt
+        ///
+        /// Because rgelt is specified as an `out` parameter, the marshaller is discarding the
+        /// pointer we passed and substituting the null reference. This then causes a null
+        /// reference exception in the shim. Calling from the UI thread avoids this marshaller.
+        /// </remarks>
+        void PopulateSnippetCacheFromExpansionEnumeration(IVsExpansionEnumeration expansionEnumerator)
+        {
+            AssertIsForeground();
+
+            var updatedSnippets = ExtractSnippetInfo(expansionEnumerator);
             var updatedSnippetShortcuts = GetShortcutsHashFromSnippets(updatedSnippets);
 
             lock (cacheGuard)
@@ -121,42 +218,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             }
         }
 
-        protected static HashSet<string> GetShortcutsHashFromSnippets(IList<SnippetInfo> updatedSnippets)
+        private IList<SnippetInfo> ExtractSnippetInfo(IVsExpansionEnumeration expansionEnumerator)
         {
-            return new HashSet<string>(updatedSnippets.Select(s => s.Shortcut), StringComparer.OrdinalIgnoreCase);
-        }
+            AssertIsForeground();
 
-        private IList<SnippetInfo> GetSnippetInfoList()
-        {
-            IVsExpansionEnumeration expansionEnumerator;
-            if (TryGetVsSnippets(out expansionEnumerator))
-            {
-                return ExtractSnippetInfo(expansionEnumerator);
-            }
-
-            return SpecializedCollections.EmptyList<SnippetInfo>();
-        }
-
-        private bool TryGetVsSnippets(out IVsExpansionEnumeration expansionEnumerator)
-        {
-            expansionEnumerator = null;
-            if (_expansionManager != null)
-            {
-                _expansionManager.EnumerateExpansions(
-                    _languageGuidForSnippets,
-                    fShortCutOnly: 0,
-                    bstrTypes: null,
-                    iCountTypes: 0,
-                    fIncludeNULLType: 1,
-                    fIncludeDuplicates: 1, // Allows snippets with the same title but different shortcuts
-                    pEnum: out expansionEnumerator);
-            }
-
-            return expansionEnumerator != null;
-        }
-
-        private static IList<SnippetInfo> ExtractSnippetInfo(IVsExpansionEnumeration expansionEnumerator)
-        {
             IList<SnippetInfo> snippetList = new List<SnippetInfo>();
 
             uint count = 0;
@@ -191,6 +256,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             }
 
             return snippetList;
+        }
+
+        protected static HashSet<string> GetShortcutsHashFromSnippets(IList<SnippetInfo> updatedSnippets)
+        {
+            return new HashSet<string>(updatedSnippets.Select(s => s.Shortcut), StringComparer.OrdinalIgnoreCase);
         }
 
         private static VsExpansion ConvertToVsExpansionAndFree(IntPtr expansionPtr)

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -23,7 +23,7 @@ class C
         <WorkItem(726497)>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteAddedToDescription_ExactMatch() As Threading.Tasks.Task
-            Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "interface")
+            Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "interface")
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:="title" & vbCrLf &
@@ -35,7 +35,7 @@ class C
         <WorkItem(726497)>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteAddedToDescription_DifferentSnippetShortcutCasing() As Threading.Tasks.Task
-            Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "intErfaCE")
+            Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "intErfaCE")
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=$"{String.Format(FeaturesResources.Keyword, "interface")}
@@ -46,7 +46,7 @@ class C
         <WorkItem(726497)>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Sub SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSubstringOfInsertedText()
-            Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "interfac")
+            Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "interfac")
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:="title" & vbCrLf &
@@ -58,7 +58,7 @@ class C
         <WorkItem(726497)>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Sub SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSuperstringOfInsertedText()
-            Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "interfaces")
+            Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "interfaces")
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "interface"))
@@ -68,7 +68,7 @@ class C
         <WorkItem(726497)>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Sub SnippetExpansionNoteAddedToDescription_DisplayTextDoesNotMatchShortcutButInsertionTextDoes()
-            Using state = Await CreateCSharpSnippetExpansionNoteTestState(_markup, "InsertionText")
+            Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "InsertionText")
 
                 state.SendTypeChars("DisplayTex")
                 Await state.AssertCompletionSession()
@@ -93,7 +93,7 @@ class C
                 WorkspaceKind.Interactive)
 
                 Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService(Of ISnippetInfoService)(), TestCSharpSnippetInfoService)
-                Await testSnippetInfoService.SetSnippetShortcuts({"for"})
+                testSnippetInfoService.SetSnippetShortcuts({"for"})
 
                 state.Workspace.Options = state.Workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, False)
 
@@ -103,7 +103,7 @@ class C
             End Using
         End Function
 
-        Private Async Function CreateCSharpSnippetExpansionNoteTestState(xElement As XElement, ParamArray snippetShortcuts As String()) As Task(Of TestState)
+        Private Function CreateCSharpSnippetExpansionNoteTestState(xElement As XElement, ParamArray snippetShortcuts As String()) As TestState
             Dim state = TestState.CreateCSharpTestState(
                 xElement,
                 New CompletionListProvider() {New MockCompletionProvider(New TextSpan(31, 10))},
@@ -111,8 +111,7 @@ class C
                 New List(Of Type) From {GetType(TestCSharpSnippetInfoService)})
 
             Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService(Of ISnippetInfoService)(), TestCSharpSnippetInfoService)
-            Await testSnippetInfoService.SetSnippetShortcuts(snippetShortcuts)
-
+            testSnippetInfoService.SetSnippetShortcuts(snippetShortcuts)
             Return state
         End Function
     End Class

--- a/src/VisualStudio/Core/Test/Completion/TestCSharpSnippetInfoService.vb
+++ b/src/VisualStudio/Core/Test/Completion/TestCSharpSnippetInfoService.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
@@ -21,8 +22,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Completion
 
         Friend Sub SetSnippetShortcuts(newSnippetShortcuts As String())
             SyncLock cacheGuard
-                Snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToList()
-                snippetShortcuts = GetShortcutsHashFromSnippets(Snippets)
+                snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToImmutableArray()
+                snippetShortcuts = GetShortcutsHashFromSnippets(snippets)
             End SyncLock
         End Sub
     End Class

--- a/src/VisualStudio/Core/Test/Completion/TestCSharpSnippetInfoService.vb
+++ b/src/VisualStudio/Core/Test/Completion/TestCSharpSnippetInfoService.vb
@@ -19,14 +19,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Completion
             MyBase.New(Nothing, asyncListeners)
         End Sub
 
-        Friend Async Function SetSnippetShortcuts(newSnippetShortcuts As String()) As Task
-            Await InitialCachePopulationTask
-
+        Friend Sub SetSnippetShortcuts(newSnippetShortcuts As String())
             SyncLock cacheGuard
-                snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToList()
-                snippetShortcuts = GetShortcutsHashFromSnippets(snippets)
+                Snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToList()
+                snippetShortcuts = GetShortcutsHashFromSnippets(Snippets)
             End SyncLock
-        End Function
+        End Sub
     End Class
 End Namespace
 

--- a/src/VisualStudio/Core/Test/Completion/TestVisualBasicSnippetInfoService.vb
+++ b/src/VisualStudio/Core/Test/Completion/TestVisualBasicSnippetInfoService.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
@@ -22,8 +23,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Completion
 
         Friend Sub SetSnippetShortcuts(newSnippetShortcuts As String())
             SyncLock cacheGuard
-                Snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToList()
-                snippetShortcuts = GetShortcutsHashFromSnippets(Snippets)
+                snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToImmutableArray()
+                snippetShortcuts = GetShortcutsHashFromSnippets(snippets)
             End SyncLock
         End Sub
     End Class

--- a/src/VisualStudio/Core/Test/Completion/TestVisualBasicSnippetInfoService.vb
+++ b/src/VisualStudio/Core/Test/Completion/TestVisualBasicSnippetInfoService.vb
@@ -20,14 +20,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Completion
             MyBase.New(Nothing, asyncListeners)
         End Sub
 
-        Friend Async Function SetSnippetShortcuts(newSnippetShortcuts As String()) As Task
-            Await InitialCachePopulationTask
-
+        Friend Sub SetSnippetShortcuts(newSnippetShortcuts As String())
             SyncLock cacheGuard
-                snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToList()
-                snippetShortcuts = GetShortcutsHashFromSnippets(snippets)
+                Snippets = newSnippetShortcuts.Select(Function(shortcut) New SnippetInfo(shortcut, "title", "description", "path")).ToList()
+                snippetShortcuts = GetShortcutsHashFromSnippets(Snippets)
             End SyncLock
-        End Function
+        End Sub
     End Class
 End Namespace
 

--- a/src/VisualStudio/Core/Test/Completion/VisualBasicCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/VisualBasicCompletionSnippetNoteTests.vb
@@ -19,7 +19,7 @@ End Class]]></document>
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteAddedToDescription_ExactMatch() As Task
-            Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interface")
+            Using state = CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interface")
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
@@ -30,7 +30,7 @@ End Class]]></document>
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteAddedToDescription_DifferentSnippetShortcutCasing() As Task
-            Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "intErfaCE")
+            Using state = CreateVisualBasicSnippetExpansionNoteTestState(_markup, "intErfaCE")
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
@@ -41,7 +41,7 @@ End Class]]></document>
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSubstringOfInsertedText() As Task
-            Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interfac")
+            Using state = CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interfac")
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
@@ -51,7 +51,7 @@ End Class]]></document>
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteNotAddedToDescription_ShortcutIsProperSuperstringOfInsertedText() As Task
-            Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interfaces")
+            Using state = CreateVisualBasicSnippetExpansionNoteTestState(_markup, "Interfaces")
                 state.SendTypeChars("Interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:=String.Format(FeaturesResources.Keyword, "Interface") & vbCrLf &
@@ -61,7 +61,7 @@ End Class]]></document>
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteNotAddedToDescription_DisplayTextMatchesShortcutButInsertionTextDoesNot() As Task
-            Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "DisplayText")
+            Using state = CreateVisualBasicSnippetExpansionNoteTestState(_markup, "DisplayText")
 
                 state.SendTypeChars("DisplayTex")
                 Await state.AssertCompletionSession()
@@ -71,7 +71,7 @@ End Class]]></document>
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteAddedToDescription_DisplayTextDoesNotMatchShortcutButInsertionTextDoes() As Task
-            Using state = Await CreateVisualBasicSnippetExpansionNoteTestState(_markup, "InsertionText")
+            Using state = CreateVisualBasicSnippetExpansionNoteTestState(_markup, "InsertionText")
 
                 state.SendTypeChars("DisplayTex")
                 Await state.AssertCompletionSession()
@@ -79,7 +79,7 @@ End Class]]></document>
             End Using
         End Function
 
-        Private Async Function CreateVisualBasicSnippetExpansionNoteTestState(xElement As XElement, ParamArray snippetShortcuts As String()) As Task(Of TestState)
+        Private Function CreateVisualBasicSnippetExpansionNoteTestState(xElement As XElement, ParamArray snippetShortcuts As String()) As TestState
             Dim state = TestState.CreateVisualBasicTestState(
                 xElement,
                 New CompletionListProvider() {New MockCompletionProvider(New TextSpan(31, 10))},
@@ -87,8 +87,7 @@ End Class]]></document>
                 New List(Of Type) From {GetType(TestVisualBasicSnippetInfoService)})
 
             Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.VisualBasic).GetService(Of ISnippetInfoService)(), TestVisualBasicSnippetInfoService)
-            Await testSnippetInfoService.SetSnippetShortcuts(snippetShortcuts)
-
+            testSnippetInfoService.SetSnippetShortcuts(snippetShortcuts)
             Return state
         End Function
     End Class


### PR DESCRIPTION
Fixes #6685

Calling IVsTextManager2.GetExpansionManager can return either an IVsExpansionManager or an IExpansionManager, and we now support reading snippet info from both.

In the IVsExpansionManager case, we behave as before this change. During package load, we kick off a task to execute later on the UI thread to synchronously enumerate the snippets.

In the IExpansionManager case, we instead enumerate the snippets asynchronously on a background thread.

For Visual Studio 2015 Update 1 RTM, we will only receive an IVsExpansionManager. Starting with Update 2 (and with some intermediate builds) we will receive IExpansionManagers by default, but the platform reserves the right to return an IVsExpansionManager as a fallback, so we must continue to support both. Because IExpansionManager already existed in Update 1, we do not need to do adaptive light-up to keep this code working on Update 1.