### PR TITLE
Correctly detect existing constructors during code generation

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
@@ -173,5 +173,12 @@ index: 1);
 @"class Program { [|int yield ;|] } ",
 @"class Program { int yield ; public Program ( int yield ) { this . yield = yield ; } } ");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestGenerateConstructorNotOfferedForDuplicate()
+        {
+            await TestMissingAsync(
+"using System ; class X { public X ( string v ) { } static void Test ( ) { new X ( new [|string|] ( ) ) ; } } ");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -910,6 +910,11 @@ class C
             {
                 throw new NotImplementedException();
             }
+
+            public string GetNameForArgument(SyntaxNode argument)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -816,6 +816,10 @@ End Class]]></a>.Value.NormalizeLineEndings()
             Public Function GetInactiveRegionSpanAroundPosition(tree As SyntaxTree, position As Integer, cancellationToken As CancellationToken) As TextSpan Implements ISyntaxFactsService.GetInactiveRegionSpanAroundPosition
                 Throw New NotImplementedException()
             End Function
+
+            Public Function GetNameForArgument(argument As SyntaxNode) As String Implements ISyntaxFactsService.GetNameForArgument
+                    Throw New NotImplementedException()
+            End Function
         End Class
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -580,5 +580,23 @@ Public Class [|;;|]Derived
 
 End Class")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function TestGenerateConstructorNotOfferedForDuplicate() As Task
+            Await TestMissingAsync(
+"Imports System
+
+Class X
+    Private v As String
+
+    Public Sub New(v As String)
+        Me.v = v
+    End Sub
+
+    Sub Test()
+        Dim x As X = New X(New [|String|]())
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -100,23 +100,23 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
             {
                 var destinationProvider = document.Project.Solution.Workspace.Services.GetLanguageServices(this.TypeToGenerateIn.Language);
                 var syntaxFacts = destinationProvider.GetService<ISyntaxFactsService>();
-                return this.TypeToGenerateIn.InstanceConstructors.Any(c => Matches(c, this.ParameterTypes, this.ParameterRefKinds, this.Arguments, syntaxFacts));
+                return this.TypeToGenerateIn.InstanceConstructors.Any(c => Matches(c, syntaxFacts));
             }
 
-            private static bool Matches(IMethodSymbol ctor, IList<ITypeSymbol> parameterTypes, IList<RefKind> parameterRefKinds, IList<TArgumentSyntax> arguments, ISyntaxFactsService service)
+            private bool Matches(IMethodSymbol ctor, ISyntaxFactsService service)
             {
-                if (ctor.Parameters.Length != parameterTypes.Count)
+                if (ctor.Parameters.Length != this.ParameterTypes.Count)
                 {
                     return false;
                 }
 
-                for (int i = 0; i < parameterTypes.Count; i++)
+                for (int i = 0; i < this.ParameterTypes.Count; i++)
                 {
                     var ctorParameter = ctor.Parameters[i];
-                    var result = SymbolEquivalenceComparer.Instance.Equals(ctorParameter.Type, parameterTypes[i]) &&
-                        ctorParameter.RefKind == parameterRefKinds[i];
+                    var result = SymbolEquivalenceComparer.Instance.Equals(ctorParameter.Type, this.ParameterTypes[i]) &&
+                        ctorParameter.RefKind == this.ParameterRefKinds[i];
                     
-                    string parameterName = GetParameterName(arguments, i, service);
+                    string parameterName = GetParameterName(service, i);
                     if (!string.IsNullOrEmpty(parameterName))
                     {
                         result &= service.IsCaseSensitive 
@@ -133,14 +133,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 return true;
             }
 
-            private static string GetParameterName(IList<TArgumentSyntax> arguments, int index, ISyntaxFactsService service)
+            private string GetParameterName(ISyntaxFactsService service, int index)
             {
-                if (index >= arguments?.Count)
+                if (index >= this.Arguments?.Count)
                 {
                     return string.Empty;
                 }
 
-                return service.GetNameForArgument(arguments?[index]);
+                return service.GetNameForArgument(this.Arguments?[index]);
             }
 
             internal List<ITypeSymbol> GetParameterTypes(

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
@@ -28,7 +28,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
         protected abstract bool TryInitializeClassDeclarationGenerationState(SemanticDocument document, SyntaxNode classDeclaration, CancellationToken cancellationToken, out SyntaxToken token, out IMethodSymbol constructor, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeConstructorInitializerGeneration(SemanticDocument document, SyntaxNode constructorInitializer, CancellationToken cancellationToken, out SyntaxToken token, out IList<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeSimpleAttributeNameGenerationState(SemanticDocument document, SyntaxNode simpleName, CancellationToken cancellationToken, out SyntaxToken token, out IList<TArgumentSyntax> arguments, out IList<TAttributeArgumentSyntax> attributeArguments, out INamedTypeSymbol typeToGenerateIn);
-
         protected abstract IList<string> GenerateParameterNames(SemanticModel semanticModel, IEnumerable<TArgumentSyntax> arguments, IList<string> reservedNames = null);
         protected virtual IList<string> GenerateParameterNames(SemanticModel semanticModel, IEnumerable<TAttributeArgumentSyntax> arguments, IList<string> reservedNames = null) { return null; }
         protected abstract string GenerateNameForArgument(SemanticModel semanticModel, TArgumentSyntax argument);

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1429,5 +1429,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return default(TextSpan);
         }
+
+        public string GetNameForArgument(SyntaxNode argument)
+        {
+            if ((argument as ArgumentSyntax)?.NameColon != null)
+            {
+                return (argument as ArgumentSyntax).NameColon.Name.Identifier.ValueText;
+            }
+
+            return string.Empty;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -156,6 +156,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         IEnumerable<SyntaxNode> GetConstructors(SyntaxNode root, CancellationToken cancellationToken);
 
         bool TryGetCorrespondingOpenBrace(SyntaxToken token, out SyntaxToken openBrace);
+
+        /// <summary>
+        /// Given a <see cref="SyntaxNode"/>, that represents and argument return the string representation of
+        /// that arguments name.
+        /// </summary>
+        string GetNameForArgument(SyntaxNode argument);
     }
 
     [Flags]

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1177,5 +1177,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Return Nothing
         End Function
-    End Class
+
+        Public Function GetNameForArgument(argument As SyntaxNode) As String Implements ISyntaxFactsService.GetNameForArgument
+           If TryCast(argument, ArgumentSyntax)?.IsNamed Then
+                Return DirectCast(argument, SimpleArgumentSyntax).NameColonEquals.Name.Identifier.ValueText
+            End If
+
+            Return String.Empty
+        End Function
+        End Class
 End Namespace


### PR DESCRIPTION
Previously we would always compare based on parameter name, and since the constructed parameter symbols were always named `string.Empty` the comparison would always fail.  Now we use the parameter name if it is provided, else we do not compare based on parameter names.