### PR TITLE
prevent `Compilation.GetSymbolsWithName() from returning null entries

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2940,7 +2940,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (includeNamespace && predicate(current.Name))
                     {
                         var container = GetSpineSymbol(spine);
-                        set.Add(GetSymbol(container, current));
+                        var symbol = GetSymbol(container, current);
+                        if (symbol != null)
+                        {
+                            set.Add(symbol);
+                        }
                     }
                 }
                 else
@@ -2948,7 +2952,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (includeType && predicate(current.Name))
                     {
                         var container = GetSpineSymbol(spine);
-                        set.Add(GetSymbol(container, current));
+                        var symbol = GetSymbol(container, current);
+                        if (symbol != null)
+                        {
+                            set.Add(symbol);
+                        }
                     }
 
                     if (includeMember)
@@ -2984,13 +2992,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 spine.Add(current);
 
                 var container = GetSpineSymbol(spine);
-                foreach (var member in container.GetMembers())
+                if (container != null)
                 {
-                    if (!member.IsTypeOrTypeAlias() &&
-                        (member.CanBeReferencedByName || member.IsExplicitInterfaceImplementation() || member.IsIndexer()) &&
-                        predicate(member.Name))
+                    foreach (var member in container.GetMembers())
                     {
-                        set.Add(member);
+                        if (!member.IsTypeOrTypeAlias() &&
+                            (member.CanBeReferencedByName || member.IsExplicitInterfaceImplementation() || member.IsIndexer()) &&
+                            predicate(member.Name))
+                        {
+                            set.Add(member);
+                        }
                     }
                 }
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2681,12 +2681,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If current.Kind = DeclarationKind.Namespace Then
                     If includeNamespace AndAlso predicate(current.Name) Then
                         Dim container = GetSpineSymbol(spine)
-                        [set].Add(GetSymbol(container, current))
+                        Dim symbol = GetSymbol(container, current)
+                        If symbol IsNot Nothing Then
+                            [set].Add(symbol)
+                        End If
                     End If
                 Else
                     If includeType AndAlso predicate(current.Name) Then
                         Dim container = GetSpineSymbol(spine)
-                        [set].Add(GetSymbol(container, current))
+                        Dim symbol = GetSymbol(container, current)
+                        If symbol IsNot Nothing Then
+                            [set].Add(symbol)
+                        End If
                     End If
 
                     If includeMember Then
@@ -2719,7 +2725,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each name In mergedType.MemberNames
                     If predicate(name) Then
                         container = If(container, GetSpineSymbol(spine))
-                        [set].UnionWith(container.GetMembers(name))
+                        If container IsNot Nothing Then
+                            [set].UnionWith(container.GetMembers(name))
+                        End If
                     End If
                 Next
 


### PR DESCRIPTION
_Fixes internal bug 173790._

We've received crash reports when searching within Solution Explorer.  Unfortunately the dumps weren't properly saved, but we do have a call stack which reports an NRE.

```
   at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.<FilterByCriteria>d__25.MoveNext() in F:\Builds\5443\DevDiv\Roslyn-Stabilization-Signed-Release\src\Open\src\Workspaces\Core\Portable\FindSymbols\SymbolFinder_Declarations.cs:line 336
   at System.Collections.Generic.List`1.InsertRange(Int32 index, IEnumerable`1 collection) in f:\dd\ndp\clr\src\BCL\system\collections\generic\list.cs:line 743
   at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.<FindSourceDeclarationsAsync>d__24.MoveNext() in F:\Builds\5443\DevDiv\Roslyn-Stabilization-Signed-Release\src\Open\src\Workspaces\Core\Portable\FindSymbols\SymbolFinder_Declarations.cs:line 327
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) in f:\dd\ndp\clr\src\BCL\system\runtime\compilerservices\TaskAwaiter.cs:line 176
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) in f:\dd\ndp\clr\src\BCL\system\runtime\compilerservices\TaskAwaiter.cs:line 156
   at Microsoft.VisualStudio.LanguageServices.Implementation.Progression.SearchGraphQuery.<FindNavigableSourceSymbolsAsync>d__6.MoveNext() in F:\Builds\5443\DevDiv\Roslyn-Stabilization-Signed-Release\src\Open\src\VisualStudio\Core\Def\Implementation\Progression\GraphQueries\SearchGraphQuery.cs:line 120
```

The offending line is [here](https://github.com/dotnet/roslyn/blob/Visual-Studio-2015-Update-1/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs#L336) and the only two methods which pass their results into `FilterByCriteria` are [`Compilation.GetSymbolsWithName()`]() and [`Find()`](https://github.com/dotnet/roslyn/blob/master/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs#L303).  I traced the calls in `Find()` and never found anything that could return `null` so I went into `Compilation.GetSymbolsWithName()` and eventually found that in both C# and VB, there is a `GetSymbol()` method that can return null which could cause a null item to be added to the result set.  Refactoring this method to be `TryGetSymbol()` seemed heavy-handed since there would still have to be a check before adding the symbol to the result set.  While auditing the code I also found that `GetSpineSymbol()` also calls `GetSymbol()` and could potentially end up returning `null` [here](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs#L3016) so I guarded the callsites to `GetSpineSymbol()`, too, with the notable exceptions of [here](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs#L2942) and [here](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs#L2950) because the subsequent calls go through `GetSymbol()` which is able to handle the `null` parameter.

@dotnet/roslyn-ide

_Update:_
After digging around some user feedback comments I was finally able to nail down a repro for VB and I've verified that without this fix the test fails with the same NRE seen originally.