### PR TITLE
Add proper symbol filtering to Imports.AddLookupSymbolsInfoInUsings.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -672,34 +672,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableArray<Symbol> candidates = Binder.GetCandidateMembers(typeOrNamespace.NamespaceOrType, name, options, originalBinder: originalBinder);
                 foreach (Symbol symbol in candidates)
                 {
-                    switch (symbol.Kind)
+                    if (!IsValidLookupCandidateInUsings(symbol))
                     {
-                        // lookup via "using namespace" ignores namespaces inside
-                        case SymbolKind.Namespace:
-                            continue;
-
-                        // lookup via "using static" ignores extension methods and non-static methods
-                        case SymbolKind.Method:
-                            if (!symbol.IsStatic || ((MethodSymbol)symbol).IsExtensionMethod)
-                            {
-                                continue;
-                            }
-
-                            break;
-
-                        // types are considered static members for purposes of "using static" feature
-                        // regardless of whether they are declared with "static" modifier or not
-                        case SymbolKind.NamedType:
-                            break;
-
-                        // lookup via "using static" ignores non-static members
-                        default:
-                            if (!symbol.IsStatic)
-                            {
-                                continue;
-                            }
-
-                            break;
+                        continue;
                     }
 
                     // Found a match in our list of normal using directives.  Mark the directive
@@ -714,6 +689,41 @@ namespace Microsoft.CodeAnalysis.CSharp
                     result.MergeEqual(res);
                 }
             }
+        }
+
+        private static bool IsValidLookupCandidateInUsings(Symbol symbol)
+        {
+            switch (symbol.Kind)
+            {
+                // lookup via "using namespace" ignores namespaces inside
+                case SymbolKind.Namespace:
+                    return false;
+
+                // lookup via "using static" ignores extension methods and non-static methods
+                case SymbolKind.Method:
+                    if (!symbol.IsStatic || ((MethodSymbol)symbol).IsExtensionMethod)
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                // types are considered static members for purposes of "using static" feature
+                // regardless of whether they are declared with "static" modifier or not
+                case SymbolKind.NamedType:
+                    break;
+
+                // lookup via "using static" ignores non-static members
+                default:
+                    if (!symbol.IsStatic)
+                    {
+                        return false;
+                    }
+
+                    break;
+            }
+
+            return true;
         }
 
         internal void LookupExtensionMethodsInUsings(
@@ -831,7 +841,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var member in namespaceSymbol.NamespaceOrType.GetMembersUnordered())
                 {
-                    if (originalBinder.CanAddLookupSymbolInfo(member, options, null))
+                    if (IsValidLookupCandidateInUsings(member) && originalBinder.CanAddLookupSymbolInfo(member, options, null))
                     {
                         result.AddSymbol(member, member.Name, member.GetArity());
                     }


### PR DESCRIPTION
Fixes #7101.

@dotnet/roslyn-compiler Please review.