### PR TITLE
Apply non-printable escaping to characters

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -228,8 +228,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public static string FormatLiteral(string value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             if (value == null)
             {
                 throw new ArgumentNullException(nameof(value));
@@ -319,8 +317,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(sbyte value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
                 // Special Case: for sbyte and short, specifically, negatives are shown
@@ -335,8 +331,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(byte value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
                 return "0x" + value.ToString("x2");
@@ -349,8 +343,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(short value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
                 // Special Case: for sbyte and short, specifically, negatives are shown
@@ -365,8 +357,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(ushort value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
                 return "0x" + value.ToString("x4");
@@ -379,8 +369,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(int value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
                 return "0x" + value.ToString("x8");
@@ -393,8 +381,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(uint value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             var pooledBuilder = PooledStringBuilder.GetInstance();
             var sb = pooledBuilder.Builder;
 
@@ -418,8 +404,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(long value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             var pooledBuilder = PooledStringBuilder.GetInstance();
             var sb = pooledBuilder.Builder;
 
@@ -443,8 +427,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(ulong value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             var pooledBuilder = PooledStringBuilder.GetInstance();
             var sb = pooledBuilder.Builder;
 
@@ -468,8 +450,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(double value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             var result = value.ToString("R", CultureInfo.InvariantCulture);
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "D" : result;
@@ -477,8 +457,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(float value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             var result = value.ToString("R", CultureInfo.InvariantCulture);
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "F" : result;
@@ -486,18 +464,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(decimal value, ObjectDisplayOptions options)
         {
-            ValidateOptions(options);
-
             var result = value.ToString(CultureInfo.InvariantCulture);
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "M" : result;
-        }
-
-        [Conditional("DEBUG")]
-        private static void ValidateOptions(ObjectDisplayOptions options)
-        {
-            // These options are mutually exclusive in C# unless we're formatting a char...should not be passed otherwise...
-            Debug.Assert(!(options.IncludesOption(ObjectDisplayOptions.UseQuotes) && options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers)));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -227,9 +227,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var useQuotes = options.IncludesOption(ObjectDisplayOptions.UseQuotes);
             var escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableCharacters);
 
+            var isVerbatim = useQuotes && !escapeNonPrintable && ContainsNewLine(value);
+
             if (useQuotes)
             {
-                if (!escapeNonPrintable)
+                if (isVerbatim)
                 {
                     builder.Append('@');
                 }
@@ -245,14 +247,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (useQuotes && c == quote)
                 {
-                    if (escapeNonPrintable)
+                    if (isVerbatim)
                     {
-                        builder.Append('\\');
+                        builder.Append(quote);
                         builder.Append(quote);
                     }
                     else
                     {
-                        builder.Append(quote);
+                        builder.Append('\\');
                         builder.Append(quote);
                     }
                 }
@@ -268,6 +270,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return pooledBuilder.ToStringAndFree();
+        }
+
+        private static bool ContainsNewLine(string s)
+        {
+            foreach (char c in s)
+            {
+                if (SyntaxFacts.IsNewLine(c))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -286,25 +286,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return pooledBuilder.ToStringAndFree();
         }
 
-        internal static string FormatString(string str, bool useQuotes)
-        {
-            if (!useQuotes)
-            {
-                return str;
-            }
-
-            var pooledBuilder = PooledStringBuilder.GetInstance();
-            var builder = pooledBuilder.Builder;
-            const char quote = '"';
-            builder.Append(quote);
-            foreach (var c in str)
-            {
-                FormatStringChar(builder, c, quote);
-            }
-            builder.Append(quote);
-            return pooledBuilder.ToStringAndFree();
-        }
-
         /// <summary>
         /// Returns a C# character literal with the given value.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var builder = pooledBuilder.Builder;
 
             var useQuotes = options.IncludesOption(ObjectDisplayOptions.UseQuotes);
-            var escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
+            var escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableCharacters);
 
             if (useQuotes)
             {
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var useQuotes = options.IncludesOption(ObjectDisplayOptions.UseQuotes);
-            var escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
+            var escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableCharacters);
 
 
             if (useQuotes)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
@@ -184,7 +184,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public static string FormatLiteral(char c, bool quote)
         {
-            return ObjectDisplay.FormatLiteral(c, quote ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None);
+            var options = ObjectDisplayOptions.EscapeNonPrintableCharacters | 
+                (quote ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None);
+            return ObjectDisplay.FormatLiteral(c, options);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public static string FormatPrimitive(object obj, bool quoteStrings, bool useHexadecimalNumbers)
         {
-            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters;
+            var options = ObjectDisplayOptions.EscapeNonPrintableCharacters;
             if (quoteStrings)
             {
                 options |= ObjectDisplayOptions.UseQuotes;
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public static string FormatLiteral(string value, bool quote)
         {
-            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters | 
+            var options = ObjectDisplayOptions.EscapeNonPrintableCharacters | 
                 (quote ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None);
             return ObjectDisplay.FormatLiteral(value, options);
         }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -591,7 +591,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="value">The character value to be represented by the returned token.</param>
         public static SyntaxToken Literal(char value)
         {
-            return Literal(ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes), value);
+            return Literal(ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters), value);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(@"""ab""", ObjectDisplay.FormatLiteral(@"ab", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
             Assert.Equal(@"""\\""", ObjectDisplay.FormatLiteral(@"\", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
 
-            Assert.Equal("\"x\"", ObjectDisplay.FormatLiteral("x", ObjectDisplayOptions.UseQuotes));
+            Assert.Equal("\"x\"", ObjectDisplay.FormatLiteral("x", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
             Assert.Equal("x", ObjectDisplay.FormatLiteral("x", ObjectDisplayOptions.None));
 
             StringBuilder sb = new StringBuilder();
@@ -246,12 +246,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void Strings_QuotesAndEscaping()
         {
-            Assert.Equal(QuoteAndEscapingCombinations(""), new[] { "", "", "\"\"", "\"\"" });
-            Assert.Equal(QuoteAndEscapingCombinations("a"), new[] { "a", "a", "\"a\"", "\"a\"" });
-            Assert.Equal(QuoteAndEscapingCombinations("\t"), new[] { "\t", "\\t", "\"\t\"", "\"\\t\"" });
-            Assert.Equal(QuoteAndEscapingCombinations("\u26F4"), new[] { "\u26F4", "\u26F4", "\"\u26F4\"", "\"\u26F4\"" });  // Miscellaneous symbol
-            Assert.Equal(QuoteAndEscapingCombinations("\u007f"), new[] { "\u007f", "\\u007f", "\"\u007f\"", "\"\\u007f\"" }); // Control character
-            Assert.Equal(QuoteAndEscapingCombinations("\""), new[] { "\"", "\"", "\"\\\"\"", "\"\\\"\"" }); // Quote
+            Assert.Equal(QuoteAndEscapingCombinations(""), new[] { "", "", "@\"\"", "\"\"" });
+            Assert.Equal(QuoteAndEscapingCombinations("a"), new[] { "a", "a", "@\"a\"", "\"a\"" });
+            Assert.Equal(QuoteAndEscapingCombinations("\t"), new[] { "\t", "\\t", "@\"\t\"", "\"\\t\"" });
+            Assert.Equal(QuoteAndEscapingCombinations("\u26F4"), new[] { "\u26F4", "\u26F4", "@\"\u26F4\"", "\"\u26F4\"" });  // Miscellaneous symbol
+            Assert.Equal(QuoteAndEscapingCombinations("\u007f"), new[] { "\u007f", "\\u007f", "@\"\u007f\"", "\"\\u007f\"" }); // Control character
+            Assert.Equal(QuoteAndEscapingCombinations("\""), new[] { "\"", "\"", "@\"\"\"\"", "\"\\\"\"" }); // Quote
         }
 
         private static IEnumerable<string> QuoteAndEscapingCombinations(string s)
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             const string value = "a\tb";
 
             Assert.Equal("a\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.None));
-            Assert.Equal("\"a\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes));
+            Assert.Equal("@\"a\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes));
             Assert.Equal("a\\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.EscapeNonPrintableCharacters));
             Assert.Equal("\"a\\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
         }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -107,21 +107,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void Characters()
         {
-            Assert.Equal("120 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints));
+            Assert.Equal("120 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints));
             Assert.Equal("120 x", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.IncludeCodePoints));
-            Assert.Equal("0x0078 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x0078 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
             Assert.Equal("0x0078 x", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
 
-            Assert.Equal("39 '\\''", ObjectDisplay.FormatLiteral('\'', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints));
+            Assert.Equal("39 '\\''", ObjectDisplay.FormatLiteral('\'', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints));
             Assert.Equal("39 '", ObjectDisplay.FormatLiteral('\'', ObjectDisplayOptions.IncludeCodePoints));
-            Assert.Equal("0x001e '\\u001e'", ObjectDisplay.FormatLiteral('\u001e', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x001e '\\u001e'", ObjectDisplay.FormatLiteral('\u001e', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
             Assert.Equal("0x001e \u001e", ObjectDisplay.FormatLiteral('\u001e', ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
 
-            Assert.Equal("0x0008 '\\b'", ObjectDisplay.FormatLiteral('\b', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x0009 '\\t'", ObjectDisplay.FormatLiteral('\t', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x000a '\\n'", ObjectDisplay.FormatLiteral('\n', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x000b '\\v'", ObjectDisplay.FormatLiteral('\v', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x000d '\\r'", ObjectDisplay.FormatLiteral('\r', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x0008 '\\b'", ObjectDisplay.FormatLiteral('\b', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x0009 '\\t'", ObjectDisplay.FormatLiteral('\t', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x000a '\\n'", ObjectDisplay.FormatLiteral('\n', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x000b '\\v'", ObjectDisplay.FormatLiteral('\v', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x000d '\\r'", ObjectDisplay.FormatLiteral('\r', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
             Assert.Equal("0x000d \r", ObjectDisplay.FormatLiteral('\r', ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
         }
 
@@ -167,13 +167,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return new[]
             {
                 ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.None),
-                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.EscapeNonPrintableStringCharacters),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.EscapeNonPrintableCharacters),
                 ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.UseQuotes),
-                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.UseQuotes),
                 ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.None),
-                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.EscapeNonPrintableStringCharacters),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.EscapeNonPrintableCharacters),
                 ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseQuotes),
-                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.UseQuotes),
             };
         }
 
@@ -192,11 +192,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(@"ab\cd\e", ObjectDisplay.FormatLiteral(@"ab\cd\e", ObjectDisplayOptions.None));
             Assert.Equal(@"\\\\", ObjectDisplay.FormatLiteral(@"\\\\", ObjectDisplayOptions.None));
 
-            Assert.Equal(@"""""", ObjectDisplay.FormatLiteral("", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
-            Assert.Equal(@"""\""\""""", ObjectDisplay.FormatLiteral(@"""""", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
-            Assert.Equal(@"""'""", ObjectDisplay.FormatLiteral(@"'", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
-            Assert.Equal(@"""ab""", ObjectDisplay.FormatLiteral(@"ab", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
-            Assert.Equal(@"""\\""", ObjectDisplay.FormatLiteral(@"\", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
+            Assert.Equal(@"""""", ObjectDisplay.FormatLiteral("", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
+            Assert.Equal(@"""\""\""""", ObjectDisplay.FormatLiteral(@"""""", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
+            Assert.Equal(@"""'""", ObjectDisplay.FormatLiteral(@"'", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
+            Assert.Equal(@"""ab""", ObjectDisplay.FormatLiteral(@"ab", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
+            Assert.Equal(@"""\\""", ObjectDisplay.FormatLiteral(@"\", ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
 
             Assert.Equal("\"x\"", ObjectDisplay.FormatLiteral("x", ObjectDisplayOptions.UseQuotes));
             Assert.Equal("x", ObjectDisplay.FormatLiteral("x", ObjectDisplayOptions.None));
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 "êëìíîïðñòóôõö÷øùúûüýþ\"";
             Assert.Equal(
                 expected,
-                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
+                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
 
             expected =
                 "\0\u0001\u0002\u0003\u0004\u0005\u0006\a\u0008\u0009\u000a\u000b\f\u000d\u000e\u000f\u0010" +
@@ -259,9 +259,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return new[]
             {
                 ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.None),
-                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.EscapeNonPrintableStringCharacters),
+                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.EscapeNonPrintableCharacters),
                 ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes),
-                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.UseQuotes),
             };
         }
 
@@ -341,26 +341,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal("a\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.None));
             Assert.Equal("\"a\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes));
-            Assert.Equal("a\\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
-            Assert.Equal("\"a\\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
+            Assert.Equal("a\\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.EscapeNonPrintableCharacters));
+            Assert.Equal("\"a\\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
         }
 
         private string FormatPrimitive(object obj, bool quoteStrings = false)
         {
             var options = quoteStrings ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None;
-            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
+            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.EscapeNonPrintableCharacters);
         }
 
         private string FormatPrimitiveUsingHexadecimalNumbers(object obj, bool quoteStrings = false)
         {
             var options = quoteStrings ? ObjectDisplayOptions.UseQuotes : ObjectDisplayOptions.None;
-            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.UseHexadecimalNumbers | ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
+            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.UseHexadecimalNumbers | ObjectDisplayOptions.EscapeNonPrintableCharacters);
         }
 
         private string FormatPrimitiveIncludingTypeSuffix(object obj, bool useHexadecimalNumbers = false)
         {
             var options = useHexadecimalNumbers ? ObjectDisplayOptions.UseHexadecimalNumbers : ObjectDisplayOptions.None;
-            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.IncludeTypeSuffix | ObjectDisplayOptions.EscapeNonPrintableStringCharacters);
+            return ObjectDisplay.FormatPrimitive(obj, options | ObjectDisplayOptions.IncludeTypeSuffix | ObjectDisplayOptions.EscapeNonPrintableCharacters);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -107,22 +107,67 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void Characters()
         {
-            Assert.Equal("120 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints));
+            Assert.Equal("120 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints));
             Assert.Equal("120 x", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.IncludeCodePoints));
-            Assert.Equal("0x0078 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x0078 'x'", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
             Assert.Equal("0x0078 x", ObjectDisplay.FormatLiteral('x', ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
 
-            Assert.Equal("39 '\\''", ObjectDisplay.FormatLiteral('\'', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints));
+            Assert.Equal("39 '\\''", ObjectDisplay.FormatLiteral('\'', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints));
             Assert.Equal("39 '", ObjectDisplay.FormatLiteral('\'', ObjectDisplayOptions.IncludeCodePoints));
-            Assert.Equal("0x001e '\\u001e'", ObjectDisplay.FormatLiteral('\u001e', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x001e '\\u001e'", ObjectDisplay.FormatLiteral('\u001e', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
             Assert.Equal("0x001e \u001e", ObjectDisplay.FormatLiteral('\u001e', ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
 
-            Assert.Equal("0x0008 '\\b'", ObjectDisplay.FormatLiteral('\b', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x0009 '\\t'", ObjectDisplay.FormatLiteral('\t', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x000a '\\n'", ObjectDisplay.FormatLiteral('\n', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x000b '\\v'", ObjectDisplay.FormatLiteral('\v', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
-            Assert.Equal("0x000d '\\r'", ObjectDisplay.FormatLiteral('\r', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x0008 '\\b'", ObjectDisplay.FormatLiteral('\b', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x0009 '\\t'", ObjectDisplay.FormatLiteral('\t', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x000a '\\n'", ObjectDisplay.FormatLiteral('\n', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x000b '\\v'", ObjectDisplay.FormatLiteral('\v', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+            Assert.Equal("0x000d '\\r'", ObjectDisplay.FormatLiteral('\r', ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
             Assert.Equal("0x000d \r", ObjectDisplay.FormatLiteral('\r', ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseHexadecimalNumbers));
+        }
+
+        [Fact]
+        public void Characters_QuotesAndEscaping()
+        {
+            Assert.Equal(QuoteAndEscapingCombinations('a'), new[] 
+            {
+                "a", "a", "'a'", "'a'",
+                "97 a", "97 a", "97 'a'", "97 'a'",
+            });
+
+            Assert.Equal(QuoteAndEscapingCombinations('\t'), new[] 
+            {
+                "\t", "\\t", "'\t'", "'\\t'",
+                "9 \t", "9 \\t", "9 '\t'", "9 '\\t'",
+            });
+
+            // Miscellaneous symbol
+            Assert.Equal(QuoteAndEscapingCombinations('\u26f4'), new[]
+            {
+                "\u26f4", "\u26f4", "'\u26f4'", "'\u26f4'",
+                "9972 \u26f4", "9972 \u26f4", "9972 '\u26f4'", "9972 '\u26f4'",
+            });
+
+            // Control character
+            Assert.Equal(QuoteAndEscapingCombinations('\u007f'), new[]
+            {
+                "\u007f", "\\u007f", "'\u007f'", "'\\u007f'",
+                "127 \u007f", "127 \\u007f", "127 '\u007f'", "127 '\\u007f'",
+            });
+        }
+
+        private static IEnumerable<string> QuoteAndEscapingCombinations(char ch)
+        {
+            return new[]
+            {
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.None),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.EscapeNonPrintableStringCharacters),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.None),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.EscapeNonPrintableStringCharacters),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.IncludeCodePoints | ObjectDisplayOptions.EscapeNonPrintableStringCharacters | ObjectDisplayOptions.UseQuotes),
+            };
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -246,12 +246,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void Strings_QuotesAndEscaping()
         {
-            Assert.Equal(QuoteAndEscapingCombinations(""), new[] { "", "", "@\"\"", "\"\"" });
-            Assert.Equal(QuoteAndEscapingCombinations("a"), new[] { "a", "a", "@\"a\"", "\"a\"" });
-            Assert.Equal(QuoteAndEscapingCombinations("\t"), new[] { "\t", "\\t", "@\"\t\"", "\"\\t\"" });
-            Assert.Equal(QuoteAndEscapingCombinations("\u26F4"), new[] { "\u26F4", "\u26F4", "@\"\u26F4\"", "\"\u26F4\"" });  // Miscellaneous symbol
-            Assert.Equal(QuoteAndEscapingCombinations("\u007f"), new[] { "\u007f", "\\u007f", "@\"\u007f\"", "\"\\u007f\"" }); // Control character
-            Assert.Equal(QuoteAndEscapingCombinations("\""), new[] { "\"", "\"", "@\"\"\"\"", "\"\\\"\"" }); // Quote
+            Assert.Equal(QuoteAndEscapingCombinations(""), new[] { "", "", "\"\"", "\"\"" });
+            Assert.Equal(QuoteAndEscapingCombinations("a"), new[] { "a", "a", "\"a\"", "\"a\"" });
+            Assert.Equal(QuoteAndEscapingCombinations("\t"), new[] { "\t", "\\t", "\"\t\"", "\"\\t\"" });
+            Assert.Equal(QuoteAndEscapingCombinations("\u26F4"), new[] { "\u26F4", "\u26F4", "\"\u26F4\"", "\"\u26F4\"" });  // Miscellaneous symbol
+            Assert.Equal(QuoteAndEscapingCombinations("\u007f"), new[] { "\u007f", "\\u007f", "\"\u007f\"", "\"\\u007f\"" }); // Control character
+            Assert.Equal(QuoteAndEscapingCombinations("\""), new[] { "\"", "\"", "\"\\\"\"", "\"\\\"\"" }); // Quote
         }
 
         private static IEnumerable<string> QuoteAndEscapingCombinations(string s)
@@ -263,6 +263,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes),
                 ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.EscapeNonPrintableCharacters | ObjectDisplayOptions.UseQuotes),
             };
+        }
+
+        [Fact]
+        public void Strings_Verbatim()
+        {
+            Assert.Equal("@\"\n\"", ObjectDisplay.FormatLiteral("\n", ObjectDisplayOptions.UseQuotes));
+            Assert.Equal("@\"\"\"\n\"", ObjectDisplay.FormatLiteral("\"\n", ObjectDisplayOptions.UseQuotes));
         }
 
         [Fact, WorkItem(529850)]
@@ -340,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             const string value = "a\tb";
 
             Assert.Equal("a\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.None));
-            Assert.Equal("@\"a\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes));
+            Assert.Equal("\"a\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes));
             Assert.Equal("a\\tb", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.EscapeNonPrintableCharacters));
             Assert.Equal("\"a\\tb\"", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
         }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -153,6 +153,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 "\u007f", "\\u007f", "'\u007f'", "'\\u007f'",
                 "127 \u007f", "127 \\u007f", "127 '\u007f'", "127 '\\u007f'",
             });
+
+            // Quote
+            Assert.Equal(QuoteAndEscapingCombinations('\''), new[]
+            {
+                "'", "'", "'\\''", "'\\''",
+                "39 '", "39 '", "39 '\\''", "39 '\\''",
+            });
         }
 
         private static IEnumerable<string> QuoteAndEscapingCombinations(char ch)
@@ -244,6 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(QuoteAndEscapingCombinations("\t"), new[] { "\t", "\\t", "\"\t\"", "\"\\t\"" });
             Assert.Equal(QuoteAndEscapingCombinations("\u26F4"), new[] { "\u26F4", "\u26F4", "\"\u26F4\"", "\"\u26F4\"" });  // Miscellaneous symbol
             Assert.Equal(QuoteAndEscapingCombinations("\u007f"), new[] { "\u007f", "\\u007f", "\"\u007f\"", "\"\\u007f\"" }); // Control character
+            Assert.Equal(QuoteAndEscapingCombinations("\""), new[] { "\"", "\"", "\"\\\"\"", "\"\\\"\"" }); // Quote
         }
 
         private static IEnumerable<string> QuoteAndEscapingCombinations(string s)

--- a/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
@@ -39,6 +39,6 @@ namespace Microsoft.CodeAnalysis
         /// In C#, replace non-printable (e.g. control) characters with dedicated (e.g. \t) or unicode (\u0001) escape sequences.
         /// In Visual Basic, replace non-printable characters with calls to ChrW and vb* constants.
         /// </summary>
-        EscapeNonPrintableStringCharacters = 1 << 4,
+        EscapeNonPrintableCharacters = 1 << 4,
     }
 }

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
         Friend Function FormatLiteral(c As Char, options As ObjectDisplayOptions) As String
             ValidateOptions(options)
 
-            If IsPrintable(c) OrElse Not options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableStringCharacters) Then
+            If IsPrintable(c) OrElse Not options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableCharacters) Then
                 Return If(options.IncludesOption(ObjectDisplayOptions.UseQuotes),
                     """" & EscapeQuote(c) & """c",
                     c.ToString())
@@ -361,7 +361,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
         Friend Iterator Function TokenizeString(str As String, options As ObjectDisplayOptions) As IEnumerable(Of Integer)
             Dim useQuotes = options.IncludesOption(ObjectDisplayOptions.UseQuotes)
             Dim useHexadecimalNumbers = options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers)
-            Dim escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
+            Dim escapeNonPrintable = options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableCharacters)
 
             If str.Length = 0 Then
                 If useQuotes Then
@@ -501,7 +501,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
         Private Sub ValidateOptions(options As ObjectDisplayOptions)
             ' This option is not supported and has no meaning in Visual Basic...should not be passed...
             Debug.Assert(Not options.IncludesOption(ObjectDisplayOptions.IncludeCodePoints))
-            Debug.Assert(Not options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableStringCharacters) Or options.IncludesOption(ObjectDisplayOptions.UseQuotes))
+            Debug.Assert(Not options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableCharacters) Or options.IncludesOption(ObjectDisplayOptions.UseQuotes))
         End Sub
 
     End Module

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -142,8 +142,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
         Friend Function FormatLiteral(c As Char, options As ObjectDisplayOptions) As String
             ValidateOptions(options)
 
-            If Not options.IncludesOption(ObjectDisplayOptions.UseQuotes) Then
-                Return c.ToString()
+            If IsPrintable(c) OrElse Not options.IncludesOption(ObjectDisplayOptions.EscapeNonPrintableStringCharacters) Then
+                Return If(options.IncludesOption(ObjectDisplayOptions.UseQuotes),
+                    """" & EscapeQuote(c) & """c",
+                    c.ToString())
             End If
 
             Dim wellKnown = GetWellKnownCharacterName(c)
@@ -151,12 +153,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 Return wellKnown
             End If
 
-            If Not IsPrintable(c) Then
-                Dim codepoint = AscW(c)
-                Return If(options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers), "ChrW(&H" & codepoint.ToString("X"), "ChrW(" & codepoint.ToString()) & ")"
-            End If
-
-            Return """"c & EscapeQuote(c) & """"c & "c"
+            Dim codepoint = AscW(c)
+            Return If(options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers), "ChrW(&H" & codepoint.ToString("X"), "ChrW(" & codepoint.ToString()) & ")"
         End Function
 
         Private Function EscapeQuote(c As Char) As String

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplay.vb
@@ -122,7 +122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function FormatPrimitive(obj As Object, quoteStrings As Boolean, useHexadecimalNumbers As Boolean) As String
             Dim options = ObjectDisplayOptions.None
             If quoteStrings Then
-                options = options Or ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters
+                options = options Or ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters
             End If
             If useHexadecimalNumbers Then
                 options = options Or ObjectDisplayOptions.UseHexadecimalNumbers
@@ -135,7 +135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim sb = pooledBuilder.Builder
 
             Dim lastKind = -1
-            For Each token As Integer In ObjectDisplay.TokenizeString(str, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.UseHexadecimalNumbers Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
+            For Each token As Integer In ObjectDisplay.TokenizeString(str, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.UseHexadecimalNumbers Or ObjectDisplayOptions.EscapeNonPrintableCharacters)
                 Dim kind = token >> 16
 
                 ' merge contiguous tokens of the same kind into a single part

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -370,7 +370,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary> Creates a token with kind StringLiteralToken from a string value. </summary>
         ''' <param name="value">The string value to be represented by the returned token.</param>
         Public Shared Function Literal(value As String) As SyntaxToken
-            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters), value)
+            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters), value)
         End Function
 
         ''' <summary> Creates a token with kind StringLiteralToken from the text and corresponding string value. </summary>
@@ -393,7 +393,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary> Creates a token with kind CharacterLiteralToken from a character value. </summary>
         ''' <param name="value">The character value to be represented by the returned token.</param>
         Public Shared Function Literal(value As Char) As SyntaxToken
-            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters), value)
+            Return Literal(VbObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters), value)
         End Function
 
         ''' <summary> Creates a token with kind CharacterLiteralToken from the text and corresponding character value. </summary>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
@@ -136,7 +136,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Return {
                 ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.None),
                 ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.UseQuotes),
-                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters)
             }
         End Function
 
@@ -165,7 +165,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             ' non-printable characters are unchanged if quoting is disabled
             Assert.Equal(s, FormatPrimitiveUsingHexadecimalNumbers(s, quoteStrings:=False))
             Assert.Equal(s, ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.None))
-            Assert.Equal("""a"" & ChrW(&HFFFF) & ChrW(&HFFFE) & vbCrLf & ""b""", ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters Or ObjectDisplayOptions.UseHexadecimalNumbers))
+            Assert.Equal("""a"" & ChrW(&HFFFF) & ChrW(&HFFFE) & vbCrLf & ""b""", ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters Or ObjectDisplayOptions.UseHexadecimalNumbers))
 
             ' "well-known" characters:
             Assert.Equal("""a"" & vbBack", FormatPrimitiveUsingHexadecimalNumbers("a" & vbBack, quoteStrings:=True))
@@ -192,7 +192,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Return {
                 ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.None),
                 ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes),
-                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
+                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters)
             }
         End Function
 
@@ -268,15 +268,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal("a" & vbTab & "b", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.None))
             Assert.Equal("""a" & vbTab & "b""", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes))
             ' Not allowed in VB: ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
-            Assert.Equal("""a"" & vbTab & ""b""", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters))
+            Assert.Equal("""a"" & vbTab & ""b""", ObjectDisplay.FormatPrimitive(value, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters))
         End Sub
 
         Private Function FormatPrimitive(obj As Object, Optional quoteStrings As Boolean = False) As String
-            Return ObjectDisplay.FormatPrimitive(obj, If(quoteStrings, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters, ObjectDisplayOptions.None))
+            Return ObjectDisplay.FormatPrimitive(obj, If(quoteStrings, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters, ObjectDisplayOptions.None))
         End Function
 
         Private Function FormatPrimitiveUsingHexadecimalNumbers(obj As Object, Optional quoteStrings As Boolean = False) As String
-            Dim options = If(quoteStrings, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters, ObjectDisplayOptions.None)
+            Dim options = If(quoteStrings, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters, ObjectDisplayOptions.None)
             Return ObjectDisplay.FormatPrimitive(obj, options Or ObjectDisplayOptions.UseHexadecimalNumbers)
         End Function
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
@@ -122,6 +122,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal("vbCr", FormatPrimitiveUsingHexadecimalNumbers(ChrW(&HD), quoteStrings:=True))
         End Sub
 
+        <Fact>
+        Public Sub Characters_QuotesAndEscaping()
+            Assert.Equal(QuoteAndEscapingCombinations("a"c), {"a", """a""c", """a""c"})
+            Assert.Equal(QuoteAndEscapingCombinations(vbTab(0)), {vbTab, """" & vbTab & """c", "vbTab"})
+            Assert.Equal(QuoteAndEscapingCombinations(ChrW(&H26F4)), {ChrW(&H26F4).ToString(), """" & ChrW(&H26F4) & """c", """" & ChrW(&H26F4) & """c"}) ' Miscellaneous symbol
+            Assert.Equal(QuoteAndEscapingCombinations(ChrW(&H7F)), {ChrW(&H7F).ToString(), """" & ChrW(&H7F) & """c", "ChrW(127)"}) ' Control character
+            Assert.Equal(QuoteAndEscapingCombinations(""""c), {"""", """""""""c", """""""""c"}) ' Quote
+        End Sub
+
+        Private Shared Function QuoteAndEscapingCombinations(ch As Char) As IEnumerable(Of String)
+            ' Disallowed in VB: ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.EscapeNonPrintableStringCharacters),
+            Return {
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.None),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(ch, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
+            }
+        End Function
+
         <Fact()>
         Public Sub Strings()
             Assert.Equal("", FormatPrimitive("", quoteStrings:=False))
@@ -159,6 +177,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal("""a"" & vbTab", FormatPrimitiveUsingHexadecimalNumbers("a" & vbTab, quoteStrings:=True))
             Assert.Equal("""a"" & vbVerticalTab", FormatPrimitiveUsingHexadecimalNumbers("a" & vbVerticalTab, quoteStrings:=True))
         End Sub
+
+        <Fact>
+        Public Sub Strings_QuotesAndEscaping()
+            Assert.Equal(QuoteAndEscapingCombinations("a"), {"a", """a""", """a"""})
+            Assert.Equal(QuoteAndEscapingCombinations(vbTab), {vbTab, """" & vbTab & """", "vbTab"})
+            Assert.Equal(QuoteAndEscapingCombinations(ChrW(&H26F4).ToString()), {ChrW(&H26F4).ToString(), """" & ChrW(&H26F4) & """", """" & ChrW(&H26F4) & """"}) ' Miscellaneous symbol
+            Assert.Equal(QuoteAndEscapingCombinations(ChrW(&H7F).ToString()), {ChrW(&H7F).ToString(), """" & ChrW(&H7F) & """", "ChrW(127)"}) ' Control character
+            Assert.Equal(QuoteAndEscapingCombinations(""""), {"""", """""""""", """"""""""}) ' Quote
+        End Sub
+
+        Private Shared Function QuoteAndEscapingCombinations(s As String) As IEnumerable(Of String)
+            ' Disallowed in VB: ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.EscapeNonPrintableStringCharacters),
+            Return {
+                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.None),
+                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes),
+                ObjectDisplay.FormatLiteral(s, ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters)
+            }
+        End Function
 
         <Fact(), WorkItem(529850)>
         Public Sub CultureInvariance()

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
@@ -217,7 +217,5 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             return ObjectDisplay.FormatLiteral(str, options);
         }
-
-        internal override ObjectDisplayOptions QuotedStringOptions => ObjectDisplayOptions.UseQuotes;
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override string FormatString(string str, ObjectDisplayOptions options)
         {
-            return ObjectDisplay.FormatString(str, useQuotes: options.IncludesOption(ObjectDisplayOptions.UseQuotes));
+            return ObjectDisplay.FormatLiteral(str, options);
         }
 
         internal override ObjectDisplayOptions QuotedStringOptions => ObjectDisplayOptions.UseQuotes;

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.Values.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override string FormatLiteral(int value, ObjectDisplayOptions options)
         {
-            return ObjectDisplay.FormatLiteral(value, options & ~(ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters));
+            return ObjectDisplay.FormatLiteral(value, options & ~(ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters));
         }
 
         internal override string FormatPrimitiveObject(object value, ObjectDisplayOptions options)

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override ObjectDisplayOptions GetValueStringOptions(bool useQuotes)
         {
-            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters;
+            var options = ObjectDisplayOptions.EscapeNonPrintableCharacters;
             if (useQuotes)
             {
                 options |= ObjectDisplayOptions.UseQuotes;

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -42,17 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return SyntaxFacts.IsWhitespace(c);
         }
 
-        internal override ObjectDisplayOptions GetValueStringOptions(bool useQuotes)
-        {
-            var options = ObjectDisplayOptions.EscapeNonPrintableCharacters;
-            if (useQuotes)
-            {
-                options |= ObjectDisplayOptions.UseQuotes;
-            }
-
-            return options;
-        }
-
         internal override string TrimAndGetFormatSpecifiers(string expression, out ReadOnlyCollection<string> formatSpecifiers)
         {
             expression = RemoveComments(expression);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     return IncludeObjectId(
                         value,
-                        FormatPrimitive(value, options & ~(ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableStringCharacters), inspectionContext),
+                        FormatPrimitive(value, options & ~(ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters), inspectionContext),
                         flags);
                 }
             }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -348,12 +348,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 if (!value.IsNull)
                 {
-                    return this.GetValueString(value, inspectionContext, QuotedStringOptions, GetValueFlags.None);
+                    return this.GetValueString(value, inspectionContext, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters, GetValueFlags.None);
                 }
             }
             else if (type.IsCharacter())
             {
-                return this.GetValueStringForCharacter(value, inspectionContext, ObjectDisplayOptions.UseQuotes);
+                return this.GetValueStringForCharacter(value, inspectionContext, ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters);
             }
 
             return null;
@@ -409,8 +409,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal abstract string FormatPrimitiveObject(object value, ObjectDisplayOptions options);
 
         internal abstract string FormatString(string str, ObjectDisplayOptions options);
-
-        internal abstract ObjectDisplayOptions QuotedStringOptions { get; }
 
         #endregion
     }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -29,7 +29,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         string IDkmClrFormatter.GetValueString(DkmClrValue value, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers)
         {
-            ObjectDisplayOptions options = GetValueStringOptions((inspectionContext.EvaluationFlags & DkmEvaluationFlags.NoQuotes) == 0);
+            var useQuotes = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.NoQuotes) == 0;
+            var options = useQuotes
+                ? ObjectDisplayOptions.UseQuotes | ObjectDisplayOptions.EscapeNonPrintableCharacters
+                : ObjectDisplayOptions.None;
             return GetValueString(value, inspectionContext, options, GetValueFlags.IncludeObjectId);
         }
 
@@ -63,8 +66,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal abstract bool IsPredefinedType(Type type);
 
         internal abstract bool IsWhitespace(char c);
-
-        internal abstract ObjectDisplayOptions GetValueStringOptions(bool useQuotes);
 
         // Note: We could be less conservative (e.g. "new C()").
         internal bool NeedsParentheses(string expr)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
@@ -171,12 +171,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return ObjectDisplay.FormatLiteral(str, options)
         End Function
 
-        Friend Overrides ReadOnly Property QuotedStringOptions As ObjectDisplayOptions
-            Get
-                Return ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters
-            End Get
-        End Property
-
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.Values.vb
@@ -173,7 +173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Friend Overrides ReadOnly Property QuotedStringOptions As ObjectDisplayOptions
             Get
-                Return ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters
+                Return ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters
             End Get
         End Property
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Friend Overrides Function GetValueStringOptions(useQuotes As Boolean) As ObjectDisplayOptions
             Return If(useQuotes,
-                ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableStringCharacters,
+                ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters,
                 ObjectDisplayOptions.None)
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -39,12 +39,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return SyntaxFacts.IsWhitespace(c)
         End Function
 
-        Friend Overrides Function GetValueStringOptions(useQuotes As Boolean) As ObjectDisplayOptions
-            Return If(useQuotes,
-                ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters,
-                ObjectDisplayOptions.None)
-        End Function
-
         Friend Overrides Function TrimAndGetFormatSpecifiers(expression As String, ByRef formatSpecifiers As ReadOnlyCollection(Of String)) As String
             expression = RemoveComments(expression)
             expression = RemoveFormatSpecifiers(expression, formatSpecifiers)

--- a/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
+++ b/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string FormatLiteral(char c, bool quote, bool includeCodePoints = false, bool useHexadecimalNumbers = false)
         {
-            var options = ObjectDisplayOptions.None;
+            var options = ObjectDisplayOptions.EscapeNonPrintableCharacters;
             if (quote)
             {
                 options |= ObjectDisplayOptions.UseQuotes;

--- a/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
+++ b/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string FormatLiteral(string value, bool quote, bool useHexadecimalNumbers = false)
         {
-            var options = ObjectDisplayOptions.EscapeNonPrintableStringCharacters;
+            var options = ObjectDisplayOptions.EscapeNonPrintableCharacters;
             if (quote)
             {
                 options |= ObjectDisplayOptions.UseQuotes;

--- a/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatter.vb
+++ b/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatter.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         Friend Overrides Function FormatLiteral(value As String, quote As Boolean, Optional useHexadecimalNumbers As Boolean = False) As String
             Dim options = ObjectDisplayOptions.None
             If quote Then
-                options = options Or ObjectDisplayOptions.UseQuotes
+                options = options Or ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters
             End If
             If useHexadecimalNumbers Then
                 options = options Or ObjectDisplayOptions.UseHexadecimalNumbers
@@ -49,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         Friend Overrides Function FormatLiteral(c As Char, quote As Boolean, Optional includeCodePoints As Boolean = False, Optional useHexadecimalNumbers As Boolean = False) As String
             Dim options = ObjectDisplayOptions.None
             If quote Then
-                options = options Or ObjectDisplayOptions.UseQuotes
+                options = options Or ObjectDisplayOptions.UseQuotes Or ObjectDisplayOptions.EscapeNonPrintableCharacters
             End If
             If includeCodePoints Then
                 options = options Or ObjectDisplayOptions.IncludeCodePoints


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/7531 only covered strings.

p.s.  I appear to have intentionally skipped characters the first time around.  If you happen to remember why, please let me know.