### PR TITLE
Remove TestWorkspace constructors that are given a list of lines.

### DIFF
--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -841,9 +841,9 @@ $$
 }");
         }
 
-        protected override Task<TestWorkspace> CreateWorkspaceAsync(string[] code)
+        protected override Task<TestWorkspace> CreateWorkspaceAsync(string code)
         {
-            return CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code);
+            return CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code);
         }
 
         protected override Action CreateNextHandler(TestWorkspace workspace)

--- a/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceMatching
     {
         protected override Task<TestWorkspace> CreateWorkspaceFromCodeAsync(string code)
         {
-            return CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code);
+            return CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]

--- a/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
@@ -108,7 +108,7 @@ class C
 
         private static async Task UncommentSelectionAsync(string markup, string expected)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(markup))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markup))
             {
                 var doc = workspace.Documents.First();
                 SetupSelection(doc.GetTextView(), doc.SelectedSpans.Select(s => Span.FromBounds(s.Start, s.End)));

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MockDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MockDiagnosticAnalyzerTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.MockDiagnos
              string source,
              params DiagnosticDescription[] expectedDiagnostics)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source))
             {
                 var actualDiagnostics = await this.GetDiagnosticsAsync(workspace);
                 actualDiagnostics.Verify(expectedDiagnostics);

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1894,7 +1894,7 @@ $$
 
         protected override Task<TestWorkspace> CreateTestWorkspaceAsync(string code)
         {
-            return CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code);
+            return CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/XmlTagCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/XmlTagCompletionTests.cs
@@ -258,7 +258,7 @@ class c { }";
 
         protected override Task<TestWorkspace> CreateTestWorkspaceAsync(string initialMarkup)
         {
-            return CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(initialMarkup);
+            return CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(initialMarkup);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -255,7 +255,7 @@ class C
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source1))
             {
                 var documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id;
                 var oldSolution = workspace.CurrentSolution;
@@ -312,7 +312,7 @@ class C
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source1))
             {
                 var documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id;
                 var oldSolution = workspace.CurrentSolution;
@@ -341,7 +341,7 @@ class C
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source))
             {
                 var document = workspace.CurrentSolution.Projects.First().Documents.First();
                 var baseActiveStatements = ImmutableArray.Create<ActiveStatementSpan>();
@@ -376,7 +376,7 @@ class C
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source1))
             {
                 var documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id;
                 var oldSolution = workspace.CurrentSolution;
@@ -407,8 +407,8 @@ class C
             var experimentalFeatures = new Dictionary<string, string>(); // no experimental features to enable
             var experimental = TestOptions.Regular.WithFeatures(experimentalFeatures);
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(
-                new[] { source }, parseOptions: experimental, compilationOptions: null, exportProvider: null))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(
+                source, parseOptions: experimental, compilationOptions: null, exportProvider: null))
             {
                 var document = workspace.CurrentSolution.Projects.First().Documents.First();
                 var baseActiveStatements = ImmutableArray.Create<ActiveStatementSpan>();
@@ -452,8 +452,8 @@ class C
                 var featuresToEnable = new Dictionary<string, string>() { { feature, "enabled" } };
                 var experimental = TestOptions.Regular.WithFeatures(featuresToEnable);
 
-                using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(
-                    new[] { source1 }, parseOptions: experimental, compilationOptions: null, exportProvider: null))
+                using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(
+                    source1, parseOptions: experimental, compilationOptions: null, exportProvider: null))
                 {
                     var documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id;
                     var oldSolution = workspace.CurrentSolution;
@@ -485,7 +485,7 @@ class C
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source))
             {
                 var document = workspace.CurrentSolution.Projects.First().Documents.First();
                 var baseActiveStatements = ImmutableArray.Create<ActiveStatementSpan>();
@@ -522,7 +522,7 @@ class C
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source1))
             {
                 var documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id;
                 var oldSolution = workspace.CurrentSolution;
@@ -561,7 +561,7 @@ namespace N
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source1))
             {
                 // fork the solution to introduce a change
                 var project = workspace.CurrentSolution.Projects.Single();
@@ -611,7 +611,7 @@ namespace N
 ";
             var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(source1))
             {
                 // fork the solution to introduce a change
                 var project = workspace.CurrentSolution.Projects.Single();

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
     {
         protected async Task ExpectExtractMethodToFailAsync(string codeWithMarker, bool allowMovingDeclaration = true, bool dontPutOutOrRefOnStruct = true)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithMarker))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker))
             {
                 var testDocument = workspace.Documents.First();
                 var textSpan = testDocument.SelectedSpans.Single();
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             bool dontPutOutOrRefOnStruct = true,
             CSharpParseOptions parseOptions = null)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new[] { codeWithMarker }, parseOptions: parseOptions))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker, parseOptions: parseOptions))
             {
                 var testDocument = workspace.Documents.Single();
                 var subjectBuffer = testDocument.TextBuffer;
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
 
         protected async Task NotSupported_ExtractMethodAsync(string codeWithMarker)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithMarker))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker))
             {
                 Assert.NotNull(await Record.ExceptionAsync(async () =>
                 {
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             bool dontPutOutOrRefOnStruct = true,
             CSharpParseOptions parseOptions = null)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new[] { codeWithMarker }, parseOptions: parseOptions))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker, parseOptions: parseOptions))
             {
                 var testDocument = workspace.Documents.Single();
                 var subjectBuffer = testDocument.TextBuffer;
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
 
         protected async Task TestSelectionAsync(string codeWithMarker, bool expectedFail = false, CSharpParseOptions parseOptions = null)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new[] { codeWithMarker }, parseOptions: parseOptions))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker, parseOptions: parseOptions))
             {
                 var testDocument = workspace.Documents.Single();
                 var namedSpans = testDocument.AnnotatedSpans;
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
 
         protected async Task IterateAllAsync(string code)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new string[] { code }, CodeAnalysis.CSharp.Test.Utilities.TestOptions.Regular))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code, CodeAnalysis.CSharp.Test.Utilities.TestOptions.Regular))
             {
                 var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
                 Assert.NotNull(document);

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
     [|void Method() {}|]
 }";
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new[] { markupCode }))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markupCode))
             {
                 var testDocument = workspace.Documents.Single();
                 var container = testDocument.GetOpenTextContainer();

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
     {
         protected async Task AssertFormatAsync(string expected, string code, bool debugMode = false, Dictionary<OptionKey, object> changedOptionSet = null, bool useTab = false, bool testWithTransformation = true)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var hostdoc = workspace.Documents.First();
 
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 
         protected async Task AssertFormatAsync(string expected, string code, IEnumerable<TextSpan> spans, bool debugMode = false, Dictionary<OptionKey, object> changedOptionSet = null, int? baseIndentation = null)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var hostdoc = workspace.Documents.First();
                 var buffer = hostdoc.GetTextBuffer();
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 
             editorOperationsFactoryService.Setup(s => s.GetEditorOperations(It.IsAny<ITextView>())).Returns(editorOperations.Object);
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithMarker))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker))
             {
                 // set up caret position
                 var testDocument = workspace.Documents.Single();
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 
         protected static async Task AssertFormatWithPasteOrReturnAsync(string expectedWithMarker, string codeWithMarker, bool allowDocumentChanges, bool isPaste = true)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithMarker))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker))
             {
                 workspace.CanApplyChangeDocument = allowDocumentChanges;
 

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             TextSpan span = default(TextSpan))
         {
             // create tree service
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 if (baseIndentation.HasValue)
                 {

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1306,7 +1306,7 @@ Program.number}"";
             int? expectedIndentation)
         {
             // create tree service
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var hostdoc = workspace.Documents.First();
 
@@ -1335,7 +1335,7 @@ Program.number}"";
             int? expectedIndentation)
         {
             // create tree service
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var hostdoc = workspace.Documents.First();
                 var buffer = hostdoc.GetTextBuffer();

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2578,7 +2578,7 @@ class C
 
             foreach (var option in optionsSet)
             {
-                using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new string[] { markup }, parseOptions: option))
+                using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markup, parseOptions: option))
                 {
                     var subjectDocument = workspace.Documents.Single();
 

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3029,7 +3029,7 @@ class Program{
 
         internal static async Task AutoFormatTokenAsync(string markup, string expected)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new string[] { markup }))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markup))
             {
                 var subjectDocument = workspace.Documents.Single();
 
@@ -3073,7 +3073,7 @@ class Program{
 
         private async Task AutoFormatOnMarkerAsync(string initialMarkup, string expected, SyntaxKind tokenKind, SyntaxKind startTokenKind)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(initialMarkup))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(initialMarkup))
             {
                 var tuple = GetService(workspace);
                 var testDocument = workspace.Documents.Single();

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatTokenTests.cs
@@ -592,7 +592,7 @@ class Program
             int indentationLine)
         {
             // create tree service
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var buffer = workspace.Documents.First().GetTextBuffer();
 

--- a/src/EditorFeatures/CSharpTest/Interactive/BraceMatching/InteractiveBraceHighlightingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/BraceMatching/InteractiveBraceHighlightingTests.cs
@@ -51,8 +51,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceHighlighting
         [WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public async Task TestCurlies()
         {
-            var code = new string[] { "public class C {", "} " };
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code, parseOptions: Options.Script))
+            var code = "public class C {\r\n}";
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code, parseOptions: Options.Script))
             {
                 var buffer = workspace.Documents.First().GetTextBuffer();
 
@@ -81,8 +81,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceHighlighting
         [WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public async Task TestTouchingItems()
         {
-            var code = new string[] { "public class C {", "  public void Foo(){}", "}" };
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code, Options.Script))
+            var code = "public class C {\r\n  public void Foo(){}\r\n}";
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code, Options.Script))
             {
                 var buffer = workspace.Documents.First().GetTextBuffer();
 
@@ -112,8 +112,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceHighlighting
         [WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public async Task TestAngles()
         {
-            var code = new string[] { "/// <summary>Foo</summary>", "public class C<T> {", "  void Foo() {", "    bool a = b < c;", "    bool d = e > f;", "  }", "} " };
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code, parseOptions: Options.Script))
+            var code = "/// <summary>Foo</summary>\r\npublic class C<T> {\r\n  void Foo() {\r\n    bool a = b < c;\r\n    bool d = e > f;\r\n  }\r\n} ";
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code, parseOptions: Options.Script))
             {
                 var buffer = workspace.Documents.First().GetTextBuffer();
 

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -423,8 +423,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
         [WpfFact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public async Task DescriptionItems()
         {
-            var code = new string[] { "public", "class", "Foo", "{ }" };
-            using (var workspace = await SetupWorkspaceAsync(string.Join(Environment.NewLine, code)))
+            var code = "public\r\nclass\r\nFoo\r\n{ }";
+            using (var workspace = await SetupWorkspaceAsync(code))
             {
                 var item = _aggregator.GetItems("F").Single(x => x.Kind != "Method");
                 var itemDisplay = item.DisplayFactory.CreateItemDisplay(item);

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
         private INavigateToItemProvider _provider;
         private NavigateToTestAggregator _aggregator;
 
-        private async Task<TestWorkspace> SetupWorkspaceAsync(params string[] lines)
+        private async Task<TestWorkspace> SetupWorkspaceAsync(string content)
         {
-            var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines);
+            var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(content);
             var aggregateListener = AggregateAsynchronousOperationListener.CreateEmptyListener();
 
             _provider = new NavigateToItemProvider(
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
         [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public async Task NoItemsForEmptyFile()
         {
-            using (var workspace = await SetupWorkspaceAsync())
+            using (var workspace = await SetupWorkspaceAsync(""))
             {
                 Assert.Empty(_aggregator.GetItems("Hello"));
             }
@@ -569,7 +569,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
         [WpfFact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
         public async Task DescriptionItems()
         {
-            using (var workspace = await SetupWorkspaceAsync("public", "class", "Foo", "{ }"))
+            using (var workspace = await SetupWorkspaceAsync("public\r\nclass\r\nFoo\r\n{ }"))
             {
                 var item = _aggregator.GetItems("F").Single(x => x.Kind != "Method");
                 var itemDisplay = item.DisplayFactory.CreateItemDisplay(item);

--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -156,7 +156,7 @@ class Program
         [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task TestNoErrorsAfterDocumentRemoved()
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class"))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync("class"))
             using (var wrapper = new DiagnosticTaggerWrapper(workspace))
             {
                 var tagger = wrapper.TaggerProvider.CreateTagger<IErrorTag>(workspace.Documents.First().GetTextBuffer());
@@ -186,7 +186,7 @@ class Program
         [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task TestNoErrorsAfterProjectRemoved()
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class"))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync("class"))
             using (var wrapper = new DiagnosticTaggerWrapper(workspace))
             {
                 var tagger = wrapper.TaggerProvider.CreateTagger<IErrorTag>(workspace.Documents.First().GetTextBuffer());
@@ -289,9 +289,9 @@ class Program
             }
         }
 
-        private static async Task<IEnumerable<ITagSpan<IErrorTag>>> GetErrorSpans(params string[] content)
+        private static async Task<IEnumerable<ITagSpan<IErrorTag>>> GetErrorSpans(string content)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(content))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(content))
             {
                 return (await GetDiagnosticsAndErrorSpans(workspace)).Item2;
             }

--- a/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
 
         private static async Task TestAsync(string codeWithMarker)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithMarker))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker))
             {
                 var commentTokens = new TodoCommentTokens();
                 var provider = new TodoCommentIncrementalAnalyzerProvider(commentTokens);

--- a/src/EditorFeatures/Test/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/Test/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
 {
     public abstract class AbstractAutomaticLineEnderTests
     {
-        protected abstract Task<TestWorkspace> CreateWorkspaceAsync(string[] code);
+        protected abstract Task<TestWorkspace> CreateWorkspaceAsync(string code);
         protected abstract Action CreateNextHandler(TestWorkspace workspace);
 
         internal abstract ICommandHandler<AutomaticLineEnderCommandArgs> CreateCommandHandler(
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
 
         protected async Task TestAsync(string expected, string code, bool completionActive = false, bool assertNextHandlerInvoked = false)
         {
-            using (var workspace = await CreateWorkspaceAsync(new string[] { code }))
+            using (var workspace = await CreateWorkspaceAsync(code))
             {
                 var view = workspace.Documents.Single().GetTextView();
                 var buffer = workspace.Documents.Single().GetTextBuffer();

--- a/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
         [WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)]
         public async Task TestFindReferencesSynchronousCall()
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class C { C() { new C(); } }"))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync("class C { C() { new C(); } }"))
             {
                 var findReferencesPresenter = new MockReferencedSymbolsPresenter();
 

--- a/src/EditorFeatures/Test/GoToAdjacentMember/AbstractGoToAdjacentMemberTests.cs
+++ b/src/EditorFeatures/Test/GoToAdjacentMember/AbstractGoToAdjacentMemberTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToAdjacentMember
 
             foreach (var kind in kinds)
             {
-                using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromLinesAsync(
+                using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromFileAsync(
                     LanguageName,
                     compilationOptions: null,
                     parseOptions: DefaultParseOptions.WithKind(kind),
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToAdjacentMember
 
         protected async Task<int?> GetTargetPositionAsync(string code, bool next)
         {
-            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromLinesAsync(
+            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromFileAsync(
                 LanguageName,
                 compilationOptions: null,
                 parseOptions: DefaultParseOptions,

--- a/src/EditorFeatures/Test/Outlining/AbstractSyntaxOutlinerTests.cs
+++ b/src/EditorFeatures/Test/Outlining/AbstractSyntaxOutlinerTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
         protected async Task VerifyRegionsAsync(string markupCode, params Tuple<string, string, string, bool, bool>[] expectedRegionData)
         {
-            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromLinesAsync(WorkspaceKind, LanguageName, compilationOptions: null, parseOptions: null, content: new[] { markupCode }))
+            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromFileAsync(WorkspaceKind, LanguageName, compilationOptions: null, parseOptions: null, content: markupCode))
             {
                 var hostDocument = workspace.Documents.Single();
                 Assert.True(hostDocument.CursorPosition.HasValue, "Test must specify a position.");
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
 
         protected async Task VerifyNoRegionsAsync(string markupCode)
         {
-            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromLinesAsync(WorkspaceKind, LanguageName, compilationOptions: null, parseOptions: null, content: new[] { markupCode }))
+            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromFileAsync(WorkspaceKind, LanguageName, compilationOptions: null, parseOptions: null, content: markupCode))
             {
                 var hostDocument = workspace.Documents.Single();
                 Assert.True(hostDocument.CursorPosition.HasValue, "Test must specify a position.");

--- a/src/EditorFeatures/Test/Outlining/OutliningTaggerTests.cs
+++ b/src/EditorFeatures/Test/Outlining/OutliningTaggerTests.cs
@@ -27,24 +27,22 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
         [WpfFact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task CSharpOutliningTagger()
         {
-            var code = new string[]
-            {
-                "using System;",
-                "namespace MyNamespace",
-                "{",
-                "#region MyRegion",
-                "    public class MyClass",
-                "    {",
-                "        static void Main(string[] args)",
-                "        {",
-                "            int x = 5;",
-                "        }",
-                "    }",
-                "#endregion",
-                "}"
-            };
+            var code =
+@"using System;
+namespace MyNamespace
+{
+#region MyRegion
+    public class MyClass
+    {
+        static void Main(string[] args)
+        {
+            int x = 5;
+        }
+    }
+#endregion
+}";
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var tags = await GetTagsFromWorkspaceAsync(workspace);
 
@@ -70,21 +68,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
         [WpfFact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task VisualBasicOutliningTagger()
         {
-            var code = new string[]
-            {
-                "Imports System",
-                "Namespace MyNamespace",
-                "#Region \"MyRegion\"",
-                "    Module MyClass",
-                "        Sub Main(args As String())",
-                "            Dim x As Integer = 5",
-                "        End Sub",
-                "    End Module",
-                "#End Region",
-                "End Namespace"
-            };
+            var code = @"Imports System
+Namespace MyNamespace
+#Region ""MyRegion""
+    Module MyClass
+        Sub Main(args As String())
+            Dim x As Integer = 5
+        End Sub
+    End Module
+#End Region
+End Namespace";
 
-            using (var workspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var tags = await GetTagsFromWorkspaceAsync(workspace);
 
@@ -110,15 +105,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
         [WpfFact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task OutliningTaggerTooltipText()
         {
-            var code = new string[]
-            {
-                "Module Module1",
-                "    Sub Main(args As String())",
-                "    End Sub",
-                "End Module",
-            };
+            var code = @"Module Module1
+    Sub Main(args As String())
+    End Sub
+End Module";
 
-            using (var workspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var tags = await GetTagsFromWorkspaceAsync(workspace);
 

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
         [WpfFact]
         public async Task TestPreviewDiagnosticTagger()
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class { }"))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync("class { }"))
             using (var previewWorkspace = new PreviewWorkspace(workspace.CurrentSolution))
             {
                 //// preview workspace and owner of the solution now share solution and its underlying text buffer
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
         [WpfFact]
         public async Task TestPreviewDiagnosticTaggerInPreviewPane()
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class { }"))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync("class { }"))
             {
                 // set up listener to wait until diagnostic finish running
                 var diagnosticService = workspace.ExportProvider.GetExportedValue<IDiagnosticService>() as DiagnosticService;

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -771,8 +771,8 @@ End Class";
 
         private async Task InsertText(string code, string text, bool expectDocumentAnalysis, string language = LanguageNames.CSharp)
         {
-            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromLinesAsync(
-                SolutionCrawler, language, compilationOptions: null, parseOptions: null, content: new string[] { code }))
+            using (var workspace = await TestWorkspaceFactory.CreateWorkspaceFromFileAsync(
+                SolutionCrawler, language, compilationOptions: null, parseOptions: null, content: code))
             {
                 var analyzer = new Analyzer();
                 var lazyWorker = new Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata>(() => new AnalyzerProvider(analyzer), Metadata.Crawler);

--- a/src/EditorFeatures/Test/TextEditor/TryGetDocumentTests.cs
+++ b/src/EditorFeatures/Test/TextEditor/TryGetDocumentTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.TextEditor
         {
             var code = @"class C
 ";
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var hostDocument = workspace.Documents.First();
                 var document = workspace.CurrentSolution.GetDocument(workspace.GetDocumentId(hostDocument));
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.TextEditor
         public async Task EmptyTextChanges()
         {
             var code = @"class C";
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var hostDocument = workspace.Documents.First();
                 var document = workspace.CurrentSolution.GetDocument(workspace.GetDocumentId(hostDocument));

--- a/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
+++ b/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
     System.Int32 int32Field2;
 }";
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode))
             {
                 var type = (ITypeSymbol)(await workspace.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
 
@@ -118,8 +118,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
     dim int32Field1 as System.Int32
 end class";
 
-            using (var csharpWorkspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode))
-            using (var vbWorkspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(vbCode))
+            using (var csharpWorkspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode))
+            using (var vbWorkspace = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(vbCode))
             {
                 var csharpType = (ITypeSymbol)(await csharpWorkspace.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
                 var vbType = (await vbWorkspace.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
@@ -190,8 +190,8 @@ class Type2
     bool field3;
     string field2;
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type2_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type2").Single();
@@ -244,8 +244,8 @@ class Type2
     dim field3 as Boolean;
     dim field2 as String;
 end class";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(vbCode1))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(vbCode1))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type2_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type2").Single();
@@ -286,7 +286,7 @@ class D
 }
 ";
 
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var typeC = (await workspace.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
                 var typeD = (await workspace.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("D").Single();
@@ -331,8 +331,8 @@ class D
 {
     int Foo() {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -358,8 +358,8 @@ class D
 {
     void Foo1() {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -385,8 +385,8 @@ class D
 {
     void Foo<T>() {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -412,8 +412,8 @@ class D
 {
     void Foo(int a) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -439,8 +439,8 @@ class D
 {
     void Foo<B>(B a) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -468,8 +468,8 @@ class D
 {
     void Foo(int a) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -497,8 +497,8 @@ class D
 {
     void Foo(int b) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -526,8 +526,8 @@ class D
 {
     void Foo(ref int a) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -553,8 +553,8 @@ class D
 {
     void Foo(int a) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -580,8 +580,8 @@ class D
 {
     void Foo(int[] a) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -609,8 +609,8 @@ class D
 {
     void Foo(string[] a) {}
 }";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -645,8 +645,8 @@ class Type1
     sub Quux()
     end sub
 end class";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(vbCode1))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(vbCode1))
             {
                 var csharpType1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var vbType1 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -692,8 +692,8 @@ class Type1(of M)
     sub Bar(x as Object)
     end sub
 end class";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(vbCode1))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(vbCode1))
             {
                 var csharpType1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var vbType1 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -726,7 +726,7 @@ end class";
     dynamic field2;
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
 
@@ -753,8 +753,8 @@ end class";
     void Foo(dynamic o1) { }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -790,8 +790,8 @@ class Type1
     void Foo(IList<string> o1) { }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -825,8 +825,8 @@ class Type1
     void Foo(IList<dynamic> o1) { }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -862,8 +862,8 @@ class Type1
     void Foo(string o1) { }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -895,8 +895,8 @@ class Type1
 }
 ";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
             {
                 var outer1 = (INamespaceSymbol)(await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetMembers("Outer").Single();
                 var outer2 = (INamespaceSymbol)(await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetMembers("Outer").Single();
@@ -974,8 +974,8 @@ class Type2<Y>
 {
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -1013,8 +1013,8 @@ class Type2
   void Foo();
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type2").Single();
@@ -1040,8 +1040,8 @@ class Type1
   void Foo();
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -1067,8 +1067,8 @@ class Type1<T>
   void Foo();
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -1100,8 +1100,8 @@ class Other
     }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var outer = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Outer").Single();
                 var other = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Other").Single();
@@ -1132,8 +1132,8 @@ class Type1
     void Foo(int o1) { }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("Type1").Single();
@@ -1166,8 +1166,8 @@ class C
     void M(ref int i) { }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode1))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(csharpCode2))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode1))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode2))
             {
                 var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
                 var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
@@ -1241,8 +1241,8 @@ class Test
     } 
 }
 ";
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var comp1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync());
                 var comp2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync());
@@ -1317,8 +1317,8 @@ Class Test
     End Sub
 End Class
 ";
-            using (var workspace1 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
-            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code))
+            using (var workspace1 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
+            using (var workspace2 = await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code))
             {
                 var comp1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync());
                 var comp2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync());
@@ -1342,8 +1342,8 @@ End Class
     }
 }";
 
-            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new[] { csharpCode }, compilationOptions: new CS.CSharpCompilationOptions(OutputKind.NetModule, moduleName: "FooModule")))
-            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new[] { csharpCode }, compilationOptions: new CS.CSharpCompilationOptions(OutputKind.NetModule, moduleName: "BarModule")))
+            using (var workspace1 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode, compilationOptions: new CS.CSharpCompilationOptions(OutputKind.NetModule, moduleName: "FooModule")))
+            using (var workspace2 = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(csharpCode, compilationOptions: new CS.CSharpCompilationOptions(OutputKind.NetModule, moduleName: "BarModule")))
             {
                 var namespace1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetNamespaceMembers().Single(n => n.Name == "N").GetNamespaceMembers().Single(n => n.Name == "M");
                 var namespace2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetNamespaceMembers().Single(n => n.Name == "N").GetNamespaceMembers().Single(n => n.Name == "M");

--- a/src/EditorFeatures/Test/Workspaces/CSharpWorkspaceFactory.cs
+++ b/src/EditorFeatures/Test/Workspaces/CSharpWorkspaceFactory.cs
@@ -1,35 +1,13 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.Composition;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
     public partial class CSharpWorkspaceFactory : TestWorkspaceFactory
     {
-        /// <summary>
-        /// Creates a single buffer in a workspace.
-        /// </summary>
-        /// <param name="lines">Lines of text, the buffer contents</param>
-        public static Task<TestWorkspace> CreateWorkspaceFromLinesAsync(params string[] lines)
-        {
-            return CreateWorkspaceFromLinesAsync(lines, parseOptions: null, compilationOptions: null, exportProvider: null);
-        }
-
-        public static Task<TestWorkspace> CreateWorkspaceFromLinesAsync(
-            string[] lines,
-            CSharpParseOptions parseOptions = null,
-            CSharpCompilationOptions compilationOptions = null,
-            ExportProvider exportProvider = null)
-        {
-            var file = lines.Join(Environment.NewLine);
-            return CreateWorkspaceFromFileAsync(file, parseOptions, compilationOptions, exportProvider);
-        }
-
         public static Task<TestWorkspace> CreateWorkspaceFromFileAsync(
             string file,
             CSharpParseOptions parseOptions = null,

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspaceFactory.cs
@@ -57,33 +57,31 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         /// Creates a single buffer in a workspace.
         /// </summary>
         /// <param name="content">Lines of text, the buffer contents</param>
-        internal static Task<TestWorkspace> CreateWorkspaceFromLinesAsync(
+        internal static Task<TestWorkspace> CreateWorkspaceFromFileAsync(
             string language,
             CompilationOptions compilationOptions,
             ParseOptions parseOptions,
-            params string[] content)
+            string content)
         {
-            var total = content.Join(Environment.NewLine);
-            return CreateWorkspaceFromFilesAsync(language, compilationOptions, parseOptions, total);
+            return CreateWorkspaceFromFilesAsync(language, compilationOptions, parseOptions, new[] { content });
         }
 
         /// <summary>
         /// Creates a single buffer in a workspace.
         /// </summary>
         /// <param name="content">Lines of text, the buffer contents</param>
-        internal static Task<TestWorkspace> CreateWorkspaceFromLinesAsync(
+        internal static Task<TestWorkspace> CreateWorkspaceFromFileAsync(
             string workspaceKind,
             string language,
             CompilationOptions compilationOptions,
             ParseOptions parseOptions,
-            params string[] content)
+            string content)
         {
-            var total = content.Join(Environment.NewLine);
-            return CreateWorkspaceFromFilesAsync(workspaceKind, language, compilationOptions, parseOptions, total);
+            return CreateWorkspaceFromFilesAsync(workspaceKind, language, compilationOptions, parseOptions, new[] { content });
         }
 
-        /// <param name="files">Can pass in multiple file contents: files will be named test1.cs, test2.cs, etc.</param>
-        internal static Task<TestWorkspace> CreateWorkspaceFromFilesAsync(
+/// <param name="files">Can pass in multiple file contents: files will be named test1.cs, test2.cs, etc.</param>
+internal static Task<TestWorkspace> CreateWorkspaceFromFilesAsync(
             string language,
             CompilationOptions compilationOptions,
             ParseOptions parseOptions,

--- a/src/EditorFeatures/Test/Workspaces/VisualBasicWorkspaceFactory.cs
+++ b/src/EditorFeatures/Test/Workspaces/VisualBasicWorkspaceFactory.cs
@@ -1,37 +1,12 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Microsoft.VisualStudio.Composition;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
     public class VisualBasicWorkspaceFactory : TestWorkspaceFactory
     {
-        /// <summary>
-        /// Creates a single buffer in a workspace.
-        /// </summary>
-        /// <param name="lines">Lines of text, the buffer contents</param>
-        public static Task<TestWorkspace> CreateWorkspaceFromLinesAsync(params string[] lines)
-        {
-            return CreateWorkspaceFromLinesAsync(lines, exportProvider: null);
-        }
-
-        public static Task<TestWorkspace> CreateWorkspaceFromLinesAsync(
-            string[] lines,
-            ExportProvider exportProvider,
-            string[] metadataReferences = null)
-        {
-            var file = lines.Join(Environment.NewLine);
-            return CreateWorkspaceFromFileAsync(file, exportProvider: exportProvider, metadataReferences: metadataReferences);
-        }
-
         public static Task<TestWorkspace> CreateWorkspaceFromFileAsync(
             string file,
             ParseOptions parseOptions = null,

--- a/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticLineEnderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticLineEnderTests.vb
@@ -269,8 +269,8 @@ End Module
                    End Sub
         End Function
 
-        Protected Overrides Function CreateWorkspaceAsync(code() As String) As Task(Of TestWorkspace)
-            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+        Protected Overrides Function CreateWorkspaceAsync(code As String) As Task(Of TestWorkspace)
+            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/AutomaticEndConstructCorrection/AutomaticEndConstructCorrectorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AutomaticEndConstructCorrection/AutomaticEndConstructCorrectorTests.vb
@@ -351,7 +351,7 @@ End Class</code>.Value
             ' do this since xml value put only vbLf
             codeWithMarker = codeWithMarker.Replace(vbLf, vbCrLf)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithMarker)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithMarker)
                 Dim document = workspace.Documents.Single()
 
                 Dim buffer = document.TextBuffer
@@ -402,7 +402,7 @@ End Class</code>.Value
         End Function
 
         Private Async Function VerifyBeginAsync(code As String, keyword As String, Optional expected As String = Nothing) As Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
                 Dim document = workspace.Documents.Single()
 
                 Dim selectedSpans = document.SelectedSpans
@@ -415,7 +415,7 @@ End Class</code>.Value
         End Function
 
         Private Async Function VerifyEndAsync(code As String, keyword As String, Optional expected As String = Nothing) As Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
                 Dim document = workspace.Documents.Single()
 
                 Dim selectedSpans = document.SelectedSpans

--- a/src/EditorFeatures/VisualBasicTest/BraceMatching/BraceHighlightingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/BraceMatching/BraceHighlightingTests.vb
@@ -41,10 +41,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)>
         Public Async Function TestParens() As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync("Module Module1",
-                             "    Function Foo(x As Integer) As Integer",
-                             "    End Function",
-                             "End Module")
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(
+"Module Module1
+    Function Foo(x As Integer) As Integer
+    End Function
+End Module")
                 Dim buffer = workspace.Documents.First().GetTextBuffer()
 
                 ' Before open parens
@@ -76,12 +77,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)>
         Public Async Function TestNestedTouchingItems() As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(
-                "Module Module1",
-                "    <SomeAttr(New With {.name = ""test""})>  ",
-                "    Sub Foo()",
-                "    End Sub",
-                "End Module")
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(
+"Module Module1
+    <SomeAttr(New With {.name = ""test""})>  
+    Sub() Foo()
+    End Sub
+End Module")
                 Dim buffer = workspace.Documents.First().GetTextBuffer()
 
                 ' pos 0 on second line is 16
@@ -151,9 +152,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)>
         Public Async Function TestUnnestedTouchingItems() As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync("Module Module1",
-                     "    Dim arr()() As Integer",
-                     "End Module")
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(
+"Module Module1
+    Dim arr()() As Integer
+End Module")
                 Dim buffer = workspace.Documents.First().GetTextBuffer()
 
                 ' x is any character, | is the cursor in the following comments
@@ -190,14 +192,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)>
         Public Async Function TestAngles() As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync("Module Module1",
-                     "    <Attribute()>",
-                     "    Sub Foo()",
-                     "        Dim x = 2 > 3",
-                     "        Dim y = 4 > 5",
-                     "        Dim z = <element> </element>",
-                     "    End Sub",
-                     "End Module")
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(
+"Module Module1
+    <Attribute()>
+    Sub Foo()
+        Dim x = 2 > 3
+        Dim y = 4 > 5
+        Dim z = <element></element>
+    End Sub
+End Module")
                 Dim buffer = workspace.Documents.First().GetTextBuffer()
 
                 Dim line4start = buffer.CurrentSnapshot.GetLineFromLineNumber(3).Start.Position
@@ -236,7 +239,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
                 result = Await ProduceTagsAsync(workspace, buffer, 18 + line5start)
                 Assert.True(result.IsEmpty)
 
-                ' |<element> </element>
+                ' |<element></element>
                 result = Await ProduceTagsAsync(workspace, buffer, 16 + line6start)
                 Assert.True(result.IsEmpty)
 
@@ -248,7 +251,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
                 result = Await ProduceTagsAsync(workspace, buffer, 26 + line6start)
                 Assert.True(result.IsEmpty)
 
-                ' <element> </element>|
+                ' <element></element>|
                 result = Await ProduceTagsAsync(workspace, buffer, 36 + line6start)
                 Assert.True(result.IsEmpty)
             End Using

--- a/src/EditorFeatures/VisualBasicTest/BraceMatching/BraceHighlightingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/BraceMatching/BraceHighlightingTests.vb
@@ -80,7 +80,7 @@ End Module")
             Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(
 "Module Module1
     <SomeAttr(New With {.name = ""test""})>  
-    Sub() Foo()
+    Sub Foo()
     End Sub
 End Module")
                 Dim buffer = workspace.Documents.First().GetTextBuffer()

--- a/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
         Inherits AbstractBraceMatcherTests
 
         Protected Overrides Function CreateWorkspaceFromCodeAsync(code As String) As Task(Of TestWorkspace)
-            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
         End Function
 
         Private Async Function TestInClassAsync(code As String, expectedCode As String) As Task

--- a/src/EditorFeatures/VisualBasicTest/CommentSelection/VisualBasicCommentSelectionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CommentSelection/VisualBasicCommentSelectionTests.vb
@@ -75,7 +75,7 @@ End Module</code>
 
             MarkupTestFile.GetSpans(code, codeWithoutMarkup, spans)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithoutMarkup)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithoutMarkup)
                 Dim doc = workspace.Documents.First()
                 SetupSelection(doc.GetTextView(), spans.Select(Function(s) Span.FromBounds(s.Start, s.End)))
 

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -1205,7 +1205,7 @@ End Class
         End Function
 
         Protected Overrides Function CreateTestWorkspaceAsync(code As String) As Task(Of TestWorkspace)
-            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
         End Function
 
         Protected Overrides ReadOnly Property DocumentationCommentCharacter As Char

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/XmlTagCompletionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/XmlTagCompletionTests.vb
@@ -16,8 +16,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.DocumentationComme
             Return New XmlTagCompletionCommandHandler(undoHistory, TestWaitIndicator.Default)
         End Function
 
-        Protected Overrides Function CreateTestWorkspaceAsync(initialMarkup As String) As Threading.Tasks.Task(Of TestWorkspace)
-            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(initialMarkup)
+        Protected Overrides Function CreateTestWorkspaceAsync(initialMarkup As String) As Task(Of TestWorkspace)
+            Return VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(initialMarkup)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.XmlTagCompletion)>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -433,7 +433,7 @@ End Class
 "
             Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(source1)
                 Dim documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id
                 Dim oldSolution = workspace.CurrentSolution
                 Dim newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2))
@@ -477,7 +477,7 @@ End Class
 "
 
             Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(source)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(source)
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim baseActiveStatements = ImmutableArray.Create(Of ActiveStatementSpan)()
                 Dim result = Await analyzer.AnalyzeDocumentAsync(workspace.CurrentSolution, baseActiveStatements, document, Nothing)
@@ -506,7 +506,7 @@ End Class
 "
 
             Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(source1)
                 Dim documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id
                 Dim oldSolution = workspace.CurrentSolution
                 Dim newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2))
@@ -532,7 +532,7 @@ End Class
 "
 
             Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(source)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(source)
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim baseActiveStatements = ImmutableArray.Create(Of ActiveStatementSpan)()
                 Dim result = Await analyzer.AnalyzeDocumentAsync(workspace.CurrentSolution, baseActiveStatements, document, Nothing)
@@ -563,7 +563,7 @@ End Class
 "
 
             Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(source1)
                 Dim documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id
                 Dim oldSolution = workspace.CurrentSolution
                 Dim newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2))
@@ -614,7 +614,7 @@ End Class
 "
             Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(source1)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(source1)
                 ' fork the solution to introduce a change
                 Dim project = workspace.CurrentSolution.Projects.Single()
                 Dim newDocId = Microsoft.CodeAnalysis.DocumentId.CreateNewId(project.Id)

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/CustomEventTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/CustomEventTests.vb
@@ -15,143 +15,143 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterCustomEvent() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Custom Event foo As System.EventHandler",
-                         "End Class"},
+                before:="Class c1
+    Custom Event foo As System.EventHandler
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "    Custom Event foo As System.EventHandler",
-                        "        AddHandler(value As EventHandler)",
-                        "",
-                        "        End AddHandler",
-                        "        RemoveHandler(value As EventHandler)",
-                        "",
-                        "        End RemoveHandler",
-                        "        RaiseEvent(sender As Object, e As EventArgs)",
-                        "",
-                        "        End RaiseEvent",
-                        "    End Event",
-                        "End Class"},
+                after:="Class c1
+    Custom Event foo As System.EventHandler
+        AddHandler(value As EventHandler)
+
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As EventArgs)
+
+        End RaiseEvent
+    End Event
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterCustomEventWithImportsStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Imports System",
-                         "Class c1",
-                         "    Custom Event foo As EventHandler",
-                         "End Class"},
+                before:="Imports System
+Class c1
+    Custom Event foo As EventHandler
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Imports System",
-                        "Class c1",
-                        "    Custom Event foo As EventHandler",
-                        "        AddHandler(value As EventHandler)",
-                        "",
-                        "        End AddHandler",
-                        "        RemoveHandler(value As EventHandler)",
-                        "",
-                        "        End RemoveHandler",
-                        "        RaiseEvent(sender As Object, e As EventArgs)",
-                        "",
-                        "        End RaiseEvent",
-                        "    End Event",
-                        "End Class"},
+                after:="Imports System
+Class c1
+    Custom Event foo As EventHandler
+        AddHandler(value As EventHandler)
+
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As EventArgs)
+
+        End RaiseEvent
+    End Event
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterCustomEventWithMissingDelegateType() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Imports System",
-                         "Class c1",
-                         "    Custom Event foo As FooHandler",
-                         "End Class"},
+                before:="Imports System
+Class c1
+    Custom Event foo As FooHandler
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Imports System",
-                        "Class c1",
-                        "    Custom Event foo As FooHandler",
-                        "        AddHandler(value As FooHandler)",
-                        "",
-                        "        End AddHandler",
-                        "        RemoveHandler(value As FooHandler)",
-                        "",
-                        "        End RemoveHandler",
-                        "        RaiseEvent()",
-                        "",
-                        "        End RaiseEvent",
-                        "    End Event",
-                        "End Class"},
+                after:="Imports System
+Class c1
+    Custom Event foo As FooHandler
+        AddHandler(value As FooHandler)
+
+        End AddHandler
+        RemoveHandler(value As FooHandler)
+
+        End RemoveHandler
+        RaiseEvent()
+
+        End RaiseEvent
+    End Event
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterCustomEventWithNonDelegateType() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Imports System",
-                         "Class c1",
-                         "    Custom Event foo As Object",
-                         "End Class"},
+                before:="Imports System
+Class c1
+    Custom Event foo As Object
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Imports System",
-                        "Class c1",
-                        "    Custom Event foo As Object",
-                        "        AddHandler(value As Object)",
-                        "",
-                        "        End AddHandler",
-                        "        RemoveHandler(value As Object)",
-                        "",
-                        "        End RemoveHandler",
-                        "        RaiseEvent()",
-                        "",
-                        "        End RaiseEvent",
-                        "    End Event",
-                        "End Class"},
+                after:="Imports System
+Class c1
+    Custom Event foo As Object
+        AddHandler(value As Object)
+
+        End AddHandler
+        RemoveHandler(value As Object)
+
+        End RemoveHandler
+        RaiseEvent()
+
+        End RaiseEvent
+    End Event
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterCustomEventWithGenericType() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Imports System",
-                         "Class c1",
-                         "    Custom Event foo As EventHandler(Of ConsoleCancelEventArgs)",
-                         "End Class"},
+                before:="Imports System
+Class c1
+    Custom Event foo As EventHandler(Of ConsoleCancelEventArgs)
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Imports System",
-                        "Class c1",
-                        "    Custom Event foo As EventHandler(Of ConsoleCancelEventArgs)",
-                        "        AddHandler(value As EventHandler(Of ConsoleCancelEventArgs))",
-                        "",
-                        "        End AddHandler",
-                        "        RemoveHandler(value As EventHandler(Of ConsoleCancelEventArgs))",
-                        "",
-                        "        End RemoveHandler",
-                        "        RaiseEvent(sender As Object, e As ConsoleCancelEventArgs)",
-                        "",
-                        "        End RaiseEvent",
-                        "    End Event",
-                        "End Class"},
+                after:="Imports System
+Class c1
+    Custom Event foo As EventHandler(Of ConsoleCancelEventArgs)
+        AddHandler(value As EventHandler(Of ConsoleCancelEventArgs))
+
+        End AddHandler
+        RemoveHandler(value As EventHandler(Of ConsoleCancelEventArgs))
+
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As ConsoleCancelEventArgs)
+
+        End RaiseEvent
+    End Event
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DoNotApplyAfterCustomEventAlreadyTerminated() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Imports System",
-                       "Class c1",
-                       "    Custom Event foo As EventHandler(Of ConsoleCancelEventArgs)",
-                       "        AddHandler(value As EventHandler(Of ConsoleCancelEventArgs))",
-                       "",
-                       "        End AddHandler",
-                       "        RemoveHandler(value As EventHandler(Of ConsoleCancelEventArgs))",
-                       "",
-                       "        End RemoveHandler",
-                       "        RaiseEvent(sender As Object, e As ConsoleCancelEventArgs)",
-                       "",
-                       "        End RaiseEvent",
-                       "    End Event",
-                       "End Class"},
+                text:="Imports System
+Class c1
+    Custom Event foo As EventHandler(Of ConsoleCancelEventArgs)
+        AddHandler(value As EventHandler(Of ConsoleCancelEventArgs))
+
+        End AddHandler
+        RemoveHandler(value As EventHandler(Of ConsoleCancelEventArgs))
+
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As ConsoleCancelEventArgs)
+
+        End RaiseEvent
+    End Event
+End Class",
                 caret:={2, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/DoLoopTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/DoLoopTests.vb
@@ -15,89 +15,89 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterUnmatchedDo() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo()",
-                         "    Do",
-                         "  End Sub",
-                         "End Class"},
+                before:="Class c1
+  Sub foo()
+    Do
+  End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Sub foo()",
-                        "    Do",
-                        "",
-                        "    Loop",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub foo()
+    Do
+
+    Loop
+  End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedDo() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo()",
-                         "    Do",
-                         "      Do",
-                         "    Loop",
-                         "  End Sub",
-                         "End Class"},
+                before:="Class c1
+  Sub foo()
+    Do
+      Do
+    Loop
+  End Sub
+End Class",
                 beforeCaret:={3, -1},
-                after:={"Class c1",
-                         "  Sub foo()",
-                         "    Do",
-                         "      Do",
-                         "",
-                         "      Loop",
-                         "    Loop",
-                         "  End Sub",
-                         "End Class"},
+                after:="Class c1
+  Sub foo()
+    Do
+      Do
+
+      Loop
+    Loop
+  End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DoNotApplyFromPairedDo() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Do",
-                       "Loop",
-                       "End Class"},
+                text:="Class c1
+Do
+Loop
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DoNotApplyFromInsideDo() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Do",
-                       "End Class"},
+                text:="Class c1
+Do
+End Class",
                 caret:={1, 1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DoNotApplyFromDoOutsideMethod() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Do",
-                       "End Class"},
+                text:="Class c1
+Do
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyDoWhile() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "Sub s",
-                         "Do While True",
-                         "End Sub",
-                         "End Class"},
+                before:="Class C
+Sub s
+Do While True
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "Sub s",
-                         "Do While True",
-                         "",
-                         "Loop",
-                         "End Sub",
-                         "End Class"},
+                 after:="Class C
+Sub s
+Do While True
+
+Loop
+End Sub
+End Class",
                 afterCaret:={3, -1})
 
         End Function
@@ -105,111 +105,111 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedDoWhile() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s",
-                         "        do While True",
-                         "            do While a",
-                         "        Loop",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s
+        do While True
+            do While a
+        Loop
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub s",
-                         "        do While True",
-                         "            do While a",
-                         "",
-                         "            Loop",
-                         "        Loop",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub s
+        do While True
+            do While a
+
+            Loop
+        Loop
+    End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyDoUntil() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s",
-                         "        do Until true",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s
+        do Until true
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    Sub s",
-                         "        do Until true",
-                         "",
-                         "        Loop",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub s
+        do Until true
+
+        Loop
+    End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedDoUntil() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s",
-                         "        do Until True",
-                         "            Do Until True",
-                         "        Loop",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s
+        do Until True
+            Do Until True
+        Loop
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub s",
-                         "        do Until True",
-                         "            Do Until True",
-                         "",
-                         "            Loop",
-                         "        Loop",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub s
+        do Until True
+            Do Until True
+
+            Loop
+        Loop
+    End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyDoWhileInBrokenSub() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s",
-                         "        Do While True",
-                         "End Class"},
+                before:="Class C
+    Sub s
+        Do While True
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    Sub s",
-                         "        Do While True",
-                         "",
-                         "        Loop",
-                         "End Class"},
+                 after:="Class C
+    Sub s
+        Do While True
+
+        Loop
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyDoUntilInvalidLocation01() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s",
-                       "    End Sub",
-                       "    do Until True",
-                       "End Class"},
+                text:="Class C
+    Sub s
+    End Sub
+    do Until True
+End Class",
                 caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyDoUntilInvalidLocation02() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Do"},
+                text:="Do",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyDoUntilInvalidLocation03() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s",
-                       "    End Sub",
-                       "    do Until",
-                       "End Class"},
+                text:="Class C
+    Sub s
+    End Sub
+    do Until
+End Class",
                 caret:={3, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructCommandHandlerTests.vb
@@ -116,9 +116,9 @@ End Module</code>.Value.Replace(vbLf, vbCrLf)
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function EndConstruct_NotOnLineFollowingToken() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                        "",
-                       ""},
+                text:="Class C
+
+",
                 caret:={2, 0})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
@@ -79,7 +79,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
                                   beforeCaret As Integer(),
                                   after As String(),
                                   afterCaret As Integer()) As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(before, exportProvider:=DisabledLineCommitExportProvider)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, before), exportProvider:=DisabledLineCommitExportProvider)
                 DisableLineCommit(workspace)
 
                 Dim textView = workspace.Documents.First().GetTextView()
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         Private Async Function VerifyNotAppliedAsync(doFunc As Func(Of VisualBasicEndConstructService, ITextView, ITextBuffer, Boolean),
                                      text As String(),
                                      caret As Integer()) As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(text)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, text))
                 Dim textView = workspace.Documents.First().GetTextView()
                 Dim subjectBuffer = workspace.Documents.First().GetTextBuffer()
 
@@ -222,7 +222,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
             afterCaret As Integer()) As Tasks.Task
 
             ' create separate composition
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync({before}, exportProvider:=DisabledLineCommitExportProvider)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(before, exportProvider:=DisabledLineCommitExportProvider)
                 DisableLineCommit(workspace)
 
                 Dim view = workspace.Documents.First().GetTextView()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
@@ -75,11 +75,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Function
 
         Private Async Function VerifyAppliedAsync(doFunc As Func(Of VisualBasicEndConstructService, ITextView, ITextBuffer, Boolean),
-                                  before As String(),
+                                  before As String,
                                   beforeCaret As Integer(),
-                                  after As String(),
+                                  after As String,
                                   afterCaret As Integer()) As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, before), exportProvider:=DisabledLineCommitExportProvider)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(before, exportProvider:=DisabledLineCommitExportProvider)
                 DisableLineCommit(workspace)
 
                 Dim textView = workspace.Documents.First().GetTextView()
@@ -127,9 +127,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Function
 
         Private Async Function VerifyNotAppliedAsync(doFunc As Func(Of VisualBasicEndConstructService, ITextView, ITextBuffer, Boolean),
-                                     text As String(),
+                                     text As String,
                                      caret As Integer()) As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, text))
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(text)
                 Dim textView = workspace.Documents.First().GetTextView()
                 Dim subjectBuffer = workspace.Documents.First().GetTextBuffer()
 
@@ -159,51 +159,51 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
             End Using
         End Function
 
-        Public Function VerifyStatementEndConstructAppliedAsync(before As String(), beforeCaret As Integer(), after As String(), afterCaret As Integer()) As Tasks.Task
+        Public Function VerifyStatementEndConstructAppliedAsync(before As String, beforeCaret As Integer(), after As String, afterCaret As Integer()) As Tasks.Task
             Return VerifyAppliedAsync(Function(s, v, b) s.TryDoEndConstructForEnterKey(v, b, CancellationToken.None), before, beforeCaret, after, afterCaret)
         End Function
 
-        Public Async Function VerifyStatementEndConstructNotAppliedAsync(text As String(), caret As Integer()) As Tasks.Task
+        Public Async Function VerifyStatementEndConstructNotAppliedAsync(text As String, caret As Integer()) As Tasks.Task
             Await VerifyNotAppliedAsync(Function(s, v, b) s.TryDoEndConstructForEnterKey(v, b, CancellationToken.None), text, caret)
         End Function
 
-        Public Function VerifyXmlElementEndConstructAppliedAsync(before As String(), beforeCaret As Integer(), after As String(), afterCaret As Integer()) As Tasks.Task
+        Public Function VerifyXmlElementEndConstructAppliedAsync(before As String, beforeCaret As Integer(), after As String, afterCaret As Integer()) As Tasks.Task
             Return VerifyAppliedAsync(Function(s, v, b) s.TryDoXmlElementEndConstruct(v, b, Nothing), before, beforeCaret, after, afterCaret)
         End Function
 
-        Public Async Function VerifyXmlElementEndConstructNotAppliedAsync(text As String(), caret As Integer()) As Tasks.Task
+        Public Async Function VerifyXmlElementEndConstructNotAppliedAsync(text As String, caret As Integer()) As Tasks.Task
             Await VerifyNotAppliedAsync(Function(s, v, b) s.TryDoXmlElementEndConstruct(v, b, Nothing), text, caret)
         End Function
 
-        Public Function VerifyXmlCommentEndConstructAppliedAsync(before As String(), beforeCaret As Integer(), after As String(), afterCaret As Integer()) As Tasks.Task
+        Public Function VerifyXmlCommentEndConstructAppliedAsync(before As String, beforeCaret As Integer(), after As String, afterCaret As Integer()) As Tasks.Task
             Return VerifyAppliedAsync(Function(s, v, b) s.TryDoXmlCommentEndConstruct(v, b, Nothing), before, beforeCaret, after, afterCaret)
         End Function
 
-        Public Async Function VerifyXmlCommentEndConstructNotAppliedAsync(text As String(), caret As Integer()) As Tasks.Task
+        Public Async Function VerifyXmlCommentEndConstructNotAppliedAsync(text As String, caret As Integer()) As Tasks.Task
             Await VerifyNotAppliedAsync(Function(s, v, b) s.TryDoXmlCommentEndConstruct(v, b, Nothing), text, caret)
         End Function
 
-        Public Function VerifyXmlCDataEndConstructAppliedAsync(before As String(), beforeCaret As Integer(), after As String(), afterCaret As Integer()) As Tasks.Task
+        Public Function VerifyXmlCDataEndConstructAppliedAsync(before As String, beforeCaret As Integer(), after As String, afterCaret As Integer()) As Tasks.Task
             Return VerifyAppliedAsync(Function(s, v, b) s.TryDoXmlCDataEndConstruct(v, b, Nothing), before, beforeCaret, after, afterCaret)
         End Function
 
-        Public Async Function VerifyXmlCDataEndConstructNotAppliedAsync(text As String(), caret As Integer()) As Tasks.Task
+        Public Async Function VerifyXmlCDataEndConstructNotAppliedAsync(text As String, caret As Integer()) As Tasks.Task
             Await VerifyNotAppliedAsync(Function(s, v, b) s.TryDoXmlCDataEndConstruct(v, b, Nothing), text, caret)
         End Function
 
-        Public Function VerifyXmlEmbeddedExpressionEndConstructAppliedAsync(before As String(), beforeCaret As Integer(), after As String(), afterCaret As Integer()) As Tasks.Task
+        Public Function VerifyXmlEmbeddedExpressionEndConstructAppliedAsync(before As String, beforeCaret As Integer(), after As String, afterCaret As Integer()) As Tasks.Task
             Return VerifyAppliedAsync(Function(s, v, b) s.TryDoXmlEmbeddedExpressionEndConstruct(v, b, Nothing), before, beforeCaret, after, afterCaret)
         End Function
 
-        Public Async Function VerifyXmlEmbeddedExpressionEndConstructNotAppliedAsync(text As String(), caret As Integer()) As Tasks.Task
+        Public Async Function VerifyXmlEmbeddedExpressionEndConstructNotAppliedAsync(text As String, caret As Integer()) As Tasks.Task
             Await VerifyNotAppliedAsync(Function(s, v, b) s.TryDoXmlEmbeddedExpressionEndConstruct(v, b, Nothing), text, caret)
         End Function
 
-        Public Function VerifyXmlProcessingInstructionEndConstructAppliedAsync(before As String(), beforeCaret As Integer(), after As String(), afterCaret As Integer()) As Tasks.Task
+        Public Function VerifyXmlProcessingInstructionEndConstructAppliedAsync(before As String, beforeCaret As Integer(), after As String, afterCaret As Integer()) As Tasks.Task
             Return VerifyAppliedAsync(Function(s, v, b) s.TryDoXmlProcessingInstructionEndConstruct(v, b, Nothing), before, beforeCaret, after, afterCaret)
         End Function
 
-        Public Async Function VerifyXmlProcessingInstructionNotAppliedAsync(text As String(), caret As Integer()) As Tasks.Task
+        Public Async Function VerifyXmlProcessingInstructionNotAppliedAsync(text As String, caret As Integer()) As Tasks.Task
             Await VerifyNotAppliedAsync(Function(s, v, b) s.TryDoXmlProcessingInstructionEndConstruct(v, b, Nothing), text, caret)
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/ForLoopTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/ForLoopTests.vb
@@ -15,170 +15,170 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyForWithIndex() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo()",
-                         "    For i = 1 To 10",
-                         "  End Sub",
-                         "End Class"},
+                before:="Class c1
+  Sub foo()
+    For i = 1 To 10
+  End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Sub foo()",
-                        "    For i = 1 To 10",
-                        "",
-                        "    Next",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub foo()
+    For i = 1 To 10
+
+    Next
+  End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyForEach() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo()",
-                        "    For Each i In collection",
-                         "  End Sub",
-                         "End Class"},
+                before:="Class c1
+  Sub foo()
+    For Each i In collection
+  End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Sub foo()",
-                        "    For Each i In collection",
-                        "",
-                        "    Next",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub foo()
+    For Each i In collection
+
+    Next
+  End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(527481)>
         Public Async Function VerifyIndexMatchedInner1() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "  Sub foo()",
-                       "    For i = 1 To 10",
-                       "      For j = 1 To 10",
-                       "      Next j",
-                       "  End Sub",
-                       "End Class"},
+                text:="Class c1
+  Sub foo()
+    For i = 1 To 10
+      For j = 1 To 10
+      Next j
+  End Sub
+End Class",
                  caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(527481)>
         Public Async Function TestVerifyIndexMatchedInner2() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo()",
-                         "    For i = 1 To 10",
-                         "      For j = 1 To 10",
-                         "      Next j",
-                         "  End Sub",
-                         "End Class"},
+                before:="Class c1
+  Sub foo()
+    For i = 1 To 10
+      For j = 1 To 10
+      Next j
+  End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Sub foo()",
-                        "    For i = 1 To 10",
-                        "",
-                        "    Next",
-                        "      For j = 1 To 10",
-                        "      Next j",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub foo()
+    For i = 1 To 10
+
+    Next
+      For j = 1 To 10
+      Next j
+  End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(527481)>
         Public Async Function VerifyIndexSharedNext() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "  Sub foo()",
-                       "    For i = 1 To 10",
-                       "      For j = 1 To 10",
-                       "    Next j, i",
-                       "  End Sub",
-                       "End Class"},
+                text:="Class c1
+  Sub foo()
+    For i = 1 To 10
+      For j = 1 To 10
+    Next j, i
+  End Sub
+End Class",
                  caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedFor() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"' NestedFor",
-                         "Class C",
-                         "    Sub s",
-                         "        For i = 1 to 10",
-                         "            For i = 1 to 10",
-                         "        Next",
-                         "    End sub",
-                         "End Class"},
+                before:="' NestedFor
+Class C
+    Sub s
+        For i = 1 to 10
+            For i = 1 to 10
+        Next
+    End sub
+End Class",
                 beforeCaret:={4, -1},
-                 after:={"' NestedFor",
-                         "Class C",
-                         "    Sub s",
-                         "        For i = 1 to 10",
-                         "            For i = 1 to 10",
-                         "",
-                         "            Next",
-                         "        Next",
-                         "    End sub",
-                         "End Class"},
+                 after:="' NestedFor
+Class C
+    Sub s
+        For i = 1 to 10
+            For i = 1 to 10
+
+            Next
+        Next
+    End sub
+End Class",
                 afterCaret:={5, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedForEach() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    function f(byval x as Integer,",
-                         "               byref y as string) as string",
-                         "        for each k in {1,2,3}",
-                         "            For each i in c",
-                         "        Next",
-                         "        return y",
-                         "    End Function",
-                         "End Class"},
+                before:="Class C
+    function f(byval x as Integer,
+               byref y as string) as string
+        for each k in {1,2,3}
+            For each i in c
+        Next
+        return y
+    End Function
+End Class",
                 beforeCaret:={4, -1},
-                 after:={"Class C",
-                         "    function f(byval x as Integer,",
-                         "               byref y as string) as string",
-                         "        for each k in {1,2,3}",
-                         "            For each i in c",
-                         "",
-                         "            Next",
-                         "        Next",
-                         "        return y",
-                         "    End Function",
-                         "End Class"},
+                 after:="Class C
+    function f(byval x as Integer,
+               byref y as string) as string
+        for each k in {1,2,3}
+            For each i in c
+
+            Next
+        Next
+        return y
+    End Function
+End Class",
                 afterCaret:={5, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyReCommitForEach() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Public Property p(byval x as Integer) as Integer",
-                       "        for each i in {1,2,3}",
-                       "        Next",
-                       "    End Property",
-                       "End Class"},
+                text:="Class C
+    Public Property p(byval x as Integer) as Integer
+        for each i in {1,2,3}
+        Next
+    End Property
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyForAtIncorrectLocation() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    For i = 1 to 10"},
+                text:="Class C
+    For i = 1 to 10",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidForSyntax() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s",
-                       "        for For",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub s
+        for For
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/IfBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/IfBlockTests.vb
@@ -15,152 +15,152 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterSimpleIfThen() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo()",
-                         "    If True Then",
-                         "  End Sub",
-                         "End Class"},
+                before:="Class c1
+  Sub foo()
+    If True Then
+  End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Sub foo()",
-                        "    If True Then",
-                        "",
-                        "    End If",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub foo()
+    If True Then
+
+    End If
+  End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterLineIfNextToThen() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Sub foo()",
-                         "        If True Then foo()",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class c1
+    Sub foo()
+        If True Then foo()
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                after:={"Class c1",
-                        "    Sub foo()",
-                        "        If True Then",
-                        "            foo()",
-                        "        End If",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class c1
+    Sub foo()
+        If True Then
+            foo()
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterLineIfWithMultipleStatements() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Sub foo()",
-                         "        If True Then foo() : foo()",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class c1
+    Sub foo()
+        If True Then foo() : foo()
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                after:={"Class c1",
-                        "    Sub foo()",
-                        "        If True Then",
-                        "            foo()",
-                        "            foo()",
-                        "        End If",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class c1
+    Sub foo()
+        If True Then
+            foo()
+            foo()
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterLineIfNextToStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Sub foo()",
-                         "        If True Then foo()",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class c1
+    Sub foo()
+        If True Then foo()
+    End Sub
+End Class",
                 beforeCaret:={2, 21},
-                after:={"Class c1",
-                        "    Sub foo()",
-                        "        If True Then",
-                        "            foo()",
-                        "        End If",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class c1
+    Sub foo()
+        If True Then
+            foo()
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifySingleLineIfWithMultiLineLambda() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        If True Then Dim x = Function(x As Integer)",
-                         "                                for each i in {1,2,3}",
-                         "                                    i += 5",
-                         "                                Next",
-                         "                                Return x",
-                         "                             End Function",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        If True Then Dim x = Function(x As Integer)
+                                for each i in {1,2,3}
+                                    i += 5
+                                Next
+                                Return x
+                             End Function
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        If True Then",
-                         "            Dim x = Function(x As Integer)",
-                         "                                for each i in {1,2,3}",
-                         "                                    i += 5",
-                         "                                Next",
-                         "                                Return x",
-                         "                             End Function",
-                         "        End If",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        If True Then
+            Dim x = Function(x As Integer)
+                                for each i in {1,2,3}
+                                    i += 5
+                                Next
+                                Return x
+                             End Function
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifySingleLineIfThenElse() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        If True Then dim x = 1 Else y = 6",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        If True Then dim x = 1 Else y = 6
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        If True Then",
-                         "            dim x = 1",
-                         "        Else",
-                         "            y = 6",
-                         "        End If",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        If True Then
+            dim x = 1
+        Else
+            y = 6
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedIf() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        If True Then",
-                         "            If True Then",
-                         "        Dim x = 5       ",
-                         "        End If",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        If True Then
+            If True Then
+        Dim x = 5       
+        End If
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        If True Then",
-                         "            If True Then",
-                         "",
-                         "            End If",
-                         "        Dim x = 5       ",
-                         "        End If",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        If True Then
+            If True Then
+
+            End If
+        Dim x = 5       
+        End If
+    End Sub
+End Class",
                 afterCaret:={4, -1})
 
         End Function
@@ -169,149 +169,149 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WorkItem(536441)>
         Public Async Function TestVerifyNestedSingleLineIf() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        If True Then If True Then X = 1 Else X = 2",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        If True Then If True Then X = 1 Else X = 2
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        If True Then",
-                         "            If True Then X = 1 Else X = 2",
-                         "        End If",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        If True Then
+            If True Then X = 1 Else X = 2
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyAddingElseIf() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        If true Then",
-                       "        ElseIf True Then",
-                       "        End If",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        If true Then
+        ElseIf True Then
+        End If
+    End Sub
+End Class",
                 caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyIfWithImplicitLC() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        If True And",
-                         "            true Then",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        If True And
+            true Then
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        If True And",
-                         "            true Then",
-                         "",
-                         "        End If",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        If True And
+            true Then
+
+        End If
+    End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyReCommitWithCode() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        If True Then",
-                       "            Dim x = 5",
-                       "            Dim y = ""abc""",
-                       "        End If",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        If True Then
+            Dim x = 5
+            Dim y = ""abc""
+        End If
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyReCommitWithoutCode() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        If True Then",
-                       "        End If",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        If True Then
+        End If
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyWithMultiLineChar() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        If True Then : Elseif true then: End If",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        If True Then : Elseif true then: End If
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, WorkItem(539576), Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyWithSkippedTokens() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        If True Then #Const foo = 2 ' x = 42",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        If True Then #Const foo = 2 ' x = 42
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                after:={"Class C",
-                        "    Sub S",
-                        "        If True Then",
-                        "            #Const foo = 2 ' x = 42",
-                        "        End If",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C
+    Sub S
+        If True Then
+            #Const foo = 2 ' x = 42
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidMissingEndIf() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        If True Then",
-                       "            Dim x = 5",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        If True Then
+            Dim x = 5
+    End Sub
+End Class",
                 caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyIfInInvalidCode() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"If True Then",
-                       "    if True then",
-                       "End If"},
+                text:="If True Then
+    if True then
+End If",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyInternationalCharacter() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Sub foo()",
-                         "        If True Then Dim xæ大% = 1",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class c1
+    Sub foo()
+        If True Then Dim xæ大% = 1
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                after:={"Class c1",
-                        "    Sub foo()",
-                        "        If True Then",
-                        "            Dim xæ大% = 1",
-                        "        End If",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class c1
+    Sub foo()
+        If True Then
+            Dim xæ大% = 1
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
@@ -319,18 +319,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact(Skip:="528838"), Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestBugFix6380() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={<code>Imports System
+                before:="Imports System
 Imports System.Collections.Generic
 Imports System.Linq
 
 Module Program
     Sub Main(args As String())
         Dim x As Integer = 0
-        If x = 0 Then #const foo = "TEST" : Console.WriteLine("TEST") : 'x = 10
+        If x = 0 Then #const foo = ""TEST"" : Console.WriteLine(""TEST"") : 'x = 10
     End Sub
-End Module</code>.Value.Replace(vbLf, vbCrLf)},
+End Module",
                 beforeCaret:={7, 22},
-                after:={<code>Imports System
+                after:="Imports System
 Imports System.Collections.Generic
 Imports System.Linq
 
@@ -338,30 +338,30 @@ Module Program
     Sub Main(args As String())
         Dim x As Integer = 0
         If x = 0 Then
-            #const foo = "TEST"
-            Console.WriteLine("TEST")            
+            #const foo = ""TEST""
+            Console.WriteLine(""TEST"")            
         End If : 'x = 10
     End Sub
-End Module</code>.Value.Replace(vbLf, vbCrLf)},
+End Module",
                 afterCaret:={8, 12})
         End Function
 
         <WpfFact(Skip:="890307"), Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(544523)>
         Public Async Function TestVerifyRewriteOfIfWithColons() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub Foo()",
-                         "        If True Then : Return : End If",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub Foo()
+        If True Then : Return : End If
+    End Sub
+End Class",
                 beforeCaret:={2, 21, 2, 22},
-                after:={"Class C",
-                        "    Sub Foo()",
-                        "        If True Then",
-                        "            Return",
-                        "        End If",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C
+    Sub Foo()
+        If True Then
+            Return
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 12})
         End Function
 
@@ -371,21 +371,21 @@ End Module</code>.Value.Replace(vbLf, vbCrLf)},
             ' correct virtual offset as part of the edit.  This is an edge case that we really just
             ' need to avoid crashing.
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub Foo()",
-                         "        If True Then Else ' asdf ",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub Foo()
+        If True Then Else ' asdf 
+    End Sub
+End Class",
                 beforeCaret:={2, 20},
-                after:={"Class C",
-                        "    Sub Foo()",
-                        "        If True Then",
-                        "",
-                        "        Else ' asdf ",
-                        "",
-                        "        End If",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C
+    Sub Foo()
+        If True Then
+
+        Else ' asdf 
+
+        End If
+    End Sub
+End Class",
                 afterCaret:={3, 0})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MethodBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MethodBlockTests.vb
@@ -7,195 +7,193 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterSimpleSubDeclarationWithTrailingComment() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo() 'Extra Comment",
-                         "End Class"},
+                before:="Class c1
+  Sub foo() 'Extra Comment
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "  Sub foo() 'Extra Comment",
-                        "",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub foo() 'Extra Comment
+
+  End Sub
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterConstructorDeclaration() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub New()",
-                         "End Class"},
+                before:="Class c1
+  Sub New()
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "  Sub New()",
-                        "",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub New()
+
+  End Sub
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterConstructorDeclarationForDesignerGeneratedClass() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"<Microsoft.VisualBasic.CompilerServices.DesignerGenerated>",
-                         "Class c1",
-                         "    Sub New()",
-                         "",
-                         "    Sub InitializeComponent()",
-                         "    End Sub",
-                         "End Class"},
+                before:="<Microsoft.VisualBasic.CompilerServices.DesignerGenerated>
+Class c1
+    Sub New()
+
+    Sub InitializeComponent()
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"<Microsoft.VisualBasic.CompilerServices.DesignerGenerated>",
-                        "Class c1",
-                        "    Sub New()",
-                        "",
-                       $"        ' {ThisCallIsRequiredByTheDesigner}",
-                        "        InitializeComponent()",
-                        "",
-                       $"        ' {AddAnyInitializationAfter}",
-                        "",
-                        "    End Sub",
-                        "",
-                        "    Sub InitializeComponent()",
-                        "    End Sub",
-                        "End Class"},
+                after:="<Microsoft.VisualBasic.CompilerServices.DesignerGenerated>
+Class c1
+    Sub New()
+        ' {ThisCallIsRequiredByTheDesigner}
+        InitializeComponent()
+        ' {AddAnyInitializationAfter}
+
+    End Sub
+
+    Sub InitializeComponent()
+    End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterConstructorDeclarationWithTrailingComment() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub New() 'Extra Comment",
-                         "End Class"},
+                before:="Class c1
+  Sub New() 'Extra Comment
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "  Sub New() 'Extra Comment",
-                        "",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub New() 'Extra Comment
+
+  End Sub
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterSimpleFunctionDeclarationWithTrailingComment() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Function foo() As Integer 'Extra Comment",
-                         "End Class"},
+                before:="Class c1
+  Function foo() As Integer 'Extra Comment
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "  Function foo() As Integer 'Extra Comment",
-                        "",
-                        "  End Function",
-                        "End Class"},
+                after:="Class c1
+  Function foo() As Integer 'Extra Comment
+
+  End Function
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DoNotApplyForInterfaceFunction() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Interface IFoo",
-                       "Function Foo() as Integer",
-                       "End Interface"},
+                text:="Interface IFoo
+Function Foo() as Integer
+End Interface",
                  caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifySubInAModule() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Module C",
-                         "Public Sub s",
-                         "End Module"},
+                before:="Module C
+Public Sub s
+End Module",
                 beforeCaret:={1, -1},
-                 after:={"Module C",
-                         "Public Sub s",
-                         "",
-                         "End Sub",
-                         "End Module"},
+                 after:="Module C
+Public Sub s
+
+End Sub
+End Module",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifySubWithParameters() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Module C",
-                         "    Private Sub s1(byval x as Integer, Optional y as Integer = 5)",
-                         "End Module"},
+                before:="Module C
+    Private Sub s1(byval x as Integer, Optional y as Integer = 5)
+End Module",
                 beforeCaret:={1, -1},
-                 after:={"Module C",
-                         "    Private Sub s1(byval x as Integer, Optional y as Integer = 5)",
-                         "",
-                         "    End Sub",
-                         "End Module"},
+                 after:="Module C
+    Private Sub s1(byval x as Integer, Optional y as Integer = 5)
+
+    End Sub
+End Module",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyFuncWithParameters() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Module C",
-                         "    Public function f(byval x as Integer,",
-                         "                      byref y as string) as string",
-                         "End Module"},
+                before:="Module C
+    Public function f(byval x as Integer,
+                      byref y as string) as string
+End Module",
                 beforeCaret:={2, -1},
-                 after:={"Module C",
-                         "    Public function f(byval x as Integer,",
-                         "                      byref y as string) as string",
-                         "",
-                         "    End function",
-                         "End Module"},
+                 after:="Module C
+    Public function f(byval x as Integer,
+                      byref y as string) as string
+
+    End function
+End Module",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyFuncNamedWithKeyWord() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    private funCtion f1(Optional x as integer = 5) as [if]",
-                         "End Class"},
+                before:="Class C
+    private funCtion f1(Optional x as integer = 5) as [if]
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class C",
-                         "    private funCtion f1(Optional x as integer = 5) as [if]",
-                         "",
-                         "    End funCtion",
-                         "End Class"},
+                 after:="Class C
+    private funCtion f1(Optional x as integer = 5) as [if]
+
+    End funCtion
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifySharedOperator() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Public Shared Operator +(ByVal a As bar, ByVal b As bar) As bar",
-                         "End Class"},
+                before:="Class C
+    Public Shared Operator +(ByVal a As bar, ByVal b As bar) As bar
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class C",
-                         "    Public Shared Operator +(ByVal a As bar, ByVal b As bar) As bar",
-                         "",
-                         "    End Operator",
-                         "End Class"},
+                 after:="Class C
+    Public Shared Operator +(ByVal a As bar, ByVal b As bar) As bar
+
+    End Operator
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyRecommit() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Protected friend sub S",
-                       "    End sub",
-                       "End Class"},
+                text:="Class C
+    Protected friend sub S
+    End sub
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidLocation01() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        Sub P",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        Sub P
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
@@ -203,11 +201,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyInvalidLocation02() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Sub S"},
+                before:="Sub S",
                 beforeCaret:={0, -1},
-                after:={"Sub S",
-                        "",
-                        "End Sub"},
+                after:="Sub S
+
+End Sub",
                 afterCaret:={1, -1})
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MethodBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MethodBlockTests.vb
@@ -45,11 +45,13 @@ Class c1
     End Sub
 End Class",
                 beforeCaret:={2, -1},
-                after:="<Microsoft.VisualBasic.CompilerServices.DesignerGenerated>
+                after:=$"<Microsoft.VisualBasic.CompilerServices.DesignerGenerated>
 Class c1
     Sub New()
+
         ' {ThisCallIsRequiredByTheDesigner}
         InitializeComponent()
+
         ' {AddAnyInitializationAfter}
 
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MiscellaneousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MiscellaneousTests.vb
@@ -17,94 +17,95 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DoesNothingOnEmptyFile() As Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={""},
+                text:="",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DoesNothingOnFileWithNoStatement() As Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"'Foo", ""},
+                text:="'Foo
+",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyLineContinuationMark() As Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    function f(byval x as Integer,",
-                       "               byref y as string) as string",
-                       "        for i = 1 to 10 _",
-                       "        return y",
-                       "    End Function",
-                       "End Class"},
+                text:="Class C
+    function f(byval x as Integer,
+               byref y as string) as string
+        for i = 1 to 10 _
+        return y
+    End Function
+End Class",
                 caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyImplicitLineContinuation() As Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    function f() as string",
-                       "        While 1 +",
-                       "        return y",
-                       "    End Function",
-                       "End Class"},
+                text:="Class C
+    function f() as string
+        While 1 +
+        return y
+    End Function
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedDo() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "        function f() as string",
-                         "            for i = 1 to 10"},
+                before:="Class C
+        function f() as string
+            for i = 1 to 10",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "        function f() as string",
-                         "            for i = 1 to 10",
-                         "",
-                         "            Next"},
+                 after:="Class C
+        function f() as string
+            for i = 1 to 10
+
+            Next",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyMultilinesChar() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    sub s",
-                         "        do :do",
-                         "        Loop",
-                         "    End sub",
-                         "End Class"},
+                before:="Class C
+    sub s
+        do :do
+        Loop
+    End sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    sub s",
-                         "        do :do",
-                         "",
-                         "            Loop",
-                         "        Loop",
-                         "    End sub",
-                         "End Class"},
+                 after:="Class C
+    sub s
+        do :do
+
+            Loop
+        Loop
+    End sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyInlineComments() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    sub s",
-                         "        If true then 'here",
-                         "    End sub",
-                         "End Class"},
+                before:="Class C
+    sub s
+        If true then 'here
+    End sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    sub s",
-                         "        If true then 'here",
-                         "",
-                         "        End If",
-                         "    End sub",
-                         "End Class"},
+                 after:="Class C
+    sub s
+        If true then 'here
+
+        End If
+    End sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
@@ -112,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         Public Async Function VerifyNotAppliedWithJunkAtEndOfLine() As Tasks.Task
             ' Try this without a newline at the end of the file
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C End Class"},
+                text:="Class C End Class",
                 caret:={0, "Class C".Length})
         End Function
 
@@ -120,8 +121,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         Public Async Function VerifyNotAppliedWithJunkAtEndOfLine2() As Tasks.Task
             ' Try this with a newline at the end of the file
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C End Class",
-                       ""},
+                text:="Class C End Class
+",
                 caret:={0, "Class C".Length})
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MiscellaneousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MiscellaneousTests.vb
@@ -128,7 +128,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         <WorkItem(539727)>
         Public Async Function DeletesSelectedText() As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync("Interface IFoo ~~")
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync("Interface IFoo ~~")
                 Dim textView = workspace.Documents.Single().GetTextView()
                 Dim subjectBuffer = workspace.Documents.First().GetTextBuffer()
 

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MultiLineLambdaTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/MultiLineLambdaTests.vb
@@ -15,364 +15,364 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyWithFunctionLambda() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Sub foo()",
-                         "    Dim x = Function()",
-                         "  End Sub",
-                         "End Class"},
+                before:="Class c1
+  Sub foo()
+    Dim x = Function()
+  End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Sub foo()",
-                        "    Dim x = Function()",
-                        "",
-                        "            End Function",
-                        "  End Sub",
-                        "End Class"},
+                after:="Class c1
+  Sub foo()
+    Dim x = Function()
+
+            End Function
+  End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyWithFunctionLambdaWithMissingEndFunction() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Function foo()",
-                         "    Dim x = Function()",
-                         "End Class"},
+                before:="Class c1
+  Function foo()
+    Dim x = Function()
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Function foo()",
-                        "    Dim x = Function()",
-                        "",
-                        "            End Function",
-                        "End Class"},
+                after:="Class c1
+  Function foo()
+    Dim x = Function()
+
+            End Function
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyWithSubLambda() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Function foo()",
-                         "    Dim x = Sub()",
-                         "  End Function",
-                         "End Class"},
+                before:="Class c1
+  Function foo()
+    Dim x = Sub()
+  End Function
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Function foo()",
-                        "    Dim x = Sub()",
-                        "",
-                        "            End Sub",
-                        "  End Function",
-                        "End Class"},
+                after:="Class c1
+  Function foo()
+    Dim x = Sub()
+
+            End Sub
+  End Function
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(544362)>
         Public Async Function TestApplyWithSubLambdaWithNoParameterParenthesis() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Function foo()",
-                         "    Dim x = Sub",
-                         "  End Function",
-                         "End Class"},
+                before:="Class c1
+  Function foo()
+    Dim x = Sub
+  End Function
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "  Function foo()",
-                        "    Dim x = Sub()",
-                        "",
-                        "            End Sub",
-                        "  End Function",
-                        "End Class"},
+                after:="Class c1
+  Function foo()
+    Dim x = Sub()
+
+            End Sub
+  End Function
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(544362)>
         Public Async Function TestApplyWithSubLambdaInsideMethodCall() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Function foo()",
-                         "    M(Sub())",
-                         "  End Function",
-                         "End Class"},
+                before:="Class c1
+  Function foo()
+    M(Sub())
+  End Function
+End Class",
                 beforeCaret:={2, 11},
-                after:={"Class c1",
-                        "  Function foo()",
-                        "    M(Sub()",
-                        "",
-                        "      End Sub)",
-                        "  End Function",
-                        "End Class"},
+                after:="Class c1
+  Function foo()
+    M(Sub()
+
+      End Sub)
+  End Function
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(544362)>
         Public Async Function TestApplyWithSubLambdaAndStatementInsideMethodCall() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Function foo()",
-                         "    M(Sub() Exit Sub)",
-                         "  End Function",
-                         "End Class"},
+                before:="Class c1
+  Function foo()
+    M(Sub() Exit Sub)
+  End Function
+End Class",
                 beforeCaret:={2, 11},
-                after:={"Class c1",
-                        "  Function foo()",
-                        "    M(Sub()",
-                        "          Exit Sub",
-                        "      End Sub)",
-                        "  End Function",
-                        "End Class"},
+                after:="Class c1
+  Function foo()
+    M(Sub()
+          Exit Sub
+      End Sub)
+  End Function
+End Class",
                 afterCaret:={3, 10})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(544362)>
         Public Async Function TestApplyWithFunctionLambdaInsideMethodCall() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "  Function foo()",
-                         "    M(Function() 1)",
-                         "  End Function",
-                         "End Class"},
+                before:="Class c1
+  Function foo()
+    M(Function() 1)
+  End Function
+End Class",
                 beforeCaret:={2, 17},
-                after:={"Class c1",
-                        "  Function foo()",
-                        "    M(Function()",
-                        "          Return 1",
-                        "      End Function)",
-                        "  End Function",
-                        "End Class"},
+                after:="Class c1
+  Function foo()
+    M(Function()
+          Return 1
+      End Function)
+  End Function
+End Class",
                 afterCaret:={3, 17})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyAnonymousType() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = New With {.x = Function(x)",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = New With {.x = Function(x)
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = New With {.x = Function(x)",
-                         "",
-                         "                               End Function",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub s()
+        Dim x = New With {.x = Function(x)
+
+                               End Function
+    End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifySingleLineLambdaFunc() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s()",
-                       "        Dim x = Function(x) x",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub s()
+        Dim x = Function(x) x
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifySingleLineLambdaSub() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s()",
-                       "        Dim y = Sub(x As Integer) x.ToString()",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub s()
+        Dim y = Sub(x As Integer) x.ToString()
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyAsDefaultParameterValue() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s(Optional ByVal f As Func(Of String, String) = Function(x As String)",
-                         "End Class"},
+                before:="Class C
+    Sub s(Optional ByVal f As Func(Of String, String) = Function(x As String)
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class C",
-                         "    Sub s(Optional ByVal f As Func(Of String, String) = Function(x As String)",
-                         "",
-                         "                                                        End Function",
-                         "End Class"},
+                 after:="Class C
+    Sub s(Optional ByVal f As Func(Of String, String) = Function(x As String)
+
+                                                        End Function
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyNestedLambda() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    sub s",
-                         "        Dim x = Function (x)",
-                         "                    Dim y = function(y)",
-                         "                End Function",
-                         "    End sub",
-                         "End Class"},
+                before:="Class C
+    sub s
+        Dim x = Function (x)
+                    Dim y = function(y)
+                End Function
+    End sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    sub s",
-                         "        Dim x = Function (x)",
-                         "                    Dim y = function(y)",
-                         "",
-                         "                            End function",
-                         "                End Function",
-                         "    End sub",
-                         "End Class"},
+                 after:="Class C
+    sub s
+        Dim x = Function (x)
+                    Dim y = function(y)
+
+                            End function
+                End Function
+    End sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyInField() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Dim x = Sub()",
-                         "End Class"},
+                before:="Class C
+    Dim x = Sub()
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class C",
-                         "    Dim x = Sub()",
-                         "",
-                         "            End Sub",
-                         "End Class"},
+                 after:="Class C
+    Dim x = Sub()
+
+            End Sub
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidLambdaSyntax() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s()",
-                       "        Sub(x)",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub s()
+        Sub(x)
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNotAppliedIfSubLambdaContainsEndSub() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s()",
-                       "        Dim x = Sub() End Sub",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub s()
+        Dim x = Sub() End Sub
+    End Sub
+End Class",
                 caret:={2, 21})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNotAppliedIfSyntaxIsFunctionLambdaContainsEndFunction() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s()",
-                       "        Dim x = Function() End Function",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub s()
+        Dim x = Function() End Function
+    End Sub
+End Class",
                 caret:={2, 26})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyLambdaWithImplicitLC() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub s()",
-                       "        Dim x = Function(y As Integer) y +",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub s()
+        Dim x = Function(y As Integer) y +
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyLambdaWithMissingParenthesis() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = Function",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = Function
+    End Sub
+End Class",
                    beforeCaret:={2, -1},
-                   after:={"Class C",
-                           "    Sub s()",
-                           "        Dim x = Function()",
-                           "",
-                           "                End Function",
-                           "    End Sub",
-                           "End Class"},
+                   after:="Class C
+    Sub s()
+        Dim x = Function()
+
+                End Function
+    End Sub
+End Class",
                    afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifySingleLineSubLambdaToMultiLine() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = Sub() f()",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = Sub() f()
+    End Sub
+End Class",
                    beforeCaret:={2, 21},
-                   after:={"Class C",
-                           "    Sub s()",
-                           "        Dim x = Sub()",
-                           "                    f()",
-                           "                End Sub",
-                           "    End Sub",
-                           "End Class"},
+                   after:="Class C
+    Sub s()
+        Dim x = Sub()
+                    f()
+                End Sub
+    End Sub
+End Class",
                    afterCaret:={3, 20})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(530683)>
         Public Async Function TestVerifySingleLineSubLambdaToMultiLineWithTrailingTrivia() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = Sub() f() ' Invokes f()",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = Sub() f() ' Invokes f()
+    End Sub
+End Class",
                    beforeCaret:={2, 21},
-                   after:={"Class C",
-                           "    Sub s()",
-                           "        Dim x = Sub()",
-                           "                    f() ' Invokes f()",
-                           "                End Sub",
-                           "    End Sub",
-                           "End Class"},
+                   after:="Class C
+    Sub s()
+        Dim x = Sub()
+                    f() ' Invokes f()
+                End Sub
+    End Sub
+End Class",
                    afterCaret:={3, 20})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifySingleLineFunctionLambdaToMultiLine() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = Function() f()",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = Function() f()
+    End Sub
+End Class",
                    beforeCaret:={2, 27},
-                   after:={"Class C",
-                           "    Sub s()",
-                           "        Dim x = Function()",
-                           "                    Return f()",
-                           "                End Function",
-                           "    End Sub",
-                           "End Class"},
+                   after:="Class C
+    Sub s()
+        Dim x = Function()
+                    Return f()
+                End Function
+    End Sub
+End Class",
                    afterCaret:={3, 27})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(530683)>
         Public Async Function TestVerifySingleLineFunctionLambdaToMultiLineWithTrailingTrivia() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = Function() 4 ' Returns Constant 4",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = Function() 4 ' Returns Constant 4
+    End Sub
+End Class",
                    beforeCaret:={2, 27},
-                   after:={"Class C",
-                           "    Sub s()",
-                           "        Dim x = Function()",
-                           "                    Return 4 ' Returns Constant 4",
-                           "                End Function",
-                           "    End Sub",
-                           "End Class"},
+                   after:="Class C
+    Sub s()
+        Dim x = Function()
+                    Return 4 ' Returns Constant 4
+                End Function
+    End Sub
+End Class",
                    afterCaret:={3, 27})
         End Function
 
@@ -380,19 +380,19 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(530683)>
         Public Async Function TestVerifySingleLineFunctionLambdaToMultiLineInsideXMLTag() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = <xml><%= Function()%></xml>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = <xml><%= Function()%></xml>
+    End Sub
+End Class",
                    beforeCaret:={2, 35},
-                   after:={"Class C",
-                           "    Sub s()",
-                           "        Dim x = <xml><%= Function()",
-                           "",
-                           "                         End Function %></xml>",
-                           "    End Sub",
-                           "End Class"},
+                   after:="Class C
+    Sub s()
+        Dim x = <xml><%= Function()
+
+                         End Function %></xml>
+    End Sub
+End Class",
                    afterCaret:={3, -1})
         End Function
 
@@ -400,19 +400,19 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(530683)>
         Public Async Function TestVerifySingleLineSubLambdaToMultiLineInsideXMLTag() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub s()",
-                         "        Dim x = <xml><%= Sub()%></xml>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub s()
+        Dim x = <xml><%= Sub()%></xml>
+    End Sub
+End Class",
                    beforeCaret:={2, 30},
-                   after:={"Class C",
-                           "    Sub s()",
-                           "        Dim x = <xml><%= Sub()",
-                           "",
-                           "                         End Sub %></xml>",
-                           "    End Sub",
-                           "End Class"},
+                   after:="Class C
+    Sub s()
+        Dim x = <xml><%= Sub()
+
+                         End Sub %></xml>
+    End Sub
+End Class",
                    afterCaret:={3, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/NamespaceBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/NamespaceBlockTests.vb
@@ -14,26 +14,26 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterNamespace() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Namespace foo"},
+                before:="Namespace foo",
                 beforeCaret:={0, -1},
-                after:={"Namespace foo",
-                        "",
-                        "End Namespace"},
+                after:="Namespace foo
+
+End Namespace",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterNestedNamespace() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Namespace foo",
-                         "Namespace bar",
-                         "End Namespace"},
+                before:="Namespace foo
+Namespace bar
+End Namespace",
                 beforeCaret:={1, -1},
-                after:={"Namespace foo",
-                        "Namespace bar",
-                        "",
-                        "End Namespace",
-                        "End Namespace"},
+                after:="Namespace foo
+Namespace bar
+
+End Namespace
+End Namespace",
                 afterCaret:={2, -1})
         End Function
 
@@ -41,8 +41,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyRecommit() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"NameSpace Bar",
-                       "End Namespace"},
+                text:="NameSpace Bar
+End Namespace",
                 caret:={0, -1})
         End Function
 
@@ -50,11 +50,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidNSInMethod() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        NameSpace T",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        NameSpace T
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
@@ -62,9 +62,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidNSInModule() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Module M",
-                       "    Namespace n",
-                       "End Module"},
+                text:="Module M
+    Namespace n
+End Module",
                 caret:={1, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorIfTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorIfTests.vb
@@ -14,28 +14,28 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterHashIf() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"#If True Then"},
+                before:="#If True Then",
                 beforeCaret:={0, -1},
-                after:={"#If True Then",
-                        "",
-                        "#End If"},
+                after:="#If True Then
+
+#End If",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterHashIfWhenEndIfExists() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"#If True Then",
-                       "#End If"},
+                text:="#If True Then
+#End If",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration), WorkItem(537976)>
         Public Async Function DontApplyAfterHashElseIfWhenEndIfExists() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"#If True Then",
-                       "#ElseIf True Then",
-                       "#End If"},
+                text:="#If True Then
+#ElseIf True Then
+#End If",
                 caret:={1, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorRegionsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorRegionsTests.vb
@@ -14,59 +14,61 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterHashRegion() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"#Region ""Foo"""},
+                before:="#Region ""Foo""",
                 beforeCaret:={0, -1},
-                after:={"#Region ""Foo""",
-                        "",
-                        "#End Region"},
+                after:="#Region ""Foo""
+
+#End Region",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterHashRegion1() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"#Region ""Foo""", "#Region ""Bar""", "#End Region"},
+                before:="#Region ""Foo""
+#Region ""Bar""
+#End Region",
                 beforeCaret:={1, -1},
-                after:={"#Region ""Foo""",
-                        "#Region ""Bar""",
-                        "",
-                        "#End Region",
-                        "#End Region"},
+                after:="#Region ""Foo""
+#Region ""Bar""
+
+#End Region
+#End Region",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterHashRegionWithoutStringConstant() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"#Region"},
+                text:="#Region",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterHashRegionWhenEndRegionExists1() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"#Region ""Foo""",
-                       "#End Region"},
+                text:="#Region ""Foo""
+#End Region",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterHashRegionWhenEndRegionExists2() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"#Region ""Foo""",
-                       "#Region ""Bar""",
-                       "#End Region",
-                       "#End Region"},
+                text:="#Region ""Foo""
+#Region ""Bar""
+#End Region
+#End Region",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterHashRegionWhenEndRegionExists3() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"#Region ""Foo""",
-                       "#Region ""Bar""",
-                       "#End Region",
-                       "#End Region"},
+                text:="#Region ""Foo""
+#Region ""Bar""
+#End Region
+#End Region",
                 caret:={1, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
@@ -14,18 +14,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForAutoProperty() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    Property foo As Integer",
-                       "End Class"},
+                text:="Class c1
+    Property foo As Integer
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForAutoPropertyWithEmptyParens() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    Property foo() As Integer",
-                       "End Class"},
+                text:="Class c1
+    Property foo() As Integer
+End Class",
                 caret:={1, -1})
         End Function
 
@@ -33,163 +33,163 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMustInheritProperty() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"MustInherit Class C",
-                       "    MustOverride Property foo(x as integer) As Integer",
-                       "End Class"},
+                text:="MustInherit Class C
+    MustOverride Property foo(x as integer) As Integer
+End Class",
             caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyForPropertyWithParameters() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Property foo(i As Integer) As Integer",
-                         "End Class"},
+                before:="Class c1
+    Property foo(i As Integer) As Integer
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "    Property foo(i As Integer) As Integer",
-                        "        Get",
-                        "",
-                        "        End Get",
-                        "        Set(value As Integer)",
-                        "",
-                        "        End Set",
-                        "    End Property",
-                        "End Class"},
+                after:="Class c1
+    Property foo(i As Integer) As Integer
+        Get
+
+        End Get
+        Set(value As Integer)
+
+        End Set
+    End Property
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForReadOnlyProperty() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    ReadOnly Property foo As Integer",
-                       "End Class"},
+                text:="Class c1
+    ReadOnly Property foo As Integer
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForReadOnlyPropertyAfterExistingGet() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    ReadOnly Property foo As Integer",
-                       "        Get",
-                       "",
-                       "        End Get",
-                       "    End Property",
-                       "End Class"},
+                text:="Class c1
+    ReadOnly Property foo As Integer
+        Get
+
+        End Get
+    End Property
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForReadOnlyWithSecondGetPropertyAfterExistingGet() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    ReadOnly Property foo As Integer",
-                       "        Get",
-                       "",
-                       "        End Get",
-                       "",
-                       "        Get",
-                       "    End Property",
-                       "End Class"},
+                text:="Class c1
+    ReadOnly Property foo As Integer
+        Get
+
+        End Get
+
+        Get
+    End Property
+End Class",
                 caret:={6, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForWriteOnlyProperty() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    WriteOnly Property foo As Integer",
-                       "End Class"},
+                text:="Class c1
+    WriteOnly Property foo As Integer
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyOnGetForRegularProperty() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Property foo As Integer",
-                         "        Get",
-                         "End Class"},
+                before:="Class c1
+    Property foo As Integer
+        Get
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "    Property foo As Integer",
-                        "        Get",
-                        "",
-                        "        End Get",
-                        "        Set(value As Integer)",
-                        "",
-                        "        End Set",
-                        "    End Property",
-                        "End Class"},
+                after:="Class c1
+    Property foo As Integer
+        Get
+
+        End Get
+        Set(value As Integer)
+
+        End Set
+    End Property
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyOnSetForRegularProperty() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Property foo As Integer",
-                         "        Set",
-                         "End Class"},
+                before:="Class c1
+    Property foo As Integer
+        Set
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "    Property foo As Integer",
-                        "        Set(value As Integer)",
-                        "",
-                        "        End Set",
-                        "        Get",
-                        "",
-                        "        End Get",
-                        "    End Property",
-                        "End Class"},
+                after:="Class c1
+    Property foo As Integer
+        Set(value As Integer)
+
+        End Set
+        Get
+
+        End Get
+    End Property
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForReadOnlyPropertyIfEndPropertyMissingWhenInvokedAfterProperty() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    ReadOnly Property foo As Integer",
-                       "        Get",
-                       "End Class"},
+                text:="Class c1
+    ReadOnly Property foo As Integer
+        Get
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyOnGetForRegularPropertyWithSetPresent() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Property foo As Integer",
-                         "        Get",
-                         "",
-                         "        Set(ByVal value As Integer)",
-                         "",
-                         "        End Set",
-                         "    End Property",
-                         "End Class"},
+                before:="Class c1
+    Property foo As Integer
+        Get
+
+        Set(ByVal value As Integer)
+
+        End Set
+    End Property
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "    Property foo As Integer",
-                        "        Get",
-                        "",
-                        "        End Get",
-                        "",
-                        "        Set(ByVal value As Integer)",
-                        "",
-                        "        End Set",
-                        "    End Property",
-                        "End Class"},
+                after:="Class c1
+    Property foo As Integer
+        Get
+
+        End Get
+
+        Set(ByVal value As Integer)
+
+        End Set
+    End Property
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForWriteOnlyPropertyWithTypeCharacter() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    WriteOnly Property foo$",
-                       "End Class"},
+                text:="Class c1
+    WriteOnly Property foo$
+End Class",
                 caret:={1, -1})
         End Function
 
@@ -197,20 +197,20 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WorkItem(536376)>
         Public Async Function TestApplyForPropertyWithIndexer() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Property foo(arg as Integer) As Integer",
-                         "End Class"},
+                before:="Class c1
+    Property foo(arg as Integer) As Integer
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "    Property foo(arg as Integer) As Integer",
-                        "        Get",
-                        "",
-                        "        End Get",
-                        "        Set(value As Integer)",
-                        "",
-                        "        End Set",
-                        "    End Property",
-                        "End Class"},
+                after:="Class c1
+    Property foo(arg as Integer) As Integer
+        Get
+
+        End Get
+        Set(value As Integer)
+
+        End Set
+    End Property
+End Class",
                 afterCaret:={3, -1})
         End Function
 
@@ -218,14 +218,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WorkItem(536391)>
         Public Async Function DontApplyForDuplicateGet() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    ReadOnly Property foo As Integer",
-                       "        Get",
-                       "",
-                       "        End Get",
-                       "        Get",
-                       "    End Property",
-                       "End Class"},
+                text:="Class c1
+    ReadOnly Property foo As Integer
+        Get
+
+        End Get
+        Get
+    End Property
+End Class",
                 caret:={5, -1})
         End Function
 
@@ -233,14 +233,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WorkItem(536391)>
         Public Async Function DontApplyForDuplicateSet() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    WriteOnly Property foo As Integer",
-                       "        Set(ByVal value As Integer)",
-                       "",
-                       "        End Set",
-                       "        Set",
-                       "    End Property",
-                       "End Class"},
+                text:="Class c1
+    WriteOnly Property foo As Integer
+        Set(ByVal value As Integer)
+
+        End Set
+        Set
+    End Property
+End Class",
                 caret:={5, -1})
         End Function
 
@@ -248,11 +248,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WorkItem(536391)>
         Public Async Function DontApplyForSetInReadOnly() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    ReadOnly Property foo As Integer",
-                       "        Set",
-                       "    End Property",
-                       "End Class"},
+                text:="Class c1
+    ReadOnly Property foo As Integer
+        Set
+    End Property
+End Class",
                 caret:={2, -1})
         End Function
 
@@ -260,20 +260,20 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForGetInReadOnly() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    WriteOnly Property foo As Integer",
-                       "        Get",
-                       "    End Property",
-                       "End Class"},
+                text:="Class c1
+    WriteOnly Property foo As Integer
+        Get
+    End Property
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInternationalCharacter() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "    WriteOnly Property fooæ",
-                       "End Class"},
+                text:="Class c1
+    WriteOnly Property fooæ
+End Class",
                 caret:={1, -1})
         End Function
 
@@ -281,9 +281,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyInsideAnInterface() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Interface IFoo",
-                       "    Property Foo(x As Integer) As String",
-                       "End Interface"},
+                text:="Interface IFoo
+    Property Foo(x As Integer) As String
+End Interface",
                 caret:={1, -1})
         End Function
 
@@ -291,17 +291,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WorkItem(2096, "https://github.com/dotnet/roslyn/issues/2096")>
         Public Async Function TestDontGenerateSetForReadonlyProperty() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Readonly Property foo(arg as Integer) As Integer",
-                         "End Class"},
+                before:="Class c1
+    Readonly Property foo(arg as Integer) As Integer
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "    Readonly Property foo(arg as Integer) As Integer",
-                        "        Get",
-                        "",
-                        "        End Get",
-                        "    End Property",
-                        "End Class"},
+                after:="Class c1
+    Readonly Property foo(arg as Integer) As Integer
+        Get
+
+        End Get
+    End Property
+End Class",
                 afterCaret:={3, -1})
         End Function
 
@@ -309,17 +309,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WorkItem(2096, "https://github.com/dotnet/roslyn/issues/2096")>
         Public Async Function TestDontGenerateGetForWriteonlyProperty() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "    Writeonly Property foo(arg as Integer) As Integer",
-                         "End Class"},
+                before:="Class c1
+    Writeonly Property foo(arg as Integer) As Integer
+End Class",
                 beforeCaret:={1, -1},
-                after:={"Class c1",
-                        "    Writeonly Property foo(arg as Integer) As Integer",
-                        "        Set(value As Integer)",
-                        "",
-                        "        End Set",
-                        "    End Property",
-                        "End Class"},
+                after:="Class c1
+    Writeonly Property foo(arg as Integer) As Integer
+        Set(value As Integer)
+
+        End Set
+    End Property
+End Class",
                 afterCaret:={3, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/SelectBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/SelectBlockTests.vb
@@ -15,108 +15,108 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterSelectKeyword() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "Sub foo()",
-                         "Select foo",
-                         "End Sub",
-                         "End Class"},
+                before:="Class c1
+Sub foo()
+Select foo
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "Sub foo()",
-                        "Select foo",
-                        "    Case ",
-                        "End Select",
-                        "End Sub",
-                        "End Class"},
+                after:="Class c1
+Sub foo()
+Select foo
+    Case 
+End Select
+End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterSelectCaseKeyword() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "Sub foo()",
-                         "Select Case foo",
-                         "End Sub",
-                         "End Class"},
+                before:="Class c1
+Sub foo()
+Select Case foo
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "Sub foo()",
-                        "Select Case foo",
-                        "    Case ",
-                        "End Select",
-                        "End Sub",
-                        "End Class"},
+                after:="Class c1
+Sub foo()
+Select Case foo
+    Case 
+End Select
+End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNestedDo() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        Select Case 1",
-                         "            Case 1",
-                         "                Select 1",
-                         "        End Select",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        Select Case 1
+            Case 1
+                Select 1
+        End Select
+    End Sub
+End Class",
                 beforeCaret:={4, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        Select Case 1",
-                         "            Case 1",
-                         "                Select 1",
-                         "                    Case ",
-                         "                End Select",
-                         "        End Select",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        Select Case 1
+            Case 1
+                Select 1
+                    Case 
+                End Select
+        End Select
+    End Sub
+End Class",
                 afterCaret:={5, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSelectBlock() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        dim x = Select 1",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        dim x = Select 1
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSelectBlock01() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Sub T",
-                       "        Select 1",
-                       "            Case 1",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class EC
+    Sub T
+        Select 1
+            Case 1
+    End Sub
+End Class",
                 caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSelectBlock02() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Select 1",
-                       "End Class"},
+                text:="Class EC
+    Select 1
+End Class",
                 caret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyReCommitSelectBlock() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        Select Case 1",
-                       "            Case 1",
-                       "        End Select",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        Select Case 1
+            Case 1
+        End Select
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/SyncLockBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/SyncLockBlockTests.vb
@@ -14,74 +14,74 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterSyncLockStatement() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "Sub foo()",
-                         "SyncLock variable",
-                         "End Sub",
-                         "End Class"},
+                before:="Class c1
+Sub foo()
+SyncLock variable
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "Sub foo()",
-                        "SyncLock variable",
-                        "",
-                        "End SyncLock",
-                        "End Sub",
-                        "End Class"},
+                after:="Class c1
+Sub foo()
+SyncLock variable
+
+End SyncLock
+End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMatchedUsing() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Sub foo()",
-                       "SyncLock variable",
-                       "End SyncLock",
-                       "End Sub",
-                       "End Class"},
+                text:="Class c1
+Sub foo()
+SyncLock variable
+End SyncLock
+End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNestedSyncBlock() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        SyncLock x",
-                         "            SyncLock y",
-                         "        End SyncLock",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        SyncLock x
+            SyncLock y
+        End SyncLock
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        SyncLock x",
-                         "            SyncLock y",
-                         "",
-                         "            End SyncLock",
-                         "        End SyncLock",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        SyncLock x
+            SyncLock y
+
+            End SyncLock
+        End SyncLock
+    End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSyntax() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        Using (SyncLock 1) ",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        Using (SyncLock 1) 
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidLocation() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Synclock 1",
-                       "End Class"},
+                text:="Class EC
+    Synclock 1
+End Class",
                 caret:={1, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TryBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TryBlockTests.vb
@@ -14,135 +14,135 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterTryStatement() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "Sub foo()",
-                         "Try",
-                         "End Sub",
-                         "End Class"},
+                before:="Class c1
+Sub foo()
+Try
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "Sub foo()",
-                        "Try",
-                        "",
-                        "Catch ex As Exception",
-                        "",
-                        "End Try",
-                        "End Sub",
-                        "End Class"},
+                after:="Class c1
+Sub foo()
+Try
+
+Catch ex As Exception
+
+End Try
+End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMatchedTryWithCatch() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Sub foo()",
-                       "Try",
-                       "Catch ex As Exception",
-                       "End Try",
-                       "End Sub",
-                       "End Class"},
+                text:="Class c1
+Sub foo()
+Try
+Catch ex As Exception
+End Try
+End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMatchedTryWithoutCatch() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Sub foo()",
-                       "Try",
-                       "End Try",
-                       "End Sub",
-                       "End Class"},
+                text:="Class c1
+Sub foo()
+Try
+End Try
+End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNestedTryBlock() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        Try",
-                         "        Catch ex As Exception",
-                         "        Finally",
-                         "            Try",
-                         "        End Try",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        Try
+        Catch ex As Exception
+        Finally
+            Try
+        End Try
+    End Sub
+End Class",
                 beforeCaret:={5, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        Try",
-                         "        Catch ex As Exception",
-                         "        Finally",
-                         "            Try",
-                         "",
-                         "            Catch ex As Exception",
-                         "",
-                         "            End Try",
-                         "        End Try",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        Try
+        Catch ex As Exception
+        Finally
+            Try
+
+            Catch ex As Exception
+
+            End Try
+        End Try
+    End Sub
+End Class",
                 afterCaret:={6, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNestedTryBlockWithCode() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        Try",
-                         "        Dim x = 1",
-                         "        Dim y = 2",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        Try
+        Dim x = 1
+        Dim y = 2
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        Try",
-                         "",
-                         "        Catch ex As Exception",
-                         "",
-                         "        End Try",
-                         "        Dim x = 1",
-                         "        Dim y = 2",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        Try
+
+        Catch ex As Exception
+
+        End Try
+        Dim x = 1
+        Dim y = 2
+    End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyMissingCatchInTryBlock() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        dim x = function(x)",
-                       "                    try",
-                       "                    End Try",
-                       "                    x += 1",
-                       "                End function",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        dim x = function(x)
+                    try
+                    End Try
+                    x += 1
+                End function
+    End Sub
+End Class",
                 caret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSyntax() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Sub S",
-                       "        Dim x = try",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class EC
+    Sub S
+        Dim x = try
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidLocation() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Sub Try",
-                       "End Class"},
+                text:="Class EC
+    Sub Try
+End Class",
                 caret:={1, -1})
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TypeBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TypeBlockTests.vb
@@ -15,195 +15,195 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterClassStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1"},
+                before:="Class c1",
                 beforeCaret:={0, -1},
-                after:={"Class c1",
-                        "",
-                        "End Class"},
+                after:="Class c1
+
+End Class",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterModuleStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Module m1"},
+                before:="Module m1",
                 beforeCaret:={0, -1},
-                after:={"Module m1",
-                        "",
-                        "End Module"},
+                after:="Module m1
+
+End Module",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMatchedClass() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "End Class"},
+                text:="Class c1
+End Class",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterInterfaceStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Interface IFoo"},
+                before:="Interface IFoo",
                 beforeCaret:={0, -1},
-                after:={"Interface IFoo",
-                        "",
-                        "End Interface"},
+                after:="Interface IFoo
+
+End Interface",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterStructureStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Structure Foo"},
+                before:="Structure Foo",
                 beforeCaret:={0, -1},
-                after:={"Structure Foo",
-                        "",
-                        "End Structure"},
+                after:="Structure Foo
+
+End Structure",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterEnumStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Enum Foo"},
+                before:="Enum Foo",
                 beforeCaret:={0, -1},
-                after:={"Enum Foo",
-                        "",
-                        "End Enum"},
+                after:="Enum Foo
+
+End Enum",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyGenericClass() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"NameSpace X",
-                         "    Class C(of T)"},
+                before:="NameSpace X
+    Class C(of T)",
                 beforeCaret:={1, -1},
-                 after:={"NameSpace X",
-                         "    Class C(of T)",
-                         "",
-                         "    End Class"},
+                 after:="NameSpace X
+    Class C(of T)
+
+    End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyStructInAClass() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Structure s",
-                         "End Class"},
+                before:="Class C
+    Structure s
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class C",
-                         "    Structure s",
-                         "",
-                         "    End Structure",
-                         "End Class"},
+                 after:="Class C
+    Structure s
+
+    End Structure
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyClassInAModule() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Module M",
-                         "    Class C",
-                         "End Module"},
+                before:="Module M
+    Class C
+End Module",
                 beforeCaret:={1, -1},
-                 after:={"Module M",
-                         "    Class C",
-                         "",
-                         "    End Class",
-                         "End Module"},
+                 after:="Module M
+    Class C
+
+    End Class
+End Module",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyClassDeclaration() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Partial Friend MustInherit Class C"},
+                before:="Partial Friend MustInherit Class C",
                 beforeCaret:={0, -1},
-                 after:={"Partial Friend MustInherit Class C",
-                         "",
-                         "End Class"},
+                 after:="Partial Friend MustInherit Class C
+
+End Class",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyEnumInAClass() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Public Enum e",
-                         "End Class"},
+                before:="Class C
+    Public Enum e
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class C",
-                         "    Public Enum e",
-                         "",
-                         "    End Enum",
-                         "End Class"},
+                 after:="Class C
+    Public Enum e
+
+    End Enum
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSyntax() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Sub S",
-                       "        Class B",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class EC
+    Sub S
+        Class B
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSyntax01() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Enum e(Of T)"},
+                text:="Enum e(Of T)",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidSyntax02() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C Class"},
+                text:="Class C Class",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyInheritsDecl() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C : Inherits B"},
+                before:="Class C : Inherits B",
                 beforeCaret:={0, -1},
-                 after:={"Class C : Inherits B",
-                         "",
-                         "End Class"},
+                 after:="Class C : Inherits B
+
+End Class",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInheritsDeclNotApplied() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C : Inherits B",
-                       "End Class"},
+                text:="Class C : Inherits B
+End Class",
                 caret:={0, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestVerifyImplementsDecl() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C : Implements IB"},
+                before:="Class C : Implements IB",
                 beforeCaret:={0, -1},
-                 after:={"Class C : Implements IB",
-                         "",
-                         "End Class"},
+                 after:="Class C : Implements IB
+
+End Class",
                 afterCaret:={1, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyImplementsDeclNotApplied() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C : Implements IB",
-                       "End Class"},
+                text:="Class C : Implements IB
+End Class",
                 caret:={0, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/UsingBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/UsingBlockTests.vb
@@ -14,93 +14,93 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterUsingStatement() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "Sub foo()",
-                         "Using variable",
-                         "End Sub",
-                         "End Class"},
+                before:="Class c1
+Sub foo()
+Using variable
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "Sub foo()",
-                        "Using variable",
-                        "",
-                        "End Using",
-                        "End Sub",
-                        "End Class"},
+                after:="Class c1
+Sub foo()
+Using variable
+
+End Using
+End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMatchedUsing() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Sub foo()",
-                       "Using variable",
-                       "End Using",
-                       "End Sub",
-                       "End Class"},
+                text:="Class c1
+Sub foo()
+Using variable
+End Using
+End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNestedUsing() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        Using y",
-                         "            Using z",
-                         "        End Using",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        Using y
+            Using z
+        End Using
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        Using y",
-                         "            Using z",
-                         "",
-                         "            End Using",
-                         "        End Using",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        Using y
+            Using z
+
+            End Using
+        End Using
+    End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyUsingWithDelegate() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        Using Func(of String, String)",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        Using Func(of String, String)
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        Using Func(of String, String)",
-                         "",
-                         "        End Using",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        Using Func(of String, String)
+
+        End Using
+    End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyUsingAtInvalidSyntax() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Sub S",
-                       "        Using x asf asdf",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class EC
+    Sub S
+        Using x asf asdf
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyUsingAtInvalidLocation() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Using x",
-                       "End Class"},
+                text:="Class EC
+    Using x
+End Class",
                 caret:={1, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhileLoopTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhileLoopTests.vb
@@ -14,88 +14,88 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterWithStatement() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "Sub foo()",
-                         "While variable",
-                         "End Sub",
-                         "End Class"},
+                before:="Class c1
+Sub foo()
+While variable
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "Sub foo()",
-                        "While variable",
-                        "",
-                        "End While",
-                        "End Sub",
-                        "End Class"},
+                after:="Class c1
+Sub foo()
+While variable
+
+End While
+End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMatchedWith() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Sub foo()",
-                       "While variable",
-                       "End While",
-                       "End Sub",
-                       "End Class"},
+                text:="Class c1
+Sub foo()
+While variable
+End While
+End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNestedWhileBlock() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        While True",
-                         "            While True",
-                         "                Dim x = 5",
-                         "        End While",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        While True
+            While True
+                Dim x = 5
+        End While
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        While True",
-                         "            While True",
-                         "",
-                         "            End While",
-                         "                Dim x = 5",
-                         "        End While",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        While True
+            While True
+
+            End While
+                Dim x = 5
+        End While
+    End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyRecommitWhileBlock() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class C",
-                       "    Sub S",
-                       "        While [while] = [while]",
-                       "        End While           ",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C
+    Sub S
+        While [while] = [while]
+        End While           
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidWhileSyntax() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Sub S",
-                       "        While asdf asdf asd",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class EC
+    Sub S
+        While asdf asdf asd
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidWhileLocation() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    While True",
-                       "End Class"},
+                text:="Class EC
+    While True
+End Class",
                 caret:={1, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhiteSpacesInsertTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhiteSpacesInsertTests.vb
@@ -14,45 +14,44 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInsertWhiteSpace() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class X",
-                         "  Sub y()",
-                         "End Class"},
+                before:="Class X
+  Sub y()
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class X",
-                         "  Sub y()",
-                         "",
-                         "  End Sub",
-                         "End Class"},
+                 after:="Class X
+  Sub y()
+
+  End Sub
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInsertTabSpace() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class X",
-                         vbTab + vbTab + "Sub y()",
-                         "End Class"},
+                before:="Class X
+		Sub y()
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class X",
-                         vbTab + vbTab + "Sub y()",
-                         "",
-                         vbTab + vbTab + "End Sub",
-                         "End Class"},
+                 after:="Class X
+		Sub y()
+		End Sub
+End Class",
                 afterCaret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInsertDoubleWideWhiteSpace() As Threading.Tasks.Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class X",
-                         " Sub y()",
-                         "End Class"},
+                before:="Class X
+ Sub y()
+End Class",
                 beforeCaret:={1, -1},
-                 after:={"Class X",
-                         " Sub y()",
-                         "",
-                         " End Sub",
-                         "End Class"},
+                 after:="Class X
+ Sub y()
+
+ End Sub
+End Class",
                 afterCaret:={2, -1})
 
         End Function

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhiteSpacesInsertTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhiteSpacesInsertTests.vb
@@ -35,6 +35,7 @@ End Class",
                 beforeCaret:={1, -1},
                  after:="Class X
 		Sub y()
+
 		End Sub
 End Class",
                 afterCaret:={2, -1})

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WithBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WithBlockTests.vb
@@ -15,95 +15,95 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function ApplyAfterWithStatement() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class c1",
-                         "Sub foo()",
-                         "With variable",
-                         "End Sub",
-                         "End Class"},
+                before:="Class c1
+Sub foo()
+With variable
+End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class c1",
-                        "Sub foo()",
-                        "With variable",
-                        "",
-                        "End With",
-                        "End Sub",
-                        "End Class"},
+                after:="Class c1
+Sub foo()
+With variable
+
+End With
+End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyForMatchedWith() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class c1",
-                       "Sub foo()",
-                       "With variable",
-                       "End With",
-                       "End Sub",
-                       "End Class"},
+                text:="Class c1
+Sub foo()
+With variable
+End With
+End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyNestedWith() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        With K",
-                         "            With K",
-                         "        End With",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        With K
+            With K
+        End With
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        With K",
-                         "            With K",
-                         "",
-                         "            End With",
-                         "        End With",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        With K
+            With K
+
+            End With
+        End With
+    End Sub
+End Class",
                 afterCaret:={4, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyWithFollowsCode() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C",
-                         "    Sub S",
-                         "        With K",
-                         "        Dim x = 5",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C
+    Sub S
+        With K
+        Dim x = 5
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                 after:={"Class C",
-                         "    Sub S",
-                         "        With K",
-                         "",
-                         "        End With",
-                         "        Dim x = 5",
-                         "    End Sub",
-                         "End Class"},
+                 after:="Class C
+    Sub S
+        With K
+
+        End With
+        Dim x = 5
+    End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidWithSyntax() As Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    Sub S",
-                       "        With using",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class EC
+    Sub S
+        With using
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function VerifyInvalidWithLocation() As Threading.Tasks.Task
             Await VerifyStatementEndConstructNotAppliedAsync(
-                text:={"Class EC",
-                       "    With True",
-                       "End Class"},
+                text:="Class EC
+    With True
+End Class",
                 caret:={1, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/XmlLiteralTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/XmlLiteralTests.vb
@@ -7,358 +7,358 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlStartElement() As Task
             Await VerifyXmlElementEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <xml>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <xml>
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <xml></xml>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <xml></xml>
+    End Sub
+End Class",
                 afterCaret:={2, 21})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlStartElementSplitAcrossLines() As Task
             Await VerifyXmlElementEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <xml",
-                         "                    >",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <xml
+                    >
+    End Sub
+End Class",
                 beforeCaret:={3, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <xml",
-                        "                    ></xml>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <xml
+                    ></xml>
+    End Sub
+End Class",
                 afterCaret:={3, 21})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlStartElementWithNamespace() As Task
             Await VerifyXmlElementEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <a:b>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <a:b>
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <a:b></a:b>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <a:b></a:b>
+    End Sub
+End Class",
                 afterCaret:={2, 21})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyInParameterDeclaration1() As Threading.Tasks.Task
             Await VerifyXmlElementEndConstructNotAppliedAsync(
-                text:={"Class C1",
-                       "    Sub M1(<xml>)",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C1
+    Sub M1(<xml>)
+    End Sub
+End Class",
                 caret:={1, 16})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyInParameterDeclaration2() As Threading.Tasks.Task
             Await VerifyXmlElementEndConstructNotAppliedAsync(
-                text:={"Class C1",
-                       "    Sub M1(i As Integer,",
-                       "           <xml>)",
-                       "    End Sub",
-                       "End Class"},
+                text:="Class C1
+    Sub M1(i As Integer,
+           <xml>)
+    End Sub
+End Class",
                 caret:={2, 16})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterXmlStartElementWithEndElement() As Threading.Tasks.Task
             Await VerifyXmlElementEndConstructNotAppliedAsync(
-                text:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <xml></xml>",
-                         "    End Sub",
-                         "End Class"},
+                text:="Class C1
+    Sub M1()
+        Dim x = <xml></xml>
+    End Sub
+End Class",
                 caret:={2, 23})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterXmlEndElement() As Threading.Tasks.Task
             Await VerifyXmlElementEndConstructNotAppliedAsync(
-                text:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = </xml>",
-                         "    End Sub",
-                         "End Class"},
+                text:="Class C1
+    Sub M1()
+        Dim x = </xml>
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterSingleXmlTag() As Threading.Tasks.Task
             Await VerifyXmlElementEndConstructNotAppliedAsync(
-                text:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <xml/>",
-                         "    End Sub",
-                         "End Class"},
+                text:="Class C1
+    Sub M1()
+        Dim x = <xml/>
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function DontApplyAfterProcessingInstruction() As Threading.Tasks.Task
             Await VerifyXmlElementEndConstructNotAppliedAsync(
-                text:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <?xml version=""1.0""?>",
-                         "    End Sub",
-                         "End Class"},
+                text:="Class C1
+    Sub M1()
+        Dim x = <?xml version=""1.0""?>
+    End Sub
+End Class",
                 caret:={2, -1})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlStartElementWhenPassedAsParameter1() As Task
             Await VerifyXmlElementEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        M2(<xml>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        M2(<xml>
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        M2(<xml></xml>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        M2(<xml></xml>
+    End Sub
+End Class",
                 afterCaret:={2, 16})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlStartElementWhenPassedAsParameter2() As Task
             Await VerifyXmlElementEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        M2(<xml>)",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        M2(<xml>)
+    End Sub
+End Class",
                 beforeCaret:={2, 16},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        M2(<xml></xml>)",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        M2(<xml></xml>)
+    End Sub
+End Class",
                 afterCaret:={2, 16})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlComment() As Task
             Await VerifyXmlCommentEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <!--",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <!--
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <!---->",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <!---->
+    End Sub
+End Class",
                 afterCaret:={2, 20})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlCommentWhenPassedAsParameter1() As Task
             Await VerifyXmlCommentEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        M2(<!--",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        M2(<!--
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        M2(<!---->",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        M2(<!---->
+    End Sub
+End Class",
                 afterCaret:={2, 15})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlCommentWhenPassedAsParameter2() As Task
             Await VerifyXmlCommentEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        M2(<!--)",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        M2(<!--)
+    End Sub
+End Class",
                 beforeCaret:={2, 15},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        M2(<!---->)",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        M2(<!---->)
+    End Sub
+End Class",
                 afterCaret:={2, 15})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlCData() As Task
             Await VerifyXmlCDataEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <![CDATA[",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <![CDATA[
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <![CDATA[]]>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <![CDATA[]]>
+    End Sub
+End Class",
                 afterCaret:={2, 25})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlCData2() As Task
             Await VerifyXmlCDataEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <Code><![CDATA[</Code>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <Code><![CDATA[</Code>
+    End Sub
+End Class",
                 beforeCaret:={2, 31},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <Code><![CDATA[]]></Code>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <Code><![CDATA[]]></Code>
+    End Sub
+End Class",
                 afterCaret:={2, 31})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlEmbeddedExpression1() As Task
             Await VerifyXmlEmbeddedExpressionEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <%=",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <%=
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <%=  %>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <%=  %>
+    End Sub
+End Class",
                 afterCaret:={2, 20})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlEmbeddedExpression2() As Task
             Await VerifyXmlEmbeddedExpressionEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <a><%=",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <a><%=
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <a><%=  %>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <a><%=  %>
+    End Sub
+End Class",
                 afterCaret:={2, 23})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlEmbeddedExpression3() As Task
             Await VerifyXmlEmbeddedExpressionEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <a><%=</a>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <a><%=</a>
+    End Sub
+End Class",
                 beforeCaret:={2, 22},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <a><%=  %></a>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <a><%=  %></a>
+    End Sub
+End Class",
                 afterCaret:={2, 23})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlProcessingInstruction() As Task
             Await VerifyXmlProcessingInstructionEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <?",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <?
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <??>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <??>
+    End Sub
+End Class",
                 afterCaret:={2, 18})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlProcessingInstructionWhenPassedAsParameter1() As Task
             Await VerifyXmlProcessingInstructionEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        M2(<?",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        M2(<?
+    End Sub
+End Class",
                 beforeCaret:={2, -1},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        M2(<??>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        M2(<??>
+    End Sub
+End Class",
                 afterCaret:={2, 13})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestApplyAfterXmlProcessingInstructionWhenPassedAsParameter2() As Task
             Await VerifyXmlProcessingInstructionEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        M2(<?)",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        M2(<?)
+    End Sub
+End Class",
                 beforeCaret:={2, 13},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        M2(<??>)",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        M2(<??>)
+    End Sub
+End Class",
                 afterCaret:={2, 13})
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
         Public Async Function TestInsertBlankLineWhenPressingEnterInEmptyXmlTag() As Task
             Await VerifyStatementEndConstructAppliedAsync(
-                before:={"Class C1",
-                         "    Sub M1()",
-                         "        Dim x = <foo></foo>",
-                         "    End Sub",
-                         "End Class"},
+                before:="Class C1
+    Sub M1()
+        Dim x = <foo></foo>
+    End Sub
+End Class",
                 beforeCaret:={2, 21},
-                after:={"Class C1",
-                        "    Sub M1()",
-                        "        Dim x = <foo>",
-                        "",
-                        "                </foo>",
-                        "    End Sub",
-                        "End Class"},
+                after:="Class C1
+    Sub M1()
+        Dim x = <foo>
+
+                </foo>
+    End Sub
+End Class",
                 afterCaret:={3, -1})
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             Dim textSpan As TextSpan
             MarkupTestFile.GetSpan(codeWithMarker.NormalizedValue, codeWithoutMarker, textSpan)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithoutMarker)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithoutMarker)
                 Dim treeAfterExtractMethod = Await ExtractMethodAsync(workspace, workspace.Documents.First(), textSpan, succeeded:=False, dontPutOutOrRefOnStruct:=dontPutOutOrRefOnStruct)
             End Using
         End Function
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             Dim textSpan As TextSpan
             MarkupTestFile.GetSpan(codeWithMarker.NormalizedValue, codeWithoutMarker, textSpan)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithoutMarker)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithoutMarker)
                 Assert.NotNull(Await Record.ExceptionAsync(Async Function()
                                                                Dim tree = Await ExtractMethodAsync(workspace, workspace.Documents.First(), textSpan)
                                                            End Function))
@@ -126,7 +126,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
 
             MarkupTestFile.GetSpans(codeWithMarker.NormalizedValue, codeWithoutMarker, namedSpans)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(codeWithoutMarker)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(codeWithoutMarker)
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)
                 Assert.NotNull(document)
 
@@ -154,8 +154,8 @@ End Class</text>
             Await TestSelectionAsync(markupWithMarker, expectedFail)
         End Function
 
-        Private Shared Async Function IterateAllAsync(ByVal code As String) As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+        Private Shared Async Function IterateAllAsync(code As String) As Tasks.Task
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)
                 Assert.NotNull(document)
 

--- a/src/EditorFeatures/VisualBasicTest/Formatting/FormattingTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/FormattingTestBase.vb
@@ -13,7 +13,7 @@ Imports Roslyn.Test.EditorUtilities
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
     Public Class FormattingTestBase
         Protected Async Function AssertFormatSpanAsync(content As String, expected As String, Optional baseIndentation As Integer? = Nothing, Optional span As TextSpan = Nothing) As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(content)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(content)
                 Dim hostdoc = workspace.Documents.First()
 
                 ' get original buffer

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2830,7 +2830,7 @@ End Class
 
         Private Shared Async Function AssertSmartIndentIndentationInProjectionAsync(markup As String,
                                                                     expectedIndentation As Integer) As Tasks.Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync({markup})
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(markup)
                 Dim subjectDocument = workspace.Documents.Single()
                 Dim projectedDocument = workspace.CreateProjectionBufferDocument(s_htmlMarkup, workspace.Documents, LanguageNames.CSharp)
 
@@ -2879,7 +2879,7 @@ End Class
 
         ''' <param name="indentationLine">0-based. The line number in code to get indentation for.</param>
         Private Shared Async Function AssertSmartIndentAsync(code As String, indentationLine As Integer, expectedIndentation As Integer?, Optional indentStyle As FormattingOptions.IndentStyle = FormattingOptions.IndentStyle.Smart) As Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync({code})
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
                 Dim buffer = workspace.Documents.First().GetTextBuffer()
 
                 SetIndentStyle(buffer, indentStyle)

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
@@ -173,7 +173,7 @@ End Class
             Dim position As Integer = 0
             MarkupTestFile.GetPosition(codeWithMarkup, code, position)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
                 Dim hostdoc = workspace.Documents.First()
                 Dim buffer = hostdoc.GetTextBuffer()
 

--- a/src/EditorFeatures/VisualBasicTest/LineSeparators/LineSeparatorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineSeparators/LineSeparatorTests.vb
@@ -279,7 +279,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
         End Function
 
         Private Async Function AssertTagsAsync(spans As IEnumerable(Of TextSpan), ParamArray lines As String()) As Tasks.Task
-            Dim tags = Await GetSpansForAsync(lines)
+            Dim tags = Await GetSpansForAsync(String.Join(Environment.NewLine, lines))
             Assert.Equal(spans.Count(), tags.Count())
 
             Dim i As Integer = 0
@@ -289,8 +289,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
             Next
         End Function
 
-        Private Async Function GetSpansForAsync(ParamArray lines As String()) As Tasks.Task(Of IEnumerable(Of TextSpan))
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines)
+        Private Async Function GetSpansForAsync(content As String) As Tasks.Task(Of IEnumerable(Of TextSpan))
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(content)
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)
                 Dim spans = Await New VisualBasicLineSeparatorService().GetLineSeparatorsAsync(document,
                     (Await document.GetSyntaxRootAsync()).FullSpan)

--- a/src/EditorFeatures/VisualBasicTest/LineSeparators/LineSeparatorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineSeparators/LineSeparatorTests.vb
@@ -23,52 +23,52 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestEmptyClass() As Task
             Await AssertTagsAsync({New TextSpan(9, 9)},
-                       "Class C",
-                       "End Class")
+                       "Class C
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestEmptyModule() As Task
             Await AssertTagsAsync({New TextSpan(10, 10)},
-                       "Module C",
-                       "End Module")
+                       "Module C
+End Module")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestEmptyStructure() As Task
             Await AssertTagsAsync({New TextSpan(13, 13)},
-                       "Structure S",
-                       "End Structure")
+                       "Structure S
+End Structure")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestEmptyInterface() As Task
             Await AssertTagsAsync({New TextSpan(13, 13)},
-                       "Interface I",
-                       "End Interface")
+                       "Interface I
+End Interface")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestEmptyEnum() As Task
             Await AssertTagsAsync({New TextSpan(8, 8)},
-                       "Enum E",
-                       "End Enum")
+                       "Enum E
+End Enum")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestEmptyNamespace() As Task
             Await AssertTagsAsync({New TextSpan(13, 13)},
-                       "Namespace N",
-                       "End Namespace")
+                       "Namespace N
+End Namespace")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestClassWithOneMethod() As Task
             Await AssertTagsAsync({New TextSpan(40, 9)},
-                       "Class C",
-                       "    Sub Method()",
-                       "    End Sub",
-                       "End Class")
+                       "Class C
+    Sub Method()
+    End Sub
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -77,13 +77,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                            New TextSpan(32, 7),
                            New TextSpan(75, 9)
                        },
-                       "Class C",
-                       "    Sub Method1()",
-                       "    End Sub",
-                       "",
-                       "    Sub Method2()",
-                       "    End Sub",
-                       "End Class")
+                       "Class C
+    Sub Method1()
+    End Sub
+
+    Sub Method2()
+    End Sub
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -92,15 +92,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                             New TextSpan(45, 7),
                             New TextSpan(101, 9)
                        },
-                       "Class C",
-                       "    Sub Method1()",
-                       "        M()",
-                       "    End Sub",
-                       "",
-                       "    Sub Method2()",
-                       "        M()",
-                       "    End Sub",
-                       "End Class")
+                       "Class C
+    Sub Method1()
+        M()
+    End Sub
+
+    Sub Method2()
+        M()
+    End Sub
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -109,12 +109,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                             New TextSpan(32, 7),
                             New TextSpan(65, 9)
                        },
-                       "Class C",
-                       "    Sub Method1()",
-                       "    End Sub",
-                       "",
-                       "    Dim X as Integer",
-                       "End Class")
+                       "Class C
+    Sub Method1()
+    End Sub
+
+    Dim X as Integer
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -123,21 +123,21 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                            New TextSpan(17, 12),
                            New TextSpan(65, 9)
                        },
-                       "Class C",
-                       "    Dim X as Integer",
-                       "",
-                       "    Sub Method1()",
-                       "    End Sub",
-                       "End Class")
+                       "Class C
+    Dim X as Integer
+
+    Sub Method1()
+    End Sub
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestEmptyClassInNamespace() As Task
             Await AssertTagsAsync({New TextSpan(41, 13)},
-                       "Namespace N",
-                       "    Class C",
-                       "    End Class",
-                       "End Namespace")
+                       "Namespace N
+    Class C
+    End Class
+End Namespace")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -146,13 +146,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                            New TextSpan(31, 9),
                            New TextSpan(73, 13)
                        },
-                       "Namespace N",
-                       "    Class C1",
-                       "    End Class",
-                       "",
-                       "    Class C2",
-                       "    End Class",
-                       "End Namespace")
+                       "Namespace N
+    Class C1
+    End Class
+
+    Class C2
+    End Class
+End Namespace")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -162,24 +162,24 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                            New TextSpan(62, 9),
                            New TextSpan(97, 13)
                        },
-                       "Namespace N",
-                       "    Class C1",
-                       "    End Class",
-                       "",
-                       "    Class C2",
-                       "    End Class",
-                       "",
-                       "    Delegate Sub D()",
-                       "End Namespace")
+                       "Namespace N
+    Class C1
+    End Class
+
+    Class C2
+    End Class
+
+    Delegate Sub D()
+End Namespace")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestNestedClass() As Task
             Await AssertTagsAsync({New TextSpan(37, 9)},
-                       "Class C",
-                       "    Class N",
-                       "    End Class",
-                       "End Class")
+                       "Class C
+    Class N
+    End Class
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -188,28 +188,28 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                            New TextSpan(27, 9),
                            New TextSpan(69, 9)
                        },
-                       "Class C",
-                       "    Class N1",
-                       "    End Class",
-                       "",
-                       "    Class N2",
-                       "    End Class",
-                       "End Class")
+                       "Class C
+    Class N1
+    End Class
+
+    Class N2
+    End Class
+End Class")
         End Function
 
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
         Public Async Function TestProperty() As Task
             Await AssertTagsAsync({New TextSpan(164, 9)},
-                       "Class C",
-                       "    Property Prop as Integer",
-                       "        Get",
-                       "            Return 42",
-                       "        End Get",
-                       "        Set(ByVal value as Integer)",
-                       "        End Set",
-                       "    End Property",
-                       "End Class")
+                       "Class C
+    Property Prop as Integer
+        Get
+            Return 42
+        End Get
+        Set(ByVal value as Integer)
+        End Set
+    End Property
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -218,17 +218,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                            New TextSpan(150, 12),
                            New TextSpan(188, 9)
                        },
-                       "Class C",
-                       "    Property Prop as Integer",
-                       "        Get",
-                       "            Return 42",
-                       "        End Get",
-                       "        Set(ByVal value as Integer)",
-                       "        End Set",
-                       "    End Property",
-                       "",
-                       "    Dim x as Integer",
-                       "End Class")
+                       "Class C
+    Property Prop as Integer
+        Get
+            Return 42
+        End Get
+        Set(ByVal value as Integer)
+        End Set
+    End Property
+
+    Dim x as Integer
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -237,10 +237,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                             New TextSpan(8, 6),
                             New TextSpan(29, 9)
                        },
-                       "Imports System",
-                       "",
-                       "Class Foo",
-                       "End Class")
+                       "Imports System
+
+Class Foo
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -249,19 +249,19 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                             New TextSpan(235, 9),
                             New TextSpan(272, 9)
                        },
-                       "Class C",
-                       "    Custom Event E as EventHandler",
-                       "        AddHandler(value as EventHandler)",
-                       "        End AddHandler",
-                       "        RemoveHandler(value as EventHandler)",
-                       "        End RemoveHandler",
-                       "        RaiseEvent()",
-                       "        End RaiseEvent",
-                       "    End Event",
-                       "",
-                       "    Dim y as Integer",
-                       "",
-                       "End Class")
+                       "Class C
+    Custom Event E as EventHandler
+        AddHandler(value as EventHandler)
+        End AddHandler
+        RemoveHandler(value as EventHandler)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+
+    Dim y as Integer
+
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.LineSeparators)>
@@ -270,16 +270,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineSeparators
                             New TextSpan(26, 7),
                             New TextSpan(59, 9)
                        },
-                       "Class C",
-                       "    Sub New",
-                       "    End Sub",
-                       "",
-                       "    Dim y as Integer",
-                       "End Class")
+                       "Class C
+    Sub New
+    End Sub
+
+    Dim y as Integer
+End Class")
         End Function
 
-        Private Async Function AssertTagsAsync(spans As IEnumerable(Of TextSpan), ParamArray lines As String()) As Tasks.Task
-            Dim tags = Await GetSpansForAsync(String.Join(Environment.NewLine, lines))
+        Private Async Function AssertTagsAsync(spans As IEnumerable(Of TextSpan), content As String) As Tasks.Task
+            Dim tags = Await GetSpansForAsync(content)
             Assert.Equal(spans.Count(), tags.Count())
 
             Dim i As Integer = 0

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -18,8 +18,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
         Private _provider As NavigateToItemProvider
         Private _aggregator As NavigateToTestAggregator
 
-        Private Async Function SetupWorkspaceAsync(ParamArray lines As String()) As Task(Of TestWorkspace)
-            Dim workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, lines))
+        Private Async Function SetupWorkspaceAsync(content As String) As Task(Of TestWorkspace)
+            Dim workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(content)
             SetupNavigateTo(workspace)
             Return workspace
         End Function
@@ -38,14 +38,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestNoItemsForEmptyFile() As Task
-            Using worker = Await SetupWorkspaceAsync()
+            Using worker = Await SetupWorkspaceAsync("")
                 Assert.Empty(_aggregator.GetItems("Hello"))
             End Using
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindClass() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "End Class")
+            Using worker = Await SetupWorkspaceAsync(
+"Class Foo
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupClass, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("Foo").Single()
                 VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Class)
@@ -54,7 +56,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindVerbatimClass() As Task
-            Using worker = Await SetupWorkspaceAsync("Class [Class]", "End Class")
+            Using worker = Await SetupWorkspaceAsync(
+"Class [Class]
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupClass, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("class").Single()
                 VerifyNavigateToResultItem(item, "Class", MatchKind.Exact, NavigateToItemKind.Class, displayName:="[Class]")
@@ -66,7 +70,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindNestedClass() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Alpha", "Class Beta", "Class Gamma", "End Class", "End Class", "End Class")
+            Using worker = Await SetupWorkspaceAsync(
+"Class Alpha
+Class Beta
+Class Gamma
+End Class
+End Class
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupClass, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Gamma").Single()
                 VerifyNavigateToResultItem(item, "Gamma", MatchKind.Exact, NavigateToItemKind.Class)
@@ -75,7 +85,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindMemberInANestedClass() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Alpha", "Class Beta", "Class Gamma", "Sub DoSomething()", "End Sub", "End Class", "End Class", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Alpha
+Class Beta
+Class Gamma
+Sub DoSomething()
+End Sub
+End Class
+End Class
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("DS").Single()
                 VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", $"{EditorFeaturesResources.Type}Alpha.Beta.Gamma")
@@ -84,7 +101,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindGenericConstrainedClass() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo(Of M As IComparable)", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo(Of M As IComparable)
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupClass, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("Foo").Single()
                 VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Class, displayName:="Foo(Of M)")
@@ -93,7 +111,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindGenericConstrainedMethod() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo(Of M As IComparable)", "Public Sub Bar(Of T As IComparable)()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo(Of M As IComparable)
+Public Sub Bar(Of T As IComparable)()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar(Of T)()", $"{EditorFeaturesResources.Type}Foo(Of M)")
@@ -102,7 +123,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindPartialClass() As Task
-            Using worker = Await SetupWorkspaceAsync("Partial Public Class Foo", "Private a As Integer", "End Class", "Partial Class Foo", "Private b As Integer", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Partial Public Class Foo
+Private a As Integer
+End Class
+Partial Class Foo
+Private b As Integer
+End Class")
 
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
@@ -119,7 +145,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindClassInNamespace() As Task
-            Using worker = Await SetupWorkspaceAsync("Namespace Bar", "Class Foo", "End Class", "End Namespace")
+            Using worker = Await SetupWorkspaceAsync("Namespace Bar
+Class Foo
+End Class
+End Namespace")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupClass, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("Foo").Single()
                 VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Class)
@@ -128,7 +157,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindStruct() As Task
-            Using worker = Await SetupWorkspaceAsync("Structure Bar", "End Structure")
+            Using worker = Await SetupWorkspaceAsync("Structure Bar
+End Structure")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupStruct, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("B").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Structure)
@@ -137,7 +167,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindEnum() As Task
-            Using worker = Await SetupWorkspaceAsync("Enum Colors", "Red", "Green", "Blue", "End Enum")
+            Using worker = Await SetupWorkspaceAsync("Enum Colors
+Red
+Green
+Blue
+End Enum")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupEnum, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("C").Single()
                 VerifyNavigateToResultItem(item, "Colors", MatchKind.Prefix, NavigateToItemKind.Enum)
@@ -146,7 +180,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindEnumMember() As Task
-            Using worker = Await SetupWorkspaceAsync("Enum Colors", "Red", "Green", "Blue", "End Enum")
+            Using worker = Await SetupWorkspaceAsync("Enum Colors
+Red
+Green
+Blue
+End Enum")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupEnumMember, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("G").Single()
                 VerifyNavigateToResultItem(item, "Green", MatchKind.Prefix, NavigateToItemKind.EnumItem)
@@ -155,7 +193,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindField1() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private Bar As Integer", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private Bar As Integer
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Ba").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -164,7 +204,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindField2() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private Bar As Integer", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private Bar As Integer
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("ba").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Prefix, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -173,7 +215,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindField3() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private Bar As Integer", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private Bar As Integer
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Assert.Empty(_aggregator.GetItems("ar"))
             End Using
@@ -181,7 +225,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindVerbatimField() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private [string] As String", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private [string] As String
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("string").Single()
                 VerifyNavigateToResultItem(item, "string", MatchKind.Exact, NavigateToItemKind.Field, displayName:="[string]", additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -193,7 +239,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindConstField() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private Const bar As String = ""bar""", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private Const bar As String = ""bar""
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupConstant, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("bar").Single()
                 VerifyNavigateToResultItem(item, "bar", MatchKind.Exact, NavigateToItemKind.Constant, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -202,11 +250,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindIndexer() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private arr As Integer()",
-                                       "Default Public Property Item(ByVal i As Integer) As Integer",
-                                       "Get", "Return arr(i)", "End Get", "Set(ByVal value As Integer)", "arr(i) = value", "End Set",
-                                       "End Property",
-                                       "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private arr As Integer()
+Default Public Property Item(ByVal i As Integer) As Integer
+Get
+Return arr(i)
+End Get
+Set(ByVal value As Integer)
+arr(i) = value
+End Set
+End Property
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Item").Single()
                 VerifyNavigateToResultItem(item, "Item", MatchKind.Exact, NavigateToItemKind.Property, "Item(Integer)", $"{EditorFeaturesResources.Type}Foo")
@@ -215,7 +269,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo), WorkItem(780993)>
         Public Async Function TestFindEvent() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Public Event Bar as EventHandler", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Public Event Bar as EventHandler
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupEvent, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Event, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -224,9 +280,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindNormalProperty() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Property Name As String",
-                                          "Get", "Return String.Empty", "End Get",
-                                          "Set(value As String)", "End Set", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Property Name As String
+Get
+Return String.Empty
+End Get
+Set(value As String)
+End Set
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Name").Single()
                 VerifyNavigateToResultItem(item, "Name", MatchKind.Exact, NavigateToItemKind.Property, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -235,7 +296,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindAutoImplementedProperty() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Property Name As String", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Property Name As String
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupProperty, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Name").Single()
                 VerifyNavigateToResultItem(item, "Name", MatchKind.Exact, NavigateToItemKind.Property, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -244,7 +307,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindMethod() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private Sub DoSomething()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private Sub DoSomething()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("DS").Single()
                 VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething()", $"{EditorFeaturesResources.Type}Foo")
@@ -253,7 +319,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindVerbatimMethod() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private Sub [Sub]()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private Sub [Sub]()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("sub").Single()
                 VerifyNavigateToResultItem(item, "Sub", MatchKind.Exact, NavigateToItemKind.Method, "[Sub]()", $"{EditorFeaturesResources.Type}Foo")
@@ -265,7 +334,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindParameterizedMethod() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private Sub DoSomething(ByVal i As Integer, s As String)", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private Sub DoSomething(ByVal i As Integer, s As String)
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("DS").Single()
                 VerifyNavigateToResultItem(item, "DoSomething", MatchKind.Regular, NavigateToItemKind.Method, "DoSomething(Integer, String)", $"{EditorFeaturesResources.Type}Foo")
@@ -274,7 +346,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindConstructor() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Sub New()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Sub New()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Foo").Single(Function(i) i.Kind = NavigateToItemKind.Method)
                 VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "New()", $"{EditorFeaturesResources.Type}Foo")
@@ -283,7 +358,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindStaticConstructor() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Shared Sub New()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Shared Sub New()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Foo").Single(Function(i) i.Kind = NavigateToItemKind.Method)
                 VerifyNavigateToResultItem(item, "Foo", MatchKind.Exact, NavigateToItemKind.Method, "Shared New()", $"{EditorFeaturesResources.Type}Foo")
@@ -292,9 +370,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindDestructor() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Implements IDisposable",
-                                       "Public Sub Dispose() Implements IDisposable.Dispose", "End Sub",
-                                       "Protected Overrides Sub Finalize()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Implements IDisposable
+Public Sub Dispose() Implements IDisposable.Dispose
+End Sub
+Protected Overrides Sub Finalize()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemProtected)
                 Dim item As NavigateToItem = _aggregator.GetItems("Finalize").Single()
                 VerifyNavigateToResultItem(item, "Finalize", MatchKind.Exact, NavigateToItemKind.Method, "Finalize()", $"{EditorFeaturesResources.Type}Foo")
@@ -308,8 +390,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindPartialMethods() As Task
-            Using worker = Await SetupWorkspaceAsync("Partial Class Foo", "Partial Private Sub Bar()", "End Sub", "End Class",
-                                       "Partial Class Foo", "Private Sub Bar()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Partial Class Foo
+Partial Private Sub Bar()
+End Sub
+End Class
+Partial Class Foo
+Private Sub Bar()
+End Sub
+End Class")
 
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
@@ -326,7 +414,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindPartialMethodDefinitionOnly() As Task
-            Using worker = Await SetupWorkspaceAsync("Partial Class Foo", "Partial Private Sub Bar()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Partial Class Foo
+Partial Private Sub Bar()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", $"{EditorFeaturesResources.Type}Foo")
@@ -335,7 +426,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindPartialMethodImplementationOnly() As Task
-            Using worker = Await SetupWorkspaceAsync("Partial Class Foo", "Private Sub Bar()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Partial Class Foo
+Private Sub Bar()
+End Sub
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar()", $"{EditorFeaturesResources.Type}Foo")
@@ -344,8 +438,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindOverriddenMethods() As Task
-            Using worker = Await SetupWorkspaceAsync("Class BaseFoo", "Public Overridable Sub Bar()", "End Sub", "End Class",
-                                       "Class DerivedFoo", "Inherits BaseFoo", "Public Overrides Sub Bar()", "MyBase.Bar()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class BaseFoo
+Public Overridable Sub Bar()
+End Sub
+End Class
+Class DerivedFoo
+Inherits BaseFoo
+Public Overrides Sub Bar()
+MyBase.Bar()
+End Sub
+End Class")
 
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
@@ -360,7 +462,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDottedPattern1() As Task
-            Using workspace = Await SetupWorkspaceAsync("namespace Foo", "namespace Bar", "class Baz", "sub Quux()", "end sub", "end class", "end namespace", "end namespace")
+            Using workspace = Await SetupWorkspaceAsync("namespace Foo
+namespace Bar
+class Baz
+sub Quux()
+end sub
+end class
+end namespace
+end namespace")
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
                     New NavigateToItem("Quux", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Prefix, True, Nothing)
@@ -374,7 +483,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDottedPattern2() As Task
-            Using workspace = Await SetupWorkspaceAsync("namespace Foo", "namespace Bar", "class Baz", "sub Quux()", "end sub", "end class", "end namespace", "end namespace")
+            Using workspace = Await SetupWorkspaceAsync("namespace Foo
+namespace Bar
+class Baz
+sub Quux()
+end sub
+end class
+end namespace
+end namespace")
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
                 }
@@ -387,7 +503,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDottedPattern3() As Task
-            Using workspace = Await SetupWorkspaceAsync("namespace Foo", "namespace Bar", "class Baz", "sub Quux()", "end sub", "end class", "end namespace", "end namespace")
+            Using workspace = Await SetupWorkspaceAsync("namespace Foo
+namespace Bar
+class Baz
+sub Quux()
+end sub
+end class
+end namespace
+end namespace")
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
                     New NavigateToItem("Quux", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Prefix, True, Nothing)
@@ -401,7 +524,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDottedPattern4() As Task
-            Using workspace = Await SetupWorkspaceAsync("namespace Foo", "namespace Bar", "class Baz", "sub Quux()", "end sub", "end class", "end namespace", "end namespace")
+            Using workspace = Await SetupWorkspaceAsync("namespace Foo
+namespace Bar
+class Baz
+sub Quux()
+end sub
+end class
+end namespace
+end namespace")
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
                     New NavigateToItem("Quux", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Exact, True, Nothing)
@@ -415,7 +545,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDottedPattern5() As Task
-            Using workspace = Await SetupWorkspaceAsync("namespace Foo", "namespace Bar", "class Baz", "sub Quux()", "end sub", "end class", "end namespace", "end namespace")
+            Using workspace = Await SetupWorkspaceAsync("namespace Foo
+namespace Bar
+class Baz
+sub Quux()
+end sub
+end class
+end namespace
+end namespace")
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
                     New NavigateToItem("Quux", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Exact, True, Nothing)
@@ -429,7 +566,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDottedPattern6() As Task
-            Using workspace = Await SetupWorkspaceAsync("namespace Foo", "namespace Bar", "class Baz", "sub Quux()", "end sub", "end class", "end namespace", "end namespace")
+            Using workspace = Await SetupWorkspaceAsync("namespace Foo
+namespace Bar
+class Baz
+sub Quux()
+end sub
+end class
+end namespace
+end namespace")
                 Dim expecteditems = New List(Of NavigateToItem)
 
                 Dim items = _aggregator.GetItems("F.F.B.B.Quux").ToList()
@@ -440,7 +584,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDottedPattern7() As Task
-            Using workspace = Await SetupWorkspaceAsync("namespace Foo", "namespace Bar", "class Baz(of X, Y, Z)", "sub Quux()", "end sub", "end class", "end namespace", "end namespace")
+            Using workspace = Await SetupWorkspaceAsync("namespace Foo
+namespace Bar
+class Baz(of X, Y, Z)
+sub Quux()
+end sub
+end class
+end namespace
+end namespace")
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
                     New NavigateToItem("Quux", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Exact, True, Nothing)
@@ -454,7 +605,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindInterface() As Task
-            Using worker = Await SetupWorkspaceAsync("Public Interface IFoo", "End Interface")
+            Using worker = Await SetupWorkspaceAsync("Public Interface IFoo
+End Interface")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupInterface, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("IF").Single()
                 VerifyNavigateToResultItem(item, "IFoo", MatchKind.Prefix, NavigateToItemKind.Interface)
@@ -463,7 +615,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindDelegateInNamespace() As Task
-            Using worker = Await SetupWorkspaceAsync("Namespace Foo", "Delegate Sub DoStuff()", "End Namespace")
+            Using worker = Await SetupWorkspaceAsync("Namespace Foo
+Delegate Sub DoStuff()
+End Namespace")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupDelegate, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("DoStuff").Single()
                 VerifyNavigateToResultItem(item, "DoStuff", MatchKind.Exact, NavigateToItemKind.Delegate)
@@ -472,7 +626,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindLambdaExpression() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Dim sqr As Func(Of Integer, Integer) = Function(x) x*x", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Dim sqr As Func(Of Integer, Integer) = Function(x) x*x
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("sqr").Single()
                 VerifyNavigateToResultItem(item, "sqr", MatchKind.Exact, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -481,7 +637,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindModule() As Task
-            Using worker = Await SetupWorkspaceAsync("Module ModuleTest", "End Module")
+            Using worker = Await SetupWorkspaceAsync("Module ModuleTest
+End Module")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupModule, StandardGlyphItem.GlyphItemFriend)
                 Dim item As NavigateToItem = _aggregator.GetItems("MT").Single()
                 VerifyNavigateToResultItem(item, "ModuleTest", MatchKind.Regular, NavigateToItemKind.Module)
@@ -490,7 +647,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindLineContinuationMethod() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Public Sub Bar(x as Integer,", "y as Integer)", "End Sub")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Public Sub Bar(x as Integer,
+y as Integer)
+End Sub")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item As NavigateToItem = _aggregator.GetItems("Bar").Single()
                 VerifyNavigateToResultItem(item, "Bar", MatchKind.Exact, NavigateToItemKind.Method, "Bar(Integer, Integer)", $"{EditorFeaturesResources.Type}Foo")
@@ -499,7 +659,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindArray() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "Private itemArray as object()", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+Private itemArray as object()
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupField, StandardGlyphItem.GlyphItemPrivate)
                 Dim item As NavigateToItem = _aggregator.GetItems("itemArray").Single
                 VerifyNavigateToResultItem(item, "itemArray", MatchKind.Exact, NavigateToItemKind.Field, additionalInfo:=$"{EditorFeaturesResources.Type}Foo")
@@ -508,8 +670,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindClassAndMethodWithSameName() As Task
-            Using worker = Await SetupWorkspaceAsync("Class Foo", "End Class",
-                                       "Class Test", "Private Sub Foo()", "End Sub", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class Foo
+End Class
+Class Test
+Private Sub Foo()
+End Sub
+End Class")
                 Dim expectedItems = New List(Of NavigateToItem) From
                 {
                     New NavigateToItem("Foo", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Exact, True, Nothing),
@@ -525,7 +691,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindMethodNestedInGenericTypes() As Task
-            Using worker = Await SetupWorkspaceAsync("Class A(Of T)", "Class B", "Structure C(Of U)", "Sub M()", "End Sub", "End Structure", "End Class", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Class A(Of T)
+Class B
+Structure C(Of U)
+Sub M()
+End Sub
+End Structure
+End Class
+End Class")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic)
                 Dim item = _aggregator.GetItems("M").Single
                 VerifyNavigateToResultItem(item, "M", MatchKind.Exact, NavigateToItemKind.Method, displayName:="M()", additionalInfo:=$"{EditorFeaturesResources.Type}A(Of T).B.C(Of U)")
@@ -535,7 +708,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
         <WorkItem(1111131)>
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindClassInNamespaceWithGlobalPrefix() As Task
-            Using worker = Await SetupWorkspaceAsync("Namespace Global.MyNS", "Public Class C", "End Class", "End Namespace")
+            Using worker = Await SetupWorkspaceAsync("Namespace Global.MyNS
+Public Class C
+End Class
+End Namespace")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupClass, StandardGlyphItem.GlyphItemPublic)
                 Dim item = _aggregator.GetItems("C").Single
                 VerifyNavigateToResultItem(item, "C", MatchKind.Exact, NavigateToItemKind.Class, displayName:="C")
@@ -545,7 +721,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
         <WorkItem(1121267)>
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestFindClassInGlobalNamespace() As Task
-            Using worker = Await SetupWorkspaceAsync("Namespace Global", "Public Class C(Of T)", "End Class", "End Namespace")
+            Using worker = Await SetupWorkspaceAsync("Namespace Global
+Public Class C(Of T)
+End Class
+End Namespace")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupClass, StandardGlyphItem.GlyphItemPublic)
                 Dim item = _aggregator.GetItems("C").Single
                 VerifyNavigateToResultItem(item, "C", MatchKind.Exact, NavigateToItemKind.Class, displayName:="C(Of T)")
@@ -555,7 +734,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
         <WorkItem(1834, "https://github.com/dotnet/roslyn/issues/1834")>
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestConstructorNotParentedByTypeBlock() As Task
-            Using worker = Await SetupWorkspaceAsync("Module Program", "End Module", "Public Sub New()", "End Sub")
+            Using worker = Await SetupWorkspaceAsync("Module Program
+End Module
+Public Sub New()
+End Sub")
                 SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupModule, StandardGlyphItem.GlyphItemFriend)
                 Assert.Equal(0, _aggregator.GetItems("New").Count)
                 Dim item = _aggregator.GetItems("Program").Single
@@ -566,7 +748,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestStartStopSanity() As Task
             ' Verify that multiple calls to start/stop don't blow up
-            Using worker = Await SetupWorkspaceAsync("Public Class Foo", "End Class")
+            Using worker = Await SetupWorkspaceAsync("Public Class Foo
+End Class")
                 ' Do one query
                 Assert.Single(_aggregator.GetItems("Foo"))
                 _provider.StopSearch()
@@ -582,7 +765,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
         Public Async Function TestDescriptionItems() As Task
-            Using workspace = Await SetupWorkspaceAsync("", "Public Class Foo", "End Class")
+            Using workspace = Await SetupWorkspaceAsync("
+Public Class Foo
+End Class")
                 Dim item As NavigateToItem = _aggregator.GetItems("F").Single()
                 Dim itemDisplay As INavigateToItemDisplay = item.DisplayFactory.CreateItemDisplay(item)
 

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
         Private _aggregator As NavigateToTestAggregator
 
         Private Async Function SetupWorkspaceAsync(ParamArray lines As String()) As Task(Of TestWorkspace)
-            Dim workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines)
+            Dim workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, lines))
             SetupNavigateTo(workspace)
             Return workspace
         End Function

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -79,7 +79,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
             Dim position As Integer = Nothing
             MarkupTestFile.GetPosition(markup, code, position)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync({code}, Nothing, metadataReferences)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code, Nothing, metadataReferences:=metadataReferences)
                 Await TestSharedAsync(workspace, position, expectedResults)
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Squiggles/ErrorSquiggleProducerTests.vb
@@ -16,13 +16,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Squiggles
         Inherits AbstractSquiggleProducerTests
 
         Private Async Function ProduceSquiggles(ParamArray lines As String()) As Task(Of IEnumerable(Of ITagSpan(Of IErrorTag)))
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, lines))
                 Return (Await GetDiagnosticsAndErrorSpans(workspace)).Item2
             End Using
         End Function
 
         Private Async Function ProduceSquiggles(analyzerMap As Dictionary(Of String, DiagnosticAnalyzer()), ParamArray lines As String()) As Task(Of IEnumerable(Of ITagSpan(Of IErrorTag)))
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(lines)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Join(Environment.NewLine, lines))
                 Return (Await GetDiagnosticsAndErrorSpans(workspace, analyzerMap)).Item2
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/TextStructureNavigation/TextStructureNavigatorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TextStructureNavigation/TextStructureNavigatorTests.vb
@@ -228,7 +228,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TextStructureNavig
             start As Integer,
             length As Integer) As Task
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
                 Dim buffer = workspace.Documents.First().GetTextBuffer()
 
                 Dim provider = New TextStructureNavigatorProvider(

--- a/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
@@ -178,7 +178,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TodoComment
             Dim list As IList(Of TextSpan) = Nothing
             MarkupTestFile.GetSpans(codeWithMarker.NormalizedValue, code, list)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code)
                 Dim commentTokens = New TodoCommentTokens()
                 Dim provider = New TodoCommentIncrementalAnalyzerProvider(commentTokens)
                 Dim worker = DirectCast(provider.CreateIncrementalAnalyzer(workspace), TodoCommentIncrementalAnalyzer)

--- a/src/VisualStudio/CSharp/Test/Debugging/DataTipInfoGetterTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/DataTipInfoGetterTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
 
         private async Task TestSpanGetterAsync(string markup, Func<Document, int, TextSpan?, Task> continuation)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(markup))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markup))
             {
                 var testHostDocument = workspace.Documents.Single();
                 var position = testHostDocument.CursorPosition.Value;

--- a/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/LocationInfoGetterTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
     {
         private async Task TestAsync(string markup, string expectedName, int expectedLineOffset, CSharpParseOptions parseOptions = null)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(new[] { markup }, parseOptions))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markup, parseOptions))
             {
                 var testDocument = workspace.Documents.Single();
                 var position = testDocument.CursorPosition.Value;

--- a/src/VisualStudio/CSharp/Test/Debugging/NameResolverTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/NameResolverTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
     {
         private async Task TestAsync(string text, string searchText, params string[] expectedNames)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(text))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(text))
             {
                 var nameResolver = new BreakpointResolver(workspace.CurrentSolution, searchText);
                 var results = await nameResolver.DoAsync(CancellationToken.None);
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Debugging
         [Fact, Trait(Traits.Feature, Traits.Features.DebuggingNameResolver)]
         public async Task TestCSharpLanguageDebugInfoCreateNameResolver()
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(" "))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(" "))
             {
                 var debugInfo = new CSharpBreakpointResolutionService();
                 var results = await debugInfo.ResolveBreakpointsAsync(workspace.CurrentSolution, "foo", CancellationToken.None);

--- a/src/VisualStudio/CSharp/Test/Debugging/ProximityExpressionsGetterTests.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/ProximityExpressionsGetterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             Console.WriteLine(typeof(FactAttribute));
 
             var text = Resources.ProximityExpressionsGetterTestFile;
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(text))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(text))
             {
                 var languageDebugInfo = new CSharpLanguageDebugInfoService();
 
@@ -124,7 +124,7 @@ namespace ConsoleApplication1
             string markup,
             Func<CSharpProximityExpressionsService, Document, int, Task> continuation)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(markup))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markup))
             {
                 var testDocument = workspace.Documents.Single();
                 var caretPosition = testDocument.CursorPosition.Value;

--- a/src/VisualStudio/CSharp/Test/Debugging/ProximityExpressionsGetterTests_Caching.cs
+++ b/src/VisualStudio/CSharp/Test/Debugging/ProximityExpressionsGetterTests_Caching.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
     {
         private async Task TestCachingAsync(string markup, params string[][] expectedArray)
         {
-            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(markup))
+            using (var workspace = await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(markup))
             {
                 var testDocument = workspace.Documents.Single();
                 var spans = testDocument.AnnotatedSpans;

--- a/src/VisualStudio/Core/Test/Debugging/DataTipInfoGetterTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/DataTipInfoGetterTests.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debuggin
         End Function
 
         Private Async Function TestSpanGetterAsync(parsedInput As String, position As Integer, continuation As Func(Of Document, Integer, Task)) As Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(parsedInput)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(parsedInput)
                 Dim debugInfo = New VisualBasicLanguageDebugInfoService()
                 Await continuation(workspace.CurrentSolution.Projects.First.Documents.First, position)
             End Using

--- a/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/LocationInfoGetterTests.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debuggin
             Dim position As Integer
             MarkupTestFile.GetPosition(text, text, position)
             Dim compilationOptions = If(rootNamespace IsNot Nothing, New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, rootNamespace:=rootNamespace), Nothing)
-            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceFromLinesAsync(LanguageNames.VisualBasic, compilationOptions, parseOptions, text)
+            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceFromFileAsync(LanguageNames.VisualBasic, compilationOptions, parseOptions, text)
                 Dim locationInfo = Await LocationInfoGetter.GetInfoAsync(
                     workspace.CurrentSolution.Projects.Single().Documents.Single(),
                     position,

--- a/src/VisualStudio/Core/Test/Debugging/NameResolverTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/NameResolverTests.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debuggin
         Private Async Function TestWithRootNamespaceAsync(rootNamespace As String, text As String, searchText As String, ParamArray expectedNames() As String) As Tasks.Task
             Dim compilationOptions = If(rootNamespace Is Nothing, Nothing, New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, rootNamespace:=rootNamespace))
 
-            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceFromLinesAsync(LanguageNames.VisualBasic, compilationOptions, Nothing, text)
+            Using workspace = Await TestWorkspaceFactory.CreateWorkspaceFromFileAsync(LanguageNames.VisualBasic, compilationOptions, Nothing, text)
                 Dim nameResolver = New BreakpointResolver(workspace.CurrentSolution, searchText)
                 Dim results = Await nameResolver.DoAsync(CancellationToken.None)
 

--- a/src/VisualStudio/Core/Test/Debugging/ProximityExpressionsGetterTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/ProximityExpressionsGetterTests.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debuggin
         ''' </summary>
         Public Async Function GenerateBaselineAsync() As Task
             Dim text = Resources.ProximityExpressionsGetterTestFile
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(text)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(text)
                 Dim languageDebugInfo = New VisualBasicLanguageDebugInfoService()
 
                 Dim hostdoc = workspace.Documents.First()
@@ -132,7 +132,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debuggin
 
         Private Async Function TestProximityExpressionsGetterAsync(markup As String,
                                                    continuation As Func(Of VisualBasicProximityExpressionsService, Document, Integer, Task)) As Task
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(markup)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(markup)
                 Dim testDocument = workspace.Documents.Single()
                 Dim snapshot = testDocument.TextBuffer.CurrentSnapshot
                 Dim caretPosition = testDocument.CursorPosition.Value
@@ -213,7 +213,7 @@ End Module</text>.Value, "local", True)
             Dim caretPosition As Integer
             MarkupTestFile.GetPosition(input, parsedInput, caretPosition)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(parsedInput)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(parsedInput)
                 Dim service = New VisualBasicProximityExpressionsService()
                 Dim hostdoc = workspace.Documents.First()
                 Dim snapshot = hostdoc.TextBuffer.CurrentSnapshot

--- a/src/VisualStudio/Core/Test/Debugging/VisualBasicBreakpointResolutionServiceTests.vb
+++ b/src/VisualStudio/Core/Test/Debugging/VisualBasicBreakpointResolutionServiceTests.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debuggin
             Dim source As String = Nothing
             MarkupTestFile.GetPositionAndSpan(markup.NormalizedValue, source, position, expectedSpan)
 
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(source)
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(source)
                 Dim document = workspace.CurrentSolution.Projects.First.Documents.First
                 Dim result As BreakpointResolutionResult = Await VisualBasicBreakpointResolutionService.GetBreakpointAsync(document, position.Value, length, CancellationToken.None)
                 Assert.True(expectedSpan.Value = result.TextSpan,

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
     Public Class DiagnosticTableDataSourceTests
         <Fact>
         Public Async Function TestCreation() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim provider = New TestDiagnosticService()
                 Dim tableManagerProvider = New TestTableManagerProvider()
 
@@ -56,7 +56,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestInitialEntries() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim provider = New TestDiagnosticService(CreateItem(workspace, documentId))
                 Dim tableManagerProvider = New TestTableManagerProvider()
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestEntryChanged() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim provider = New TestDiagnosticService()
                 Dim tableManagerProvider = New TestTableManagerProvider()
@@ -100,7 +100,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -141,7 +141,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestSnapshotEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -189,7 +189,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestInvalidEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -219,7 +219,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestNoHiddenEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId, DiagnosticSeverity.Error)
@@ -246,7 +246,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestProjectEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim projectId = workspace.CurrentSolution.Projects.First().Id
 
                 Dim item = CreateItem(workspace, projectId, Nothing, DiagnosticSeverity.Error)
@@ -272,8 +272,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestMultipleWorkspace() As Task
-            Using workspace1 = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
-                Using workspace2 = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace1 = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
+                Using workspace2 = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                     Dim documentId = workspace1.CurrentSolution.Projects.First().DocumentIds.First()
                     Dim projectId = documentId.ProjectId
 
@@ -307,7 +307,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <WpfFact>
         Public Async Function TestDetailExpander() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -344,7 +344,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestHyperLink() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -376,7 +376,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestBingHyperLink() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -408,7 +408,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestHelpLink() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -437,7 +437,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestHelpKeyword() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -466,7 +466,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestBingHelpLink() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -495,7 +495,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestBingHelpLink_NoCustomType() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync("class A { int 111a; }")
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync("class A { int 111a; }")
                 Dim diagnostic = (Await workspace.CurrentSolution.Projects.First().GetCompilationAsync()).GetDiagnostics().First(Function(d) d.Id = "CS1519")
 
                 Dim helpMessage = diagnostic.GetBingHelpMessage(workspace)
@@ -512,7 +512,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestErrorSource() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -541,7 +541,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestWorkspaceDiagnostic() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 
@@ -571,7 +571,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestProjectDiagnostic() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim projectId = documentId.ProjectId
 

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
     Public Class ExternalDiagnosticUpdateSourceTests
         <Fact>
         Public Async Function TestExternalDiagnostics_SupportGetDiagnostics() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim waiter = New Waiter()
                 Dim service = New TestDiagnosticAnalyzerService()
                 Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, New MockDiagnosticUpdateSourceRegistrationService(), waiter)
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestExternalDiagnostics_RaiseEvents() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim waiter = New Waiter()
                 Dim service = New TestDiagnosticAnalyzerService()
                 Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, New MockDiagnosticUpdateSourceRegistrationService(), waiter)
@@ -55,7 +55,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestExternalDiagnostics_DuplicatedError() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim waiter = New Waiter()
 
                 Dim project = workspace.CurrentSolution.Projects.First()
@@ -80,7 +80,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestBuildStartEvent() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim waiter = New Waiter()
 
                 Dim project = workspace.CurrentSolution.Projects.First()
@@ -120,7 +120,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Assert.True(DiagnosticData.PropertiesForBuildDiagnostic.TryGetValue(WellKnownDiagnosticPropertyNames.Origin, value))
             Assert.Equal(WellKnownDiagnosticTags.Build, value)
 
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim project = workspace.CurrentSolution.Projects.First()
 
                 Dim diagnostic = GetDiagnosticData(workspace, project.Id, isBuildDiagnostic:=True)

--- a/src/VisualStudio/Core/Test/Diagnostics/MiscDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/MiscDiagnosticUpdateSourceTests.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Dim code = <code>
 class 123 { }
                        </code>
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code.ToString())
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code.ToString())
                 Dim miscService = New MiscellaneousDiagnosticAnalyzerService(
                     New TestDiagnosticAnalyzerService(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap()),
                     New MockDiagnosticUpdateSourceRegistrationService())
@@ -67,7 +67,7 @@ class 123 { }
             Dim code = <code>
 class 123 { }
                        </code>
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(code.ToString())
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(code.ToString())
                 Dim miscService = New MiscellaneousDiagnosticAnalyzerService(
                     New TestDiagnosticAnalyzerService(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap()),
                     New MockDiagnosticUpdateSourceRegistrationService())
@@ -92,7 +92,7 @@ class 123 { }
 Class 123
 End Class
                        </code>
-            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromLinesAsync(code.ToString())
+            Using workspace = Await VisualBasicWorkspaceFactory.CreateWorkspaceFromFileAsync(code.ToString())
                 Dim miscService = New MiscellaneousDiagnosticAnalyzerService(
                     New TestDiagnosticAnalyzerService(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap()),
                     New MockDiagnosticUpdateSourceRegistrationService())

--- a/src/VisualStudio/Core/Test/Diagnostics/TodoListTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/TodoListTableDataSourceTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
     Public Class TodoListTableDataSourceTests
         <Fact>
         Public Async Function TestCreation() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim provider = New TestTodoListProvider()
                 Dim tableManagerProvider = New TestTableManagerProvider()
 
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestInitialEntries() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim provider = New TestTodoListProvider(CreateItem(workspace, documentId))
                 Dim tableManagerProvider = New TestTableManagerProvider()
@@ -67,7 +67,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestEntryChanged() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
                 Dim provider = New TestTodoListProvider()
                 Dim tableManagerProvider = New TestTableManagerProvider()
@@ -92,7 +92,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -133,7 +133,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestSnapshotEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -181,7 +181,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestSnapshotTranslateTo() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -211,7 +211,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestSnapshotTranslateTo2() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -244,7 +244,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestSnapshotTranslateTo3() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)
@@ -277,7 +277,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
         <Fact>
         Public Async Function TestInvalidEntry() As Task
-            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromLinesAsync(String.Empty)
+            Using workspace = Await CSharpWorkspaceFactory.CreateWorkspaceFromFileAsync(String.Empty)
                 Dim documentId = workspace.CurrentSolution.Projects.First().DocumentIds.First()
 
                 Dim item = CreateItem(workspace, documentId)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxTreeExtensions.cs
@@ -236,6 +236,5 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return syntaxTree.GetRoot(cancellationToken).FindTokenOnLeftOfPosition(
                 position, includeSkipped, includeDirectives, includeDocumentationComments);
         }
-
     }
 }


### PR DESCRIPTION
THese helpers were used to make VB workspace construction easier when VB didn't have
an easy way to make multi-line strings.

Now htat VB can make multi-line strings, we no longer need these entrypoints.