### PR TITLE
Strengthen implementation of MetadataHelpers.GetInfoForImmediateNamespaceMembers against unconventional/obfuscated namespace names in metadata.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -176,9 +176,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             //    Value – contains a sequence similar to the one passed to this function, but
             //            calculated for the child namespace. 
             IEnumerable<KeyValuePair<string, IEnumerable<IGrouping<string, TypeDefinitionHandle>>>> nestedNamespaces = null;
+            bool isGlobalNamespace = this.IsGlobalNamespace;
 
             MetadataHelpers.GetInfoForImmediateNamespaceMembers(
-                this.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat).Length,
+                isGlobalNamespace,
+                isGlobalNamespace ? 0 : this.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat).Length,
                 typesByNS,
                 StringComparer.Ordinal,
                 out nestedTypes, out nestedNamespaces);

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataHelpersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataHelpersTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Test.Utilities;
@@ -394,6 +397,90 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 expectedTypeArguments: null,
                 expectedPointerCount: 0,
                 expectedArrayRanks: new[] { 1 });
+        }
+
+        [Fact, WorkItem(7396, "https://github.com/dotnet/roslyn/issues/7396")]
+        public void ObfuscatedNamespaceNames_01()
+        {
+            var result = new ArrayBuilder<IGrouping<string, TypeDefinitionHandle>>();
+
+            foreach (var namespaceName in new[] { "A.", "A.a", "A..", "A.-" })
+            {
+                result.Add(new Grouping<string, TypeDefinitionHandle>(namespaceName, new[] { new TypeDefinitionHandle() }));
+            }
+
+            result.Sort(new PEModule.TypesByNamespaceSortComparer(StringComparer.Ordinal));
+
+            // This is equivalent to the result of PEModule.GroupTypesByNamespaceOrThrow
+            IEnumerable<IGrouping<string, TypeDefinitionHandle>> typesByNS = result;
+
+            // The following code is equivalent to code in PENamespaceSymbol.LoadAllMembers
+
+            IEnumerable<IGrouping<string, TypeDefinitionHandle>> nestedTypes = null;
+            IEnumerable<KeyValuePair<string, IEnumerable<IGrouping<string, TypeDefinitionHandle>>>> nestedNamespaces = null;
+
+            MetadataHelpers.GetInfoForImmediateNamespaceMembers(
+                false,
+                "A".Length,
+                typesByNS,
+                StringComparer.Ordinal,
+                out nestedTypes, out nestedNamespaces);
+
+            // We don't expect duplicate keys in nestedNamespaces at this point.
+            Assert.False(nestedNamespaces.GroupBy(pair => pair.Key).Where(g => g.Count() > 1).Any());
+
+            var array = nestedNamespaces.ToArray();
+            Assert.Equal(3, array.Length);
+            Assert.Equal("", array[0].Key);
+            Assert.Equal(2, array[0].Value.Count());
+            Assert.Equal("-", array[1].Key);
+            Assert.Equal(1, array[1].Value.Count());
+            Assert.Equal("a", array[2].Key);
+            Assert.Equal(1, array[2].Value.Count());
+        }
+
+        [Fact, WorkItem(7396, "https://github.com/dotnet/roslyn/issues/7396")]
+        public void ObfuscatedNamespaceNames_02()
+        {
+            var result = new ArrayBuilder<IGrouping<string, TypeDefinitionHandle>>();
+
+            foreach (var namespaceName in new[] { ".a", ".b" })
+            {
+                result.Add(new Grouping<string, TypeDefinitionHandle>(namespaceName, new[] { new TypeDefinitionHandle() }));
+            }
+
+            result.Sort(new PEModule.TypesByNamespaceSortComparer(StringComparer.Ordinal));
+
+            // This is equivalent to the result of PEModule.GroupTypesByNamespaceOrThrow
+            IEnumerable<IGrouping<string, TypeDefinitionHandle>> typesByNS = result;
+
+            // The following code is equivalent to code in PENamespaceSymbol.LoadAllMembers
+
+            IEnumerable<IGrouping<string, TypeDefinitionHandle>> nestedTypes = null;
+            IEnumerable<KeyValuePair<string, IEnumerable<IGrouping<string, TypeDefinitionHandle>>>> nestedNamespaces = null;
+
+            MetadataHelpers.GetInfoForImmediateNamespaceMembers(
+                true, // global namespace
+                0, // global namespace
+                typesByNS,
+                StringComparer.Ordinal,
+                out nestedTypes, out nestedNamespaces);
+
+            var nestedNS = nestedNamespaces.Single();
+
+            Assert.Equal("", nestedNS.Key);
+            Assert.Equal(2, nestedNS.Value.Count());
+
+            MetadataHelpers.GetInfoForImmediateNamespaceMembers(
+                false,
+                nestedNS.Key.Length,
+                nestedNS.Value,
+                StringComparer.Ordinal,
+                out nestedTypes, out nestedNamespaces);
+
+            Assert.Equal(2, nestedNamespaces.Count());
+            Assert.Equal("a", nestedNamespaces.ElementAt(0).Key);
+            Assert.Equal("b", nestedNamespaces.ElementAt(1).Key);
         }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -621,7 +621,7 @@ namespace Microsoft.CodeAnalysis
             return result;
         }
 
-        private class TypesByNamespaceSortComparer : IComparer<IGrouping<string, TypeDefinitionHandle>>
+        internal class TypesByNamespaceSortComparer : IComparer<IGrouping<string, TypeDefinitionHandle>>
         {
             private readonly StringComparer _nameComparer;
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
@@ -167,8 +167,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Dim nestedNamespaces As IEnumerable(Of KeyValuePair(Of String, IEnumerable(Of IGrouping(Of String, TypeDefinitionHandle)))) = Nothing
 
             'TODO: Perhaps there is a cheaper way to calculate the length of the name without actually building it with ToDisplayString.
+            Dim isGlobalNamespace As Boolean = Me.IsGlobalNamespace
+
             MetadataHelpers.GetInfoForImmediateNamespaceMembers(
-                ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat).Length,
+                isGlobalNamespace,
+                If(isGlobalNamespace, 0, ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat).Length),
                 typesByNS,
                 CaseInsensitiveComparison.Comparer,
                 nestedTypes, nestedNamespaces)


### PR DESCRIPTION
Fixes #7396.

@dotnet/roslyn-compiler Please review.