### PR TITLE
Add tests for reset REPL from project and send to REPL

### DIFF
--- a/src/EditorFeatures/Test/AbstractCommandHandlerTestState.cs
+++ b/src/EditorFeatures/Test/AbstractCommandHandlerTestState.cs
@@ -45,6 +45,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         ///     {|Selection:SomeMethodCall()
         ///     AnotherMethodCall()$$|}
         /// End Sub
+        ///
+        /// You can use multiple selection spans to create box selections.
+        ///
+        /// Sub Foo
+        ///     {|Selection:$$box|}11111
+        ///     {|Selection:sel|}111
+        ///     {|Selection:ect|}1
+        ///     {|Selection:ion|}1111111
+        /// End Sub
         /// </summary>
         public AbstractCommandHandlerTestState(
             XElement workspaceElement,
@@ -64,26 +73,39 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
             if (cursorDocument.AnnotatedSpans.TryGetValue("Selection", out selectionSpanList))
             {
-                var span = selectionSpanList.First();
+                var firstSpan = selectionSpanList.First();
+                var lastSpan = selectionSpanList.Last();
                 var cursorPosition = cursorDocument.CursorPosition.Value;
 
-                Assert.True(cursorPosition == span.Start || cursorPosition == span.Start + span.Length,
+                Assert.True(cursorPosition == firstSpan.Start || cursorPosition == firstSpan.End
+                            || cursorPosition == lastSpan.Start || cursorPosition == lastSpan.End,
                     "cursorPosition wasn't at an endpoint of the 'Selection' annotated span");
 
-                _textView.Selection.Select(
-                    new SnapshotSpan(_subjectBuffer.CurrentSnapshot, new Span(span.Start, span.Length)),
-                    isReversed: cursorPosition == span.Start);
+                _textView.Selection.Mode = selectionSpanList.Count > 1
+                    ? TextSelectionMode.Box
+                    : TextSelectionMode.Stream;
 
-                if (selectionSpanList.Count > 1)
+                SnapshotPoint boxSelectionStart, boxSelectionEnd;
+                bool isReversed;
+
+                if (cursorPosition == firstSpan.Start || cursorPosition == lastSpan.End)
                 {
-                    _textView.Selection.Mode = TextSelectionMode.Box;
-                    foreach (var additionalSpan in selectionSpanList.Skip(1))
-                    {
-                        _textView.Selection.Select(
-                            new SnapshotSpan(_subjectBuffer.CurrentSnapshot, new Span(additionalSpan.Start, additionalSpan.Length)),
-                            isReversed: false);
-                    }
+                    // Top-left and bottom-right corners used as anchor points.
+                    boxSelectionStart = new SnapshotPoint(_subjectBuffer.CurrentSnapshot, firstSpan.Start);
+                    boxSelectionEnd = new SnapshotPoint(_subjectBuffer.CurrentSnapshot, lastSpan.End);
+                    isReversed = cursorPosition == firstSpan.Start;
                 }
+                else
+                {
+                    // Top-right and bottom-left corners used as anchor points.
+                    boxSelectionStart = new SnapshotPoint(_subjectBuffer.CurrentSnapshot, firstSpan.End);
+                    boxSelectionEnd = new SnapshotPoint(_subjectBuffer.CurrentSnapshot, lastSpan.Start);
+                    isReversed = cursorPosition == firstSpan.End;
+                }
+
+                _textView.Selection.Select(
+                        new SnapshotSpan(boxSelectionStart, boxSelectionEnd),
+                        isReversed: isReversed);
             }
             else
             {

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -148,6 +148,7 @@
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests2" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.VisualBasic.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.VisualStudio.Services.UnitTests" />
+    <InternalsVisibleToTest Include="Roslyn.VisualStudio.CSharp.UnitTests" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/ResetInteractive.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/ResetInteractive.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Interactive;
+using Microsoft.VisualStudio.InteractiveWindow;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Interactive
+{
+    /// <summary>
+    /// ResetInteractive class that implements base functionality for reset interactive command.
+    /// Does not depend on VS classes to make it easier to stub out and test.
+    /// </summary>
+    internal abstract class ResetInteractive
+    {
+        private readonly Func<string, string> _createReference;
+
+        private readonly Func<string, string> _createImport;
+
+        internal event EventHandler ExecutionCompleted;
+
+        internal ResetInteractive(Func<string, string> createReference, Func<string, string> createImport)
+        {
+            _createReference = createReference;
+            _createImport = createImport;
+        }
+
+        internal Task Execute(IInteractiveWindow interactiveWindow, string title)
+        {
+            ImmutableArray<string> references, referenceSearchPaths, sourceSearchPaths, namespacesToImport;
+            string projectDirectory;
+
+            if (GetProjectProperties(out references, out referenceSearchPaths, out sourceSearchPaths, out namespacesToImport, out projectDirectory))
+            {
+                // Now, we're going to do a bunch of async operations.  So create a wait
+                // indicator so the user knows something is happening, and also so they cancel.
+                var waitIndicator = GetWaitIndicator();
+                var waitContext = waitIndicator.StartWait(title, InteractiveEditorFeaturesResources.BuildingProject, allowCancel: true);
+
+                var resetInteractiveTask = ResetInteractiveAsync(
+                    interactiveWindow,
+                    references,
+                    referenceSearchPaths,
+                    sourceSearchPaths,
+                    namespacesToImport,
+                    projectDirectory,
+                    waitContext);
+
+                // Once we're done resetting, dismiss the wait indicator and focus the REPL window.
+                return resetInteractiveTask.SafeContinueWith(
+                    _ =>
+                    {
+                        waitContext.Dispose();
+                        ExecutionCompleted?.Invoke(this, new EventArgs());
+                    },
+                    TaskScheduler.FromCurrentSynchronizationContext());
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task ResetInteractiveAsync(
+            IInteractiveWindow interactiveWindow,
+            ImmutableArray<string> referencePaths,
+            ImmutableArray<string> referenceSearchPaths,
+            ImmutableArray<string> sourceSearchPaths,
+            ImmutableArray<string> namespacesToImport,
+            string projectDirectory,
+            IWaitContext waitContext)
+        {
+            // First, open the repl window.
+            IInteractiveEvaluator evaluator = interactiveWindow.Evaluator;
+
+            // If the user hits the cancel button on the wait indicator, then we want to stop the
+            // build.
+            waitContext.CancellationToken.Register(() =>
+                CancelBuildProject(), useSynchronizationContext: true);
+
+            // First, start a build.
+            // If the build fails do not reset the REPL.
+            var builtSuccessfully = await BuildProject().ConfigureAwait(true);
+            if (!builtSuccessfully)
+            {
+                return;
+            }
+
+            // Then reset the REPL
+            waitContext.Message = InteractiveEditorFeaturesResources.ResettingInteractive;
+            await interactiveWindow.Operations.ResetAsync(initialize: true).ConfigureAwait(true);
+
+            // TODO: load context from an rsp file.
+
+            // Now send the reference paths we've collected to the repl.
+            // The SetPathsAsync method is not available through an Interface.
+            // Execute the method only if the cast to a concrete InteractiveEvaluator succeeds.
+            InteractiveEvaluator interactiveEvaluator = evaluator as InteractiveEvaluator;
+            if (interactiveEvaluator != null)
+            {
+                await interactiveEvaluator.SetPathsAsync(referenceSearchPaths, sourceSearchPaths, projectDirectory).ConfigureAwait(true);
+            }
+
+            await interactiveWindow.SubmitAsync(new[]
+            {
+                referencePaths.Select(_createReference).Join("\r\n"),
+                namespacesToImport.Select(_createImport).Join("\r\n")
+            }).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Gets the properties of the currently selected projects necessary for reset.
+        /// </summary>
+        protected abstract bool GetProjectProperties(
+            out ImmutableArray<string> references,
+            out ImmutableArray<string> referenceSearchPaths,
+            out ImmutableArray<string> sourceSearchPaths,
+            out ImmutableArray<string> namespacesToImport,
+            out string projectDirectory);
+
+        /// <summary>
+        /// A method that should trigger an async project build.
+        /// </summary>
+        /// <returns>Whether or not the build was successful.</returns>
+        protected abstract Task<bool> BuildProject();
+
+        /// <summary>
+        /// A method that should trigger a project cancellation.
+        /// </summary>
+        protected abstract void CancelBuildProject();
+
+        protected abstract IWaitIndicator GetWaitIndicator();
+    }
+}

--- a/src/Interactive/EditorFeatures/Core/InteractiveEditorFeatures.csproj
+++ b/src/Interactive/EditorFeatures/Core/InteractiveEditorFeatures.csproj
@@ -107,7 +107,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.CSharp.Repl" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.VisualBasic.Repl" />
-    <InternalsVisibleTo Include="Microsoft.VisualStudio.InteractiveServices" />    
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.InteractiveServices" />
     <!-- The rest are for test purposes only. -->
     <InternalsVisibleToTest Include="Roslyn.Hosting.Diagnostics" />
     <InternalsVisibleToTest Include="Roslyn.InteractiveHost.UnitTests" />
@@ -134,6 +134,7 @@
     <Compile Include="Extensibility\Interactive\InteractiveCommandHandler.cs" />
     <Compile Include="Extensibility\Interactive\InteractiveEvaluator.cs" />
     <Compile Include="Extensibility\Interactive\CSharpVBInteractiveCommandContentTypes.cs" />
+    <Compile Include="Extensibility\Interactive\ResetInteractive.cs" />
     <Compile Include="Implementation\Completion\InteractiveCommandCompletionService.cs" />
     <Compile Include="Implementation\Completion\Presentation\CompletionPresenter.cs" />
     <Compile Include="Implementation\Interactive\InertClassifierProvider.cs" />

--- a/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.Designer.cs
+++ b/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Building Project.
+        /// </summary>
+        internal static string BuildingProject {
+            get {
+                return ResourceManager.GetString("BuildingProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Print a list of referenced assemblies..
         /// </summary>
         internal static string ReferencesCommandDescription {
@@ -102,6 +111,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string ResettingExecutionEngine {
             get {
                 return ResourceManager.GetString("ResettingExecutionEngine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resetting Interactive.
+        /// </summary>
+        internal static string ResettingInteractive {
+            get {
+                return ResourceManager.GetString("ResettingInteractive", resourceCulture);
             }
         }
         

--- a/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.resx
+++ b/src/Interactive/EditorFeatures/Core/InteractiveEditorFeaturesResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BuildingProject" xml:space="preserve">
+    <value>Building Project</value>
+  </data>
   <data name="ReferencesCommandDescription" xml:space="preserve">
     <value>Print a list of referenced assemblies.</value>
   </data>
@@ -131,6 +134,9 @@
   </data>
   <data name="ResettingExecutionEngine" xml:space="preserve">
     <value>Resetting execution engine.</value>
+  </data>
+  <data name="ResettingInteractive" xml:space="preserve">
+    <value>Resetting Interactive</value>
   </data>
   <data name="WindowSetAgainException" xml:space="preserve">
     <value>The CurrentWindow property may only be assigned once.</value>

--- a/src/InteractiveWindow/Editor/InteractiveWindow.csproj
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <InternalsVisibleToTest Include="Roslyn.InteractiveWindow.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests2" />
+    <InternalsVisibleToTest Include="Roslyn.VisualStudio.CSharp.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.InteractiveServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.VsInteractiveWindow" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures" />

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -19,11 +19,17 @@
     <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Platform.VSEditor, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
   <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\..\Interactive\EditorFeatures\Core\InteractiveEditorFeatures.csproj">
+      <Project>{92412d1a-0f23-45b5-b196-58839c524917}</Project>
+      <Name>InteractiveEditorFeatures</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\Test\Utilities\Portable.FX45\TestUtilities.FX45.csproj">
       <Project>{f7712928-1175-47b3-8819-ee086753dee2}</Project>
       <Name>TestUtilities.FX45</Name>
@@ -147,6 +153,7 @@
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>false</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Internal, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>false</Private>
     </Reference>
@@ -187,6 +194,14 @@
     <Compile Include="Debugging\DataTipInfoGetterTests.cs" />
     <Compile Include="Debugging\LocationInfoGetterTests.cs" />
     <Compile Include="Debugging\NameResolverTests.cs" />
+    <Compile Include="Interactive\Commands\InteractiveCommandHandlerTests.cs" />
+    <Compile Include="Interactive\Commands\TestInteractiveCommandHandler.cs" />
+    <Compile Include="Interactive\Commands\InteractiveWindowCommandHandlerTestState.cs" />
+    <Compile Include="Interactive\InteractiveWindowEditorsFactoryService.cs" />
+    <Compile Include="Interactive\InteractiveWindowTestHost.cs" />
+    <Compile Include="Interactive\Commands\ResetInteractiveTests.cs" />
+    <Compile Include="Interactive\Commands\TestResetInteractive.cs" />
+    <Compile Include="Interactive\TestInteractiveEvaluator.cs" />
     <Compile Include="PersistentStorage\SolutionSizeTests.cs" />
     <Compile Include="ProjectSystemShim\CSharpReferencesTests.cs" />
     <Compile Include="ProjectSystemShim\SourceFileHandlingTests.cs" />

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveCommandHandlerTests.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveCommandHandlerTests.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
+{
+    internal class InteractiveCommandHandlerTests
+    {
+        private const string ExampleCode1 =
+@"var x = 1;
+Task.Run(() => { return 1; });";
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public void TestExecuteInInteractiveWithoutSelection()
+        {
+            AssertUnavailableExecuteInInteractive("$$");
+            AssertUnavailableExecuteInInteractive($"{ExampleCode1}$$");
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public void TestExecuteInInteractiveWithEmptyBuffer()
+        {
+            AssertExecuteInInteractive(@"{|Selection:var x = 1;$$|}", "var x = 1;");
+            AssertExecuteInInteractive($@"{{|Selection:{ExampleCode1}$$|}}", ExampleCode1);
+            AssertExecuteInInteractive(
+$@"var o = new object[] {{ 1, 2, 3 }};
+Console.WriteLine(o);
+{{|Selection:{ExampleCode1}$$|}}
+
+Console.WriteLine(x);", ExampleCode1);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public void TestExecuteInInteractiveWithBoxSelection()
+        {
+            string expectedBoxSubmissionResult = @"int x;
+int y;";
+            AssertExecuteInInteractive(
+$@"some text {{|Selection:$$int x;|}} also here
+text some {{|Selection:int y;|}} here also", expectedBoxSubmissionResult);
+            AssertExecuteInInteractive(
+$@"some text {{|Selection:int x;$$|}} also here
+text some {{|Selection:int y;|}} here also", expectedBoxSubmissionResult);
+            AssertExecuteInInteractive(
+$@"some text {{|Selection:int x;|}} also here
+text some {{|Selection:$$int y;|}} here also", expectedBoxSubmissionResult);
+            AssertExecuteInInteractive(
+$@"some text {{|Selection:int x;|}} also here
+text some {{|Selection:int y;$$|}} here also", expectedBoxSubmissionResult);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public void TestExecuteInInteractiveWithNonEmptyBuffer()
+        {
+            // Execute in interactive clears the existing current buffer before execution.
+            // Therefore `var x = 1;` will not be executed.
+            AssertExecuteInInteractive(
+                @"{|Selection:var y = 2;$$|}",
+                "var y = 2;",
+                submissionBuffer: "var x = 1;");
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public void TestCopyToInteractiveWithoutSelection()
+        {
+            AssertUnavailableCopyToInteractive("$$");
+            AssertUnavailableCopyToInteractive($"{ExampleCode1}$$");
+            AssertUnavailableCopyToInteractive($"{ExampleCode1}$$", submissionBuffer: "var x = 1;");
+            AssertUnavailableCopyToInteractive($"{ExampleCode1}$$", submissionBuffer: "x = 2;");
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public void TestCopyToInteractive()
+        {
+            AssertCopyToInteractive($"{{|Selection:{ExampleCode1}$$|}}", ExampleCode1);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public void TestCopyToInteractiveWithNonEmptyBuffer()
+        {
+          // Copy to interactive does not clear the existing buffer.
+          // Therefore `var x = 1;` will still be present in the final buffer.
+            AssertCopyToInteractive(
+                $"{{|Selection:{ExampleCode1}$$|}}",
+                $"var x = 1;\r\n{ExampleCode1}",
+                submissionBuffer: "var x = 1;");
+        }
+
+        private static void AssertUnavailableCopyToInteractive(string code, string submissionBuffer = null)
+        {
+            using (var workspace = InteractiveWindowCommandHandlerTestState.CreateTestState(code))
+            {
+                PrepareSubmissionBuffer(submissionBuffer, workspace);
+                Assert.Equal(CommandState.Unavailable, workspace.GetStateForCopyToInteractive());
+            }
+        }
+
+        private static void AssertCopyToInteractive(string code, string expectedBufferText, string submissionBuffer = null)
+        {
+            using (var workspace = InteractiveWindowCommandHandlerTestState.CreateTestState(code))
+            {
+                PrepareSubmissionBuffer(submissionBuffer, workspace);
+                workspace.SendCopyToInteractive();
+                Assert.Equal(expectedBufferText, workspace.WindowCurrentLanguageBuffer.CurrentSnapshot.GetText());
+            }
+        }
+
+        private static void AssertUnavailableExecuteInInteractive(string code)
+        {
+            using (var workspace = InteractiveWindowCommandHandlerTestState.CreateTestState(code))
+            {
+                Assert.Equal(CommandState.Unavailable, workspace.GetStateForExecuteInInteractive());
+            }
+        }
+
+        private static void AssertExecuteInInteractive(string code, string expectedSubmission, string submissionBuffer = null)
+        {
+            List<string> submissions = new List<string>();
+            EventHandler<string> appendSubmission = (_, item) => { submissions.Add(item.TrimEnd()); };
+
+            using (var workspace = InteractiveWindowCommandHandlerTestState.CreateTestState(code))
+            {
+                PrepareSubmissionBuffer(submissionBuffer, workspace);
+                Assert.Equal(CommandState.Available, workspace.GetStateForExecuteInInteractive());
+
+                workspace.Evaluator.OnExecute += appendSubmission;
+                workspace.ExecuteInInteractive();
+                AssertEx.Equal(new string[] { expectedSubmission }, submissions);
+            }
+        }
+
+        private static void PrepareSubmissionBuffer(string submissionBuffer, InteractiveWindowCommandHandlerTestState workspace)
+        {
+            if (string.IsNullOrEmpty(submissionBuffer))
+            {
+                return;
+            }
+
+            workspace.WindowCurrentLanguageBuffer.Insert(0, submissionBuffer);
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveWindowCommandHandlerTestState.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveWindowCommandHandlerTestState.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.CodeAnalysis.Editor.Interactive;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
+{
+    /// <summary>
+    /// This class creates a mock execution state that allows to send CopyToInteractive and ExeciteInInteractive.
+    /// Commands against a mock InteractiveWindow.
+    /// </summary>
+    internal class InteractiveWindowCommandHandlerTestState : AbstractCommandHandlerTestState
+    {
+        public InteractiveWindowTestHost TestHost { get; }
+
+        private InteractiveCommandHandler _commandHandler;
+
+        public ITextView WindowTextView => TestHost.Window.TextView;
+
+        public ITextBuffer WindowCurrentLanguageBuffer => TestHost.Window.CurrentLanguageBuffer;
+
+        public ITextSnapshot WindowSnapshot => WindowCurrentLanguageBuffer.CurrentSnapshot;
+
+        public TestInteractiveEvaluator Evaluator => TestHost.Evaluator;
+
+        private ICommandHandler<ExecuteInInteractiveCommandArgs> ExecuteInInteractiveCommandHandler => _commandHandler;
+
+        private ICommandHandler<CopyToInteractiveCommandArgs> CopyToInteractiveCommandHandler => _commandHandler;
+
+        public InteractiveWindowCommandHandlerTestState(XElement workspaceElement)
+            : base(workspaceElement)
+        {
+            TestHost = new InteractiveWindowTestHost();
+
+            _commandHandler = new TestInteractiveCommandHandler(
+                TestHost.Window,
+                GetExportedValue<IContentTypeRegistryService>(),
+                GetExportedValue<IEditorOptionsFactoryService>(),
+                GetExportedValue<IEditorOperationsFactoryService>());
+        }
+
+        public static InteractiveWindowCommandHandlerTestState CreateTestState(string markup)
+        {
+            var workspaceXml = XElement.Parse($@"
+                    <Workspace>
+                        <Project Language=""C#"" CommonReferences=""true"">
+                            <Document>{markup}</Document>
+                        </Project>
+                    </Workspace>
+                ");
+
+            return new InteractiveWindowCommandHandlerTestState(workspaceXml);
+        }
+
+        public void SendCopyToInteractive()
+        {
+            var copyToInteractiveArgs = new CopyToInteractiveCommandArgs(TextView, SubjectBuffer);
+            CopyToInteractiveCommandHandler.ExecuteCommand(copyToInteractiveArgs, () => { });
+        }
+
+        public CommandState GetStateForCopyToInteractive()
+        {
+            var copyToInteractiveArgs = new CopyToInteractiveCommandArgs(TextView, SubjectBuffer);
+            return CopyToInteractiveCommandHandler.GetCommandState(
+                copyToInteractiveArgs, () => { return CommandState.Unavailable; });
+        }
+
+        public void ExecuteInInteractive()
+        {
+            var executeInInteractiveArgs = new ExecuteInInteractiveCommandArgs(TextView, SubjectBuffer);
+            ExecuteInInteractiveCommandHandler.ExecuteCommand(executeInInteractiveArgs, () => { });
+        }
+
+        public CommandState GetStateForExecuteInInteractive()
+        {
+            var executeInInteractiveArgs = new ExecuteInInteractiveCommandArgs(TextView, SubjectBuffer);
+            return ExecuteInInteractiveCommandHandler.GetCommandState(
+                executeInInteractiveArgs, () => { return CommandState.Unavailable; });
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Test.Utilities;
+using Xunit;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Editor.Host;
+using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
+{
+    public class ResetInteractiveTests
+    {
+        private string WorkspaceXmlStr =>
+@"<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""ResetInteractiveVisualBasicSubproject"" CommonReferences=""true"">
+        <Document FilePath=""VisualBasicDocument""></Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""ResetInteractiveTestsAssembly"" CommonReferences=""true"">
+        <ProjectReference>ResetInteractiveVisualBasicSubproject</ProjectReference>
+        <Document FilePath=""ResetInteractiveTestsDocument""></Document>
+    </Project>
+</Workspace>";
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Interactive)]
+        public async void TestResetREPLWithProjectContext()
+        {
+            using (var workspace = await TestWorkspace.CreateAsync(WorkspaceXmlStr))
+            {
+                var project = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.AssemblyName == "ResetInteractiveTestsAssembly");
+                var document = project.Documents.FirstOrDefault(d => d.FilePath == "ResetInteractiveTestsDocument");
+                var replReferenceCommands = GetProjectReferences(workspace, project).Select(r => CreateReplReferenceCommand(r));
+
+                Assert.True(replReferenceCommands.Any(rc => rc.EndsWith(@"ResetInteractiveTestsAssembly.dll""")));
+                Assert.True(replReferenceCommands.Any(rc => rc.EndsWith(@"ResetInteractiveVisualBasicSubproject.dll""")));
+
+                var expectedSubmissions = new List<string> {
+                    string.Join("\r\n", replReferenceCommands) + "\r\n",
+                    string.Join("\r\n", @"using ""ns1"";", @"using ""ns2"";") + "\r\n"};
+                AssertResetInteractive(workspace, project, buildSucceeds: true, expectedSubmissions: expectedSubmissions);
+
+                // Test that no submissions are executed if the build fails.
+                AssertResetInteractive(workspace, project, buildSucceeds: false, expectedSubmissions: new List<string>());
+            }
+        }
+
+        private async void AssertResetInteractive(
+            TestWorkspace workspace,
+            Project project,
+            bool buildSucceeds,
+            List<string> expectedSubmissions)
+        {
+            InteractiveWindowTestHost testHost = new InteractiveWindowTestHost();
+            List<string> executedSubmissionCalls = new List<string>();
+            EventHandler<string> ExecuteSubmission = (_, code) => { executedSubmissionCalls.Add(code); };
+
+            testHost.Evaluator.OnExecute += ExecuteSubmission;
+
+            IWaitIndicator waitIndicator = workspace.GetService<IWaitIndicator>();
+
+            TestResetInteractive resetInteractive = new TestResetInteractive(
+                waitIndicator,
+                CreateReplReferenceCommand,
+                CreateImport,
+                buildSucceeds: buildSucceeds)
+            {
+                References = ImmutableArray.CreateRange(GetProjectReferences(workspace, project)),
+                ReferenceSearchPaths = ImmutableArray.Create("rsp1", "rsp2"),
+                SourceSearchPaths = ImmutableArray.Create("ssp1", "ssp2"),
+                NamespacesToImport = ImmutableArray.Create("ns1", "ns2"),
+                ProjectDirectory = "pj",
+            };
+
+            await resetInteractive.Execute(testHost.Window, "Interactive C#");
+
+            // Validate that the project was rebuilt.
+            Assert.Equal(1, resetInteractive.BuildProjectCount);
+            Assert.Equal(0, resetInteractive.CancelBuildProjectCount);
+
+            AssertEx.Equal(expectedSubmissions, executedSubmissionCalls);
+
+            testHost.Evaluator.OnExecute -= ExecuteSubmission;
+        }
+
+        /// <summary>
+        /// Simulates getting all project references.
+        /// </summary>
+        /// <param name="workspace">Workspace with the solution.</param>
+        /// <param name="project">A project that should be built.</param>
+        /// <returns>A list of paths that should be referenced.</returns>
+        private IEnumerable<string> GetProjectReferences(TestWorkspace workspace, Project project)
+        {
+            var metadataReferences = project.MetadataReferences.Select(r => r.Display);
+            var projectReferences = project.ProjectReferences.SelectMany(p => GetProjectReferences(
+                workspace,
+                workspace.CurrentSolution.GetProject(p.ProjectId)));
+            var outputReference = new string[] { project.OutputFilePath };
+
+            return metadataReferences.Union(projectReferences).Concat(outputReference);
+        }
+
+        private string CreateReplReferenceCommand(string referenceName)
+        {
+            return $@"#r ""{referenceName}""";
+        }
+
+        private string CreateImport(string importName)
+        {
+            return $@"using ""{importName}"";";
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/TestInteractiveCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/TestInteractiveCommandHandler.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Editor.Interactive;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
+{
+    internal class TestInteractiveCommandHandler : InteractiveCommandHandler
+    {
+        private IInteractiveWindow _interactiveWindow;
+
+        public TestInteractiveCommandHandler(
+            IInteractiveWindow interactiveWindow,
+            IContentTypeRegistryService contentTypeRegistryService,
+            IEditorOptionsFactoryService editorOptionsFactoryService,
+            IEditorOperationsFactoryService editorOperationsFactoryService)
+            : base(contentTypeRegistryService, editorOptionsFactoryService, editorOperationsFactoryService)
+        {
+            _interactiveWindow = interactiveWindow;
+        }
+
+        protected override IInteractiveWindow OpenInteractiveWindow(bool focus)
+        {
+            return _interactiveWindow;
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.VisualStudio.LanguageServices.Interactive;
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
+{
+    internal class TestResetInteractive : ResetInteractive
+    {
+        private IWaitIndicator _waitIndicator;
+
+        private bool _buildSucceeds;
+
+        internal int BuildProjectCount { get; private set; }
+
+        internal int CancelBuildProjectCount { get; private set; }
+
+        internal ImmutableArray<string> References { get; set; }
+
+        internal ImmutableArray<string> ReferenceSearchPaths { get; set; }
+
+        internal ImmutableArray<string> SourceSearchPaths { get; set; }
+
+        internal ImmutableArray<string> NamespacesToImport { get; set; }
+
+        internal string ProjectDirectory { get; set; }
+
+        public TestResetInteractive(IWaitIndicator waitIndicator, Func<string, string> createReference, Func<string, string> createImport, bool buildSucceeds)
+            : base(createReference, createImport)
+        {
+            _waitIndicator = waitIndicator;
+            _buildSucceeds = buildSucceeds;
+        }
+
+        protected override void CancelBuildProject()
+        {
+            CancelBuildProjectCount++;
+        }
+
+        protected override Task<bool> BuildProject()
+        {
+            BuildProjectCount++;
+            return Task.FromResult(_buildSucceeds);
+        }
+
+        protected override bool GetProjectProperties(
+            out ImmutableArray<string> references,
+            out ImmutableArray<string> referenceSearchPaths,
+            out ImmutableArray<string> sourceSearchPaths,
+            out ImmutableArray<string> namespacesToImport,
+            out string projectDirectory)
+        {
+            references = References;
+            referenceSearchPaths = ReferenceSearchPaths;
+            sourceSearchPaths = SourceSearchPaths;
+            namespacesToImport = NamespacesToImport;
+            projectDirectory = ProjectDirectory;
+            return true;
+        }
+
+        protected override IWaitIndicator GetWaitIndicator()
+        {
+            return _waitIndicator;
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowEditorsFactoryService.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowEditorsFactoryService.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+using Roslyn.Test.Utilities;
+using Microsoft.VisualStudio.InteractiveWindow;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive
+{
+    [Export(typeof(IInteractiveWindowEditorFactoryService))]
+    internal class InteractiveWindowEditorsFactoryService : IInteractiveWindowEditorFactoryService
+    {
+        public const string ContentType = "text";
+
+        private readonly ITextBufferFactoryService _textBufferFactoryService;
+        private readonly ITextEditorFactoryService _textEditorFactoryService;
+        private readonly IContentTypeRegistryService _contentTypeRegistry;
+
+        [ImportingConstructor]
+        public InteractiveWindowEditorsFactoryService(ITextBufferFactoryService textBufferFactoryService, ITextEditorFactoryService textEditorFactoryService, IContentTypeRegistryService contentTypeRegistry)
+        {
+            _textBufferFactoryService = textBufferFactoryService;
+            _textEditorFactoryService = textEditorFactoryService;
+            _contentTypeRegistry = contentTypeRegistry;
+        }
+
+        IWpfTextView IInteractiveWindowEditorFactoryService.CreateTextView(IInteractiveWindow window, ITextBuffer buffer, ITextViewRoleSet roles)
+        {
+            WpfTestCase.RequireWpfFact($"Creates an IWpfTextView in {nameof(InteractiveWindowEditorsFactoryService)}");
+
+            var textView = _textEditorFactoryService.CreateTextView(buffer, roles);
+            return _textEditorFactoryService.CreateTextViewHost(textView, false).TextView;
+        }
+
+        ITextBuffer IInteractiveWindowEditorFactoryService.CreateAndActivateBuffer(IInteractiveWindow window)
+        {
+            IContentType contentType;
+            if (!window.Properties.TryGetProperty(typeof(IContentType), out contentType))
+            {
+                contentType = _contentTypeRegistry.GetContentType(ContentType);
+            }
+
+            return _textBufferFactoryService.CreateTextBuffer(contentType);
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowTestHost.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowTestHost.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition.Hosting;
+using System.Linq;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive
+{
+    public sealed class InteractiveWindowTestHost : IDisposable
+    {
+        internal readonly IInteractiveWindow Window;
+        internal readonly TestInteractiveEvaluator Evaluator;
+
+        private readonly CompositionContainer ExportProvider;
+
+        private static readonly Lazy<AggregateCatalog> _lazyCatalog = new Lazy<AggregateCatalog>(() =>
+        {
+            var types = new[] { typeof(TestWaitIndicator), typeof(TestInteractiveEvaluator), typeof(InteractiveWindow) }.Concat(GetVisualStudioTypes());
+            return new AggregateCatalog(types.Select(t => new AssemblyCatalog(t.Assembly)));
+        });
+
+        internal InteractiveWindowTestHost(Action<InteractiveWindow.State> stateChangedHandler = null)
+        {
+            ExportProvider = new CompositionContainer(
+                _lazyCatalog.Value,
+                CompositionOptions.DisableSilentRejection | CompositionOptions.IsThreadSafe);
+
+            var contentTypeRegistryService = ExportProvider.GetExport<IContentTypeRegistryService>().Value;
+            Evaluator = new TestInteractiveEvaluator();
+            Window = ExportProvider.GetExport<IInteractiveWindowFactoryService>().Value.CreateWindow(Evaluator);
+            ((InteractiveWindow)Window).StateChanged += stateChangedHandler;
+            Window.InitializeAsync().Wait();
+        }
+
+        private static Type[] GetVisualStudioTypes()
+        {
+            var types = new[]
+            {
+                // EDITOR
+
+                // Microsoft.VisualStudio.Platform.VSEditor.dll:
+                typeof(VisualStudio.Platform.VSEditor.EventArgsHelper),
+
+                // Microsoft.VisualStudio.Text.Logic.dll:
+                //   Must include this because several editor options are actually stored as exported information 
+                //   on this DLL.  Including most importantly, the tab size information.
+                typeof(VisualStudio.Text.Editor.DefaultOptions),
+
+                // Microsoft.VisualStudio.Text.UI.dll:
+                //   Include this DLL to get several more EditorOptions including WordWrapStyle.
+                typeof(VisualStudio.Text.Editor.WordWrapStyle),
+
+                // Microsoft.VisualStudio.Text.UI.Wpf.dll:
+                //   Include this DLL to get more EditorOptions values.
+                typeof(VisualStudio.Text.Editor.HighlightCurrentLineOption),
+
+                // BasicUndo.dll:
+                //   Include this DLL to satisfy ITextUndoHistoryRegistry
+                typeof(BasicUndo.IBasicUndoHistory),
+
+                // Microsoft.VisualStudio.Language.StandardClassification.dll:
+                typeof(VisualStudio.Language.StandardClassification.PredefinedClassificationTypeNames)
+            };
+
+            return types;
+        }
+
+        public void Dispose()
+        {
+            if (Window != null)
+            {
+                // close interactive host process:
+                Window.Evaluator?.Dispose();
+
+                // dispose buffer:
+                Window.Dispose();
+            }
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Test/Interactive/TestInteractiveEvaluator.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/TestInteractiveEvaluator.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.InteractiveWindow;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive
+{
+    internal sealed class TestInteractiveEvaluator : IInteractiveEvaluator
+    {
+        internal event EventHandler<string> OnExecute;
+
+        public IInteractiveWindow CurrentWindow { get; set; }
+
+        public void Dispose()
+        {
+        }
+
+        public Task<ExecutionResult> InitializeAsync()
+        {
+            return Task.FromResult(ExecutionResult.Success);
+        }
+
+        public Task<ExecutionResult> ResetAsync(bool initialize = true)
+        {
+            return Task.FromResult(ExecutionResult.Success);
+        }
+
+        public bool CanExecuteCode(string text)
+        {
+            return true;
+        }
+
+        public Task<ExecutionResult> ExecuteCodeAsync(string text)
+        {
+            OnExecute?.Invoke(this, text);
+            return Task.FromResult(ExecutionResult.Success);
+        }
+
+        public string FormatClipboard()
+        {
+            return null;
+        }
+
+        public void AbortExecution()
+        {
+        }
+
+        public string GetConfiguration()
+        {
+            return "config";
+        }
+
+        public string GetPrompt()
+        {
+            return "> ";
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -106,15 +106,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Building Project.
-        /// </summary>
-        internal static string BuildingProject {
-            get {
-                return ResourceManager.GetString("BuildingProject", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to C#/VB Build Table Data Source.
         /// </summary>
         internal static string BuildTableSourceName {
@@ -999,15 +990,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string RemoveSuppressMultipleOccurrences {
             get {
                 return ResourceManager.GetString("RemoveSuppressMultipleOccurrences", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Resetting Interactive.
-        /// </summary>
-        internal static string ResettingInteractive {
-            get {
-                return ResourceManager.GetString("ResettingInteractive", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -135,12 +135,6 @@
   <data name="FileNameMustHaveTheExtension" xml:space="preserve">
     <value>File name must have the "{0}" extension.</value>
   </data>
-  <data name="BuildingProject" xml:space="preserve">
-    <value>Building Project</value>
-  </data>
-  <data name="ResettingInteractive" xml:space="preserve">
-    <value>Resetting Interactive</value>
-  </data>
   <data name="Debugger" xml:space="preserve">
     <value>Debugger</value>
   </data>

--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             var resetInteractiveFromProjectCommand = new OleMenuCommand(
                 (sender, args) =>
                 {
-                    var resetInteractive = new ResetInteractive(
+                    var resetInteractive = new VsResetInteractive(
                         (DTE)this.GetService(typeof(SDTE)),
                         _componentModel,
                         (IVsMonitorSelection)this.GetService(typeof(SVsShellMonitorSelection)),
@@ -95,7 +95,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
 
                     var vsInteractiveWindow = _interactiveWindowProvider.Open(instanceId: 0, focus: true);
 
-                    resetInteractive.Execute(vsInteractiveWindow, LanguageName + " Interactive");
+                    EventHandler focusWindow = null;
+                    focusWindow = (s, e) =>
+                    {
+                        // We have to set focus to the Interactive Window *after* the wait indicator is dismissed.
+                        vsInteractiveWindow.Show(focus: true);
+                        resetInteractive.ExecutionCompleted -= focusWindow;
+                    };
+
+                    resetInteractive.Execute(vsInteractiveWindow.InteractiveWindow, LanguageName + " Interactive");
+                    resetInteractive.ExecutionCompleted += focusWindow;
                 },
                 GetResetInteractiveFromProjectCommandID());
 

--- a/src/VisualStudio/InteractiveServices/VisualStudioInteractiveServices.csproj
+++ b/src/VisualStudio/InteractiveServices/VisualStudioInteractiveServices.csproj
@@ -200,7 +200,7 @@
     <Compile Include="Interactive\VsInteractiveWindowPackage.cs" />
     <Compile Include="Interactive\VsInteractiveWindowProvider.cs" />
     <Compile Include="Interactive\CommonVsUtils.cs" />
-    <Compile Include="Interactive\ResetInteractive.cs" />
+    <Compile Include="Interactive\VsResetInteractive.cs" />
     <Compile Include="Interactive\ScriptingOleCommandTarget.cs" />
     <Compile Include="Interactive\VsUpdateSolutionEvents.cs" />
   </ItemGroup>


### PR DESCRIPTION
Adds unit tests that check the reset REPL with project context command and copy code to REPL/execute code in REPL.

Refactors ResetInteractive to make the class easily testable without all VS references and services.
Fixes AbstractCommandHandlerTestState in order to make tests that check copy to interactive with block selections actually contain block selections.