### PR TITLE
made metadatareference check in compilation tracker to actually work.

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReference/CompilationReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/CompilationReference.cs
@@ -4,13 +4,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
     /// Reference to another C# or VB compilation.
     /// </summary>
-    public abstract class CompilationReference : MetadataReference
+    public abstract class CompilationReference : MetadataReference, IEquatable<CompilationReference>
     {
         public Compilation Compilation { get { return CompilationCore; } }
         internal abstract Compilation CompilationCore { get; }
@@ -109,6 +110,38 @@ namespace Microsoft.CodeAnalysis
             {
                 return Compilation.AssemblyName;
             }
+        }
+
+        public bool Equals(CompilationReference other)
+        {
+            if (object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other == null)
+            {
+                return false;
+            }
+
+            // MetadataProperty implements value equality
+            return object.ReferenceEquals(this.Compilation, other.Compilation) && object.Equals(this.Properties, other.Properties);
+        }
+
+        public override bool Equals(object obj)
+        {
+            var compilation = obj as CompilationReference;
+            if (compilation == null)
+            {
+                return false;
+            }
+
+            return Equals(compilation);
+        }
+
+        public override int GetHashCode()
+        {
+            return Hash.Combine(this.Compilation.GetHashCode(), this.Properties.GetHashCode());
         }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReference/CompilationReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/CompilationReference.cs
@@ -114,29 +114,23 @@ namespace Microsoft.CodeAnalysis
 
         public bool Equals(CompilationReference other)
         {
-            if (object.ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
             if (other == null)
             {
                 return false;
             }
 
+            if (object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
             // MetadataProperty implements value equality
-            return object.ReferenceEquals(this.Compilation, other.Compilation) && object.Equals(this.Properties, other.Properties);
+            return object.Equals(this.Compilation, other.Compilation) && object.Equals(this.Properties, other.Properties);
         }
 
         public override bool Equals(object obj)
         {
-            var compilation = obj as CompilationReference;
-            if (compilation == null)
-            {
-                return false;
-            }
-
-            return Equals(compilation);
+            return Equals(obj as CompilationReference);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -699,3 +699,6 @@ static Microsoft.CodeAnalysis.Semantics.OperationExtensions.Descendants(this Mic
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.DescendantsAndSelf(this Microsoft.CodeAnalysis.Semantics.IOperation operation) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Semantics.IOperation>
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.GetRootOperation(this Microsoft.CodeAnalysis.ISymbol symbol, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.Semantics.IOperation
 Microsoft.CodeAnalysis.SyntaxNode.FindTrivia(int position, System.Func<Microsoft.CodeAnalysis.SyntaxTrivia, bool> stepInto) -> Microsoft.CodeAnalysis.SyntaxTrivia
+Microsoft.CodeAnalysis.CompilationReference.Equals(Microsoft.CodeAnalysis.CompilationReference other) -> bool
+override Microsoft.CodeAnalysis.CompilationReference.Equals(object obj) -> bool
+override Microsoft.CodeAnalysis.CompilationReference.GetHashCode() -> int

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -103,6 +103,7 @@
     <Compile Include="GeneratedCodeRecognitionTests.cs" />
     <Compile Include="WorkspaceTests\MSBuildWorkspaceTests.cs" />
     <Compile Include="WorkspaceTests\MSBuildWorkspaceTestBase.cs" />
+    <Compile Include="WorkspaceTests\WorkspaceReferenceTests.cs" />
     <Compile Include="WorkspaceTests\WorkspaceTestBase.cs" />
     <Compile Include="SolutionTests\ProjectDependencyGraphTests.cs" />
     <Compile Include="SolutionTests\ProjectInfoTests.cs" />

--- a/src/Workspaces/CoreTest/WorkspaceTests/WorkspaceReferenceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/WorkspaceReferenceTests.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
+{
+    public class WorkspaceReferenceTests
+    {
+        [Fact]
+        public async Task PEReferenceTest()
+        {
+            using (var ws = new AdhocWorkspace())
+            {
+                var projectInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp,
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var project = ws.AddProject(projectInfo);
+
+                // get original references
+                var compilation1 = await project.GetCompilationAsync();
+                var references1 = compilation1.ExternalReferences;
+
+                // change project
+                var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
+                var document = ws.AddDocument(info);
+
+                // get new compilation
+                var compilation2 = await document.Project.GetCompilationAsync();
+                var references2 = compilation2.ExternalReferences;
+
+                Assert.Equal(references1, references2);
+            }
+        }
+
+        [Fact]
+        public async Task P2PReferenceTest()
+        {
+            using (var ws = new AdhocWorkspace())
+            {
+                var referenceInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "ReferenceProject",
+                    "ReferenceProject",
+                    LanguageNames.CSharp,
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var referenceProject = ws.AddProject(referenceInfo);
+
+                var projectInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp,
+                    projectReferences: ImmutableArray.Create<ProjectReference>(new ProjectReference(referenceInfo.Id)),
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var project = ws.AddProject(projectInfo);
+
+                // get original references
+                var compilation1 = await project.GetCompilationAsync();
+                var references1 = compilation1.ExternalReferences;
+
+                // change project
+                var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
+                var document = ws.AddDocument(info);
+
+                // get new compilation
+                var compilation2 = await document.Project.GetCompilationAsync();
+                var references2 = compilation2.ExternalReferences;
+
+                Assert.Equal(references1, references2);
+            }
+        }
+
+        [Fact]
+        public async Task CrossLanguageReferenceTest()
+        {
+            using (var ws = new AdhocWorkspace())
+            {
+                var referenceInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "ReferenceProject",
+                    "ReferenceProject",
+                    LanguageNames.VisualBasic,
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var referenceProject = ws.AddProject(referenceInfo);
+
+                var projectInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp,
+                    projectReferences: ImmutableArray.Create<ProjectReference>(new ProjectReference(referenceInfo.Id)),
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var project = ws.AddProject(projectInfo);
+
+                // get original references
+                var compilation1 = await project.GetCompilationAsync();
+                var references1 = compilation1.ExternalReferences;
+
+                // change project
+                var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
+                var document = ws.AddDocument(info);
+
+                // get new compilation
+                var compilation2 = await document.Project.GetCompilationAsync();
+                var references2 = compilation2.ExternalReferences;
+
+                Assert.Equal(references1, references2);
+            }
+        }
+
+        [Fact]
+        public async Task CompilationReferenceChangedTest()
+        {
+            using (var ws = new AdhocWorkspace())
+            {
+                var referenceInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "ReferenceProject",
+                    "ReferenceProject",
+                    LanguageNames.CSharp,
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var referenceProject = ws.AddProject(referenceInfo);
+
+                var projectInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp,
+                    projectReferences: ImmutableArray.Create<ProjectReference>(new ProjectReference(referenceInfo.Id)),
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var project = ws.AddProject(projectInfo);
+
+                // get original references
+                var compilation1 = await project.GetCompilationAsync();
+                var references1 = compilation1.ExternalReferences;
+
+                // change project
+                var referenceDocumentInfo = DocumentInfo.Create(DocumentId.CreateNewId(referenceProject.Id), "code.cs");
+                var referenceDocument = ws.AddDocument(referenceDocumentInfo);
+
+                var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
+                var document = ws.AddDocument(info);
+
+                // get new compilation
+                var compilation2 = await document.Project.GetCompilationAsync();
+                var references2 = compilation2.ExternalReferences;
+
+                Assert.NotEqual(references1, references2);
+            }
+        }
+
+        [Fact]
+        public async Task PEReferenceChangedTest()
+        {
+            using (var ws = new AdhocWorkspace())
+            {
+                var projectInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp,
+                    metadataReferences: ImmutableArray.Create<MetadataReference>(PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location)));
+
+                var project = ws.AddProject(projectInfo);
+
+                // get original references
+                var compilation1 = await project.GetCompilationAsync();
+                var references1 = compilation1.ExternalReferences;
+
+                // change project
+                var forkedProject = project.WithMetadataReferences(ImmutableArray.Create<MetadataReference>(
+                    PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location),
+                    PortableExecutableReference.CreateFromFile(typeof(Workspace).Assembly.Location)));
+
+                // get new compilation
+                var compilation2 = await forkedProject.GetCompilationAsync();
+                var references2 = compilation2.ExternalReferences;
+
+                Assert.NotEqual(references1, references2);
+            }
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/WorkspaceTests/WorkspaceReferenceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/WorkspaceReferenceTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
     public class WorkspaceReferenceTests
     {
         [Fact]
-        public async Task PEReferenceTest()
+        public async Task CheckPEReferencesSameAfterSolutionChangedTest()
         {
             using (var ws = new AdhocWorkspace())
             {
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
                 var compilation1 = await project.GetCompilationAsync();
                 var references1 = compilation1.ExternalReferences;
 
-                // change project
+                // just some arbitary action to create new snpahost that doesnt affect references
                 var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
                 var document = ws.AddDocument(info);
 
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
         }
 
         [Fact]
-        public async Task P2PReferenceTest()
+        public async Task CheckP2PReferencesSameAfterSolutionChangedTest()
         {
             using (var ws = new AdhocWorkspace())
             {
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
                 var compilation1 = await project.GetCompilationAsync();
                 var references1 = compilation1.ExternalReferences;
 
-                // change project
+                // just some arbitary action to create new snpahost that doesnt affect references
                 var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
                 var document = ws.AddDocument(info);
 
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
         }
 
         [Fact]
-        public async Task CrossLanguageReferenceTest()
+        public async Task CheckCrossLanguageReferencesSameAfterSolutionChangedTest()
         {
             using (var ws = new AdhocWorkspace())
             {
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
                 var compilation1 = await project.GetCompilationAsync();
                 var references1 = compilation1.ExternalReferences;
 
-                // change project
+                // just some arbitary action to create new snpahost that doesnt affect references
                 var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
                 var document = ws.AddDocument(info);
 
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
         }
 
         [Fact]
-        public async Task CompilationReferenceChangedTest()
+        public async Task CheckP2PReferencesNotSameAfterReferenceChangedTest()
         {
             using (var ws = new AdhocWorkspace())
             {
@@ -153,10 +153,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
                 var compilation1 = await project.GetCompilationAsync();
                 var references1 = compilation1.ExternalReferences;
 
-                // change project
+                // some random action that causes reference project to be changed.
                 var referenceDocumentInfo = DocumentInfo.Create(DocumentId.CreateNewId(referenceProject.Id), "code.cs");
                 var referenceDocument = ws.AddDocument(referenceDocumentInfo);
 
+                // just some arbitary action to create new snpahost that doesnt affect references
                 var info = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "code.cs");
                 var document = ws.AddDocument(info);
 
@@ -169,7 +170,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
         }
 
         [Fact]
-        public async Task PEReferenceChangedTest()
+        public async Task CheckPEReferencesNotSameAfterReferenceChangedTest()
         {
             using (var ws = new AdhocWorkspace())
             {
@@ -187,7 +188,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
                 var compilation1 = await project.GetCompilationAsync();
                 var references1 = compilation1.ExternalReferences;
 
-                // change project
+                // explicitly change references
                 var forkedProject = project.WithMetadataReferences(ImmutableArray.Create<MetadataReference>(
                     PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location),
                     PortableExecutableReference.CreateFromFile(typeof(Workspace).Assembly.Location)));


### PR DESCRIPTION
added Equality support in CompilationReference so that it uses value equality check rather than default reference equality check.
...

this should let CompilationTracker to work correctly for this line (http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Workspace/Solution/Solution.CompilationTracker.cs,648)

PE reference is okay since workspace make sure we re-use same metadata reference for PE references if it hasn't been changed.