### PR TITLE
Add a "Test" target that can be used to test an xunit project

### DIFF
--- a/build/Targets/Roslyn.Toolsets.Xunit.targets
+++ b/build/Targets/Roslyn.Toolsets.Xunit.targets
@@ -2,10 +2,20 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <XUnitPath>$(NuGetPackageRoot)\xunit.runner.console\2.1.0\tools\xunit.console.x86.exe</XUnitPath>
+    <XUnitTestResultsDirectory>$(OutDir)\xUnitResults</XUnitTestResultsDirectory>
+    <XUnitArguments>"$(OutDir)\$(AssemblyName).dll" -html "$(XUnitTestResultsDirectory)\$(AssemblyName).html" -noshadow</XUnitArguments>
+  </PropertyGroup>
+
+  <Target Name="Test" DependsOnTargets="Build">
+    <MakeDir Directories="$(XUnitTestResultsDirectory)" />
+    <Exec Command="&quot;$(XUnitPath)&quot; $(XUnitArguments)" />
+  </Target>
+
+  <PropertyGroup>
     <StartAction Condition="'$(StartActions)' == ''">Program</StartAction>
-    <StartProgram Condition="'$(StartProgram)' == ''">$(NuGetPackageRoot)\xunit.runner.console\2.1.0\tools\xunit.console.x86.exe</StartProgram>
-    <StartArguments Condition="'$(StartArguments)' == ''">$(AssemblyName).dll -html $(OurDir)\xUnitResults\$(AssemblyName).html -noshadow</StartArguments>
-    <StartWorkingDirectory Condition="'$(StartWorkingDirectory)' == ''">$(OutDir)</StartWorkingDirectory>
+    <StartProgram Condition="'$(StartProgram)' == ''">$(XUnitPath)</StartProgram>
+    <StartArguments Condition="'$(StartArguments)' == ''">$(XUnitArguments)</StartArguments>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This isn't intended as a replacement for our other test scripts, but is handy if you aren't editing in Visual Studio and want to re-run something quickly.

(Maybe long term would replace BuildAndTest with just MSBuild Roslyn.sln /t:Test, which would be pretty.)

Review: @dotnet/roslyn-infrastructure, @dotnet/roslyn-ide 