### PR TITLE
Find references with multiple projects with same assembly name

### DIFF
--- a/src/EditorFeatures/Test/Workspaces/TestHostProject.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestHostProject.cs
@@ -143,14 +143,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             : this(languageServices, compilationOptions, parseOptions, "Test", references)
         {
         }
-
         internal TestHostProject(
             HostLanguageServices languageServices,
             CompilationOptions compilationOptions,
             ParseOptions parseOptions,
             string assemblyName,
             params MetadataReference[] references)
-            : this(languageServices, compilationOptions, parseOptions, assemblyName, references, SpecializedCollections.EmptyArray<TestHostDocument>())
+            : this(languageServices, compilationOptions, parseOptions, assemblyName: assemblyName, projectName: assemblyName, references: references, documents: SpecializedCollections.EmptyArray<TestHostDocument>())
         {
         }
 
@@ -159,6 +158,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             CompilationOptions compilationOptions,
             ParseOptions parseOptions,
             string assemblyName,
+            string projectName,
             IList<MetadataReference> references,
             IList<TestHostDocument> documents,
             IList<TestHostDocument> additionalDocuments = null,
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             IList<AnalyzerReference> analyzerReferences = null)
         {
             _assemblyName = assemblyName;
-            _name = assemblyName;
+            _name = projectName;
             _id = ProjectId.CreateNewId(debugName: this.AssemblyName);
             _languageServices = languageServices;
             _compilationOptions = compilationOptions;

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspace_Create.cs
@@ -47,11 +47,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private const string IncludeXmlDocCommentsAttributeName = "IncludeXmlDocComments";
         private const string IsLinkFileAttributeName = "IsLinkFile";
         private const string LinkAssemblyNameAttributeName = "LinkAssemblyName";
+        private const string LinkProjectNameAttributeName = "LinkProjectName";
         private const string LinkFilePathAttributeName = "LinkFilePath";
         private const string PreprocessorSymbolsAttributeName = "PreprocessorSymbols";
         private const string AnalyzerDisplayAttributeName = "Name";
         private const string AnalyzerFullPathAttributeName = "FullPath";
         private const string AliasAttributeName = "Alias";
+        private const string ProjectNameAttribute = "Name";
 
         /// <summary>
         /// Creates a single buffer in a workspace.

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LinkedFiles.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LinkedFiles.vb
@@ -129,5 +129,61 @@ End Class
                 AssertEx.SetEqual(references.Select(Function(r) r.Definition.ContainingAssembly.Name), {"VBProj1"})
             End Using
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Function TestLinkedFiles_LinkedFilesWithSameAssemblyNameNoReferences() As Task
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="LinkedProj" Name="CSProj.1">
+        <Document FilePath="C.cs"><![CDATA[
+class {|Definition:$$C|}
+{
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="C#" CommonReferences="true" AssemblyName="LinkedProj" Name="CSProj.2">
+        <Document IsLinkFile="true" LinkProjectName="CSProj.1" LinkFilePath="C.cs"/>
+    </Project>
+</Workspace>
+
+            Return TestAsync(definition)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Function TestLinkedFiles_LinkedFilesWithSameAssemblyNameWithReferences() As Task
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" AssemblyName="LinkedProj" Name="CSProj.1">
+        <Document FilePath="C.cs"><![CDATA[
+public class {|Definition:$$C|}
+{
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="C#" CommonReferences="true" AssemblyName="LinkedProj" Name="CSProj.2">
+        <Document IsLinkFile="true" LinkProjectName="CSProj.1" LinkFilePath="C.cs"/>
+    </Project>
+    <Project Language="C#" CommonReferences="true" AssemblyName="ReferencingProject1">
+        <ProjectReference>CSProj.1</ProjectReference>
+        <Document FilePath="D.cs"><![CDATA[
+public class D : [|$$C|]
+{
+}]]>
+        </Document>
+    </Project>
+    <Project Language="C#" CommonReferences="true" AssemblyName="ReferencingProject2">
+        <ProjectReference>CSProj.2</ProjectReference>
+        <Document FilePath="E.cs"><![CDATA[
+public class D : [|$$C|]
+{
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Return TestAsync(definition)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -41,13 +41,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                Where(Function(loc) IsInSource(workspace, loc, uiVisibleOnly)).
                                GroupBy(Function(loc) loc.SourceTree).
                                ToDictionary(
-                                    Function(g) GetFilePath(workspace, document.Project.Solution, g.Key),
+                                    Function(g) GetFilePathAndProjectLabel(document.Project.Solution, g.Key),
                                     Function(g) g.Select(Function(loc) loc.SourceSpan).Distinct().ToList())
 
                     Dim documentsWithAnnotatedSpans = workspace.Documents.Where(Function(d) d.AnnotatedSpans.Any())
-                    AssertEx.Equal(documentsWithAnnotatedSpans.Select(Function(d) d.FilePath).Order(), actualDefinitions.Keys.Order())
+                    Assert.Equal(Of String)(documentsWithAnnotatedSpans.Select(Function(d) GetFilePathAndProjectLabel(workspace, d)).Order(), actualDefinitions.Keys.Order())
                     For Each doc In documentsWithAnnotatedSpans
-                        AssertEx.Equal(doc.AnnotatedSpans("Definition").Order(), actualDefinitions(doc.FilePath).Order())
+                        Assert.Equal(Of Text.TextSpan)(doc.AnnotatedSpans("Definition").Order(), actualDefinitions(GetFilePathAndProjectLabel(workspace, doc)).Order())
                     Next
 
                     Dim actualReferences =
@@ -57,15 +57,15 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                Distinct().
                                GroupBy(Function(loc) loc.SourceTree).
                                ToDictionary(
-                                   Function(g) GetFilePath(workspace, document.Project.Solution, g.Key),
+                                   Function(g) GetFilePathAndProjectLabel(document.Project.Solution, g.Key),
                                    Function(g) g.Select(Function(loc) loc.SourceSpan).Distinct().ToList())
 
                     Dim expectedDocuments = workspace.Documents.Where(Function(d) d.SelectedSpans.Any())
-                    AssertEx.Equal(expectedDocuments.Select(Function(d) d.FilePath).Order(), actualReferences.Keys.Order())
+                    Assert.Equal(expectedDocuments.Select(Function(d) GetFilePathAndProjectLabel(workspace, d)).Order(), actualReferences.Keys.Order())
 
                     For Each doc In expectedDocuments
                         Dim expectedSpans = doc.SelectedSpans.Order()
-                        Dim actualSpans = actualReferences(doc.FilePath).Order()
+                        Dim actualSpans = actualReferences(GetFilePathAndProjectLabel(workspace, doc)).Order()
 
                         AssertEx.Equal(expectedSpans, actualSpans)
                     Next
@@ -81,10 +81,18 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             End If
         End Function
 
-        Private Function GetFilePath(workspace As TestWorkspace, solution As Solution, syntaxTree As SyntaxTree) As String
+        Private Shared Function GetFilePathAndProjectLabel(solution As Solution, syntaxTree As SyntaxTree) As String
             Dim document = solution.GetDocument(syntaxTree)
-            Dim id = document.Id
-            Return workspace.GetTestDocument(id).FilePath
+            Return GetFilePathAndProjectLabel(document)
+        End Function
+
+        Private Shared Function GetFilePathAndProjectLabel(document As Document) As String
+            Return $"{document.Project.Name}: {document.FilePath}"
+        End Function
+
+        Private Shared Function GetFilePathAndProjectLabel(workspace As TestWorkspace, hostDocument As TestHostDocument) As String
+            Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
+            Return GetFilePathAndProjectLabel(document)
         End Function
 
         Private Shared Function Timeout(Of T)(_task As Task(Of T), milliseconds As Integer) As Task(Of T)

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -13,61 +13,62 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
         Private Async Function TestAsync(definition As XElement, Optional searchSingleFileOnly As Boolean = False, Optional uiVisibleOnly As Boolean = False) As Task
 
             Using workspace = Await TestWorkspace.CreateAsync(definition)
-                Dim cursorDocument = workspace.Documents.First(Function(d) d.CursorPosition.HasValue)
-                Dim cursorPosition = cursorDocument.CursorPosition.Value
+                For Each cursorDocument In workspace.Documents.Where(Function(d) d.CursorPosition.HasValue)
+                    Dim cursorPosition = cursorDocument.CursorPosition.Value
 
-                Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
-                Assert.NotNull(document)
+                    Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
+                    Assert.NotNull(document)
 
-                Dim symbol = Await SymbolFinder.FindSymbolAtPositionAsync(document, cursorPosition)
-                Dim result = SpecializedCollections.EmptyEnumerable(Of ReferencedSymbol)()
-                If symbol IsNot Nothing Then
+                    Dim symbol = Await SymbolFinder.FindSymbolAtPositionAsync(document, cursorPosition)
+                    Dim result = SpecializedCollections.EmptyEnumerable(Of ReferencedSymbol)()
+                    If symbol IsNot Nothing Then
 
-                    Dim scope = If(searchSingleFileOnly, ImmutableHashSet.Create(Of Document)(document), Nothing)
+                        Dim scope = If(searchSingleFileOnly, ImmutableHashSet.Create(Of Document)(document), Nothing)
 
-                    result = result.Concat(Await SymbolFinder.FindReferencesAsync(symbol, document.Project.Solution, progress:=Nothing, documents:=scope))
-                End If
+                        result = result.Concat(Await SymbolFinder.FindReferencesAsync(symbol, document.Project.Solution, progress:=Nothing, documents:=scope))
+                    End If
 
-                Dim actualDefinitions =
-                    result.FilterUnreferencedSyntheticDefinitions().
-                           Where(Function(r)
-                                     Return Not r.Definition.IsImplicitlyDeclared OrElse
-                                        (r.Definition.Kind = SymbolKind.Property AndAlso
-                                        r.Definition.ContainingSymbol IsNot Nothing AndAlso
-                                        r.Definition.ContainingSymbol.Kind = SymbolKind.NamedType AndAlso
-                                        DirectCast(r.Definition.ContainingSymbol, INamedTypeSymbol).IsAnonymousType)
-                                 End Function).
-                           SelectMany(Function(r) r.Definition.Locations).
-                           Where(Function(loc) IsInSource(workspace, loc, uiVisibleOnly)).
-                           GroupBy(Function(loc) loc.SourceTree).
-                           ToDictionary(
-                                Function(g) GetFilePath(workspace, document.Project.Solution, g.Key),
-                                Function(g) g.Select(Function(loc) loc.SourceSpan).Distinct().ToList())
+                    Dim actualDefinitions =
+                        result.FilterUnreferencedSyntheticDefinitions().
+                               Where(Function(r)
+                                         Return Not r.Definition.IsImplicitlyDeclared OrElse
+                                            (r.Definition.Kind = SymbolKind.Property AndAlso
+                                            r.Definition.ContainingSymbol IsNot Nothing AndAlso
+                                            r.Definition.ContainingSymbol.Kind = SymbolKind.NamedType AndAlso
+                                            DirectCast(r.Definition.ContainingSymbol, INamedTypeSymbol).IsAnonymousType)
+                                     End Function).
+                               SelectMany(Function(r) r.Definition.Locations).
+                               Where(Function(loc) IsInSource(workspace, loc, uiVisibleOnly)).
+                               GroupBy(Function(loc) loc.SourceTree).
+                               ToDictionary(
+                                    Function(g) GetFilePath(workspace, document.Project.Solution, g.Key),
+                                    Function(g) g.Select(Function(loc) loc.SourceSpan).Distinct().ToList())
 
-                Dim documentsWithAnnotatedSpans = workspace.Documents.Where(Function(d) d.AnnotatedSpans.Any())
-                AssertEx.Equal(documentsWithAnnotatedSpans.Select(Function(d) d.FilePath).Order(), actualDefinitions.Keys.Order())
-                For Each doc In documentsWithAnnotatedSpans
-                    AssertEx.Equal(doc.AnnotatedSpans("Definition").Order(), actualDefinitions(doc.FilePath).Order())
-                Next
+                    Dim documentsWithAnnotatedSpans = workspace.Documents.Where(Function(d) d.AnnotatedSpans.Any())
+                    AssertEx.Equal(documentsWithAnnotatedSpans.Select(Function(d) d.FilePath).Order(), actualDefinitions.Keys.Order())
+                    For Each doc In documentsWithAnnotatedSpans
+                        AssertEx.Equal(doc.AnnotatedSpans("Definition").Order(), actualDefinitions(doc.FilePath).Order())
+                    Next
 
-                Dim actualReferences =
-                    result.FilterUnreferencedSyntheticDefinitions().
-                           SelectMany(Function(r) r.Locations.Select(Function(loc) loc.Location)).
-                           Where(Function(loc) IsInSource(workspace, loc, uiVisibleOnly)).
-                           Distinct().
-                           GroupBy(Function(loc) loc.SourceTree).
-                           ToDictionary(
-                               Function(g) GetFilePath(workspace, document.Project.Solution, g.Key),
-                               Function(g) g.Select(Function(loc) loc.SourceSpan).Distinct().ToList())
+                    Dim actualReferences =
+                        result.FilterUnreferencedSyntheticDefinitions().
+                               SelectMany(Function(r) r.Locations.Select(Function(loc) loc.Location)).
+                               Where(Function(loc) IsInSource(workspace, loc, uiVisibleOnly)).
+                               Distinct().
+                               GroupBy(Function(loc) loc.SourceTree).
+                               ToDictionary(
+                                   Function(g) GetFilePath(workspace, document.Project.Solution, g.Key),
+                                   Function(g) g.Select(Function(loc) loc.SourceSpan).Distinct().ToList())
 
-                Dim expectedDocuments = workspace.Documents.Where(Function(d) d.SelectedSpans.Any())
-                AssertEx.Equal(expectedDocuments.Select(Function(d) d.FilePath).Order(), actualReferences.Keys.Order())
+                    Dim expectedDocuments = workspace.Documents.Where(Function(d) d.SelectedSpans.Any())
+                    AssertEx.Equal(expectedDocuments.Select(Function(d) d.FilePath).Order(), actualReferences.Keys.Order())
 
-                For Each doc In expectedDocuments
-                    Dim expectedSpans = doc.SelectedSpans.Order()
-                    Dim actualSpans = actualReferences(doc.FilePath).Order()
+                    For Each doc In expectedDocuments
+                        Dim expectedSpans = doc.SelectedSpans.Order()
+                        Dim actualSpans = actualReferences(doc.FilePath).Order()
 
-                    AssertEx.Equal(expectedSpans, actualSpans)
+                        AssertEx.Equal(expectedSpans, actualSpans)
+                    Next
                 Next
             End Using
         End Function

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -94,22 +94,5 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
             Return GetFilePathAndProjectLabel(document)
         End Function
-
-        Private Shared Function Timeout(Of T)(_task As Task(Of T), milliseconds As Integer) As Task(Of T)
-            Dim source = New TaskCompletionSource(Of Task(Of T))()
-            Dim tasks = {_task, Task.Delay(milliseconds)}
-            Dim taskFunc As Action(Of Task) = Sub(completedTask)
-                                                  If completedTask Is _task Then
-                                                      source.SetResult(_task)
-                                                  Else
-                                                      source.SetCanceled()
-                                                  End If
-                                              End Sub
-
-            Task.Factory.ContinueWhenAny(
-                tasks, taskFunc, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
-
-            Return source.Task.Unwrap()
-        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Workspaces/TryFindSourceDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/Workspaces/TryFindSourceDefinitionTests.vb
@@ -214,5 +214,42 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 Assert.True(mappedMember.Locations.All(Function(Loc) Loc.IsInSource))
             End Using
         End Function
+
+
+        <Fact>
+        Public Async Function TestFindRetargetedClass() As Task
+            Dim workspaceDefinition =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferencesPortable="true">
+        <Document>
+            namespace N
+            {
+                public class CSClass
+                {
+                }
+            }
+        </Document>
+    </Project>
+    <Project Language="C#" AssemblyName="CSharpAssembly2" CommonReferences="true">
+        <ProjectReference>CSharpAssembly</ProjectReference>
+    </Project>
+</Workspace>
+
+            Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition)
+                Dim retargetedCompilation = Await GetProject(workspace.CurrentSolution, "CSharpAssembly").GetCompilationAsync()
+                Dim originalClass = retargetedCompilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single()
+                Dim retargetingCompilation = Await GetProject(workspace.CurrentSolution, "CSharpAssembly2").GetCompilationAsync()
+                Dim retargetedClass = retargetingCompilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single()
+
+                ' The retargeted class should not have the same assembly identity as the originating assembly, but
+                ' should come through the compilation reference
+                Assert.NotEqual(retargetedClass.ContainingAssembly, retargetedCompilation.Assembly)
+                Assert.IsAssignableFrom(Of CompilationReference)(retargetingCompilation.GetMetadataReference(retargetedClass.ContainingAssembly))
+
+                Dim mappedMember = Await SymbolFinder.FindSourceDefinitionAsync(retargetedClass, workspace.CurrentSolution)
+
+                Assert.Equal(Of ISymbol)(originalClass, mappedMember)
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -21,14 +21,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     /// </summary>
     internal static class DependentProjectsFinder
     {
+        /// <summary>
+        /// A helper struct used for keying in <see cref="s_dependentProjectsCache"/>.
+        /// </summary>
         private struct DefinitionProject
         {
-            private readonly bool _isSourceProject;
+            private readonly ProjectId _sourceProjectId;
             private readonly string _assemblyName;
 
-            public DefinitionProject(bool isSourceProject, string assemblyName)
+            public DefinitionProject(ProjectId sourceProjectId, string assemblyName)
             {
-                _isSourceProject = isSourceProject;
+                _sourceProjectId = sourceProjectId;
                 _assemblyName = assemblyName;
             }
         }
@@ -155,7 +158,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 // We cache the dependent projects for non-private symbols, check in the cache first.
                 ConcurrentDictionary<DefinitionProject, IEnumerable<DependentProject>> dependentProjectsMap = s_dependentProjectsCache.GetValue(solution, s_createDependentProjectsMapCallback);
-                var key = new DefinitionProject(isSourceProject: sourceProject != null, assemblyName: containingAssembly.Name.ToLower());
+                var key = new DefinitionProject(sourceProjectId: sourceProject?.Id, assemblyName: containingAssembly.Name.ToLower());
 
                 if (!dependentProjectsMap.TryGetValue(key, out dependentProjects))
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             using (Logger.LogBlock(FunctionId.FindReference_DetermineAllSymbolsAsync, _cancellationToken))
             {
-                var result = new ConcurrentSet<ISymbol>(SymbolEquivalenceComparer.Instance);
+                var result = new ConcurrentSet<ISymbol>(MetadataUnifyingEquivalenceComparer.Instance);
                 await DetermineAllSymbolsCoreAsync(symbol, result).ConfigureAwait(false);
                 return result;
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingEquivalenceComparer.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingEquivalenceComparer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+
+namespace Microsoft.CodeAnalysis.FindSymbols
+{
+    internal sealed class MetadataUnifyingEquivalenceComparer : IEqualityComparer<ISymbol>
+    {
+        public static readonly IEqualityComparer<ISymbol> Instance = new MetadataUnifyingEquivalenceComparer();
+
+        private MetadataUnifyingEquivalenceComparer()
+        {
+        }
+
+        public bool Equals(ISymbol x, ISymbol y)
+        {
+            // If either symbol is from source, then we must do stricter equality. Consider this:
+            //
+            //     S1 <-> M <-> S2     (where S# = source symbol, M = some metadata symbol)
+            //
+            // In this case, imagine that both the comparisons denoted by <-> were done with the
+            // SymbolEquivalenceComparer, and returned true. If S1 and S2 were from different projects,
+            // they would compare false but transitivity would say they must be true. Another way to think
+            // of this is any use of a source symbol "poisons" the comparison and requires it to be stricter.
+            if (x == null || y == null || IsInSource(x) || IsInSource(y))
+            {
+                return object.Equals(x, y);
+            }
+
+            // Both of the symbols are from metadata, so defer to the equivalence comparer
+            return SymbolEquivalenceComparer.Instance.Equals(x, y);
+        }
+
+        public int GetHashCode(ISymbol obj)
+        {
+            if (IsInSource(obj))
+            {
+                return obj.GetHashCode();
+            }
+            else
+            {
+                return SymbolEquivalenceComparer.Instance.GetHashCode(obj);
+            }
+        }
+
+        private static bool IsInSource(ISymbol symbol)
+        {
+            return symbol.Locations.Any(l => l.IsInSource);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -103,15 +103,39 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             Solution solution,
             CancellationToken cancellationToken)
         {
-            // If it's already in source, then just return it.
+            // If it's already in source, then we might already be done
             if (InSource(symbol))
             {
-                return symbol;
-            }
+                // If our symbol doesn't have a containing assembly, there's nothing better we can do to map this
+                // symbol somewhere else. The common case for this is a merged INamespaceSymbol that spans assemblies.
+                if (symbol.ContainingAssembly == null)
+                {
+                    return symbol;
+                }
 
-            // If it's not in metadata, then we can't map it back to source.
-            if (!symbol.Locations.Any(loc => loc.IsInMetadata))
+                // Just because it's a source symbol doesn't mean we have the final symbol we actually want. In retargeting cases,
+                // the retargeted symbol is from "source" but isn't equal to the actual source definition in the other project. Thus,
+                // we only want to return symbols from source here if it actually came from a project's compilation's assembly. If it isn't
+                // then we have a retargeting scenario and want to take our usual path below as if it was a metadata reference
+                foreach (var sourceProject in solution.Projects)
+                {
+                    Compilation compilation;
+
+                    // If our symbol is actually a "regular" source symbol, then we know the compilation is holding the symbol alive
+                    // and thus TryGetCompilation is sufficient. For another example of this pattern, see Solution.GetProject(IAssemblySymbol)
+                    // which we happen to call below.
+                    if (sourceProject.TryGetCompilation(out compilation))
+                    {
+                        if (symbol.ContainingAssembly.Equals(compilation.Assembly))
+                        {
+                            return symbol;
+                        }
+                    }
+                }
+            }
+            else if (!symbol.Locations.Any(loc => loc.IsInMetadata))
             {
+                // We have a symbol that's neither in source nor metadata
                 return null;
             }
 

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -384,6 +384,7 @@
     <Compile Include="FindSymbols\DeclaredSymbolInfo.cs" />
     <Compile Include="FindSymbols\FindReferences\Finders\ILanguageServiceReferenceFinder.cs" />
     <Compile Include="FindSymbols\SymbolTree\ISymbolTreeInfoCacheService.cs" />
+    <Compile Include="FindSymbols\FindReferences\MetadataUnifyingEquivalenceComparer.cs" />
     <Compile Include="Utilities\ArraySlice.cs" />
     <Compile Include="Utilities\BKTree.cs" />
     <Compile Include="FindSymbols\SyntaxTree\AbstractSyntaxTreeInfo.cs" />


### PR DESCRIPTION
If you tried doing find references when you had the same file linked into more than one project with the same assembly name, various things would go wrong. This makes things go right.

The core of this work is in commit 1bc98ab105d788fa7645046d09772afdc1e9920d, with the rest of the commits being general work to bring our test infrastructure up to spec to actually create tests for this scenario.

*Review:* @dotnet/roslyn-ide