### PR TITLE
Add CodeFix to convert async methods to non-async.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -179,6 +179,7 @@
     <Compile Include="CodeActions\IntroduceVariable\IntroduceVariableTests.cs" />
     <Compile Include="CodeActions\InvertIf\InvertIfTests.cs" />
     <Compile Include="CodeActions\LambdaSimplifier\LambdaSimplifierTests.cs" />
+    <Compile Include="Diagnostics\MakeMethodSynchronous\MakeMethodSynchronousTests.cs" />
     <Compile Include="CodeActions\MoveDeclarationNearReference\MoveDeclarationNearReferenceTests.cs" />
     <Compile Include="CodeActions\Preview\ErrorCases\ExceptionInCodeAction.cs" />
     <Compile Include="CodeActions\Preview\PreviewExceptionTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous;

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
@@ -116,6 +116,32 @@ compareTokens: false);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestTrailingTrivia()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async // comment
+    Task [|Foo|]()
+    {
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
         public async Task TestRenameMethod()
         {
             await TestAsync(
@@ -228,6 +254,34 @@ class C
     {
         Func<string, Task> f =
             a => { };
+    }
+}",
+compareTokens: false);
+        }
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestLambdaWithExpressionBody()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<string, Task> f =
+            async [|a|] => 1;
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<string, Task> f =
+            a => 1;
     }
 }",
 compareTokens: false);

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.MakeMethodSynchronous;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -314,6 +315,40 @@ class C
     }
 }",
 compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestFixAll()
+        {
+            await TestAsync(
+@"using System.Threading.Tasks;
+
+public class Class1
+{
+    {|FixAllInDocument:async Task FooAsync()
+    {
+        BarAsync();
+    }
+
+    async Task<int> BarAsync()
+    {
+        FooAsync();
+    }|}
+}",
+@"using System.Threading.Tasks;
+
+public class Class1
+{
+    void Foo()
+    {
+        Bar();
+    }
+
+    int Bar()
+    {
+        Foo();
+    }
+}", compareTokens: false, fixAllActionEquivalenceKey: AbstractMakeMethodSynchronousCodeFixProvider.EquivalenceKey);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.MakeMethodSynchronous
+{
+    public class MakeMethodSynchronousTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
+        {
+            return Tuple.Create<DiagnosticAnalyzer, CodeFixProvider>(null, new CSharpMakeMethodSynchronousCodeFixProvider());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestTaskReturnType()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task [|Foo|]()
+    {
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestTaskOfTReturnType()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task<int> [|Foo|]()
+    {
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    int Foo()
+    {
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestRenameMethod()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task [|FooAsync|]()
+    {
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestRenameMethod1()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task [|FooAsync|]()
+    {
+    }
+
+    void Bar()
+    {
+        FooAsync();
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+    }
+
+    void Bar()
+    {
+        Foo();
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestParenthesizedLambda()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<Task> f =
+            async [|()|] => { };
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<Task> f =
+            () => { };
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestSimpleLambda()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<string, Task> f =
+            async [|a|] => { };
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<string, Task> f =
+            a => { };
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestAnonymousMethod()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<Task> f =
+            async [|delegate|] { };
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    void Foo()
+    {
+        Func<Task> f =
+            delegate { };
+    }
+}",
+compareTokens: false);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
@@ -66,6 +66,56 @@ compareTokens: false);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestSecondModifier()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    public async Task [|Foo|]()
+    {
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    public void Foo()
+    {
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestFirstModifier()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async public Task [|Foo|]()
+    {
+    }
+}",
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    public void Foo()
+    {
+    }
+}",
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
         public async Task TestRenameMethod()
         {
             await TestAsync(

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -61,6 +61,7 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsInvertIf = "CodeActions.InvertIf";
             public const string CodeActionsInvokeDelegateWithConditionalAccess = "CodeActions.InvokeDelegateWithConditionalAccess";
             public const string CodeActionsLambdaSimplifier = "CodeActions.LambdaSimplifier";
+            public const string CodeActionsMakeMethodSynchronous = "CodeActions.MakeMethodSynchronous";
             public const string CodeActionsMoveDeclarationNearReference = "CodeActions.MoveDeclarationNearReference";
             public const string CodeActionsMoveToTopOfFile = "CodeActions.MoveToTopOfFile";
             public const string CodeActionsReplaceMethodWithProperty = "CodeActions.ReplaceMethodWithProperty";

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -205,6 +205,7 @@
     <Compile Include="Diagnostics\ImplementInterface\ImplementInterfaceCommandHandlerTests.vb" />
     <Compile Include="Diagnostics\ImplementInterface\ImplementInterfaceTests.vb" />
     <Compile Include="Diagnostics\InsertMissingCast\InsertMissingCastTests.vb" />
+    <Compile Include="Diagnostics\MakeMethodSynchronous\MakeMethodSynchronousTests.vb" />
     <Compile Include="Diagnostics\MoveToTopOfFile\MoveToTopOfFileTests.vb" />
     <Compile Include="Diagnostics\OverloadBase\OverloadBaseTests.vb" />
     <Compile Include="Diagnostics\RemoveUnnecessaryCast\RemoveUnnecessaryCastTests.vb" />

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
@@ -22,7 +22,7 @@ End Class",
 "Imports System.Threading.Tasks
 
 Class C
-    Sub Foo() 
+    Sub Foo()
     End Sub
 End Class",
 compareTokens:=False)
@@ -58,7 +58,7 @@ End Class",
 "Imports System.Threading.Tasks
 
 Class C
-    Public Sub Foo() 
+    Public Sub Foo()
     End Sub
 End Class",
 compareTokens:=False)
@@ -76,7 +76,7 @@ End Class",
 "Imports System.Threading.Tasks
 
 Class C
-    Public Sub Foo() 
+    Public Sub Foo()
     End Sub
 End Class",
 compareTokens:=False)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
@@ -1,0 +1,235 @@
+﻿Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.MakeMethodSynchronous
+    Public Class MakeMethodSynchronousTests
+        Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
+
+        Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, CodeFixProvider)
+            Return Tuple.Create(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New VisualBasicMakeMethodSynchronousCodeFixProvider())
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestTaskReturnType() As Task
+            Await TestAsync(
+"Imports System.Threading.Tasks
+
+Class C
+    Async Function [|Foo|]() As Task
+    End Function
+End Class",
+"Imports System.Threading.Tasks
+
+Class C
+    Sub Foo() 
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestTaskOfTReturnType() As Task
+            Await TestAsync(
+"Imports System.Threading.Tasks
+
+Class C
+    Async Function [|Foo|]() As Task(of String)
+    End Function
+End Class",
+"Imports System.Threading.Tasks
+
+Class C
+    Function Foo() As String
+    End Function
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestSecondModifier() As Task
+            Await TestAsync(
+"Imports System.Threading.Tasks
+
+Class C
+    Public Async Function [|Foo|]() As Task
+    End Function
+End Class",
+"Imports System.Threading.Tasks
+
+Class C
+    Public Sub Foo() 
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestFirstModifier() As Task
+            Await TestAsync(
+"Imports System.Threading.Tasks
+
+Class C
+    Async Public Function [|Foo|]() As Task
+    End Function
+End Class",
+"Imports System.Threading.Tasks
+
+Class C
+    Public Sub Foo() 
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestRenameMethod() As Task
+            Await TestAsync(
+"Imports System.Threading.Tasks
+
+Class C
+    Async Sub [|FooAsync|]()
+    End Sub
+End Class",
+"Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestRenameMethod1() As Task
+            Await TestAsync(
+"Imports System.Threading.Tasks
+
+Class C
+    Async Sub [|FooAsync|]()
+    End Sub
+
+    Sub Bar()
+        FooAsync()
+    End Sub
+End Class",
+"Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+    End Sub
+
+    Sub Bar()
+        Foo()
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestSingleLineSubLambda() As Task
+            Await TestAsync(
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Action(of Task) =
+            Async [|Sub|]() Return
+    End Sub
+End Class",
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Action(of Task) =
+            Sub() Return
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestSingleLineFunctionLambda() As Task
+            Await TestAsync(
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Func(of Task) =
+            Async [|Function|]() 1
+    End Sub
+End Class",
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Func(of Task) =
+            Function() 1
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestMultiLineSubLambda() As Task
+            Await TestAsync(
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Action(of Task) =
+            Async [|Sub|]()
+                Return
+            End Sub
+    End Sub
+End Class",
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Action(of Task) =
+            Sub()
+                Return
+            End Sub
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestMultiLineFunctionLambda() As Task
+            Await TestAsync(
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Func(of Task) =
+            Async [|Function|]()
+                Return 1
+            End Function
+    End Sub
+End Class",
+"Imports System
+Imports System.Threading.Tasks
+
+Class C
+    Sub Foo()
+        dim f as Func(of Task) =
+            Function()
+                Return 1
+            End Function
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Microsoft.CodeAnalysis.CodeFixes
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
 

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -325,6 +325,7 @@
     <Compile Include="LanguageServices\CSharpSymbolDisplayService.cs" />
     <Compile Include="LanguageServices\CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs" />
     <Compile Include="LanguageServices\CSharpSymbolDisplayServiceFactory.cs" />
+    <Compile Include="MakeMethodSynchronous\CSharpMakeMethodSynchronousCodeFixProvider.cs" />
     <Compile Include="MetadataAsSource\CSharpMetadataAsSourceService.cs" />
     <Compile Include="MetadataAsSource\CSharpMetadataAsSourceServiceFactory.cs" />
     <Compile Include="OrganizeImports\CSharpOrganizeImportsService.cs" />

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.MakeMethodSynchronous;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal class CSharpMakeMethodSynchronousCodeFixProvider : AbstractMakeMethodSynchronousCodeFixProvider
+    {
+        private const string CS1998 = nameof(CS1998); // This async method lacks 'await' operators and will run synchronously.
+
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(CS1998);
+
+        protected override bool IsMethodOrAnonymousFunction(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.MethodDeclaration) || node.IsAnyLambdaOrAnonymousMethod();
+        }
+
+        protected override SyntaxNode RemoveAsyncTokenAndFixReturnType(IMethodSymbol methodSymbolOpt, SyntaxNode node)
+        {
+            return node.TypeSwitch(
+                (MethodDeclarationSyntax method) => FixMethod(methodSymbolOpt, method),
+                (AnonymousMethodExpressionSyntax method) => FixAnonymousMethod(method),
+                (ParenthesizedLambdaExpressionSyntax lambda) => FixParenthesizedLambda(lambda),
+                (SimpleLambdaExpressionSyntax lambda) => FixSimpleLambda(lambda),
+                _ => node);
+        }
+
+        private SyntaxNode FixMethod(IMethodSymbol methodSymbol, MethodDeclarationSyntax method)
+        {
+            var newReturnType = method.ReturnType;
+            if (methodSymbol.ReturnType.Name == "Task")
+            {
+                // If the return type is Task<T>, then make the new return type "T".
+                // If it is task, then make the new return type "void".
+                newReturnType = methodSymbol.ReturnType.GetTypeArguments().Length == 1
+                    ? methodSymbol.ReturnType.GetTypeArguments()[0].GenerateTypeSyntax()
+                    : SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword));
+
+                newReturnType = newReturnType.WithTriviaFrom(method.ReturnType);
+            }
+
+            var asyncTokenIndex = method.Modifiers.IndexOf(SyntaxKind.AsyncKeyword);
+            SyntaxTokenList newModifiers;
+            if (asyncTokenIndex == 0)
+            {
+                // Have to move the trivia on teh async token appropriately.
+                var asyncLeadingTrivia = method.Modifiers[0].LeadingTrivia;
+
+                if (method.Modifiers.Count > 1)
+                {
+                    // Move the trivia to the next modifier;
+                    newModifiers = method.Modifiers.Replace(
+                        method.Modifiers[1],
+                        method.Modifiers[1].WithPrependedLeadingTrivia(asyncLeadingTrivia));
+                    newModifiers = newModifiers.RemoveAt(0);
+                }
+                else
+                {
+                    // move it to the return type.
+                    newModifiers = method.Modifiers.RemoveAt(0);
+                    newReturnType = newReturnType.WithPrependedLeadingTrivia(asyncLeadingTrivia);
+                }
+            }
+            else
+            {
+                newModifiers = method.Modifiers.RemoveAt(asyncTokenIndex);
+            }
+
+            return method.WithReturnType(newReturnType).WithModifiers(newModifiers);
+        }
+
+        private SyntaxNode FixParenthesizedLambda(ParenthesizedLambdaExpressionSyntax lambda)
+        {
+            return lambda.WithAsyncKeyword(default(SyntaxToken)).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
+        }
+
+        private SyntaxNode FixSimpleLambda(SimpleLambdaExpressionSyntax lambda)
+        {
+            return lambda.WithAsyncKeyword(default(SyntaxToken)).WithPrependedLeadingTrivia(lambda.AsyncKeyword.LeadingTrivia);
+        }
+
+        private SyntaxNode FixAnonymousMethod(AnonymousMethodExpressionSyntax method)
+        {
+            return method.WithAsyncKeyword(default(SyntaxToken)).WithPrependedLeadingTrivia(method.AsyncKeyword.LeadingTrivia);
+        }
+    }
+}

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -245,6 +245,7 @@
     <Compile Include="IntroduceVariable\AbstractIntroduceVariableService.AbstractIntroduceVariableCodeAction.cs" />
     <Compile Include="IntroduceVariable\AbstractIntroduceVariableService.IntroduceVariableAllOccurrenceCodeAction.cs" />
     <Compile Include="LanguageServices\ProjectInfoService\IProjectInfoService.cs" />
+    <Compile Include="MakeMethodSynchronous\AbstractMakeMethodSynchronousCodeFixProvider.cs" />
     <Compile Include="Navigation\NavigationOptions.cs" />
     <Compile Include="Navigation\NavigationOptionsProvider.cs" />
     <Compile Include="QuickInfo\QuickInfoUtilities.cs" />

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -1358,6 +1358,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Make method synchronous..
+        /// </summary>
+        internal static string Make_method_synchronous {
+            get {
+                return ResourceManager.GetString("Make_method_synchronous", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to method.
         /// </summary>
         internal static string Method {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -882,4 +882,7 @@ Do you want to continue?</value>
   <data name="WRN_UnableToLoadAnalyzer" xml:space="preserve">
     <value>Unable to load Analyzer assembly {0}: {1}</value>
   </data>
+  <data name="Make_method_synchronous" xml:space="preserve">
+    <value>Make method synchronous.</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.MakeMethodSynchronous
+{
+    internal abstract class AbstractMakeMethodSynchronousCodeFixProvider : CodeFixProvider
+    {
+        protected abstract bool IsMethodOrAnonymousFunction(SyntaxNode node);
+        protected abstract SyntaxNode RemoveAsyncTokenAndFixReturnType(IMethodSymbol methodSymbolOpt, SyntaxNode node);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var cancellationToken = context.CancellationToken;
+            var document = context.Document;
+            var diagnostic = context.Diagnostics.First();
+
+            var token = diagnostic.Location.FindToken(cancellationToken);
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            for (var node = token.Parent; node != null; node = node.Parent)
+            {
+                if (IsMethodOrAnonymousFunction(node))
+                {
+                    context.RegisterCodeFix(new MyCodeAction(FeaturesResources.Make_method_synchronous,
+                        c => FixNodeAsync(context.Document, node, c)), diagnostic);
+                    return;
+                }
+            }
+        }
+
+        private const string AsyncSuffix = "Async";
+
+        private async Task<Solution> FixNodeAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var methodSymbolOpt = semanticModel.GetDeclaredSymbol(node) as IMethodSymbol;
+
+            // If the method ends with 'Async' then remove that as part of the fix.
+            if (methodSymbolOpt?.MethodKind == MethodKind.Ordinary && 
+                methodSymbolOpt.Name.Length > AsyncSuffix.Length && 
+                methodSymbolOpt.Name.EndsWith(AsyncSuffix))
+            {
+                return await RenameThenRemoveAsyncTokenAsync(document, node, methodSymbolOpt, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                return await RemoveAsyncTokenAsync(document, methodSymbolOpt, node, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<Solution> RenameThenRemoveAsyncTokenAsync(Document document, SyntaxNode node, IMethodSymbol methodSymbol, CancellationToken cancellationToken)
+        {
+            var name = methodSymbol.Name;
+            var newName = name.Substring(0, name.Length - AsyncSuffix.Length);
+            var solution = document.Project.Solution;
+            var options = solution.Workspace.Options;
+
+            // Store the path to this node.  That way we can find it post rename.
+            var syntaxPath = new SyntaxPath(node);
+
+            // Rename the method to remove the 'Async' suffix, then remove the 'async' keyword.
+            var newSolution = await Renamer.RenameSymbolAsync(solution, methodSymbol, newName, options, cancellationToken).ConfigureAwait(false);
+            var newDocument = newSolution.GetDocument(document.Id);
+            var newRoot = await newDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            SyntaxNode newNode;
+            if (syntaxPath.TryResolve<SyntaxNode>(newRoot, out newNode))
+            {
+                var semanticModel = await newDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var newMethod = (IMethodSymbol)semanticModel.GetDeclaredSymbol(newNode, cancellationToken);
+                return await RemoveAsyncTokenAsync(newDocument, newMethod, newNode, cancellationToken).ConfigureAwait(false);
+            }
+
+            return newSolution;
+        }
+
+        private async Task<Solution> RemoveAsyncTokenAsync(Document document, IMethodSymbol methodSymbolOpt, SyntaxNode node, CancellationToken cancellationToken)
+        {
+            var newNode = RemoveAsyncTokenAndFixReturnType(methodSymbolOpt, node);
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = root.ReplaceNode(node, newNode);
+
+            var newDocument = document.WithSyntaxRoot(newRoot);
+            return newDocument.Project.Solution;
+        }
+
+        private class MyCodeAction : CodeAction.SolutionChangeAction
+        {
+            public MyCodeAction(
+                string title,
+                Func<CancellationToken, Task<Solution>> createChangedSolution,
+                string equivalenceKey = null) : base(title, createChangedSolution, equivalenceKey)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -359,6 +359,7 @@
     <Compile Include="LanguageServices\VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb" />
     <Compile Include="LanguageServices\VisualBasicSymbolDisplayService.vb" />
     <Compile Include="LanguageServices\VisualBasicSymbolDisplayServiceFactory.vb" />
+    <Compile Include="MakeMethodSynchronous\VisualBasicMakeMethodSynchronousCodeFixProvider.vb" />
     <Compile Include="MetadataAsSource\VisualBasicMetadataAsSourceService.vb" />
     <Compile Include="MetadataAsSource\VisualBasicMetadataAsSourceServiceFactory.vb" />
     <Compile Include="OrganizeImports\VisualBasicOrganizeImportsService.Rewriter.vb" />

--- a/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
@@ -1,0 +1,136 @@
+﻿
+Imports System.Collections.Immutable
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.MakeMethodSynchronous
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicMakeMethodSynchronousCodeFixProvider
+        Inherits AbstractMakeMethodSynchronousCodeFixProvider
+
+        Private Const BC42356 As String = NameOf(BC42356) ' This async method lacks 'Await' operators and so will run synchronously.
+
+        Private Shared ReadOnly diagnosticIds As ImmutableArray(Of String) = ImmutableArray.Create(BC42356)
+
+        Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
+            Get
+                Return diagnosticIds
+            End Get
+        End Property
+
+        Protected Overrides Function IsMethodOrAnonymousFunction(node As SyntaxNode) As Boolean
+            Return node.IsKind(SyntaxKind.FunctionBlock) OrElse
+                node.IsKind(SyntaxKind.SubBlock) OrElse
+                node.IsKind(SyntaxKind.MultiLineFunctionLambdaExpression) OrElse
+                node.IsKind(SyntaxKind.MultiLineSubLambdaExpression) OrElse
+                node.IsKind(SyntaxKind.SingleLineFunctionLambdaExpression) OrElse
+                node.IsKind(SyntaxKind.SingleLineSubLambdaExpression)
+        End Function
+
+        Protected Overrides Function RemoveAsyncTokenAndFixReturnType(methodSymbolOpt As IMethodSymbol, node As SyntaxNode, taskType As ITypeSymbol, taskOfTType As ITypeSymbol) As SyntaxNode
+            If node.IsKind(SyntaxKind.SingleLineSubLambdaExpression) OrElse
+                node.IsKind(SyntaxKind.SingleLineFunctionLambdaExpression) Then
+
+                Return FixSingleLineLambdaExpression(DirectCast(node, SingleLineLambdaExpressionSyntax))
+            ElseIf node.IsKind(SyntaxKind.MultiLineSubLambdaExpression) OrElse
+                    node.IsKind(SyntaxKind.MultiLineFunctionLambdaExpression) Then
+
+                Return FixMultiLineLambdaExpression(DirectCast(node, MultiLineLambdaExpressionSyntax))
+            ElseIf node.IsKind(SyntaxKind.SubBlock) Then
+                Return FixSubBlock(DirectCast(node, MethodBlockSyntax))
+            Else
+                Return FixFunctionBlock(methodSymbolOpt, DirectCast(node, MethodBlockSyntax), taskType, taskOfTType)
+            End If
+        End Function
+
+        Private Function FixFunctionBlock(methodSymbol As IMethodSymbol, node As MethodBlockSyntax, taskType As ITypeSymbol, taskOfTType As ITypeSymbol) As SyntaxNode
+            Dim functionStatement = node.SubOrFunctionStatement
+
+            ' if this returns Task<T>, then we want to convert this to a T returning function.
+            ' if this returns Task, then we want to convert it to a Sub method.
+            If methodSymbol.ReturnType.OriginalDefinition.Equals(taskOfTType) Then
+                Dim newAsClause = functionStatement.AsClause.WithType(methodSymbol.ReturnType.GetTypeArguments()(0).GenerateTypeSyntax())
+                Dim newFunctionStatement = functionStatement.WithAsClause(newAsClause)
+                newFunctionStatement = RemoveAsyncKeyword(newFunctionStatement)
+                Return node.WithSubOrFunctionStatement(newFunctionStatement)
+            ElseIf methodSymbol.ReturnType.OriginalDefinition Is taskType Then
+                ' Convert this to a 'Sub' method.
+                Dim subStatement = SyntaxFactory.SubStatement(
+                    functionStatement.AttributeLists,
+                    functionStatement.Modifiers,
+                    SyntaxFactory.Token(SyntaxKind.SubKeyword).WithTriviaFrom(functionStatement.SubOrFunctionKeyword),
+                    functionStatement.Identifier,
+                    functionStatement.TypeParameterList,
+                    functionStatement.ParameterList,
+                    functionStatement.AsClause,
+                    functionStatement.HandlesClause,
+                    functionStatement.ImplementsClause)
+
+                subStatement = subStatement.RemoveNode(subStatement.AsClause, SyntaxRemoveOptions.KeepTrailingTrivia)
+                subStatement = RemoveAsyncKeyword(subStatement)
+
+                Dim endSubStatement = SyntaxFactory.EndSubStatement(
+                    node.EndSubOrFunctionStatement.EndKeyword,
+                    SyntaxFactory.Token(SyntaxKind.SubKeyword).WithTriviaFrom(node.EndSubOrFunctionStatement.BlockKeyword))
+
+                Return SyntaxFactory.SubBlock(subStatement, node.Statements, endSubStatement)
+            Else
+                Dim newFunctionStatement = RemoveAsyncKeyword(functionStatement)
+                Return node.WithSubOrFunctionStatement(newFunctionStatement)
+            End If
+        End Function
+
+        Private Function FixSubBlock(node As MethodBlockSyntax) As SyntaxNode
+            Dim newSubStatement = RemoveAsyncKeyword(node.SubOrFunctionStatement)
+            Return node.WithSubOrFunctionStatement(newSubStatement)
+        End Function
+
+        Private Shared Function RemoveAsyncKeyword(subOrFunctionStatement As MethodStatementSyntax) As MethodStatementSyntax
+            Dim modifiers = subOrFunctionStatement.Modifiers
+            Dim asyncTokenIndex = modifiers.IndexOf(SyntaxKind.AsyncKeyword)
+
+            Dim newSubKeyword = subOrFunctionStatement.SubOrFunctionKeyword
+            Dim newModifiers As SyntaxTokenList
+            If asyncTokenIndex = 0 Then
+                ' Have to move the trivia on teh async token appropriately.
+                Dim asyncLeadingTrivia = modifiers(0).LeadingTrivia
+
+                If modifiers.Count > 1 Then
+                    ' Move the trivia to the next modifier;
+                    newModifiers = modifiers.Replace(
+                        modifiers(1),
+                        modifiers(1).WithPrependedLeadingTrivia(asyncLeadingTrivia))
+                    newModifiers = newModifiers.RemoveAt(0)
+                Else
+                    ' move it to the return type.
+                    newModifiers = modifiers.RemoveAt(0)
+                    newSubKeyword = newSubKeyword.WithPrependedLeadingTrivia(asyncLeadingTrivia)
+                End If
+            Else
+                newModifiers = modifiers.RemoveAt(asyncTokenIndex)
+            End If
+
+            Dim newSubStatement = subOrFunctionStatement.WithModifiers(newModifiers).WithSubOrFunctionKeyword(newSubKeyword)
+            Return newSubStatement
+        End Function
+
+        Private Function FixMultiLineLambdaExpression(node As MultiLineLambdaExpressionSyntax) As SyntaxNode
+            Dim header As LambdaHeaderSyntax = GetNewHeader(node)
+            Return node.WithSubOrFunctionHeader(header).WithLeadingTrivia(node.GetLeadingTrivia())
+        End Function
+
+        Private Function FixSingleLineLambdaExpression(node As SingleLineLambdaExpressionSyntax) As SingleLineLambdaExpressionSyntax
+            Dim header As LambdaHeaderSyntax = GetNewHeader(node)
+            Return node.WithSubOrFunctionHeader(header).WithLeadingTrivia(node.GetLeadingTrivia())
+        End Function
+
+        Private Shared Function GetNewHeader(node As LambdaExpressionSyntax) As LambdaHeaderSyntax
+            Dim header = DirectCast(node.SubOrFunctionHeader, LambdaHeaderSyntax)
+            Dim asyncKeywordIndex = header.Modifiers.IndexOf(SyntaxKind.AsyncKeyword)
+            Dim newHeader = header.WithModifiers(header.Modifiers.RemoveAt(asyncKeywordIndex))
+            Return newHeader
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
         Private Function FixFunctionBlock(methodSymbol As IMethodSymbol, node As MethodBlockSyntax, taskType As ITypeSymbol, taskOfTType As ITypeSymbol) As SyntaxNode
             Dim functionStatement = node.SubOrFunctionStatement
 
-            ' if this returns Task<T>, then we want to convert this to a T returning function.
+            ' if this returns Task(of T), then we want to convert this to a T returning function.
             ' if this returns Task, then we want to convert it to a Sub method.
             If methodSymbol.ReturnType.OriginalDefinition.Equals(taskOfTType) Then
                 Dim newAsClause = functionStatement.AsClause.WithType(methodSymbol.ReturnType.GetTypeArguments()(0).GenerateTypeSyntax())
@@ -91,10 +91,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
             Dim modifiers = subOrFunctionStatement.Modifiers
             Dim asyncTokenIndex = modifiers.IndexOf(SyntaxKind.AsyncKeyword)
 
-            Dim newSubKeyword = subOrFunctionStatement.SubOrFunctionKeyword
+            Dim newSubOrFunctionKeyword = subOrFunctionStatement.SubOrFunctionKeyword
             Dim newModifiers As SyntaxTokenList
             If asyncTokenIndex = 0 Then
-                ' Have to move the trivia on teh async token appropriately.
+                ' Have to move the trivia on the async token appropriately.
                 Dim asyncLeadingTrivia = modifiers(0).LeadingTrivia
 
                 If modifiers.Count > 1 Then
@@ -104,16 +104,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
                         modifiers(1).WithPrependedLeadingTrivia(asyncLeadingTrivia))
                     newModifiers = newModifiers.RemoveAt(0)
                 Else
-                    ' move it to the return type.
+                    ' move it to the 'sub' or 'function' keyword.
                     newModifiers = modifiers.RemoveAt(0)
-                    newSubKeyword = newSubKeyword.WithPrependedLeadingTrivia(asyncLeadingTrivia)
+                    newSubOrFunctionKeyword = newSubOrFunctionKeyword.WithPrependedLeadingTrivia(asyncLeadingTrivia)
                 End If
             Else
                 newModifiers = modifiers.RemoveAt(asyncTokenIndex)
             End If
 
-            Dim newSubStatement = subOrFunctionStatement.WithModifiers(newModifiers).WithSubOrFunctionKeyword(newSubKeyword)
-            Return newSubStatement
+            Dim newSubOrFunctionStatement = subOrFunctionStatement.WithModifiers(newModifiers).WithSubOrFunctionKeyword(newSubOrFunctionKeyword)
+            Return newSubOrFunctionStatement
         End Function
 
         Private Function FixMultiLineLambdaExpression(node As MultiLineLambdaExpressionSyntax) As SyntaxNode


### PR DESCRIPTION
Useful when the async method no longer contains any 'await's and you want to make it a synchronous method.

VB implementation upcoming.