### PR TITLE
Enable specifying top-level binder options via an internal compilation option

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -21,19 +21,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal readonly BinderFlags Flags;
 
+        /// <summary>
+        /// Used to create a root binder.
+        /// </summary>
+        internal Binder(CSharpCompilation compilation)
+        {
+            Debug.Assert(compilation != null);
+            this.Flags = compilation.Options.TopLevelBinderFlags;
+            this.Compilation = compilation;
+        }
+
         internal Binder(Binder next)
         {
             Debug.Assert(next != null);
             _next = next;
             this.Flags = next.Flags;
             this.Compilation = next.Compilation;
-        }
-
-        internal Binder(CSharpCompilation compilation)
-        {
-            Debug.Assert(compilation != null);
-            this.Flags = BinderFlags.None;
-            this.Compilation = compilation;
         }
 
         protected Binder(Binder next, BinderFlags flags)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
@@ -86,6 +86,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestProperty((old, value) => old.WithMetadataReferenceResolver(value), opt => opt.MetadataReferenceResolver, new TestMetadataReferenceResolver());
             TestProperty((old, value) => old.WithAssemblyIdentityComparer(value), opt => opt.AssemblyIdentityComparer, new DesktopAssemblyIdentityComparer(new AssemblyPortabilityPolicy()));
             TestProperty((old, value) => old.WithStrongNameProvider(value), opt => opt.StrongNameProvider, new DesktopStrongNameProvider());
+
+            TestProperty((old, value) => old.WithTopLevelBinderFlags(value), opt => opt.TopLevelBinderFlags, BinderFlags.IgnoreCorLibraryDuplicatedTypes);
+            TestProperty((old, value) => old.WithMetadataImportOptions(value), opt => opt.MetadataImportOptions, MetadataImportOptions.Internal);
         }
 
         [Fact]
@@ -319,7 +322,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             ReflectionAssert.AssertPublicAndInternalFieldsAndProperties(
                 typeof(CSharpCompilationOptions),
                 "AllowUnsafe",
-                "Usings");
+                "Usings",
+                "TopLevelBinderFlags");
         }
 
         [Fact]
@@ -356,12 +360,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             StrongNameProvider strongNameProvider = new DesktopStrongNameProvider();
             MetadataImportOptions metadataImportOptions = 0;
             bool reportSuppressedDiagnostics = false;
+            var topLevelBinderFlags = BinderFlags.None;
+            var publicSign = false;
+
             return new CSharpCompilationOptions(OutputKind.ConsoleApplication, reportSuppressedDiagnostics, moduleName, mainTypeName, scriptClassName, usings,
                 optimizationLevel, checkOverflow, allowUnsafe, cryptoKeyContainer, cryptoKeyFile, cryptoPublicKey, delaySign,
                 platform, generalDiagnosticOption, warningLevel, specificDiagnosticOptions,
                 concurrentBuild, deterministic, extendedCustomDebugInformation, debugPlusMode, xmlReferenceResolver, sourceReferenceResolver, metadataReferenceResolver,
-                assemblyIdentityComparer, strongNameProvider, metadataImportOptions,
-                publicSign: false);
+                assemblyIdentityComparer, strongNameProvider, metadataImportOptions, publicSign, topLevelBinderFlags);
         }
 
         private sealed class MetadataReferenceResolverWithEquality : MetadataReferenceResolver

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -641,14 +641,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 @namespace = @namespace.ContainingNamespace;
             }
 
-            var binder = (new BuckStopsHereBinder(compilation)).WithAdditionalFlags(
-                BinderFlags.SuppressObsoleteChecks |
-                BinderFlags.IgnoreAccessibility |
-                BinderFlags.UnsafeRegion |
-                BinderFlags.UncheckedRegion |
-                BinderFlags.AllowManagedAddressOf |
-                BinderFlags.AllowAwaitInUnsafeContext |
-                BinderFlags.IgnoreCorLibraryDuplicatedTypes);
+            Binder binder = new BuckStopsHereBinder(compilation);
             var hasImports = !importRecordGroups.IsDefaultOrEmpty;
             var numImportStringGroups = hasImports ? importRecordGroups.Length : 0;
             var currentStringGroup = numImportStringGroups - 1;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -127,6 +127,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             platform: Platform.AnyCpu, // Platform should match PEModule.Machine, in this case I386.
             optimizationLevel: OptimizationLevel.Release,
             assemblyIdentityComparer: IdentityComparer).
-            WithMetadataImportOptions(MetadataImportOptions.All);
+            WithMetadataImportOptions(MetadataImportOptions.All).
+            WithTopLevelBinderFlags(
+                BinderFlags.SuppressObsoleteChecks |
+                BinderFlags.IgnoreAccessibility |
+                BinderFlags.UnsafeRegion |
+                BinderFlags.UncheckedRegion |
+                BinderFlags.AllowManagedAddressOf |
+                BinderFlags.AllowAwaitInUnsafeContext |
+                BinderFlags.IgnoreCorLibraryDuplicatedTypes);
     }
 }

--- a/src/Scripting/CSharp/CSharpScriptCompiler.cs
+++ b/src/Scripting/CSharp/CSharpScriptCompiler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting
                     sourceReferenceResolver: script.Options.SourceResolver,
                     metadataReferenceResolver: script.Options.MetadataResolver,
                     assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default
-                ),
+                ).WithTopLevelBinderFlags(BinderFlags.IgnoreCorLibraryDuplicatedTypes),
                 previousSubmission,
                 script.ReturnType,
                 script.GlobalsType


### PR DESCRIPTION
… and use it in scripting to ignore duplicate corlib types.

Also changes the EE compiler to use the compilation option rather than setting the flags directly on the binder. Eventually we should eliminate the need to create a custom binder in the EEs and use the same compiler features that scripting uses.

This change introduces an internal compilation option. We can later add public enum that contains a subset of binder flags that actually make sense to set outside of the compiler. 

This change also makes it easier to accommodate the feature request from the CLR that asks us for suppressing accessibility checks for the entire compilation.

Implements a workaround for https://github.com/dotnet/cli/issues/320. A proposal for a better (more robust) solution is tracked by https://github.com/dotnet/corefx/issues/5540.