### PR TITLE
Add ability to opt in and opt out of nullability warnings

### DIFF
--- a/docs/features/NullableReferenceTypes/ImplementationNotes.md
+++ b/docs/features/NullableReferenceTypes/ImplementationNotes.md
@@ -115,3 +115,56 @@ namespace System.Runtime.CompilerServices
     }
 }
 ```
+
+
+**Opting in and opting out of nullability warnings**
+
+It is possible to suppress all nulability warnings originating from declarations in certain referenced 
+assembly by applying the following attribute:
+```
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Opt out of nullability warnings that could originate from definitions in the given assembly. 
+    /// The attribute is not preserved in metadata and ignored if present in metadata.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Module, AllowMultiple = true)]
+    class NullableOptOutForAssemblyAttribute : Attribute
+    {
+        /// <param name=""assemblyName"">An assembly name - a simple name plus its PublicKey, if any.""/></param>
+        public NullableOptOutForAssemblyAttribute(string assemblyName) { }
+    }
+}
+``` 
+
+It is possible to apply the following attribute to a declaration itself in order to opt in or opt out all consumers 
+from nullability warnings originating from the declaration. 
+The attribute can be applied to a module, type, method, event, field or property. The closest attribute application wins. 
+If nullable reference types feature is enabled, the warnings are opted into on the module level by default, i.e.
+explicit attribute application is not needed in this case.
+When a method definition is opted out of the warnings, nullablility warnings in its method body are also suppressed.
+
+```
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Opt-out or opt into nullability warnings that could originate from source code and definition(s) ...
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Module | // in this module. If nullable reference types feature is enabled, the warnings are opted into on the module level by default
+                    AttributeTargets.Class | // in this class
+                    AttributeTargets.Constructor | // of this constructor
+                    AttributeTargets.Delegate | // of this delegate
+                    AttributeTargets.Event | // of this event
+                    AttributeTargets.Field | // of this field
+                    AttributeTargets.Interface | // in this interface
+                    AttributeTargets.Method | // of this method
+                    AttributeTargets.Property | // of this property
+                    AttributeTargets.Struct, // in this structure
+                    AllowMultiple = false)]
+    class NullableOptOutAttribute : Attribute
+    {
+        public NullableOptOutAttribute(bool flag = true) { }
+    }
+}
+```
+

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -527,8 +527,13 @@
     <Compile Include="Symbols\Attributes\PEAttributeData.cs" />
     <Compile Include="Symbols\Attributes\RetargetingAttributeData.cs" />
     <Compile Include="Symbols\Attributes\SourceAttributeData.cs" />
+    <Compile Include="Symbols\Attributes\WellKnownAttributeData\EventWellKnownAttributeData.cs" />
+    <Compile Include="Symbols\Attributes\WellKnownAttributeData\FieldWellKnownAttributeData.cs" />
+    <Compile Include="Symbols\Attributes\WellKnownAttributeData\MethodWellKnownAttributeData.cs" />
+    <Compile Include="Symbols\Attributes\WellKnownAttributeData\ModuleWellKnownAttributeData.cs" />
     <Compile Include="Symbols\Attributes\WellKnownAttributeData\ParameterEarlyWellKnownAttributeData.cs" />
     <Compile Include="Symbols\Attributes\WellKnownAttributeData\PropertyEarlyWellKnownAttributeData.cs" />
+    <Compile Include="Symbols\Attributes\WellKnownAttributeData\PropertyWellKnownAttributeData.cs" />
     <Compile Include="Symbols\Attributes\WellKnownAttributeData\TypeWellKnownAttributeData.cs" />
     <Compile Include="Symbols\BaseTypeAnalysis.cs" />
     <Compile Include="Symbols\ByRefReturnErrorTypeSymbol.cs" />

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2908,10 +2908,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(!(symbol is TypeSymbol));
 
-            // We don't support nullable annotations in metadata yet.
-            // So, we'll ignore them for symbols defined in other modules/assemblies.
-            // This is probably not always accurate when generic instantiations are involved, but is a good starting point.
-            return (object)symbol.ContainingModule == this.SourceModule && symbol.IsDefinition;
+            var symbolContainingModule = symbol.ContainingModule;
+
+            // TODO: This is probably not always accurate when generic instantiations are involved, but is a good starting point.
+            if ((object)symbolContainingModule != null && symbolContainingModule.UtilizesNullableReferenceTypes && symbol.IsDefinition)
+            {
+                var symbolContainingAssembly = symbolContainingModule.ContainingAssembly;
+
+                return (object)symbolContainingAssembly != null && !((SourceModuleSymbol)SourceModule).IsNullableOptOutForAssembly(symbolContainingAssembly);
+            }
+
+            return false;
         }
 
         private class SymbolSearcher

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2915,7 +2915,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var symbolContainingAssembly = symbolContainingModule.ContainingAssembly;
 
-                return (object)symbolContainingAssembly != null && !((SourceModuleSymbol)SourceModule).IsNullableOptOutForAssembly(symbolContainingAssembly);
+                return (object)symbolContainingAssembly != null && !((SourceModuleSymbol)SourceModule).IsNullableOptOutForAssembly(symbolContainingAssembly) &&
+                       !symbol.NullableOptOut;
             }
 
             return false;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -322,7 +322,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 walker._convertInsufficientExecutionStackExceptionToCancelledByStackGuardException = true;
 
-                if ((node.SyntaxTree.Options as CSharpParseOptions)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true)
+                if ((node.SyntaxTree.Options as CSharpParseOptions)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
+                    !member.NullableOptOut)
                 {
                     walker._performStaticNullChecks = true;
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -2994,10 +2994,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool RespectNullableAnnotations(Symbol symbol)
         {
-            Debug.Assert(!(symbol is TypeSymbol));
-
-            // TODO: This is probably not always accurate when generic instantiations are involved, but is a good starting point.
-            return symbol.ContainingModule.UtilizesNullableReferenceTypes && symbol.IsDefinition; 
+            return compilation.RespectNullableAnnotations(symbol); 
         }
 
         protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method, ParameterSymbol parameter)

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -620,6 +620,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 case SymbolKind.NetModule:
                     // Note that DefaultCharSetAttribute is emitted to metadata, although it's also decoded and used when emitting P/Invoke
+
+                    if (IsTargetAttribute(target, AttributeDescription.NullableOptOutForAssemblyAttribute))
+                    {
+                        return false;
+                    }
                     break;
 
                 case SymbolKind.NamedType:

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/EventWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/EventWellKnownAttributeData.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class EventWellKnownAttributeData : CommonEventWellKnownAttributeData
+    {
+        #region NullableOptOutAttribute
+
+        private bool? _nullableOptOut;
+        public bool? NullableOptOut
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableOptOut;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableOptOut = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/FieldWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/FieldWellKnownAttributeData.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class FieldWellKnownAttributeData : CommonFieldWellKnownAttributeData
+    {
+        #region NullableOptOutAttribute
+
+        private bool? _nullableOptOut;
+        public bool? NullableOptOut
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableOptOut;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableOptOut = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class MethodWellKnownAttributeData : CommonMethodWellKnownAttributeData
+    {
+        #region NullableOptOutAttribute
+
+        private bool? _nullableOptOut;
+        public bool? NullableOptOut
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableOptOut;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableOptOut = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ModuleWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ModuleWellKnownAttributeData.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class ModuleWellKnownAttributeData : CommonModuleWellKnownAttributeData
+    {
+        #region NullableOptOutAttribute
+
+        private bool? _nullableOptOut;
+        public bool? NullableOptOut
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableOptOut;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableOptOut = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class PropertyWellKnownAttributeData : CommonPropertyWellKnownAttributeData
+    {
+        #region NullableOptOutAttribute
+
+        private bool? _nullableOptOut;
+        public bool? NullableOptOut
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableOptOut;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableOptOut = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownAttributeData.cs
@@ -32,5 +32,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         #endregion
+
+        #region NullableOptOutAttribute
+
+        private bool? _nullableOptOut;
+        public bool? NullableOptOut
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableOptOut;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableOptOut = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -85,6 +85,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasSpecialName { get; }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return ContainingType?.NullableOptOut == true;
+            }
+        }
+
         /// <summary>
         /// Gets the attributes on event's associated field, if any.
         /// Returns an empty <see cref="ImmutableArray&lt;AttributeData&gt;"/> if

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -157,6 +157,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract ConstantValue GetConstantValue(ConstantFieldsInProgress inProgress, bool earlyDecodingWellKnownAttributes);
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+
+                var associatedSymbol = AssociatedSymbol;
+                if ((object)associatedSymbol != null)
+                {
+                    switch (associatedSymbol.Kind)
+                    {
+                        case SymbolKind.Property:
+                        case SymbolKind.Event:
+                            return associatedSymbol.NullableOptOut;
+                    }
+
+                }
+
+                return ContainingType?.NullableOptOut == true;
+            }
+        }
+
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -151,6 +151,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Returns value 'Local' of the <see cref="SymbolKind"/>
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -465,5 +465,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get { return null; }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var moduleSymbol = _containingType.ContainingPEModule;
+                bool optOut;
+
+                return moduleSymbol.Module.HasNullableOptOutAttribute(_handle, out optOut) ? optOut : base.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -507,5 +507,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get { return null; }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var moduleSymbol = _containingType.ContainingPEModule;
+                bool optOut;
+
+                return moduleSymbol.Module.HasNullableOptOutAttribute(_handle, out optOut) ? optOut : base.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -682,6 +682,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var moduleSymbol = _containingType.ContainingPEModule;
+                bool optOut;
+
+                return moduleSymbol.Module.HasNullableOptOutAttribute(_handle, out optOut) ? optOut : base.NullableOptOut;
+            }
+        }
+
         public override ImmutableArray<Location> Locations => _containingType.ContainingPEModule.MetadataLocation.Cast<MetadataLocation, Location>();
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -690,5 +690,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return Module.UtilizesNullableReferenceTypes();
             }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                bool optOut;
+                return _module.HasNullableOptOutAttribute(EntityHandle.ModuleDefinition, out optOut) ? optOut : base.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -1930,6 +1930,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                bool optOut;
+
+                return this.ContainingPEModule.Module.HasNullableOptOutAttribute(_handle, out optOut) ? optOut : base.NullableOptOut;
+            }
+        }
+
         internal override bool IsComImport
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -659,5 +659,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get { return null; }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var moduleSymbol = _containingType.ContainingPEModule;
+                bool optOut;
+
+                return moduleSymbol.Module.HasNullableOptOutAttribute(_handle, out optOut) ? optOut : base.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -938,6 +938,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree);
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+
+                switch (MethodKind)
+                {
+                    case MethodKind.PropertyGet:
+                    case MethodKind.PropertySet:
+                    case MethodKind.EventAdd:
+                    case MethodKind.EventRemove:
+                        var propertyOrEvent = AssociatedSymbol;
+                        if ((object)propertyOrEvent != null)
+                        {
+                            return propertyOrEvent.NullableOptOut;
+                        }
+                        break;
+                }
+
+                return ContainingType?.NullableOptOut == true;
+            }
+        }
+
         #region IMethodSymbol Members
 
         MethodKind IMethodSymbol.MethodKind

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -197,6 +197,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                // We are in by default.
+                return false;
+            }
+        }
+
         /// <summary>
         /// Returns an array of assembly identities for assemblies referenced by this module.
         /// Items at the same position from ReferencedAssemblies and from ReferencedAssemblySymbols 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1196,6 +1196,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+
+                var container = ContainingType;
+
+                if ((object)container != null)
+                {
+                    return container.NullableOptOut;
+                }
+
+                return ContainingModule?.NullableOptOut == true;
+            }
+        }
+
         /// <summary>
         /// Marshalling charset of string data fields within the type (string formatting flags in metadata).
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -216,6 +216,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract ConstantValue ExplicitDefaultConstantValue { get; }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return ContainingSymbol?.NullableOptOut == true;
+            }
+        }
+
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -143,6 +143,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasSpecialName { get; }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return ContainingType?.NullableOptOut == true;
+            }
+        }
+
         /// <summary>
         /// The 'get' accessor of the property, or null if the property is write-only.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingEventSymbol.cs
@@ -323,5 +323,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get { return null; }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                return _underlyingEvent.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingFieldSymbol.cs
@@ -287,5 +287,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get { return null; }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                return _underlyingField.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingMethodSymbol.cs
@@ -577,5 +577,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             // retargeting symbols refer to a symbol from another compilation, they don't define locals in the current compilation
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                return _underlyingMethod.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -292,5 +292,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get { return null; }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                return _underlyingModule.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -569,5 +569,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             return _underlyingType.GetGuidString(out guidString);
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                return _underlyingType.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingPropertySymbol.cs
@@ -391,5 +391,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get { return null; }
         }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                return _underlyingProperty.NullableOptOut;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -628,7 +628,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if ((object)info != null)
                 {
-                    diagnostics.Add(info, Location.None);
+                    diagnostics.Add(info, NoLocation.Singleton);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonEventWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        internal EventWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 attributesBag = this.GetAttributesBag();
             }
 
-            return (CommonEventWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            return (EventWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
         /// <summary>
@@ -283,7 +283,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
-                arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasSpecialNameAttribute = true;
+                arguments.GetOrCreateData<EventWellKnownAttributeData>().HasSpecialNameAttribute = true;
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableOptOutAttribute))
+            {
+                arguments.GetOrCreateData<EventWellKnownAttributeData>().NullableOptOut = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
             }
         }
 
@@ -293,6 +297,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data != null && data.HasSpecialNameAttribute;
+            }
+        }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableOptOut ?? base.NullableOptOut;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonFieldWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        internal FieldWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 attributesBag = this.GetAttributesBag();
             }
 
-            return (CommonFieldWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            return (FieldWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
         /// <summary>
@@ -311,11 +311,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
-                arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().HasSpecialNameAttribute = true;
+                arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NonSerializedAttribute))
             {
-                arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().HasNonSerializedAttribute = true;
+                arguments.GetOrCreateData<FieldWellKnownAttributeData>().HasNonSerializedAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.FieldOffsetAttribute))
             {
@@ -337,12 +337,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // Set field offset even if the attribute specifies an invalid value, so that
                     // post-validation knows that the attribute is applied and reports better errors.
-                    arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().SetFieldOffset(offset);
+                    arguments.GetOrCreateData<FieldWellKnownAttributeData>().SetFieldOffset(offset);
                 }
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
             {
-                MarshalAsAttributeDecoder<CommonFieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
+                MarshalAsAttributeDecoder<FieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.FixedBufferAttribute))
             {
@@ -362,6 +362,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 VerifyConstantValueMatches(attribute.DecodeDecimalConstantValue(), ref arguments);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableOptOutAttribute))
+            {
+                arguments.GetOrCreateData<FieldWellKnownAttributeData>().NullableOptOut = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
+            }
         }
 
         /// <summary>
@@ -373,7 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (!attrValue.IsBad)
             {
-                var data = arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>();
+                var data = arguments.GetOrCreateData<FieldWellKnownAttributeData>();
                 ConstantValue constValue;
 
                 if (this.IsConst)
@@ -425,7 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(_lazyCustomAttributesBag.IsDecodedWellKnownAttributeDataComputed);
             Debug.Assert(symbolPart == AttributeLocation.None);
 
-            var data = (CommonFieldWellKnownAttributeData)decodedData;
+            var data = (FieldWellKnownAttributeData)decodedData;
             int? fieldOffset = data != null ? data.Offset : null;
 
             if (fieldOffset.HasValue)
@@ -516,6 +520,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data != null ? data.Offset : null;
+            }
+        }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableOptOut ?? base.NullableOptOut;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -705,6 +705,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
+                                !overridingMember.NullableOptOut &&
                                 overridingMember.DeclaringCompilation?.RespectNullableAnnotations(overriddenMember) == true &&
                                 !overridingMemberType.Equals(overriddenMemberType, TypeSymbolEqualityOptions.SameType | TypeSymbolEqualityOptions.CompareNullableModifiersForReferenceTypes))
                             {
@@ -748,6 +749,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
+                                !overridingMember.NullableOptOut &&
                                 overridingMember.DeclaringCompilation?.RespectNullableAnnotations(overriddenMember) == true &&
                                 !overridingMemberType.Equals(overriddenMemberType, TypeSymbolEqualityOptions.SameType | TypeSymbolEqualityOptions.CompareNullableModifiersForReferenceTypes))
                             {
@@ -781,6 +783,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
                                 !overridingMember.IsImplicitlyDeclared && !overridingMember.IsAccessor() &&
+                                !overridingMember.NullableOptOut &&
                                 overridingMember.DeclaringCompilation?.RespectNullableAnnotations(overriddenMember) == true &&
                                 !MemberSignatureComparer.HaveSameReturnTypes(overridingMethod, overriddenMethod, TypeSymbolEqualityOptions.SameType | TypeSymbolEqualityOptions.CompareNullableModifiersForReferenceTypes))
                             {
@@ -790,6 +793,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
                             !overridingMember.IsImplicitlyDeclared && !overridingMember.IsAccessor() &&
+                            !overridingMember.NullableOptOut &&
                             overridingMember.DeclaringCompilation?.RespectNullableAnnotations(overriddenMember) == true)
                         {
                             ImmutableArray<ParameterSymbol> overridingParameters = overridingMember.GetParameters();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1054,7 +1054,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if (((CSharpParseOptions)implementation.Locations[0].SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
-                implementation.DeclaringCompilation?.RespectNullableAnnotations(definition) == true)
+                !implementation.NullableOptOut)
             {
                 ImmutableArray<ParameterSymbol> implementationParameters = implementation.Parameters;
                 ImmutableArray<ParameterSymbol> definitionParameters = definition.ConstructIfGeneric(implementation.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).Parameters;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonMethodWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        internal MethodWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -842,7 +842,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 attributesBag = this.GetAttributesBag();
             }
 
-            return (CommonMethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            return (MethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
         /// <summary>
@@ -1064,11 +1064,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (attribute.IsTargetAttribute(this, AttributeDescription.PreserveSigAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().SetPreserveSignature(arguments.Index);
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().SetPreserveSignature(arguments.Index);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.MethodImplAttribute))
             {
-                AttributeData.DecodeMethodImplAttribute<CommonMethodWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(ref arguments, MessageProvider.Instance);
+                AttributeData.DecodeMethodImplAttribute<MethodWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>(ref arguments, MessageProvider.Instance);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DllImportAttribute))
             {
@@ -1076,7 +1076,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasSpecialNameAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ConditionalAttribute))
             {
@@ -1084,11 +1084,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasSuppressUnmanagedCodeSecurityAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicSecurityMethodAttribute))
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasDynamicSecurityMethodAttribute = true;
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasDynamicSecurityMethodAttribute = true;
             }
             else if (VerifyObsoleteAttributeAppliedToMethod(ref arguments, AttributeDescription.ObsoleteAttribute))
             {
@@ -1109,12 +1109,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     arguments.Diagnostics.Add(ErrorCode.ERR_SecurityCriticalOrSecuritySafeCriticalOnAsync, arguments.AttributeSyntaxOpt.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
                 }
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableOptOutAttribute))
+            {
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().NullableOptOut = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
+            }
             else
             {
                 var compilation = this.DeclaringCompilation;
                 if (attribute.IsSecurityAttribute(compilation))
                 {
-                    attribute.DecodeSecurityAttribute<CommonMethodWellKnownAttributeData>(this, compilation, ref arguments);
+                    attribute.DecodeSecurityAttribute<MethodWellKnownAttributeData>(this, compilation, ref arguments);
                 }
             }
         }
@@ -1317,7 +1321,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!hasErrors)
             {
-                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().SetDllImport(
+                arguments.GetOrCreateData<MethodWellKnownAttributeData>().SetDllImport(
                     arguments.Index,
                     moduleName,
                     importName,
@@ -1422,6 +1426,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableOptOut ?? base.NullableOptOut;
+            }
+        }
+
         internal sealed override bool RequiresSecurityObject
         {
             get
@@ -1443,7 +1456,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override IEnumerable<Cci.SecurityAttribute> GetSecurityInformation()
         {
             var attributesBag = this.GetAttributesBag();
-            var wellKnownData = (CommonMethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            var wellKnownData = (MethodWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
             if (wellKnownData != null)
             {
                 SecurityWellKnownAttributeData securityData = wellKnownData.SecurityInformation;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -685,6 +685,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.True;
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableOptOutAttribute))
+            {
+                arguments.GetOrCreateData<TypeWellKnownAttributeData>().NullableOptOut = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
+            }
             else
             {
                 var compilation = this.DeclaringCompilation;
@@ -818,6 +822,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data != null && data.HasSpecialNameAttribute;
+            }
+        }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableOptOut ?? base.NullableOptOut;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -984,7 +984,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        private CommonPropertyWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        private PropertyWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -992,7 +992,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 attributesBag = this.GetAttributesBag();
             }
 
-            return (CommonPropertyWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            return (PropertyWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
         /// <summary>
@@ -1118,12 +1118,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
-                arguments.GetOrCreateData<CommonPropertyWellKnownAttributeData>().HasSpecialNameAttribute = true;
+                arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
             {
                 // DynamicAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableOptOutAttribute))
+            {
+                arguments.GetOrCreateData<PropertyWellKnownAttributeData>().NullableOptOut = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
             }
         }
 
@@ -1326,6 +1330,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private static BaseParameterListSyntax GetParameterListSyntax(BasePropertyDeclarationSyntax syntax)
         {
             return (syntax.Kind() == SyntaxKind.IndexerDeclaration) ? ((IndexerDeclarationSyntax)syntax).ParameterList : null;
+        }
+
+        internal override bool NullableOptOut
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableOptOut ?? base.NullableOptOut;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -824,6 +824,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// Is module/type/method/field/property/event/parameter definition opted out of nullable warnings. Not valid to call on non-definitions.
+        /// </summary>
+        internal virtual bool NullableOptOut
+        {
+            get
+            {
+                Debug.Assert(false);
+                return false;
+            }
+        }
+
         internal DiagnosticInfo GetUseSiteDiagnosticForSymbolOrContainingType()
         {
             var info = this.GetUseSiteDiagnostic();

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1043,6 +1043,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (((CSharpParseOptions)implementingMember.Locations[0].SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking) == true &&
                 !implementingMember.IsImplicitlyDeclared && !implementingMember.IsAccessor() &&
+                !implementingMember.NullableOptOut &&
                 implementingMember.DeclaringCompilation?.RespectNullableAnnotations(interfaceMember) == true)
             {
                 Symbol implementedMember;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -42,6 +42,25 @@ namespace System.Runtime.CompilerServices
         /// <param name=""assemblyName"">An assembly name - a simple name plus its PublicKey, if any.""/></param>
         public NullableOptOutForAssemblyAttribute(string assemblyName) { }
     }
+
+    /// <summary>
+    /// Opt-out or opt into nullability warnings that could originate from source code and definition(s) ...
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Module | // in this module. If nullable reference types feature is enabled, the warnings are opted into on the module level by default
+                    AttributeTargets.Class | // in this class
+                    AttributeTargets.Constructor | // of this constructor
+                    AttributeTargets.Delegate | // of this delegate
+                    AttributeTargets.Event | // of this event
+                    AttributeTargets.Field | // of this field
+                    AttributeTargets.Interface | // in this interface
+                    AttributeTargets.Method | // of this method
+                    AttributeTargets.Property | // of this property
+                    AttributeTargets.Struct, // in this structure
+                    AllowMultiple = false)]
+    class NullableOptOutAttribute : Attribute
+    {
+        public NullableOptOutAttribute(bool flag = true) { }
+    }
 }
 "; 
 
@@ -1207,6 +1226,50 @@ class B2 : A
         }
 
         [Fact]
+        public void Overriding_21()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    { 
+    }
+}
+
+abstract class A
+{
+    public abstract event System.Action<string> E1; 
+    public abstract event System.Action<string>? E2; 
+}
+
+class B1 : A
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override event System.Action<string?> E1 {add {} remove{}}
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override event System.Action<string> E2 {add {} remove{}}
+}
+
+class B2 : A
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override event System.Action<string?> E1; // 2
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override event System.Action<string> E2; // 2
+
+    void Dummy()
+    {
+        var e1 = E1;
+        var e2 = E2;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib(new[] { source, attributesDefinitions }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            compilation.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Implementing_01()
         {
             var source = @"
@@ -1493,6 +1556,53 @@ class B2 : A2
         }
 
         [Fact]
+        public void Overriding_22()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    { 
+    }
+}
+
+abstract class A1
+{
+    public abstract string?[] P1 {get; set;} 
+    public abstract string[] P2 {get; set;} 
+
+    public abstract string?[] this[int x] {get; set;} 
+    public abstract string[] this[short x] {get; set;} 
+}
+
+class B1 : A1
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override string[] P1 {get; set;} 
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override string[]? P2 {get; set;} 
+    
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override string[] this[int x] // 1
+    {
+        get {throw new System.NotImplementedException();}
+        set {}
+    } 
+    
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override string[]? this[short x] // 2
+    {
+        get {throw new System.NotImplementedException();}
+        set {}
+    } 
+}
+";
+            var compilation = CreateCompilationWithMscorlib(new[] { source, attributesDefinitions }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            compilation.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Implementing_03()
         {
             var source = @"
@@ -1733,6 +1843,43 @@ class B : A
         }
 
         [Fact]
+        public void Overriding_23()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    { 
+    }
+}
+
+abstract class A
+{
+    public abstract string[] M1(); 
+    public abstract T[] M2<T>() where T : class; 
+}
+
+class B : A
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override string?[] M1()
+    {
+        return new string?[] {};
+    } 
+
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override S?[] M2<S>()
+    {
+        return new S?[] {};
+    } 
+}
+";
+            var compilation = CreateCompilationWithMscorlib(new[] { source, attributesDefinitions }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            compilation.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Implementing_05()
         {
             var source = @"
@@ -1869,6 +2016,43 @@ class B : IA
         }
 
         [Fact]
+        public void Implementing_11()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    { 
+    }
+}
+
+interface IA
+{
+    string[] M1(); 
+    T[] M2<T>() where T : class; 
+}
+
+class B : IA
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    string?[] IA.M1()
+    {
+        return new string?[] {};
+    } 
+
+    [System.Runtime.CompilerServices.NullableOptOut]
+    S?[] IA.M2<S>() 
+    {
+        return new S?[] {};
+    } 
+}
+";
+            var compilation = CreateCompilationWithMscorlib(new[] { source, attributesDefinitions }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            compilation.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Overriding_19()
         {
             var source = @"
@@ -1923,6 +2107,41 @@ class B : A
             var m3 = b.GetMember<MethodSymbol>("M3");
             Assert.True(m3.Parameters[0].Type.Equals(m3.OverriddenMethod.ConstructIfGeneric(m3.TypeParameters.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations)).Parameters[0].Type,
                 TypeSymbolEqualityOptions.SameType | TypeSymbolEqualityOptions.CompareNullableModifiersForReferenceTypes));
+        }
+
+        [Fact]
+        public void Overriding_24()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    { 
+    }
+}
+
+abstract class A
+{
+    public abstract void M1(string[] x); 
+    public abstract void M2<T>(T[] x) where T : class; 
+}
+
+class B : A
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override void M1(string?[] x)
+    {
+    } 
+
+    [System.Runtime.CompilerServices.NullableOptOut]
+    public override void M2<T>(T?[] x)
+    {
+    } 
+}
+";
+            var compilation = CreateCompilationWithMscorlib(new[] { source, attributesDefinitions }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            compilation.VerifyDiagnostics();
         }
 
         [Fact]
@@ -2355,6 +2574,60 @@ partial class C1
 
             Assert.True(m1Impl.Parameters[3].Type.Equals(m1Def.Parameters[3].Type,
                 TypeSymbolEqualityOptions.SameType | TypeSymbolEqualityOptions.CompareNullableModifiersForReferenceTypes));
+        }
+
+        [Fact]
+        public void PartialMethods_02()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    { 
+    }
+}
+
+partial class C1
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    partial void M1<T>(T x, T?[] y, System.Action<T> z, System.Action<T?[]?>?[]? u) where T : class;
+}
+
+partial class C1
+{
+    partial void M1<T>(T? x, T[]? y, System.Action<T?> z, System.Action<T?[]?>?[]? u) where T : class
+    { }
+}";
+            var compilation = CreateCompilationWithMscorlib(new[] { source, attributesDefinitions }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            compilation.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void PartialMethods_03()
+        {
+            var source = @"
+class C
+{
+    public static void Main()
+    { 
+    }
+}
+
+partial class C1
+{
+    partial void M1<T>(T x, T?[] y, System.Action<T> z, System.Action<T?[]?>?[]? u) where T : class;
+}
+
+partial class C1
+{
+    [System.Runtime.CompilerServices.NullableOptOut]
+    partial void M1<T>(T? x, T[]? y, System.Action<T?> z, System.Action<T?[]?>?[]? u) where T : class
+    { }
+}";
+            var compilation = CreateCompilationWithMscorlib(new[] { source, attributesDefinitions }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"));
+
+            compilation.VerifyDiagnostics();
         }
 
         [Fact]
@@ -10851,6 +11124,1749 @@ class C
     // [module:System.Runtime.CompilerServices.NullableOptOutForAssembly("name3, Version=1")]
     Diagnostic(ErrorCode.WRN_InvalidAssemblyName, @"System.Runtime.CompilerServices.NullableOptOutForAssembly(""name3, Version=1"")").WithArguments("name3, Version=1").WithLocation(6, 9)
                 );
+        }
+
+        [Fact]
+        public void NullableOptOut_01()
+        {
+            string lib = @"
+using System;
+
+public class CL0 
+{
+    public class CL1 
+    {
+        public Action F1;
+        public Action? F2;
+
+        public Action P1 { get; set; }
+        public Action? P2 { get; set; }
+
+        public Action M1() { throw new System.NotImplementedException(); }
+        public Action? M2() { return null; }
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        public event Action E1;
+        public event Action? E2;
+
+        [System.Runtime.CompilerServices.NullableOptOut]
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut]
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut]
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut]
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut]
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut]
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_02()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(true)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+public class CL0 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(true)]
+    public class CL1 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action F1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? F2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action P1 { get; set; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? P2 { get; set; }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action M1() { throw new System.NotImplementedException(); }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? M2() { return null; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+
+partial class C 
+{
+
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action E1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action? E2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+partial class C 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(true)]
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(
+    // (18,18): warning CS8201: Possible null reference assignment.
+    //             E1 = x11;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+    // (24,19): hidden CS8207: Expression is probably never null.
+    //             x12 = E1 ?? x12;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x13 = E2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                );
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            var expected = new[] {
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                };
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
+        }
+
+        [Fact]
+        public void NullableOptOut_03()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(true)]
+";
+
+            string lib = @"
+using System;
+
+public class CL0 
+{
+    public class CL1 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action F1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? F2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action P1 { get; set; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? P2 { get; set; }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action M1() { throw new System.NotImplementedException(); }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? M2() { return null; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+
+partial class C 
+{
+
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action E1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action? E2;
+
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_04()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(false)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+public class CL0 
+{
+    public class CL1 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action F1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? F2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action P1 { get; set; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? P2 { get; set; }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action M1() { throw new System.NotImplementedException(); }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? M2() { return null; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action E1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action? E2;
+
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+partial class C 
+{
+    partial class B 
+    {
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_05()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(false)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+public class CL0 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(true)]
+    public class CL1 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action F1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? F2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action P1 { get; set; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? P2 { get; set; }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action M1() { throw new System.NotImplementedException(); }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public Action? M2() { return null; }
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action E1;
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        public event Action? E2;
+
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+partial class C 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(true)]
+    partial class B 
+    {
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_06()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(false)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+public class CL0 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(false)]
+    public class CL1 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public Action F1;
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public Action? F2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public Action P1 { get; set; }
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public Action? P2 { get; set; }
+
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public Action M1() { throw new System.NotImplementedException(); }
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public Action? M2() { return null; }
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+partial class C 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(false)]
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public event Action E1;
+        [System.Runtime.CompilerServices.NullableOptOut(true)]
+        public event Action? E2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_07()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(false)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+public class CL0 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(true)]
+    public class CL1 
+    {
+        public Action F1;
+        public Action? F2;
+
+        public Action P1 { get; set; }
+        public Action? P2 { get; set; }
+
+        public Action M1() { throw new System.NotImplementedException(); }
+        public Action? M2() { return null; }
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+partial class C 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(true)]
+    partial class B 
+    {
+        public event Action E1;
+        public event Action? E2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_08()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(false)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+public class CL0 
+{
+    public class CL1 
+    {
+        public Action F1;
+        public Action? F2;
+
+        public Action P1 { get; set; }
+        public Action? P2 { get; set; }
+
+        public Action M1() { throw new System.NotImplementedException(); }
+        public Action? M2() { return null; }
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+partial class C 
+{
+    partial class B 
+    {
+        public event Action E1;
+        public event Action? E2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_09()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(true)]
+";
+
+            string lib = @"
+using System;
+
+public class CL0 
+{
+    public class CL1 
+    {
+        public Action F1;
+        public Action? F2;
+
+        public Action P1 { get; set; }
+        public Action? P2 { get; set; }
+
+        public Action M1() { throw new System.NotImplementedException(); }
+        public Action? M2() { return null; }
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        public event Action E1;
+        public event Action? E2;
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+partial class C 
+{
+    partial class B 
+    {
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        [System.Runtime.CompilerServices.NullableOptOut(false)]
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableOptOut_10()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(true)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+public class CL0 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(false)]
+    public class CL1 
+    {
+        public Action F1;
+        public Action? F2;
+
+        public Action P1 { get; set; }
+        public Action? P2 { get; set; }
+
+        public Action M1() { throw new System.NotImplementedException(); }
+        public Action? M2() { return null; }
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+
+partial class C 
+{
+
+    partial class B 
+    {
+        
+        public event Action E1;
+        
+        public event Action? E2;
+
+        
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(true)]
+partial class C 
+{
+    [System.Runtime.CompilerServices.NullableOptOut(false)]
+    partial class B 
+    {
+        
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(
+    // (18,18): warning CS8201: Possible null reference assignment.
+    //             E1 = x11;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+    // (24,19): hidden CS8207: Expression is probably never null.
+    //             x12 = E1 ?? x12;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x13 = E2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                );
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            var expected = new[] {
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                };
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
+        }
+
+        [Fact]
+        public void NullableOptOut_11()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(true)]
+";
+
+            string lib = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+public class CL0 
+{
+    
+    public class CL1 
+    {
+        public Action F1;
+        public Action? F2;
+
+        public Action P1 { get; set; }
+        public Action? P2 { get; set; }
+
+        public Action M1() { throw new System.NotImplementedException(); }
+        public Action? M2() { return null; }
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+
+partial class C 
+{
+
+    partial class B 
+    {
+        
+        public event Action E1;
+        
+        public event Action? E2;
+
+        
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+[System.Runtime.CompilerServices.NullableOptOut(false)]
+partial class C 
+{
+    
+    partial class B 
+    {
+        
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(
+    // (18,18): warning CS8201: Possible null reference assignment.
+    //             E1 = x11;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+    // (24,19): hidden CS8207: Expression is probably never null.
+    //             x12 = E1 ?? x12;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x13 = E2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                );
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            var expected = new[] {
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                };
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
+        }
+
+        [Fact]
+        public void NullableOptOut_12()
+        {
+            string moduleAttributes = @"
+[module:System.Runtime.CompilerServices.NullableOptOut(false)]
+";
+
+            string lib = @"
+using System;
+
+
+public class CL0 
+{
+    
+    public class CL1 
+    {
+        public Action F1;
+        public Action? F2;
+
+        public Action P1 { get; set; }
+        public Action? P2 { get; set; }
+
+        public Action M1() { throw new System.NotImplementedException(); }
+        public Action? M2() { return null; }
+        public void M3(Action x3) {}
+    }
+}
+";
+
+            string source1 = @"
+using System;
+
+
+partial class C 
+{
+
+    partial class B 
+    {
+        
+        public event Action E1;
+        
+        public event Action? E2;
+
+        
+        void Test11(Action? x11)
+        {
+            E1 = x11;
+        }
+
+        
+        void Test12(Action x12)
+        {
+            x12 = E1 ?? x12;
+        }
+
+        
+        void Test13(Action x13)
+        {
+            x13 = E2;
+        }
+    }
+}
+";
+
+            string source2 = @"
+using System;
+
+
+partial class C 
+{
+    
+    partial class B 
+    {
+        
+        void Test21(CL0.CL1 c, Action? x21)
+        {
+            c.F1 = x21;
+            c.P1 = x21;
+            c.M3(x21);
+        }
+
+        
+        void Test22(CL0.CL1 c, Action x22)
+        {
+            x22 = c.F1 ?? x22;
+            x22 = c.P1 ?? x22;
+            x22 = c.M1() ?? x22;
+        }
+
+        
+        void Test23(CL0.CL1 c, Action x23)
+        {
+            x23 = c.F2;
+            x23 = c.P2;
+            x23 = c.M2();
+        }
+    }
+}
+";
+
+            CSharpCompilation c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib, source1, source2 },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(
+    // (18,18): warning CS8201: Possible null reference assignment.
+    //             E1 = x11;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(18, 18),
+    // (24,19): hidden CS8207: Expression is probably never null.
+    //             x12 = E1 ?? x12;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(24, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x13 = E2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "E2").WithLocation(30, 19),
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                );
+
+            CSharpCompilation c1 = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, lib },
+                                                                parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                                                options: TestOptions.ReleaseDll);
+
+            c1.VerifyDiagnostics();
+
+            var expected = new[] {
+    // (13,20): warning CS8201: Possible null reference assignment.
+    //             c.F1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(13, 20),
+    // (14,20): warning CS8201: Possible null reference assignment.
+    //             c.P1 = x21;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x21").WithLocation(14, 20),
+    // (15,18): warning CS8204: Possible null reference argument for parameter 'x3' in 'void CL1.M3(Action x3)'.
+    //             c.M3(x21);
+    Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x21").WithArguments("x3", "void CL1.M3(Action x3)").WithLocation(15, 18),
+    // (21,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.F1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.F1").WithLocation(21, 19),
+    // (22,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.P1 ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.P1").WithLocation(22, 19),
+    // (23,19): hidden CS8207: Expression is probably never null.
+    //             x22 = c.M1() ?? x22;
+    Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c.M1()").WithLocation(23, 19),
+    // (29,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.F2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.F2").WithLocation(29, 19),
+    // (30,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.P2;
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.P2").WithLocation(30, 19),
+    // (31,19): warning CS8201: Possible null reference assignment.
+    //             x23 = c.M2();
+    Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c.M2()").WithLocation(31, 19)
+                };
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.ToMetadataReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
+
+            c = CreateCompilationWithMscorlib(new[] { attributesDefinitions, moduleAttributes, source2 }, new[] { c1.EmitToImageReference() },
+                                              parseOptions: TestOptions.Regular.WithFeature("staticNullChecking", "true"),
+                                              options: TestOptions.ReleaseDll);
+
+            c.VerifyDiagnostics(expected);
         }
 
         [Fact(Skip = "TODO")]

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -72,6 +72,7 @@ namespace Microsoft.CodeAnalysis
         private delegate bool AttributeValueExtractor<T>(out T value, ref BlobReader sigReader);
         private static readonly AttributeValueExtractor<string> s_attributeStringValueExtractor = CrackStringInAttributeValue;
         private static readonly AttributeValueExtractor<StringAndInt> s_attributeStringAndIntValueExtractor = CrackStringAndIntInAttributeValue;
+        private static readonly AttributeValueExtractor<bool> s_attributeBooleanValueExtractor = CrackBooleanInAttributeValue;
         private static readonly AttributeValueExtractor<short> s_attributeShortValueExtractor = CrackShortInAttributeValue;
         private static readonly AttributeValueExtractor<int> s_attributeIntValueExtractor = CrackIntInAttributeValue;
         private static readonly AttributeValueExtractor<long> s_attributeLongValueExtractor = CrackLongInAttributeValue;
@@ -1474,6 +1475,18 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
+        internal static bool CrackBooleanInAttributeValue(out bool value, ref BlobReader sig)
+        {
+            if (sig.RemainingBytes >= 1)
+            {
+                value = sig.ReadBoolean();
+                return true;
+            }
+
+            value = false;
+            return false;
+        }
+
         internal static bool CrackByteInAttributeValue(out byte value, ref BlobReader sig)
         {
             if (sig.RemainingBytes >= 1)
@@ -2320,6 +2333,20 @@ namespace Microsoft.CodeAnalysis
             }
 
             return TryExtractBoolArrayValueFromAttribute(info.Handle, out nullableTransforms);
+        }
+
+        internal bool HasNullableOptOutAttribute(EntityHandle token, out bool value)
+        {
+            AttributeInfo info = FindTargetAttribute(token, AttributeDescription.NullableOptOutAttribute);
+            Debug.Assert(!info.HasValue || info.SignatureIndex == 0);
+
+            if (info.HasValue && TryExtractValueFromAttribute(info.Handle, out value, s_attributeBooleanValueExtractor))
+            {
+                return true;
+            }
+
+            value = false;
+            return false;
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -390,6 +390,7 @@ namespace Microsoft.CodeAnalysis
         };
 
         private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
+        private static readonly byte[][] s_signaturesOfNullableOptOutForAssemblyAttribute = { s_signature_HasThis_Void_String };
 
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
@@ -497,5 +498,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription AssemblyAlgorithmIdAttribute = new AttributeDescription("System.Reflection", "AssemblyAlgorithmIdAttribute", s_signaturesOfAssemblyAlgorithmIdAttribute);
         internal static readonly AttributeDescription DeprecatedAttribute = new AttributeDescription("Windows.Foundation.Metadata", "DeprecatedAttribute", s_signaturesOfDeprecatedAttribute);
         internal static readonly AttributeDescription NullableAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableAttribute", s_signaturesOfNullableAttribute);
+        internal static readonly AttributeDescription NullableOptOutForAssemblyAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableOptOutForAssemblyAttribute", s_signaturesOfNullableOptOutForAssemblyAttribute);
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -391,6 +391,7 @@ namespace Microsoft.CodeAnalysis
 
         private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
         private static readonly byte[][] s_signaturesOfNullableOptOutForAssemblyAttribute = { s_signature_HasThis_Void_String };
+        private static readonly byte[][] s_signaturesOfNullableOptOutAttribute = { s_signature_HasThis_Void_Boolean };
 
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
@@ -499,5 +500,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription DeprecatedAttribute = new AttributeDescription("Windows.Foundation.Metadata", "DeprecatedAttribute", s_signaturesOfDeprecatedAttribute);
         internal static readonly AttributeDescription NullableAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableAttribute", s_signaturesOfNullableAttribute);
         internal static readonly AttributeDescription NullableOptOutForAssemblyAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableOptOutForAssemblyAttribute", s_signaturesOfNullableOptOutForAssemblyAttribute);
+        internal static readonly AttributeDescription NullableOptOutAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableOptOutAttribute", s_signaturesOfNullableOptOutAttribute);
     }
 }


### PR DESCRIPTION
It is possible to suppress all nulability warnings originating from declarations in certain referenced 
assembly by applying the following attribute:
```
namespace System.Runtime.CompilerServices
{
    /// <summary>
    /// Opt out of nullability warnings that could originate from definitions in the given assembly. 
    /// The attribute is not preserved in metadata and ignored if present in metadata.
    /// </summary>
    [AttributeUsage(AttributeTargets.Module, AllowMultiple = true)]
    class NullableOptOutForAssemblyAttribute : Attribute
    {
        /// <param name=""assemblyName"">An assembly name - a simple name plus its PublicKey, if any.""/></param>
        public NullableOptOutForAssemblyAttribute(string assemblyName) { }
    }
}
``` 

It is possible to apply the following attribute to a declaration itself in order to opt in or opt out all consumers 
from nullability warnings originating from the declaration. 
The attribute can be applied to a module, type, method, event, field or property. The closest attribute application wins. 
If nullable reference types feature is enabled, the warnings are opted into on the module level by default, i.e.
explicit attribute application is not needed in this case.
When a method definition is opted out of the warnings, nullablility warnings in its method body are also suppressed.

```
namespace System.Runtime.CompilerServices
{
    /// <summary>
    /// Opt-out or opt into nullability warnings that could originate from source code and definition(s) ...
    /// </summary>
    [AttributeUsage(AttributeTargets.Module | // in this module. If nullable reference types feature is enabled, the warnings are opted into on the module level by default
                    AttributeTargets.Class | // in this class
                    AttributeTargets.Constructor | // of this constructor
                    AttributeTargets.Delegate | // of this delegate
                    AttributeTargets.Event | // of this event
                    AttributeTargets.Field | // of this field
                    AttributeTargets.Interface | // in this interface
                    AttributeTargets.Method | // of this method
                    AttributeTargets.Property | // of this property
                    AttributeTargets.Struct, // in this structure
                    AllowMultiple = false)]
    class NullableOptOutAttribute : Attribute
    {
        public NullableOptOutAttribute(bool flag = true) { }
    }
}
```

@dotnet/roslyn-compiler Please review.