### PR TITLE
removed closed file diagnostic option

### DIFF
--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticInsideMethodBody.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticInsideMethodBody.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <PerfEnableEtwDiagnosticLogger/>
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevel.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevel.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <PerfEnableEtwDiagnosticLogger/>
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevelWithErrorHub.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfDiagnosticTopLevelWithErrorHub.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <PerfEnableEtwDiagnosticLogger/>
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefs.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefs.xml
@@ -9,7 +9,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true" />
     <OpenFile FileName="LanguageParser.cs" />
     <GoToLine LineNumber="1" />

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefsIEnumerable.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfFindRefsIEnumerable.xml
@@ -9,7 +9,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true" />
     <OpenFile FileName="SyntaxTriviaList.Enumerator.cs" />
     <GoToLine LineNumber="1" />

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTyping.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTyping.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="false" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="false" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>
   </InitTest>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingAnalyzers.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingAnalyzers.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />
     <AddAnalyzersToSolution CommonAnalyzers="Microsoft.CodeAnalysis.FxCopAnalyzers.dll"

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingAnalyzersWithErrorHub.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingAnalyzersWithErrorHub.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />
     <AddAnalyzersToSolution CommonAnalyzers="Microsoft.CodeAnalysis.FxCopAnalyzers.dll"

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingDiagnostics.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingDiagnostics.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>
   </InitTest>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingDiagnosticsMultipliedDelay.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfGoldilocksTypingDiagnosticsMultipliedDelay.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>
   </InitTest>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfLightBulb.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfLightBulb.xml
@@ -8,7 +8,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <PerfEnableEtwLightBulbLogger/>
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfNavigateToRoslyn.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfNavigateToRoslyn.xml
@@ -8,7 +8,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <WaitForSolutionCrawler/>
   </InitTest>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfPaste.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfPaste.xml
@@ -10,7 +10,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true" />
   </InitTest>
 

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameRoslyn.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameRoslyn.xml
@@ -12,7 +12,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <OpenFile FileName="LanguageParser.cs"/>
     <GoToLine LineNumber="411"/>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameTypeRoslyn.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfRenameTypeRoslyn.xml
@@ -12,7 +12,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-CSharp.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <OpenFile FileName="ReadOnlyArray`1.cs"/>
     <GoToLine LineNumber="24"/>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfSolutionLoad.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPerfSolutionLoad.xml
@@ -4,7 +4,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
   </InitTest>
 
   <ScenarioList>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpPgoTyping.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpPgoTyping.xml
@@ -3,7 +3,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <AddProject ProjectName="TestProj" LanguageName="C#"  ProjectTemplate="ConsoleApplication"/>
     <ForceGC/>
   </InitTest>

--- a/src/EditorFeatures/CSharpTest/PerfTests/CSharpVenusPgoTyping.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/CSharpVenusPgoTyping.xml
@@ -3,7 +3,7 @@
   <!-- Contains a simple typing scenario for Websites (script blocks in markup) -->
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <AddProject ProjectName="CSharpWebSite" LanguageName="C# - Web" ProjectTemplate="Website"/>
     <AddItem FileName="Default.aspx" UseCodeSeparation="true" Language="CSharp" />
     <ForceGC/>

--- a/src/EditorFeatures/CSharpTest/PerfTests/MiniPicassoPgo.xml
+++ b/src/EditorFeatures/CSharpTest/PerfTests/MiniPicassoPgo.xml
@@ -3,7 +3,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="C#"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\MiniPicasso\Picasso.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
   </InitTest>
 

--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
@@ -10,8 +10,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
     {
         public void ShowErrorInfoForCodeFix(string codefixName, Action OnEnableClicked, Action OnEnableAndIgnoreClicked, Action OnClose)
         {
-            var message = LogMessage.Create($"{codefixName} crashed");
-            Logger.Log(FunctionId.Extension_Exception, message);
+            ShowErrorInfo($"{codefixName} crashed", OnClose);
+        }
+
+        public void ShowErrorInfo(string title, Action OnClose)
+        {
+            Logger.Log(FunctionId.Extension_Exception, title);
         }
     }
 }

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
@@ -280,8 +280,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                     Dim optionService = workspace.Services.GetService(Of IOptionService)()
                     optionService.SetOptions(
                         optionService.GetOptions().WithChangedOption(ServiceComponentOnOffOptions.DiagnosticProvider, False) _
-                                                  .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp, False) _
-                                                  .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic, False))
+                                                  .WithChangedOption(RunTimeOptions.FullSolutionAnalysis, False))
                 End If
 
                 Dim registrationService = workspace.Services.GetService(Of ISolutionCrawlerRegistrationService)()

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticInsideMethodBody.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticInsideMethodBody.xml
@@ -7,7 +7,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <PerfEnableEtwDiagnosticLogger/>
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticTopLevel.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfDiagnosticTopLevel.xml
@@ -7,7 +7,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <PerfEnableEtwDiagnosticLogger/>
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefs.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefs.xml
@@ -9,7 +9,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true" />
     <OpenFile FileName="SourceNamedTypeSymbol.vb" />
     <GoToLine LineNumber="1"/>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefsIEnumerable.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfFindRefsIEnumerable.xml
@@ -9,7 +9,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true" />
     <OpenFile FileName="SyntaxTriviaList.Enumerable.vb" />
     <GoToLine LineNumber="1" />

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTyping.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTyping.xml
@@ -7,7 +7,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="false" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="false" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>
   </InitTest>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTypingAnalyzers.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTypingAnalyzers.xml
@@ -7,7 +7,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <Wait Seconds="60" />
     <AddAnalyzersToSolution CommonAnalyzers="Microsoft.CodeAnalysis.FxCopAnalyzers.dll"

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTypingDiagnostics.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTypingDiagnostics.xml
@@ -7,7 +7,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>
   </InitTest>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTypingDiagnosticsMultipliedDelay.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfGoldilocksTypingDiagnosticsMultipliedDelay.xml
@@ -7,7 +7,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>
   </InitTest>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfLightBulb.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfLightBulb.xml
@@ -7,7 +7,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <PerfEnableEtwLightBulbLogger/>
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <ForceGC/>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfNavigateToRoslyn.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfNavigateToRoslyn.xml
@@ -16,7 +16,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <WaitForSolutionCrawler/>
   </InitTest>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfPaste.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfPaste.xml
@@ -10,7 +10,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
   </InitTest>
 

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfRenameRoslyn.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfRenameRoslyn.xml
@@ -11,7 +11,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <OpenProject ProjectFile="C:\Roslyn\LegacyTest\RealworldProjects\RoslynSolutions\Roslyn-VB.sln" DeleteSuoFileBeforeOpening="true" DeleteIDECacheBeforeOpening="true"/>
     <OpenFile FileName="Parser.vb"/>
     <GoToLine LineNumber="1114"/>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfSolutionLoad.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPerfSolutionLoad.xml
@@ -4,7 +4,7 @@
   <InitTest>
     <EnsureCodeMarker />
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
   </InitTest>
 
   <ScenarioList>

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPgoOpenFile.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPgoOpenFile.xml
@@ -3,7 +3,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <AddProject ProjectName="TestProj" LanguageName="Visual Basic"  ProjectTemplate="None"/>
     <!-- This file is the same one the AusGov RPS test opens. -->
     <AddExistingItem ProjectName="TestProj" FileName="PerfTests\Sources\IndividualDS.vb" />

--- a/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPgoTyping.xml
+++ b/src/EditorFeatures/VisualBasicTest/PerfTests/BasicPgoTyping.xml
@@ -3,7 +3,7 @@
 <TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">
   <InitTest>
     <StartTarget DontResetOptions="true" />
-    <EnableClosedFileDiagnostic Enabled="true" Language="Visual Basic"/>
+    <EnableFullSolutionAnalysis Enabled="true" />
     <AddProject ProjectName="TestProj" LanguageName="Visual Basic"  ProjectTemplate="ConsoleApplication"/>
   </InitTest>
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 return e.Option.Feature == SimplificationOptions.PerLanguageFeatureName ||
                        e.Option.Feature == SimplificationOptions.NonPerLanguageFeatureName ||
-                       e.Option == ServiceFeatureOnOffOptions.ClosedFileDiagnostic ||
+                       e.Option == RunTimeOptions.FullSolutionAnalysis ||
                        e.Option == InternalDiagnosticsOptions.UseDiagnosticEngineV2 ||
                        Analyzer.NeedsReanalysisOnOptionChanged(sender, e);
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -103,15 +103,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             return SpecializedTasks.EmptyTask;
         }
 
-        private bool CheckOption(Workspace workspace, string language, bool documentOpened)
+        private bool CheckOption(Workspace workspace, string language, bool forceAnalysis)
         {
             var optionService = workspace.Services.GetService<IOptionService>();
-            if (optionService == null || optionService.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language))
+            if (optionService == null || optionService.GetOption(RunTimeOptions.FullSolutionAnalysis))
             {
                 return true;
             }
 
-            if (documentOpened)
+            if (forceAnalysis)
             {
                 return true;
             }
@@ -337,8 +337,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         {
             try
             {
-                // Compilation actions can report diagnostics on open files, so "documentOpened = true"
-                if (!CheckOption(project.Solution.Workspace, project.Language, documentOpened: true))
+                // we only report project diagnostics when full solution analysis is on.
+                if (!CheckOption(project.Solution.Workspace, project.Language, forceAnalysis: false))
                 {
                     return;
                 }

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -253,8 +253,8 @@
     <Compile Include="ReplaceMethodWithProperty\IReplaceMethodWithPropertyService.cs" />
     <Compile Include="Shared\Options\OrganizerOptionsProvider.cs" />
     <Compile Include="Shared\Options\ServiceComponentOnOffOptionsProvider.cs" />
-    <Compile Include="Shared\Options\ServiceFeatureOnOffOptions.cs" />
-    <Compile Include="Shared\Options\ServiceFeatureOnOffOptionsProvider.cs" />
+    <Compile Include="Shared\Options\RuntimeOptions.cs" />
+    <Compile Include="Shared\Options\RunTimeOptionsProvider.cs" />
     <Compile Include="Shared\Utilities\LinkedFilesSymbolEquivalenceComparer.cs" />
     <Compile Include="Shared\Utilities\SupportedPlatformData.cs" />
     <Compile Include="Completion\Providers\SymbolCompletionItem.cs" />

--- a/src/Features/Core/Portable/Shared/Options/RunTimeOptionsProvider.cs
+++ b/src/Features/Core/Portable/Shared/Options/RunTimeOptionsProvider.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Options
 {
     [ExportOptionProvider, Shared]
     internal class RunTimeOptionsProvider : IOptionProvider
     {
-        private readonly IEnumerable<IOption> _options = new List<IOption> { RunTimeOptions.FullSolutionAnalysis }.ToImmutableArray();
+        private readonly IEnumerable<IOption> _options = SpecializedCollections.SingletonEnumerable(RunTimeOptions.FullSolutionAnalysis);
 
         public IEnumerable<IOption> GetOptions() => _options;
     }

--- a/src/Features/Core/Portable/Shared/Options/RunTimeOptionsProvider.cs
+++ b/src/Features/Core/Portable/Shared/Options/RunTimeOptionsProvider.cs
@@ -9,16 +9,10 @@ using Microsoft.CodeAnalysis.Options.Providers;
 namespace Microsoft.CodeAnalysis.Shared.Options
 {
     [ExportOptionProvider, Shared]
-    internal class ServiceFeatureOnOffOptionsProvider : IOptionProvider
+    internal class RunTimeOptionsProvider : IOptionProvider
     {
-        private readonly IEnumerable<IOption> _options = new List<IOption>
-            {
-                ServiceFeatureOnOffOptions.ClosedFileDiagnostic
-            }.ToImmutableArray();
+        private readonly IEnumerable<IOption> _options = new List<IOption> { RunTimeOptions.FullSolutionAnalysis }.ToImmutableArray();
 
-        public IEnumerable<IOption> GetOptions()
-        {
-            return _options;
-        }
+        public IEnumerable<IOption> GetOptions() => _options;
     }
 }

--- a/src/Features/Core/Portable/Shared/Options/RuntimeOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/RuntimeOptions.cs
@@ -4,10 +4,13 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Shared.Options
 {
-    internal static class ServiceFeatureOnOffOptions
+    /// <summary>
+    /// Options that aren't persisted. options here will be reset to default on new process.
+    /// </summary>
+    internal static class RunTimeOptions
     {
         public const string OptionName = "ServiceFeaturesOnOff";
 
-        public static readonly PerLanguageOption<bool> ClosedFileDiagnostic = new PerLanguageOption<bool>(OptionName, "Closed File Diagnostic", defaultValue: true);
+        public static readonly Option<bool> FullSolutionAnalysis = new Option<bool>(OptionName, "FullSolutionAnalysisDiagnostic", defaultValue: true);
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(PlaceSystemNamespaceFirst, OrganizerOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp);
             BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptions.DontPutOutOrRefOnStruct, LanguageNames.CSharp);
             BindToOption(AllowMovingDeclaration, ExtractMethodOptions.AllowMovingDeclaration, LanguageNames.CSharp);
-            BindToOption(ClosedFileDiagnostics, ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp);
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -36,12 +36,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set { SetBooleanOption(CompletionOptions.TriggerOnTypingLetters, value); }
         }
 
-        public int ClosedFileDiagnostics
-        {
-            get { return GetBooleanOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic); }
-            set { SetBooleanOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, value); }
-        }
-
         public int DisplayLineSeparators
         {
             get { return GetBooleanOption(FeatureOnOffOptions.LineSeparator); }

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
@@ -43,8 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         CSharpFormattingOptions.SpacingFeatureName,
         CSharpFormattingOptions.WrappingFeatureName,
         FormattingOptions.InternalTabFeatureName,
-        FeatureOnOffOptions.OptionName,
-        ServiceFeatureOnOffOptions.OptionName), Shared]
+        FeatureOnOffOptions.OptionName), Shared]
     internal sealed class CSharpSettingsManagerOptionSerializer : AbstractSettingsManagerOptionSerializer
     {
         [ImportingConstructor]
@@ -86,7 +85,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
                     typeof(SimplificationOptions),
                     typeof(CSharpCodeStyleOptions),
                     typeof(ExtractMethodOptions),
-                    typeof(ServiceFeatureOnOffOptions),
                     typeof(CSharpFormattingOptions)
                 };
 
@@ -123,7 +121,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
                     option == CompletionOptions.TriggerOnTypingLetters ||
                     option.Feature == SimplificationOptions.PerLanguageFeatureName ||
                     option.Feature == ExtractMethodOptions.FeatureName ||
-                    option.Feature == ServiceFeatureOnOffOptions.OptionName ||
                     option.Feature == FormattingOptions.InternalTabFeatureName)
                 {
                     return true;

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             public async Task AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
             {
-                // if closed file diagnostic is off and document is not opened, then don't do anything
+                // if full analysis is off and document is not opened, then don't do anything
                 if (!_workspace.Options.GetOption(RunTimeOptions.FullSolutionAnalysis) && !document.IsOpen())
                 {
                     return;
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
-                // no closed file diagnostic and file is not opened, remove any existing diagnostics
+                // full analysis is off and file is not opened, remove any existing diagnostics
                 if (!_workspace.Options.GetOption(RunTimeOptions.FullSolutionAnalysis) && !document.IsOpen())
                 {
                     RaiseEmptyDiagnosticUpdated(document.Id);

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             public async Task AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
             {
                 // if closed file diagnostic is off and document is not opened, then don't do anything
-                if (!_workspace.Options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, document.Project.Language) && !document.IsOpen())
+                if (!_workspace.Options.GetOption(RunTimeOptions.FullSolutionAnalysis) && !document.IsOpen())
                 {
                     return;
                 }
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 // no closed file diagnostic and file is not opened, remove any existing diagnostics
-                if (!_workspace.Options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, document.Project.Language) && !document.IsOpen())
+                if (!_workspace.Options.GetOption(RunTimeOptions.FullSolutionAnalysis) && !document.IsOpen())
                 {
                     RaiseEmptyDiagnosticUpdated(document.Id);
                 }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -439,6 +439,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to VS turned off full solution analysis due to memory concern. please re-start VS if you want full solution analysis back..
+        /// </summary>
+        internal static string FullSolutionAnalysisOff {
+            get {
+                return ResourceManager.GetString("FullSolutionAnalysisOff", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Generated name:.
         /// </summary>
         internal static string GeneratedName {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -439,7 +439,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to VS turned off full solution analysis due to memory concern. please re-start VS if you want full solution analysis back..
+        ///   Looks up a localized string similar to Full solution analysis disabled due to low memory. Restart VS to restore full solution analysis..
         /// </summary>
         internal static string FullSolutionAnalysisOff {
             get {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -513,4 +513,7 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   <data name="SynchronizingWithClassView" xml:space="preserve">
     <value>Synchronizing with {0}...</value>
   </data>
+  <data name="FullSolutionAnalysisOff" xml:space="preserve">
+    <value>VS turned off full solution analysis due to memory concern. please re-start VS if you want full solution analysis back.</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -514,6 +514,6 @@ Use the dropdown to view and switch to other projects this file may belong to.</
     <value>Synchronizing with {0}...</value>
   </data>
   <data name="FullSolutionAnalysisOff" xml:space="preserve">
-    <value>VS turned off full solution analysis due to memory concern. please re-start VS if you want full solution analysis back.</value>
+    <value>Full solution analysis disabled due to low memory. Restart VS to restore full solution analysis.</value>
   </data>
 </root>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -25,7 +25,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(NavigateToObjectBrowser, VisualStudioNavigationOptions.NavigateToObjectBrowser, LanguageNames.VisualBasic)
             BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptions.DontPutOutOrRefOnStruct, LanguageNames.VisualBasic)
             BindToOption(AllowMovingDeclaration, ExtractMethodOptions.AllowMovingDeclaration, LanguageNames.VisualBasic)
-            BindToOption(ClosedFileDiagnostics, ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -44,15 +44,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             End Set
         End Property
 
-        Public Property ClosedFileDiagnostics As Boolean
-            Get
-                Return GetBooleanOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic)
-            End Get
-            Set(value As Boolean)
-                SetBooleanOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, value)
-            End Set
-        End Property
-
         Public Property RenameTrackingPreview As Boolean
             Get
                 Return GetBooleanOption(FeatureOnOffOptions.RenameTrackingPreview)

--- a/src/VisualStudio/VisualBasic/Impl/Options/VisualBasicSettingsManagerOptionSerializer.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/VisualBasicSettingsManagerOptionSerializer.vb
@@ -20,7 +20,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         SimplificationOptions.PerLanguageFeatureName,
         ExtractMethodOptions.FeatureName,
         FeatureOnOffOptions.OptionName,
-        ServiceFeatureOnOffOptions.OptionName,
         FormattingOptions.InternalTabFeatureName,
         VisualStudioNavigationOptions.FeatureName), [Shared]>
     Friend NotInheritable Class VisualBasicSettingsManagerOptionSerializer
@@ -49,7 +48,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
                 GetType(FormattingOptions),
                 GetType(ExtractMethodOptions),
                 GetType(SimplificationOptions),
-                GetType(ServiceFeatureOnOffOptions),
                 GetType(VisualStudioNavigationOptions)}
 
             Dim Flags As BindingFlags = BindingFlags.Public Or BindingFlags.Static
@@ -87,7 +85,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
                 Return [option].Feature = FormattingOptions.InternalTabFeatureName Or
                        [option].Feature = ExtractMethodOptions.FeatureName Or
                        [option].Feature = SimplificationOptions.PerLanguageFeatureName Or
-                       [option].Feature = ServiceFeatureOnOffOptions.OptionName Or
                        [option].Feature = VisualStudioNavigationOptions.FeatureName
             End If
 

--- a/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
@@ -8,5 +8,6 @@ namespace Microsoft.CodeAnalysis.Extensions
     internal interface IErrorReportingService : IWorkspaceService
     {
         void ShowErrorInfoForCodeFix(string codefixName, Action OnEnableClicked, Action OnEnableAndIgnoreClicked, Action OnClose);
+        void ShowErrorInfo(string title, Action OnClose);
     }
 }


### PR DESCRIPTION
following design meeting decision, I removed closed file diagnostic options from UI. this should remove confusion on what closed file diagnostics means for user experience and how much efforts we need to do to support this option (see https://github.com/dotnet/roslyn/issues/4364 for more detail). 

basically, one thinks this option as performance switch, meaning, we should do as less work as possible to improve VS performance, the other think this is functionality switch meaning, we should make sure we include diagnostics from all open files even though that is as much expensive as full solution analysis or even more.

...

even though the option is removed from UI, it still live as internal option for OOM prevention option. when we are notified by shell that we have low memory, we will turn off full solution analysis and let user know it has been turned off. this will prevent us from OOM and give users an option, either they continue working or close and re-open vs safely.

...

when full solution analysis is off, experience will be quite similar to pre-Roslyn C# LS experience. errors only from opened files, closed file errors comes from build and stay there until replaced by opened file errors.