### PR TITLE
Tweak ordering of NavigateTo items.

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -822,6 +822,7 @@ class D
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        [WorkItem(7855, "https://github.com/dotnet/Roslyn/issues/7855")]
         public async Task DottedPattern7()
         {
             var source = "namespace Foo { namespace Bar { class Baz<X,Y,Z> { void Quux() { } } } }";
@@ -829,7 +830,7 @@ class D
             {
                 var expecteditems = new List<NavigateToItem>
                 {
-                    new NavigateToItem("Quux", NavigateToItemKind.Method, "csharp", null, null, MatchKind.Exact, true, null)
+                    new NavigateToItem("Quux", NavigateToItemKind.Method, "csharp", null, null, MatchKind.Prefix, true, null)
                 };
 
                 var items = _aggregator.GetItems("Baz.Q");

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -583,6 +583,7 @@ end namespace")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.NavigateTo)>
+        <WorkItem(7855, "https://github.com/dotnet/Roslyn/issues/7855")>
         Public Async Function TestDottedPattern7() As Task
             Using workspace = Await SetupWorkspaceAsync("namespace Foo
 namespace Bar
@@ -594,7 +595,7 @@ end namespace
 end namespace")
                 Dim expecteditems = New List(Of NavigateToItem) From
                 {
-                    New NavigateToItem("Quux", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Exact, True, Nothing)
+                    New NavigateToItem("Quux", NavigateToItemKind.Method, "vb", Nothing, Nothing, MatchKind.Prefix, True, Nothing)
                 }
 
                 Dim items = _aggregator.GetItems("Baz.Q").ToList()

--- a/src/Features/Core/Portable/Shared/Utilities/PatternMatcher.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/PatternMatcher.cs
@@ -247,7 +247,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             // -1 because the last part was checked against the name, and only the rest
             // of the parts are checked against the container.
-            if (_dotSeparatedSegments.Length - 1 > containerParts.Length)
+            var relevantDotSeparatedSegmentLength = _dotSeparatedSegments.Length - 1;
+            if (relevantDotSeparatedSegmentLength > containerParts.Length)
             {
                 // There weren't enough container parts to match against the pattern parts.
                 // So this definitely doesn't match.
@@ -256,11 +257,12 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             // So far so good.  Now break up the container for the candidate and check if all
             // the dotted parts match up correctly.
-            var totalMatch = candidateMatch.ToList();
+            var totalMatch = new List<PatternMatch>();
 
-            for (int i = _dotSeparatedSegments.Length - 2, j = containerParts.Length - 1;
-                    i >= 0;
-                    i--, j--)
+            // Don't need to check the last segment.  We did that as the very first bail out step.
+            for (int i = 0, j = containerParts.Length - relevantDotSeparatedSegmentLength;
+                 i < relevantDotSeparatedSegmentLength;
+                 i++, j++)
             {
                 var segment = _dotSeparatedSegments[i];
                 var containerName = containerParts[j];
@@ -273,6 +275,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
                 totalMatch.AddRange(containerMatch);
             }
+
+            totalMatch.AddRange(candidateMatch);
 
             // Success, this symbol's full name matched against the dotted name the user was asking
             // about.


### PR DESCRIPTION
Searching for "Microsoft.CodeAnalysis.ISymbol" should prefer "ISymbol" over "IAliasSymbol".

Fixes: https://github.com/dotnet/Roslyn/issues/7855