### PR TITLE
Turn off AppDomain isolation in xunit to fix #8060.

### DIFF
--- a/src/VisualStudio/ProjectSystem/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/App.config
+++ b/src/VisualStudio/ProjectSystem/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/App.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="xunit.methodDisplay" value="method"/>
+    <add key="xunit.appDomain" value="denied" />
+    <add key="xunit.methodDisplay" value="method" />
     <add key="xunit.shadowCopy" value="false"/>
   </appSettings>
 </configuration>


### PR DESCRIPTION
This will cause us to avoid hitting the EventListener bug:
https://github.com/dotnet/roslyn/issues/6358.