### PR TITLE
Add culture dependant object formatting in REPL

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return pooledBuilder.ToStringAndFree();
         }
 
-        internal static string FormatLiteral(sbyte value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(sbyte value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
@@ -345,11 +345,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(FormatCulture(options));
+                return value.ToString(GetFormatCulture(cultureInfo));
             }
         }
 
-        internal static string FormatLiteral(byte value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(byte value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
@@ -357,11 +357,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(FormatCulture(options));
+                return value.ToString(GetFormatCulture(cultureInfo));
             }
         }
 
-        internal static string FormatLiteral(short value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(short value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
@@ -371,11 +371,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(FormatCulture(options));
+                return value.ToString(GetFormatCulture(cultureInfo));
             }
         }
 
-        internal static string FormatLiteral(ushort value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(ushort value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
@@ -383,11 +383,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(FormatCulture(options));
+                return value.ToString(GetFormatCulture(cultureInfo));
             }
         }
 
-        internal static string FormatLiteral(int value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(int value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             if (options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers))
             {
@@ -395,11 +395,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(FormatCulture(options));
+                return value.ToString(GetFormatCulture(cultureInfo));
             }
         }
 
-        internal static string FormatLiteral(uint value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(uint value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             var pooledBuilder = PooledStringBuilder.GetInstance();
             var sb = pooledBuilder.Builder;
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                sb.Append(value.ToString(FormatCulture(options)));
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)));
             }
 
             if (options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix))
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return pooledBuilder.ToStringAndFree();
         }
 
-        internal static string FormatLiteral(long value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(long value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             var pooledBuilder = PooledStringBuilder.GetInstance();
             var sb = pooledBuilder.Builder;
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                sb.Append(value.ToString(FormatCulture(options)));
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)));
             }
 
             if (options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix))
@@ -445,7 +445,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return pooledBuilder.ToStringAndFree();
         }
 
-        internal static string FormatLiteral(ulong value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(ulong value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
             var pooledBuilder = PooledStringBuilder.GetInstance();
             var sb = pooledBuilder.Builder;
@@ -457,7 +457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                sb.Append(value.ToString(FormatCulture(options)));
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)));
             }
 
             if (options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix))
@@ -468,32 +468,30 @@ namespace Microsoft.CodeAnalysis.CSharp
             return pooledBuilder.ToStringAndFree();
         }
 
-        internal static string FormatLiteral(double value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(double value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
-            var result = value.ToString("R", FormatCulture(options));
+            var result = value.ToString("R", GetFormatCulture(cultureInfo));
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "D" : result;
         }
 
-        internal static string FormatLiteral(float value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(float value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
-            var result = value.ToString("R", FormatCulture(options));
+            var result = value.ToString("R", GetFormatCulture(cultureInfo));
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "F" : result;
         }
 
-        internal static string FormatLiteral(decimal value, ObjectDisplayOptions options)
+        internal static string FormatLiteral(decimal value, ObjectDisplayOptions options, CultureInfo cultureInfo = null)
         {
-            var result = value.ToString(FormatCulture(options));
+            var result = value.ToString(GetFormatCulture(cultureInfo));
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "M" : result;
         }
 
-        private static CultureInfo FormatCulture(ObjectDisplayOptions options)
+        private static CultureInfo GetFormatCulture(CultureInfo cultureInfo)
         {
-            return options.IncludesOption(ObjectDisplayOptions.UseCurrentCulture)
-                ? CultureInfo.CurrentCulture
-                : CultureInfo.InvariantCulture;
+            return cultureInfo ?? CultureInfo.InvariantCulture;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(CultureInfo.InvariantCulture);
+                return value.ToString(FormatCulture(options));
             }
         }
 
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(CultureInfo.InvariantCulture);
+                return value.ToString(FormatCulture(options));
             }
         }
 
@@ -371,7 +371,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(CultureInfo.InvariantCulture);
+                return value.ToString(FormatCulture(options));
             }
         }
 
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(CultureInfo.InvariantCulture);
+                return value.ToString(FormatCulture(options));
             }
         }
 
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return value.ToString(CultureInfo.InvariantCulture);
+                return value.ToString(FormatCulture(options));
             }
         }
 
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                sb.Append(value.ToString(CultureInfo.InvariantCulture));
+                sb.Append(value.ToString(FormatCulture(options)));
             }
 
             if (options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix))
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                sb.Append(value.ToString(CultureInfo.InvariantCulture));
+                sb.Append(value.ToString(FormatCulture(options)));
             }
 
             if (options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix))
@@ -457,7 +457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                sb.Append(value.ToString(CultureInfo.InvariantCulture));
+                sb.Append(value.ToString(FormatCulture(options)));
             }
 
             if (options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix))
@@ -470,23 +470,30 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static string FormatLiteral(double value, ObjectDisplayOptions options)
         {
-            var result = value.ToString("R", CultureInfo.InvariantCulture);
+            var result = value.ToString("R", FormatCulture(options));
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "D" : result;
         }
 
         internal static string FormatLiteral(float value, ObjectDisplayOptions options)
         {
-            var result = value.ToString("R", CultureInfo.InvariantCulture);
+            var result = value.ToString("R", FormatCulture(options));
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "F" : result;
         }
 
         internal static string FormatLiteral(decimal value, ObjectDisplayOptions options)
         {
-            var result = value.ToString(CultureInfo.InvariantCulture);
+            var result = value.ToString(FormatCulture(options));
 
             return options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) ? result + "M" : result;
+        }
+
+        private static CultureInfo FormatCulture(ObjectDisplayOptions options)
+        {
+            return options.IncludesOption(ObjectDisplayOptions.UseCurrentCulture)
+                ? CultureInfo.CurrentCulture
+                : CultureInfo.InvariantCulture;
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -283,16 +283,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 var decimalValue = new Decimal(12.5);
                 Assert.Equal("12,5", decimalValue.ToString());
                 Assert.Equal("12.5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.None));
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.UseCurrentCulture));
                 Assert.Equal("12.5M", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.IncludeTypeSuffix));
 
                 double doubleValue = 12.5;
                 Assert.Equal("12,5", doubleValue.ToString());
                 Assert.Equal("12.5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.None));
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.UseCurrentCulture));
                 Assert.Equal("12.5D", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.IncludeTypeSuffix));
 
                 float singleValue = 12.5F;
                 Assert.Equal("12,5", singleValue.ToString());
                 Assert.Equal("12.5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.None));
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.UseCurrentCulture));
                 Assert.Equal("12.5F", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.IncludeTypeSuffix));
             }
             finally

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -283,20 +283,29 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 var decimalValue = new Decimal(12.5);
                 Assert.Equal("12,5", decimalValue.ToString());
                 Assert.Equal("12.5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.None));
-                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.UseCurrentCulture));
+                Assert.Equal("12.5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.None, CultureInfo.InvariantCulture));
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.None, Thread.CurrentThread.CurrentCulture));
                 Assert.Equal("12.5M", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.IncludeTypeSuffix));
 
                 double doubleValue = 12.5;
                 Assert.Equal("12,5", doubleValue.ToString());
                 Assert.Equal("12.5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.None));
-                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.UseCurrentCulture));
+                Assert.Equal("12.5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.None, CultureInfo.InvariantCulture));
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.None, Thread.CurrentThread.CurrentCulture));
                 Assert.Equal("12.5D", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.IncludeTypeSuffix));
 
                 float singleValue = 12.5F;
                 Assert.Equal("12,5", singleValue.ToString());
                 Assert.Equal("12.5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.None));
-                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.UseCurrentCulture));
+                Assert.Equal("12.5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.None, CultureInfo.InvariantCulture));
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.None, Thread.CurrentThread.CurrentCulture));
                 Assert.Equal("12.5F", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.IncludeTypeSuffix));
+
+                int intValue = 12;
+                Assert.Equal("12", intValue.ToString());
+                Assert.Equal("12", ObjectDisplay.FormatLiteral(intValue, ObjectDisplayOptions.None));
+                Assert.Equal("12", ObjectDisplay.FormatLiteral(intValue, ObjectDisplayOptions.None, CultureInfo.InvariantCulture));
+                Assert.Equal("12", ObjectDisplay.FormatLiteral(intValue, ObjectDisplayOptions.None, Thread.CurrentThread.CurrentCulture));
             }
             finally
             {

--- a/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
@@ -40,5 +40,10 @@ namespace Microsoft.CodeAnalysis
         /// In Visual Basic, replace non-printable characters with calls to ChrW and vb* constants.
         /// </summary>
         EscapeNonPrintableCharacters = 1 << 4,
+
+        /// <summary>
+        /// Whether or not to use the current culture instead of invariant culture.
+        /// </summary>
+        UseCurrentCulture = 1 << 5,
     }
 }

--- a/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/ObjectDisplayOptions.cs
@@ -40,10 +40,5 @@ namespace Microsoft.CodeAnalysis
         /// In Visual Basic, replace non-printable characters with calls to ChrW and vb* constants.
         /// </summary>
         EscapeNonPrintableCharacters = 1 << 4,
-
-        /// <summary>
-        /// Whether or not to use the current culture instead of invariant culture.
-        /// </summary>
-        UseCurrentCulture = 1 << 5,
     }
 }

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/ObjectDisplay.vb
@@ -161,27 +161,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             Return If(c = """", """""", c)
         End Function
 
-        Friend Function FormatLiteral(value As SByte, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As SByte, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             If options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers) Then
                 Return "&H" & If(value >= 0, value.ToString("X2"), CInt(value).ToString("X8"))
             Else
-                Return value.ToString(CultureInfo.InvariantCulture)
+                Return value.ToString(GetFormatCulture(cultureInfo))
             End If
         End Function
 
-        Friend Function FormatLiteral(value As Byte, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As Byte, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             If options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers) Then
                 Return "&H" & value.ToString("X2")
             Else
-                Return value.ToString(CultureInfo.InvariantCulture)
+                Return value.ToString(GetFormatCulture(cultureInfo))
             End If
         End Function
 
-        Friend Function FormatLiteral(value As Short, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As Short, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             Dim pooledBuilder = PooledStringBuilder.GetInstance()
@@ -191,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 sb.Append("&H")
                 sb.Append(If(value >= 0, value.ToString("X4"), CInt(value).ToString("X8")))
             Else
-                sb.Append(value.ToString(CultureInfo.InvariantCulture))
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)))
             End If
 
             If options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) Then
@@ -201,7 +201,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             Return pooledBuilder.ToStringAndFree()
         End Function
 
-        Friend Function FormatLiteral(value As UShort, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As UShort, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             Dim pooledBuilder = PooledStringBuilder.GetInstance()
@@ -211,7 +211,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 sb.Append("&H")
                 sb.Append(value.ToString("X4"))
             Else
-                sb.Append(value.ToString(CultureInfo.InvariantCulture))
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)))
             End If
 
             If options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) Then
@@ -221,7 +221,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             Return pooledBuilder.ToStringAndFree()
         End Function
 
-        Friend Function FormatLiteral(value As Integer, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As Integer, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             Dim pooledBuilder = PooledStringBuilder.GetInstance()
@@ -231,7 +231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 sb.Append("&H")
                 sb.Append(value.ToString("X8"))
             Else
-                sb.Append(value.ToString(CultureInfo.InvariantCulture))
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)))
             End If
 
             If options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) Then
@@ -241,7 +241,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             Return pooledBuilder.ToStringAndFree()
         End Function
 
-        Friend Function FormatLiteral(value As UInteger, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As UInteger, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             Dim pooledBuilder = PooledStringBuilder.GetInstance()
@@ -251,7 +251,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 sb.Append("&H")
                 sb.Append(value.ToString("X8"))
             Else
-                sb.Append(value.ToString(CultureInfo.InvariantCulture))
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)))
             End If
 
             If options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) Then
@@ -261,7 +261,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             Return pooledBuilder.ToStringAndFree()
         End Function
 
-        Friend Function FormatLiteral(value As Long, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As Long, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             Dim pooledBuilder = PooledStringBuilder.GetInstance()
@@ -271,7 +271,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 sb.Append("&H")
                 sb.Append(value.ToString("X16"))
             Else
-                sb.Append(value.ToString(CultureInfo.InvariantCulture))
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)))
             End If
 
             If options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) Then
@@ -281,7 +281,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             Return pooledBuilder.ToStringAndFree()
         End Function
 
-        Friend Function FormatLiteral(value As ULong, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As ULong, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
             Dim pooledBuilder = PooledStringBuilder.GetInstance()
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
                 sb.Append("&H")
                 sb.Append(value.ToString("X16"))
             Else
-                sb.Append(value.ToString(CultureInfo.InvariantCulture))
+                sb.Append(value.ToString(GetFormatCulture(cultureInfo)))
             End If
 
             If options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix) Then
@@ -301,26 +301,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             Return pooledBuilder.ToStringAndFree()
         End Function
 
-        Friend Function FormatLiteral(value As Double, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As Double, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
-            Dim result = value.ToString("R", CultureInfo.InvariantCulture)
+            Dim result = value.ToString("R", GetFormatCulture(cultureInfo))
 
             Return If(options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix), result & "R", result)
         End Function
 
-        Friend Function FormatLiteral(value As Single, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As Single, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
-            Dim result = value.ToString("R", CultureInfo.InvariantCulture)
+            Dim result = value.ToString("R", GetFormatCulture(cultureInfo))
 
             Return If(options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix), result & "F", result)
         End Function
 
-        Friend Function FormatLiteral(value As Decimal, options As ObjectDisplayOptions) As String
+        Friend Function FormatLiteral(value As Decimal, options As ObjectDisplayOptions, Optional cultureInfo As CultureInfo = Nothing) As String
             ValidateOptions(options)
 
-            Dim result = value.ToString(CultureInfo.InvariantCulture)
+            Dim result = value.ToString(GetFormatCulture(cultureInfo))
 
             Return If(options.IncludesOption(ObjectDisplayOptions.IncludeTypeSuffix), result & "D", result)
         End Function
@@ -495,6 +495,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay
             End Select
 
             Return Nothing
+        End Function
+
+        Private Function GetFormatCulture(cultureInfo As CultureInfo) As CultureInfo
+            Return If(cultureInfo, CultureInfo.InvariantCulture)
         End Function
 
         <Conditional("DEBUG")>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/ObjectDisplayTests.vb
@@ -209,14 +209,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
                 Dim decimalValue As New Decimal(12.5)
                 Assert.Equal("12,5", decimalValue.ToString())
                 Assert.Equal("12.5", FormatPrimitive(decimalValue))
+                Assert.Equal("12.5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.None, CultureInfo.InvariantCulture))
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(decimalValue, ObjectDisplayOptions.None, CurrentThread.CurrentCulture))
 
                 Dim doubleValue As Double = 12.5
                 Assert.Equal("12,5", doubleValue.ToString())
                 Assert.Equal("12.5", FormatPrimitive(doubleValue))
+                Assert.Equal("12.5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.None, CultureInfo.InvariantCulture))
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(doubleValue, ObjectDisplayOptions.None, CurrentThread.CurrentCulture))
 
                 Dim singleValue As Single = 12.5
                 Assert.Equal("12,5", singleValue.ToString())
                 Assert.Equal("12.5", FormatPrimitive(singleValue))
+                Assert.Equal("12.5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.None, CultureInfo.InvariantCulture))
+                Assert.Equal("12,5", ObjectDisplay.FormatLiteral(singleValue, ObjectDisplayOptions.None, CurrentThread.CurrentCulture))
+
             Finally
                 CurrentThread.CurrentCulture = originalCulture
             End Try

--- a/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
+++ b/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 {
@@ -65,57 +66,57 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string FormatLiteral(sbyte value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(byte value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(short value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(ushort value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(int value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(uint value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(long value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(ulong value, bool useHexadecimalNumbers = false)
         {
-            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers));
+            return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture);
         }
 
         internal override string FormatLiteral(double value)
         {
-            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture);
+            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, UIFormatCulture);
         }
 
         internal override string FormatLiteral(float value)
         {
-            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture);
+            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, UIFormatCulture);
         }
 
         internal override string FormatLiteral(decimal value)
         {
-            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture);
+            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, UIFormatCulture);
         }
 
         internal override string FormatLiteral(DateTime value)

--- a/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
+++ b/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatter.cs
@@ -105,17 +105,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string FormatLiteral(double value)
         {
-            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None);
+            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture);
         }
 
         internal override string FormatLiteral(float value)
         {
-            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None);
+            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture);
         }
 
         internal override string FormatLiteral(decimal value)
         {
-            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None);
+            return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture);
         }
 
         internal override string FormatLiteral(DateTime value)

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -82,10 +82,38 @@ Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
         }
 
         [Fact]
-        public void DisplayResults()
+        [WorkItem(7133)]
+        public void TestDisplayResultsWithCurrentUICulture()
         {
             var runner = CreateRunner(input:
 @"using static System.Globalization.CultureInfo;
+DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
+Math.PI
+DefaultThreadCurrentUICulture = GetCultureInfo(""de-DE"")
+Math.PI
+");
+            runner.RunInteractive();
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+$@"Microsoft (R) Visual C# Interactive Compiler version {CompilerVersion}
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Type ""#help"" for more information.
+> using static System.Globalization.CultureInfo;
+> DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
+[en-GB]
+> Math.PI
+3.1415926535897931
+> DefaultThreadCurrentUICulture = GetCultureInfo(""de-DE"")
+[de-DE]
+> Math.PI
+3,1415926535897931
+>", runner.Console.Out.ToString());
+
+            // Tests that DefaultThreadCurrentUICulture is respected and not DefaultThreadCurrentCulture.
+            runner = CreateRunner(input:
+@"using static System.Globalization.CultureInfo;
+DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
 DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
 Math.PI
 DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
@@ -99,6 +127,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 Type ""#help"" for more information.
 > using static System.Globalization.CultureInfo;
+> DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
+[en-GB]
 > DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
 [en-GB]
 > Math.PI
@@ -106,7 +136,7 @@ Type ""#help"" for more information.
 > DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
 [de-DE]
 > Math.PI
-3,1415926535897931
+3.1415926535897931
 >", runner.Console.Out.ToString());
         }
 

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -82,6 +82,35 @@ Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
         }
 
         [Fact]
+        public void DisplayResults()
+        {
+            var runner = CreateRunner(input:
+@"using static System.Globalization.CultureInfo;
+DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
+Math.PI
+DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
+Math.PI
+");
+            runner.RunInteractive();
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+$@"Microsoft (R) Visual C# Interactive Compiler version {CompilerVersion}
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Type ""#help"" for more information.
+> using static System.Globalization.CultureInfo;
+> DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
+[en-GB]
+> Math.PI
+3.1415926535897931
+> DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
+[de-DE]
+> Math.PI
+3,1415926535897931
+>", runner.Console.Out.ToString());
+        }
+
+        [Fact]
         public void Void()
         {
             var runner = CreateRunner(input:

--- a/src/Scripting/Core/Hosting/ObjectFormatter/ObjectFormatter.cs
+++ b/src/Scripting/Core/Hosting/ObjectFormatter/ObjectFormatter.cs
@@ -531,7 +531,9 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
 
         internal static ObjectDisplayOptions GetObjectDisplayOptions(bool useHexadecimalNumbers)
         {
-            return useHexadecimalNumbers ? ObjectDisplayOptions.UseHexadecimalNumbers : ObjectDisplayOptions.None;
+            return useHexadecimalNumbers
+                ? ObjectDisplayOptions.UseHexadecimalNumbers | ObjectDisplayOptions.UseCurrentCulture
+                : ObjectDisplayOptions.UseCurrentCulture;
         }
 
         /// <summary>

--- a/src/Scripting/Core/Hosting/ObjectFormatter/ObjectFormatter.cs
+++ b/src/Scripting/Core/Hosting/ObjectFormatter/ObjectFormatter.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -336,7 +337,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
 
             public void AppendLine()
             {
-                // remove line length limit so that we can insert a new line even 
+                // remove line length limit so that we can insert a new line even
                 // if the previous one hit maxed out the line limit:
                 _currentLimit = _lengthLimit;
 
@@ -529,11 +530,13 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         /// </summary>
         internal virtual bool IsHiddenMember(MemberInfo member) => false;
 
+        internal static CultureInfo UIFormatCulture => CultureInfo.CurrentUICulture;
+
         internal static ObjectDisplayOptions GetObjectDisplayOptions(bool useHexadecimalNumbers)
         {
             return useHexadecimalNumbers
-                ? ObjectDisplayOptions.UseHexadecimalNumbers | ObjectDisplayOptions.UseCurrentCulture
-                : ObjectDisplayOptions.UseCurrentCulture;
+                ? ObjectDisplayOptions.UseHexadecimalNumbers
+                : ObjectDisplayOptions.None;
         }
 
         /// <summary>

--- a/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatter.vb
+++ b/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatter.vb
@@ -61,47 +61,47 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Function
 
         Friend Overrides Function FormatLiteral(value As SByte, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Byte, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Short, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As UShort, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Integer, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As UInteger, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Long, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As ULong, Optional useHexadecimalNumbers As Boolean = False) As String
-            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers))
+            Return ObjectDisplay.FormatLiteral(value, GetObjectDisplayOptions(useHexadecimalNumbers), UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Double) As String
-            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture)
+            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Single) As String
-            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture)
+            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, UIFormatCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Decimal) As String
-            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture)
+            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None, UIFormatCulture)
         End Function
 
         Friend Overrides Function GetPrimitiveTypeName(type As SpecialType) As String
@@ -246,4 +246,3 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
     End Class
 
 End Namespace
-

--- a/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatter.vb
+++ b/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatter.vb
@@ -93,15 +93,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Function
 
         Friend Overrides Function FormatLiteral(value As Double) As String
-            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None)
+            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Single) As String
-            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None)
+            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture)
         End Function
 
         Friend Overrides Function FormatLiteral(value As Decimal) As String
-            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.None)
+            Return ObjectDisplay.FormatLiteral(value, ObjectDisplayOptions.UseCurrentCulture)
         End Function
 
         Friend Overrides Function GetPrimitiveTypeName(type As SpecialType) As String

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -129,6 +129,32 @@ Type ""#help"" for more information.
 >", runner.Console.Out.ToString())
         End Sub
 
+        Public Sub TestDisplayResults()
+            Dim runner = CreateRunner(args:={}, input:="Imports System.Globalization
+CultureInfo.DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
+Math.PI
+CultureInfo.DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
+Math.PI")
+
+            runner.RunInteractive()
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+"Microsoft (R) Visual Basic Interactive Compiler version " + CompilerVersion + "
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Type ""#help"" for more information.
+> using static System.Globalization.CultureInfo;
+> DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
+[en-GB]
+> Math.PI
+3.1415926535897931
+> DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
+[de-DE]
+> Math.PI
+3,1415926535897931
+>", runner.Console.Out.ToString())
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -129,12 +129,14 @@ Type ""#help"" for more information.
 >", runner.Console.Out.ToString())
         End Sub
 
-        Public Sub TestDisplayResults()
+        <Fact()>
+        <WorkItem(7133)>
+        Public Sub TestDisplayResultsWithCurrentUICulture()
             Dim runner = CreateRunner(args:={}, input:="Imports System.Globalization
-CultureInfo.DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
-Math.PI
-CultureInfo.DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
-Math.PI")
+System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(""en-GB"")
+? System.Math.PI
+System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(""de-DE"")
+? System.Math.PI")
 
             runner.RunInteractive()
 
@@ -143,15 +145,38 @@ Math.PI")
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 Type ""#help"" for more information.
-> using static System.Globalization.CultureInfo;
-> DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
-[en-GB]
-> Math.PI
+> Imports System.Globalization
+> System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(""en-GB"")
+> ? System.Math.PI
 3.1415926535897931
-> DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
-[de-DE]
-> Math.PI
+> System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(""de-DE"")
+> ? System.Math.PI
 3,1415926535897931
+>", runner.Console.Out.ToString())
+
+            ' Tests that DefaultThreadCurrentUICulture is respected and not DefaultThreadCurrentCulture.
+            runner = CreateRunner(args:={}, input:="Imports System.Globalization
+System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(""en-GB"")
+System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.GetCultureInfo(""en-GB"")
+? System.Math.PI
+System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.GetCultureInfo(""de-DE"")
+? System.Math.PI")
+
+            runner.RunInteractive()
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+"Microsoft (R) Visual Basic Interactive Compiler version " + CompilerVersion + "
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Type ""#help"" for more information.
+> Imports System.Globalization
+> System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(""en-GB"")
+> System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.GetCultureInfo(""en-GB"")
+> ? System.Math.PI
+3.1415926535897931
+> System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.GetCultureInfo(""de-DE"")
+> ? System.Math.PI
+3.1415926535897931
 >", runner.Console.Out.ToString())
         End Sub
 


### PR DESCRIPTION
When the REPL displays the output information it gets presented in the
culture of the running submission.

Handles issue #7133 