### PR TITLE
Remove # character from VSIX descriptions.

### DIFF
--- a/src/Samples/CSharp/ConvertToAutoProperty/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ConvertToAutoProperty/Impl/source.extension.vsixmanifest
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="ConvertToAutoPropertyRefactoring.Microsoft.a95ab02d-0f23-4c9a-a8d2-b29692654076" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Convert to Auto Property for C#</DisplayName>
+    <DisplayName>Convert to Auto Property for CSharp</DisplayName>
     <Description xml:space="preserve">This is a sample C# code refactoring that converts properties to auto-implemented properties using the .NET Compiler Platform ("Roslyn") SDK Preview.</Description>
   </Metadata>
   <Installation>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="ImplementNotifyPropertyChanged.4f1499c0-20db-4a1d-a357-819c30d74aaa" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Implement INotifyPropertyChanged for C#</DisplayName>
+    <DisplayName>Implement INotifyPropertyChanged for CSharp</DisplayName>
     <Description xml:space="preserve">This is a sample extension to implement INotifyPropertyChanged using the .NET Compiler Platform ("Roslyn") SDK Preview.</Description>
   </Metadata>
   <Installation>

--- a/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="MakeConstCS.Microsoft.601d632a-0bfd-4ef1-8d17-3bd25daec3f3" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Make Const for C#</DisplayName>
+    <DisplayName>Make Const for CSharp</DisplayName>
     <Description>This is a sample code issue extension for the Microsoft Roslyn CTP.</Description>
   </Metadata>
   <Installation>


### PR DESCRIPTION
These characters cause problems with MEF with how they make directory paths.
The bug in MEF will get fixed in Dev15.  However, in the meantime, this gives
us a workaround so that we stop getting mef corruption errors.