### PR TITLE
don't assume a file uri is absolute

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ContainsChildrenGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ContainsChildrenGraphQuery.cs
@@ -53,9 +53,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                                 // even when its extension fails to say so. One option would be to call DTEWrapper.IsRegisteredForLangService,
                                 // which may not be called here however since deadlock could happen.
 
-                                string ext = Path.GetExtension(uri.AbsolutePath);
-                                if (!string.IsNullOrEmpty(ext) &&
-                                    (ext.Equals(".cs", StringComparison.OrdinalIgnoreCase) || ext.Equals(".vb", StringComparison.OrdinalIgnoreCase)))
+                                // The Uri returned by `GetNestedValueByName()` above isn't necessarily absolute and the `OriginalString` is
+                                // the only property that doesn't throw if the UriKind is relative, so `OriginalString` must be used instead
+                                // of `AbsolutePath`.
+                                string ext = Path.GetExtension(uri.OriginalString);
+                                if (ext.Equals(".cs", StringComparison.OrdinalIgnoreCase) || ext.Equals(".vb", StringComparison.OrdinalIgnoreCase))
                                 {
                                     graphBuilder.AddDeferredPropertySet(node, DgmlNodeProperties.ContainsChildren, false);
                                 }


### PR DESCRIPTION
_Fixes internal bug 165369._

We received customer feedback about a crash in VS that we weren't able to repro but contained a dump.  Examining the dump revealed that the error was the `AbsolutePath` property on `System.Uri` was being accessed on a relative (non-absolute) `Uri`.  Inspecting all `System.Uri` heap objects reported a number of items with relative paths which would have caused the exception seen in the dump.  See below for example `Uri`s extracted from the dump.

The fix is to instead use the `OriginalString` property on `System.Uri`, because that's the only property that's guaranteed not to throw on a relative `Uri`.  I've also confirmed that [`Path.GetExtension()`](http://referencesource.microsoft.com/#mscorlib/system/io/path.cs,f424e433705aeb09) will only ever return `null` if its parameter (`OriginalString`) is `null`, but the [`System.Uri` constructor](http://referencesource.microsoft.com/#System/net/System/URI.cs,d9fc45d783ee73ff,references) explicitly disallows this, so the `null` check was able to be removed.

**Example `Uri`s:**
- `file:///C:/WebApplication1/WebApplication1/WebApplication1.vbproj` // absolute
- `/C:/WebApplication1/WebApplication1/Startup.vb` // relative, and likely the cause of the crash

**Follow up:**
Contact other internal teams to inform them that they're mixing relative and absolute `Uri`s in the project system.

@dotnet/roslyn-ide