### PR TITLE
changed meaning of closed file diagnostic option. now it is solely fo…

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             return SpecializedTasks.EmptyTask;
         }
 
-        private bool CheckOption(Workspace workspace, string language, bool documentOpened)
+        private bool CheckOption(Workspace workspace, string language, bool forceAnalysis)
         {
             var optionService = workspace.Services.GetService<IOptionService>();
             if (optionService == null || optionService.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language))
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return true;
             }
 
-            if (documentOpened)
+            if (forceAnalysis)
             {
                 return true;
             }
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             try
             {
                 // Compilation actions can report diagnostics on open files, so "documentOpened = true"
-                if (!CheckOption(project.Solution.Workspace, project.Language, documentOpened: true))
+                if (!CheckOption(project.Solution.Workspace, project.Language, forceAnalysis: false))
                 {
                     return;
                 }

--- a/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
@@ -8,6 +8,11 @@ namespace Microsoft.CodeAnalysis.Shared.Options
     {
         public const string OptionName = "ServiceFeaturesOnOff";
 
+        /// <summary>
+        /// this option is solely for performance. don't confused by option name. 
+        /// this option doesn't mean we will show all diagnostics that belong to opened files when turned off,
+        /// rather it means we will only show diagnostics that are cheap to calculate for small scope such as opened files.
+        /// </summary>
         public static readonly PerLanguageOption<bool> ClosedFileDiagnostic = new PerLanguageOption<bool>(OptionName, "Closed File Diagnostic", defaultValue: true);
     }
 }

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -385,7 +385,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show diagnostics for closed _files.
+        ///   Looks up a localized string similar to Enable full solution _analysis.
         /// </summary>
         internal static string Option_ClosedFileDiagnostics {
             get {

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -325,7 +325,7 @@
     <value>_Move local declaration to the extracted method if it is not used elsewhere</value>
   </data>
   <data name="Option_ClosedFileDiagnostics" xml:space="preserve">
-    <value>Show diagnostics for closed _files</value>
+    <value>Enable full solution _analysis</value>
   </data>
   <data name="Option_DisplayLineSeparators" xml:space="preserve">
     <value>_Show procedure line separators</value>

--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.Designer.vb
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.Designer.vb
@@ -110,7 +110,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Show diagnostics for closed _files.
+        '''  Looks up a localized string similar to Enable full solution _analysis.
         '''</summary>
         Friend Shared ReadOnly Property Option_ClosedFileDiagnostics() As String
             Get

--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
@@ -142,7 +142,7 @@
     <value>Automatic _insertion of Interface and MustOverride members</value>
   </data>
   <data name="Option_ClosedFileDiagnostics" xml:space="preserve">
-    <value>Show diagnostics for closed _files</value>
+    <value>Enable full solution _analysis</value>
   </data>
   <data name="Option_DisplayLineSeparators" xml:space="preserve">
     <value>_Show procedure line separators</value>


### PR DESCRIPTION
…r performance. when the option is off, we will only do very minimum work for diagnostics for smal scope such as opened files.

...

this is alternative fix for https://github.com/dotnet/roslyn/issues/4364 (see other fix here - https://github.com/dotnet/roslyn/pull/8033)
