### PR TITLE
made diagnostic tags to be removed faster and inserted slower.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.Tagger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
     internal partial class SyntacticClassificationTaggerProvider
     {
-        private partial class Tagger : ITagger<IClassificationTag>, IDisposable
+        private class Tagger : ITagger<IClassificationTag>, IDisposable
         {
             private TagComputer _tagComputer;
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             // we will show new tags to users very slowly. 
             // don't confused this with data changed event which is for tag producer (which is set to NearImmediate).
             // this delay is for letting editor know about newly added tags.
-            protected override TaggerDelay NewTagsNotificationDelay => TaggerDelay.OnIdle;
+            protected override TaggerDelay AddedTagNotificationDelay => TaggerDelay.OnIdle;
 
             protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
             {

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
@@ -52,6 +52,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             void ITaggerEventSource.Connect() { }
             void ITaggerEventSource.Disconnect() { }
 
+            // we will show new tags to users very slowly. 
+            // don't confused this with data changed event which is for tag producer (which is set to NearImmediate).
+            // this delay is for letting editor know about newly added tags.
+            protected override TaggerDelay NewTagsNotificationDelay => TaggerDelay.OnIdle;
+
             protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
             {
                 // We act as a source of events ourselves.  When the diagnostics service tells
@@ -138,7 +143,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     _latestSourceText = sourceText;
                     _latestEditorSnapshot = editorSnapshot;
                 }
-                this.Changed?.Invoke(this, new TaggerEventArgs(TaggerDelay.Medium));
+
+                // unlike any other tagger, actual work to produce data is done by other service rather than tag provider itself.
+                // so we don't need to do any big delay for diagnostic tagger (producer) to reduce doing expensive work repeatedly. that is already
+                // taken cared by the external service (diagnostic service).
+                this.Changed?.Invoke(this, new TaggerEventArgs(TaggerDelay.NearImmediate));
             }
         }
     }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -112,8 +112,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 RecalculateTagsOnChanged(new TaggerEventArgs(TaggerDelay.Short));
             }
 
-            public TaggerDelay NewTagsNotificationDelay => _dataSource.AddedTagNotificationDelay;
-            public TaggerDelay OldTagNotificationDelay => _dataSource.RemovedTagNotificationDelay;
+            public TaggerDelay AddedTagNotificationDelay => _dataSource.AddedTagNotificationDelay;
+            public TaggerDelay RemovedTagNotificationDelay => _dataSource.RemovedTagNotificationDelay;
 
             private ITaggerEventSource CreateEventSource()
             {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -90,10 +90,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 var snapshot = _subjectBuffer.CurrentSnapshot;
                 var oldTagTree = GetTagTree(snapshot, oldTagTrees);
-                var newTagTree = GetTagTree(snapshot, this.CachedTagTrees);
-
-                var difference = ComputeDifference(snapshot, newTagTree, oldTagTree);
-                RaiseTagsChanged(snapshot.TextBuffer, difference);
+                
+                // everything from old tree is removed.
+                RaiseTagsChanged(snapshot.TextBuffer, new DiffResult(added: null, removed: oldTagTree.GetSpans(snapshot).Select(s => s.Span)));
             }
 
             private void OnSubjectBufferChanged(object sender, TextContentChangedEventArgs e)
@@ -193,11 +192,13 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 var oldTagTrees = this.CachedTagTrees;
                 this.CachedTagTrees = oldTagTrees.SetItem(snapshot.TextBuffer, newTagTree);
 
-                // Grab our old tags. We might not have any, so in this case we'll just pretend it's
-                // empty
-                var oldTagTree = GetTagTree(snapshot, oldTagTrees);
+                // Not sure why we are diffing when we already have tagsToRemove. is it due to _tagSpanComparer might return
+                // different result than GetIntersectingSpans?
+                //
+                // treeForBuffer basically points to oldTagTrees. case where oldTagTrees not exist is already taken cared by
+                // CachedTagTrees.TryGetValue.
+                var difference = ComputeDifference(snapshot, newTagTree, treeForBuffer);
 
-                var difference = ComputeDifference(snapshot, newTagTree, oldTagTree);
                 RaiseTagsChanged(snapshot.TextBuffer, difference);
             }
 
@@ -594,7 +595,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 object newState,
                 CancellationToken cancellationToken)
             {
-                var bufferToChanges = new Dictionary<ITextBuffer, NormalizedSnapshotSpanCollection>();
+                var bufferToChanges = new Dictionary<ITextBuffer, DiffResult>();
                 using (Logger.LogBlock(FunctionId.Tagger_TagSource_ProcessNewTags, cancellationToken))
                 {
                     foreach (var latestBuffer in newTagTrees.Keys)
@@ -609,8 +610,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                         else
                         {
                             // It's a new buffer, so report all spans are changed
-                            var allSpans = new NormalizedSnapshotSpanCollection(newTagTrees[latestBuffer].GetSpans(snapshot).Select(t => t.Span));
-                            bufferToChanges[latestBuffer] = allSpans;
+                            bufferToChanges[latestBuffer] = new DiffResult(added: newTagTrees[latestBuffer].GetSpans(snapshot).Select(t => t.Span), removed: null);
                         }
                     }
 
@@ -619,8 +619,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                         if (!newTagTrees.ContainsKey(oldBuffer))
                         {
                             // This buffer disappeared, so let's notify that the old tags are gone
-                            var allSpans = new NormalizedSnapshotSpanCollection(oldTagTrees[oldBuffer].GetSpans(oldBuffer.CurrentSnapshot).Select(t => t.Span));
-                            bufferToChanges[oldBuffer] = allSpans;
+                            bufferToChanges[oldBuffer] = new DiffResult(added: null, removed: oldTagTrees[oldBuffer].GetSpans(oldBuffer.CurrentSnapshot).Select(t => t.Span));
                         }
                     }
                 }
@@ -640,7 +639,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
             private void UpdateStateAndReportChanges(
                 ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> newTagTrees,
-                Dictionary<ITextBuffer, NormalizedSnapshotSpanCollection> bufferToChanges,
+                Dictionary<ITextBuffer, DiffResult> bufferToChanges,
                 object newState)
             {
                 _workQueue.AssertIsForeground();
@@ -673,13 +672,12 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 RaiseTagsChanged(bufferToChanges);
             }
 
-            private NormalizedSnapshotSpanCollection ComputeDifference(
+            private DiffResult ComputeDifference(
                 ITextSnapshot snapshot,
                 TagSpanIntervalTree<TTag> latestSpans,
                 TagSpanIntervalTree<TTag> previousSpans)
             {
-                return new NormalizedSnapshotSpanCollection(
-                    Difference(latestSpans.GetSpans(snapshot), previousSpans.GetSpans(snapshot), _dataSource.TagComparer));
+                return Difference(latestSpans.GetSpans(snapshot), previousSpans.GetSpans(snapshot), _dataSource.TagComparer);
             }
 
             /// <summary>

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 var snapshot = _subjectBuffer.CurrentSnapshot;
                 var oldTagTree = GetTagTree(snapshot, oldTagTrees);
-                
+
                 // everything from old tree is removed.
                 RaiseTagsChanged(snapshot.TextBuffer, new DiffResult(added: null, removed: oldTagTree.GetSpans(snapshot).Select(s => s.Span)));
             }
@@ -189,8 +189,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 var snapshot = e.After;
 
-                var oldTagTrees = this.CachedTagTrees;
-                this.CachedTagTrees = oldTagTrees.SetItem(snapshot.TextBuffer, newTagTree);
+                this.CachedTagTrees = this.CachedTagTrees.SetItem(snapshot.TextBuffer, newTagTree);
 
                 // Not sure why we are diffing when we already have tagsToRemove. is it due to _tagSpanComparer might return
                 // different result than GetIntersectingSpans?

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _batchChangeNotifier.Resume();
             }
 
-            private void OnTagsChangedForBuffer(ICollection<KeyValuePair<ITextBuffer, NormalizedSnapshotSpanCollection>> changes)
+            private void OnTagsChangedForBuffer(ICollection<KeyValuePair<ITextBuffer, DiffResult>> changes)
             {
                 _tagSource.AssertIsForeground();
 
@@ -94,8 +95,25 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     }
 
                     // Now report them back to the UI on the main thread.
-                    _batchChangeNotifier.EnqueueChanges(change.Value);
+
+                    // We ask to update UI immediately for removed tags
+                    NotifyEditors(change.Value.Removed, _tagSource.OldTagNotificationDelay);
+                    NotifyEditors(change.Value.Added, _tagSource.NewTagsNotificationDelay);
                 }
+            }
+
+            private void NotifyEditors(NormalizedSnapshotSpanCollection changes, TaggerDelay delay)
+            {
+                if (delay == TaggerDelay.NearImmediate)
+                {
+                    // if delay is immediate, we let notifier knows about the change right away
+                    _batchChangeNotifier.EnqueueChanges(changes);
+                    return;
+                }
+
+                // if delay is anything more than that, we let notifier knows about the change after given delay
+                // event notification is not cancellable.
+                _tagSource.RegisterNotification(() => _batchChangeNotifier.EnqueueChanges(changes), (int)delay.ComputeTimeDelay(_subjectBuffer).TotalMilliseconds, CancellationToken.None);
             }
 
             public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -104,6 +104,14 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
             private void NotifyEditors(NormalizedSnapshotSpanCollection changes, TaggerDelay delay)
             {
+                _tagSource.AssertIsForeground();
+
+                if (changes.Count == 0)
+                {
+                    // nothing to do.
+                    return;
+                }
+
                 if (delay == TaggerDelay.NearImmediate)
                 {
                     // if delay is immediate, we let notifier knows about the change right away

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -97,8 +97,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     // Now report them back to the UI on the main thread.
 
                     // We ask to update UI immediately for removed tags
-                    NotifyEditors(change.Value.Removed, _tagSource.OldTagNotificationDelay);
-                    NotifyEditors(change.Value.Added, _tagSource.NewTagsNotificationDelay);
+                    NotifyEditors(change.Value.Removed, _tagSource.RemovedTagNotificationDelay);
+                    NotifyEditors(change.Value.Added, _tagSource.AddedTagNotificationDelay);
                 }
             }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -70,6 +70,16 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         protected virtual IEnumerable<Option<bool>> Options => SpecializedCollections.EmptyEnumerable<Option<bool>>();
         protected virtual IEnumerable<PerLanguageOption<bool>> PerLanguageOptions => SpecializedCollections.EmptyEnumerable<PerLanguageOption<bool>>();
 
+        /// <summary>
+        /// This controls what delay tagger will use to let editor know about newly inserted tags
+        /// </summary>
+        protected virtual TaggerDelay NewTagsNotificationDelay => TaggerDelay.NearImmediate;
+
+        /// <summary>
+        /// This controls what delay tagger will use to let editor know about just deleted tags.
+        /// </summary>
+        protected virtual TaggerDelay OldTagNotificationDelay => TaggerDelay.NearImmediate;
+
 #if DEBUG
         public readonly string StackTrace;
 #endif
@@ -211,6 +221,20 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         protected virtual Task ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition)
         {
             return SpecializedTasks.EmptyTask;
+        }
+
+        private struct DiffResult
+        {
+            public NormalizedSnapshotSpanCollection Added { get; }
+            public NormalizedSnapshotSpanCollection Removed { get; }
+
+            public DiffResult(IEnumerable<SnapshotSpan> added, IEnumerable<SnapshotSpan> removed)
+            {
+                Added = added != null ? new NormalizedSnapshotSpanCollection(added) : NormalizedSnapshotSpanCollection.Empty;
+                Removed = removed != null ? new NormalizedSnapshotSpanCollection(removed) : NormalizedSnapshotSpanCollection.Empty;
+            }
+
+            public int Count => Added.Count + Removed.Count;
         }
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -73,12 +73,12 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// <summary>
         /// This controls what delay tagger will use to let editor know about newly inserted tags
         /// </summary>
-        protected virtual TaggerDelay NewTagsNotificationDelay => TaggerDelay.NearImmediate;
+        protected virtual TaggerDelay AddedTagNotificationDelay => TaggerDelay.NearImmediate;
 
         /// <summary>
         /// This controls what delay tagger will use to let editor know about just deleted tags.
         /// </summary>
-        protected virtual TaggerDelay OldTagNotificationDelay => TaggerDelay.NearImmediate;
+        protected virtual TaggerDelay RemovedTagNotificationDelay => TaggerDelay.NearImmediate;
 
 #if DEBUG
         public readonly string StackTrace;
@@ -227,6 +227,11 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         {
             public NormalizedSnapshotSpanCollection Added { get; }
             public NormalizedSnapshotSpanCollection Removed { get; }
+
+            public DiffResult(List<SnapshotSpan> added, List<SnapshotSpan> removed) :
+                this(added?.Count == 0 ? null : (IEnumerable<SnapshotSpan>)added, removed?.Count == 0 ? null : (IEnumerable<SnapshotSpan>)removed)
+            {
+            }
 
             public DiffResult(IEnumerable<SnapshotSpan> added, IEnumerable<SnapshotSpan> removed)
             {

--- a/src/Features/Core/Portable/SolutionCrawler/InternalSolutionCrawlerOptions.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/InternalSolutionCrawlerOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public const string OptionName = "SolutionCrawler";
 
         public static readonly Option<bool> SolutionCrawler = new Option<bool>("FeatureManager/Components", "Solution Crawler", defaultValue: true);
-        public static readonly Option<int> ActiveFileWorkerBackOffTimeSpanInMS = new Option<int>(OptionName, "Active file worker backoff timespan in ms", defaultValue: 800);
+        public static readonly Option<int> ActiveFileWorkerBackOffTimeSpanInMS = new Option<int>(OptionName, "Active file worker backoff timespan in ms", defaultValue: 400);
         public static readonly Option<int> AllFilesWorkerBackOffTimeSpanInMS = new Option<int>(OptionName, "All files worker backoff timespan in ms", defaultValue: 1500);
         public static readonly Option<int> EntireProjectWorkerBackOffTimeSpanInMS = new Option<int>(OptionName, "Entire project analysis worker backoff timespan in ms", defaultValue: 5000);
         public static readonly Option<int> SemanticChangeBackOffTimeSpanInMS = new Option<int>(OptionName, "Semantic change backoff timespan in ms", defaultValue: 100);


### PR DESCRIPTION
experience seems actually quite better than before.

anyway, 2 main changes are

1. active file analysis delay got shorten to 400ms from 800ms.
2. notification to editor on removed tags are now 50ms but added tags are now 1.5 seconds.

...

more detail explanations below

for #1. the delay change is only for 1 file (a file that has focus). all other file analysis delay is same as before (1.5 seconds). so I believe perf impact due to this should be fairly small. and it is still better than RTM which was 200ms. also, after RTM, we already made LB behavior not to be affected by this delay. so this change shouldn't affect LB behavior.

for #2. tagger actually has many small delays in them.
2 main ones are

1) delay to produce tags
2) delay to notify editor about changed tags.

1) is to reduce doing repeated works to generate tags. for diagnostic tagger, this actually is not needed since unlike any other tagger, diagnostic tagger uses external service (diagnostic service) which already does all these things (basically #1 delay is logically doing what 1) is trying to do)

now 1) delay is set to NearImmediate (50ms)

2) is to prevent us from abusing editors too much with a lot of notifications. basically this delay make sure we only ping editor once in a while (used to be 50ms) and aggregate events between them.

now, 2) is split into 2 different delays. one for adding new tags and the other for removing old tags.

adding new tags is now set to 1.5 seconds and removing old tags is set to 50ms.