### PR TITLE
use predefined type keywords if the real types would only be bracketed

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
@@ -4390,6 +4390,78 @@ End Class
 
             Await TestAsync(input, expected)
         End Function
+
+        <WorkItem(7955, "https://github.com/dotnet/roslyn/issues/7955")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function UsePredefinedTypeKeywordIfTextIsTheSame() As Task
+            Dim input =
+        <Workspace>
+            <Project Language="Visual Basic" CommonReferences="true">
+                <Document>
+                    <![CDATA[
+Imports System
+
+Class C
+    Sub M(p As {|Simplify:[String]|})
+    End Sum
+End Class
+]]>
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+                  <![CDATA[
+Imports System
+
+Class C
+    Sub M(p As String)
+    End Sum
+End Class
+]]></text>
+
+            Await TestAsync(input, expected, DontPreferIntrinsicPredefinedTypeKeywordInDeclaration)
+        End Function
+
+        <WorkItem(7955, "https://github.com/dotnet/roslyn/issues/7955")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function DontUsePredefinedTypeKeyword() As Task
+            Dim input =
+        <Workspace>
+            <Project Language="Visual Basic" CommonReferences="true">
+                <Document>
+                    <![CDATA[
+Imports System
+
+Class C
+    Sub M(p As {|Simplify:Int32|})
+    End Sum
+End Class
+]]>
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+                  <![CDATA[
+Imports System
+
+Class C
+    Sub M(p As Int32)
+    End Sum
+End Class
+]]></text>
+
+            Await TestAsync(input, expected, DontPreferIntrinsicPredefinedTypeKeywordInDeclaration)
+        End Function
+#End Region
+
+#Region "Helpers"
+
+        Shared DontPreferIntrinsicPredefinedTypeKeywordInDeclaration As Dictionary(Of OptionKey, Object) = New Dictionary(Of OptionKey, Object) From {{New OptionKey(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, LanguageNames.VisualBasic), False}}
+
 #End Region
 
     End Class

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxExtensions.vb
@@ -1290,20 +1290,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     ' QualifiedNames can't contain PredefinedTypeNames (although MemberAccessExpressions can).
                     ' In other words, the left side of a QualifiedName can't be a PredefinedTypeName.
                     If nameHasNoAlias AndAlso aliasInfo Is Nothing AndAlso Not name.Parent.IsKind(SyntaxKind.QualifiedName) Then
-                        If PreferPredefinedTypeKeywordInDeclarations(name, optionSet) OrElse
-                           PreferPredefinedTypeKeywordInMemberAccess(name, optionSet) Then
-                            Dim type = semanticModel.GetTypeInfo(name).Type
-                            If type IsNot Nothing Then
-                                Dim keywordKind = GetPredefinedKeywordKind(type.SpecialType)
-                                If keywordKind <> SyntaxKind.None Then
-                                    replacementNode = SyntaxFactory.PredefinedType(
-                                                        SyntaxFactory.Token(
-                                                            name.GetLeadingTrivia(),
-                                                            keywordKind,
-                                                            name.GetTrailingTrivia()))
-
+                        Dim type = semanticModel.GetTypeInfo(name).Type
+                        If type IsNot Nothing Then
+                            Dim keywordKind = GetPredefinedKeywordKind(type.SpecialType)
+                            If keywordKind <> SyntaxKind.None Then
+                                ' But do simplify to predefined type if not simplifying results in just the addition of escaping
+                                '   brackets.  E.g., even if specified otherwise, prefer `String` to `[String]`.
+                                Dim token = SyntaxFactory.Token(
+                                    name.GetLeadingTrivia(),
+                                    keywordKind,
+                                    name.GetTrailingTrivia())
+                                Dim valueText = TryCast(name, IdentifierNameSyntax)?.Identifier.ValueText
+                                If token.Text = valueText OrElse
+                                   PreferPredefinedTypeKeywordInDeclarations(name, optionSet) OrElse
+                                   PreferPredefinedTypeKeywordInMemberAccess(name, optionSet) Then
+                                    replacementNode = SyntaxFactory.PredefinedType(token)
                                     issueSpan = name.Span
-
                                     Return name.CanReplaceWithReducedNameInContext(replacementNode, semanticModel, cancellationToken)
                                 End If
                             End If


### PR DESCRIPTION
e.g., always prefer `String` to `[String]` in VB even if real types are preferred.

Fixes #7955.