### PR TITLE
made VS to automatically disable full solution analysis if we detect …

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
@@ -10,8 +10,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
     {
         public void ShowErrorInfoForCodeFix(string codefixName, Action OnEnableClicked, Action OnEnableAndIgnoreClicked, Action OnClose)
         {
-            var message = LogMessage.Create($"{codefixName} crashed");
-            Logger.Log(FunctionId.Extension_Exception, message);
+            ShowErrorInfo($"{codefixName} crashed", OnClose);
+        }
+
+        public void ShowErrorInfo(string title, Action OnClose)
+        {
+            Logger.Log(FunctionId.Extension_Exception, title);
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -126,6 +126,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return e.Option.Feature == SimplificationOptions.PerLanguageFeatureName ||
                        e.Option.Feature == SimplificationOptions.NonPerLanguageFeatureName ||
                        e.Option == ServiceFeatureOnOffOptions.ClosedFileDiagnostic ||
+                       e.Option == RuntimeOptions.FullSolutionAnalysis ||
                        e.Option == InternalDiagnosticsOptions.UseDiagnosticEngineV2 ||
                        Analyzer.NeedsReanalysisOnOptionChanged(sender, e);
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -105,8 +105,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
         private bool CheckOption(Workspace workspace, string language, bool documentOpened)
         {
-            var optionService = workspace.Services.GetService<IOptionService>();
-            if (optionService == null || optionService.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language))
+            if (workspace.Options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language) &&
+                workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
             {
                 return true;
             }

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -254,6 +254,8 @@
     <Compile Include="ReplaceMethodWithProperty\ReplaceMethodWithPropertyCodeRefactoringProvider.cs" />
     <Compile Include="ReplaceMethodWithProperty\IReplaceMethodWithPropertyService.cs" />
     <Compile Include="Shared\Options\OrganizerOptionsProvider.cs" />
+    <Compile Include="Shared\Options\RuntimeOptions.cs" />
+    <Compile Include="Shared\Options\RuntimeOptionsProvider.cs" />
     <Compile Include="Shared\Options\ServiceComponentOnOffOptionsProvider.cs" />
     <Compile Include="Shared\Options\ServiceFeatureOnOffOptions.cs" />
     <Compile Include="Shared\Options\ServiceFeatureOnOffOptionsProvider.cs" />

--- a/src/Features/Core/Portable/Shared/Options/RuntimeOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/RuntimeOptions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Shared.Options
+{
+    /// <summary>
+    /// Options that aren't persisted. options here will be reset to default on new process.
+    /// </summary>
+    internal static class RuntimeOptions
+    {
+        public const string OptionName = "Runtime";
+
+        public static readonly Option<bool> FullSolutionAnalysis = new Option<bool>(OptionName, "Full Solution Analysis", defaultValue: true);
+    }
+}

--- a/src/Features/Core/Portable/Shared/Options/RuntimeOptionsProvider.cs
+++ b/src/Features/Core/Portable/Shared/Options/RuntimeOptionsProvider.cs
@@ -9,9 +9,9 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.Shared.Options
 {
     [ExportOptionProvider, Shared]
-    internal class ServiceFeatureOnOffOptionsProvider : IOptionProvider
+    internal class RuntimeOptionsProvider : IOptionProvider
     {
-        private readonly IEnumerable<IOption> _options = SpecializedCollections.SingletonEnumerable(ServiceFeatureOnOffOptions.ClosedFileDiagnostic);
+        private readonly IEnumerable<IOption> _options = SpecializedCollections.SingletonEnumerable(RuntimeOptions.FullSolutionAnalysis);
         public IEnumerable<IOption> GetOptions() => _options;
     }
 }

--- a/src/Features/Core/Portable/Shared/Options/ServiceComponentOnOffOptionsProvider.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceComponentOnOffOptionsProvider.cs
@@ -1,24 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Options
 {
     [ExportOptionProvider, Shared]
     internal class ServiceComponentOnOffOptionsProvider : IOptionProvider
     {
-        private readonly IEnumerable<IOption> _options = new List<IOption>
-            {
-                ServiceComponentOnOffOptions.DiagnosticProvider
-            }.ToImmutableArray();
-
-        public IEnumerable<IOption> GetOptions()
-        {
-            return _options;
-        }
+        private readonly IEnumerable<IOption> _options = SpecializedCollections.SingletonEnumerable(ServiceComponentOnOffOptions.DiagnosticProvider);
+        public IEnumerable<IOption> GetOptions() => _options;
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Versions;
 using Roslyn.Utilities;
@@ -329,6 +330,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private void OnSolutionAdded(Solution solution)
             {
+                // first make sure full solution analysis is on.
+                _optionService.SetOptions(solution.Workspace.Options.WithChangedOption(RuntimeOptions.FullSolutionAnalysis, true));
+
                 var asyncToken = _listener.BeginAsyncOperation("OnSolutionAdded");
                 _eventProcessingQueue.ScheduleTask(() =>
                 {

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(PlaceSystemNamespaceFirst, OrganizerOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp);
             BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptions.DontPutOutOrRefOnStruct, LanguageNames.CSharp);
             BindToOption(AllowMovingDeclaration, ExtractMethodOptions.AllowMovingDeclaration, LanguageNames.CSharp);
-            BindToOption(ClosedFileDiagnostics, ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp);
+            BindToFullSolutionAnalysisOption(ClosedFileDiagnostics, LanguageNames.CSharp);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             public async Task AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
             {
                 // if closed file diagnostic is off and document is not opened, then don't do anything
-                if (!_workspace.Options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, document.Project.Language) && !document.IsOpen())
+                if (!CheckOptions(document))
                 {
                     return;
                 }
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             {
                 // no closed file diagnostic and file is not opened, remove any existing diagnostics
-                if (!_workspace.Options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, document.Project.Language) && !document.IsOpen())
+                if (!CheckOptions(document))
                 {
                     RaiseEmptyDiagnosticUpdated(document.Id);
                 }
@@ -148,6 +148,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             public void RemoveProject(ProjectId projectId)
             {
+            }
+
+            private bool CheckOptions(Document document)
+            {
+                if (_workspace.Options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, document.Project.Language) &&
+                    _workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
+                {
+                    return true;
+                }
+
+                return document.IsOpen();
             }
 
             private class MiscUpdateArgsId : BuildToolId.Base<DocumentId>, ISupportLiveUpdate

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -439,7 +439,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Full solution analysis disabled due to low memory. go to tools-&gt;options and search &quot;Enable full solution analysis&quot; to turn it back on or restart VS to restore full solution analysis..
+        ///   Looks up a localized string similar to Low memory detected. Full solution analysis disabled for this solution..
         /// </summary>
         internal static string FullSolutionAnalysisOff {
             get {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -439,6 +439,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Full solution analysis disabled due to low memory. go to tools-&gt;options and search &quot;Enable full solution analysis&quot; to turn it back on or restart VS to restore full solution analysis..
+        /// </summary>
+        internal static string FullSolutionAnalysisOff {
+            get {
+                return ResourceManager.GetString("FullSolutionAnalysisOff", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Generated name:.
         /// </summary>
         internal static string GeneratedName {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -514,6 +514,6 @@ Use the dropdown to view and switch to other projects this file may belong to.</
     <value>Synchronizing with {0}...</value>
   </data>
   <data name="FullSolutionAnalysisOff" xml:space="preserve">
-    <value>Full solution analysis disabled due to low memory. go to tools-&gt;options and search "Enable full solution analysis" to turn it back on or restart VS to restore full solution analysis.</value>
+    <value>Low memory detected. Full solution analysis disabled for this solution.</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -513,4 +513,7 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   <data name="SynchronizingWithClassView" xml:space="preserve">
     <value>Synchronizing with {0}...</value>
   </data>
+  <data name="FullSolutionAnalysisOff" xml:space="preserve">
+    <value>Full solution analysis disabled due to low memory. go to tools-&gt;options and search "Enable full solution analysis" to turn it back on or restart VS to restore full solution analysis.</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -38,11 +38,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         protected void BindToOption(CheckBox checkbox, Option<bool> optionKey)
         {
-            Binding binding = new Binding();
-
-            binding.Source = new OptionBinding<bool>(OptionService, optionKey);
-            binding.Path = new PropertyPath("Value");
-            binding.UpdateSourceTrigger = UpdateSourceTrigger.Explicit;
+            var binding = new Binding()
+            {
+                Source = new OptionBinding<bool>(OptionService, optionKey),
+                Path = new PropertyPath("Value"),
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
 
             var bindingExpression = checkbox.SetBinding(CheckBox.IsCheckedProperty, binding);
             _bindingExpressions.Add(bindingExpression);
@@ -50,11 +51,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         protected void BindToOption(CheckBox checkbox, PerLanguageOption<bool> optionKey, string languageName)
         {
-            Binding binding = new Binding();
-
-            binding.Source = new PerLanguageOptionBinding<bool>(OptionService, optionKey, languageName);
-            binding.Path = new PropertyPath("Value");
-            binding.UpdateSourceTrigger = UpdateSourceTrigger.Explicit;
+            var binding = new Binding()
+            {
+                Source = new PerLanguageOptionBinding<bool>(OptionService, optionKey, languageName),
+                Path = new PropertyPath("Value"),
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
 
             var bindingExpression = checkbox.SetBinding(CheckBox.IsCheckedProperty, binding);
             _bindingExpressions.Add(bindingExpression);
@@ -62,11 +64,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         protected void BindToOption(TextBox textBox, Option<int> optionKey)
         {
-            Binding binding = new Binding();
-
-            binding.Source = new OptionBinding<int>(OptionService, optionKey);
-            binding.Path = new PropertyPath("Value");
-            binding.UpdateSourceTrigger = UpdateSourceTrigger.Explicit;
+            var binding = new Binding()
+            {
+                Source = new OptionBinding<int>(OptionService, optionKey),
+                Path = new PropertyPath("Value"),
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
 
             var bindingExpression = textBox.SetBinding(TextBox.TextProperty, binding);
             _bindingExpressions.Add(bindingExpression);
@@ -74,11 +77,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         protected void BindToOption(TextBox textBox, PerLanguageOption<int> optionKey, string languageName)
         {
-            Binding binding = new Binding();
-
-            binding.Source = new PerLanguageOptionBinding<int>(OptionService, optionKey, languageName);
-            binding.Path = new PropertyPath("Value");
-            binding.UpdateSourceTrigger = UpdateSourceTrigger.Explicit;
+            var binding = new Binding()
+            {
+                Source = new PerLanguageOptionBinding<int>(OptionService, optionKey, languageName),
+                Path = new PropertyPath("Value"),
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
 
             var bindingExpression = textBox.SetBinding(TextBox.TextProperty, binding);
             _bindingExpressions.Add(bindingExpression);
@@ -86,11 +90,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         protected void BindToFullSolutionAnalysisOption(CheckBox checkbox, string languageName)
         {
-            Binding binding = new Binding();
-
-            binding.Source = new FullSolutionAnalysisOptionBinding(OptionService, languageName);
-            binding.Path = new PropertyPath("Value");
-            binding.UpdateSourceTrigger = UpdateSourceTrigger.Explicit;
+            Binding binding = new Binding()
+            {
+                Source = new FullSolutionAnalysisOptionBinding(OptionService, languageName),
+                Path = new PropertyPath("Value"),
+                UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            };
 
             var bindingExpression = checkbox.SetBinding(CheckBox.IsCheckedProperty, binding);
             _bindingExpressions.Add(bindingExpression);

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -84,6 +84,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             _bindingExpressions.Add(bindingExpression);
         }
 
+        protected void BindToFullSolutionAnalysisOption(CheckBox checkbox, string languageName)
+        {
+            Binding binding = new Binding();
+
+            binding.Source = new FullSolutionAnalysisOptionBinding(OptionService, languageName);
+            binding.Path = new PropertyPath("Value");
+            binding.UpdateSourceTrigger = UpdateSourceTrigger.Explicit;
+
+            var bindingExpression = checkbox.SetBinding(CheckBox.IsCheckedProperty, binding);
+            _bindingExpressions.Add(bindingExpression);
+        }
+
         internal virtual void LoadSettings()
         {
             foreach (var bindingExpression in _bindingExpressions)
@@ -96,6 +108,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         {
             foreach (var bindingExpression in _bindingExpressions)
             {
+                if (!bindingExpression.IsDirty)
+                {
+                    continue;
+                }
+
                 bindingExpression.UpdateSource();
             }
         }

--- a/src/VisualStudio/Core/Impl/Options/FullSolutionAnalysisOptionBinding.cs
+++ b/src/VisualStudio/Core/Impl/Options/FullSolutionAnalysisOptionBinding.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Options;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
+{
+    internal class FullSolutionAnalysisOptionBinding
+    {
+        private readonly IOptionService _optionService;
+        private readonly string _languageName;
+
+        private readonly Option<bool> _fullSolutionAnalysis;
+        private readonly PerLanguageOption<bool> _closedFileDiagnostics;
+
+        public FullSolutionAnalysisOptionBinding(IOptionService optionService, string languageName)
+        {
+            _optionService = optionService;
+            _languageName = languageName;
+
+            _fullSolutionAnalysis = RuntimeOptions.FullSolutionAnalysis;
+            _closedFileDiagnostics = ServiceFeatureOnOffOptions.ClosedFileDiagnostic;
+        }
+
+        public bool Value
+        {
+            get
+            {
+                return _optionService.GetOption(_closedFileDiagnostics, _languageName) &&
+                       _optionService.GetOption(_fullSolutionAnalysis);
+            }
+
+            set
+            {
+                var oldOptions = _optionService.GetOptions();
+
+                // set normal option first
+                var newOptions = oldOptions.WithChangedOption(_closedFileDiagnostics, _languageName, value);
+
+                // we only enable this option if it is disabled. we never disable this option here.
+                if (value)
+                {
+                    newOptions = newOptions.WithChangedOption(_fullSolutionAnalysis, value);
+                }
+
+                _optionService.SetOptions(newOptions);
+                OptionLogger.Log(oldOptions, newOptions);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
+++ b/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
@@ -303,6 +303,7 @@
     <Compile Include="CodeModel\RootCodeModel.cs" />
     <Compile Include="CodeModel\SyntaxNodeKey.cs" />
     <Compile Include="CodeModel\TextManagerAdapter.cs" />
+    <Compile Include="Options\FullSolutionAnalysisOptionBinding.cs" />
     <Compile Include="Options\OptionLogger.cs" />
     <Compile Include="Options\OptionPreviewControl.xaml.cs">
       <DependentUpon>OptionPreviewControl.xaml</DependentUpon>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(NavigateToObjectBrowser, VisualStudioNavigationOptions.NavigateToObjectBrowser, LanguageNames.VisualBasic)
             BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptions.DontPutOutOrRefOnStruct, LanguageNames.VisualBasic)
             BindToOption(AllowMovingDeclaration, ExtractMethodOptions.AllowMovingDeclaration, LanguageNames.VisualBasic)
-            BindToOption(ClosedFileDiagnostics, ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic)
+            BindToFullSolutionAnalysisOption(ClosedFileDiagnostics, LanguageNames.VisualBasic)
         End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
@@ -8,5 +8,6 @@ namespace Microsoft.CodeAnalysis.Extensions
     internal interface IErrorReportingService : IWorkspaceService
     {
         void ShowErrorInfoForCodeFix(string codefixName, Action OnEnableClicked, Action OnEnableAndIgnoreClicked, Action OnClose);
+        void ShowErrorInfo(string title, Action OnClose);
     }
 }


### PR DESCRIPTION
…low memory for VS.

user can either explicitly turn it back on or re-start VS to re-enable the full solution analysis.