### PR TITLE
Update restore.ps1 to use WebClient.DownloadFile

### DIFF
--- a/build/scripts/restore.ps1
+++ b/build/scripts/restore.ps1
@@ -7,7 +7,7 @@ $nugetZipFilename = ($nugetZipUrl.Segments | select -Last 1)
 $outFilePath = "${env:TEMP}\$nugetZipFilename"
 if (-not(Test-Path $outFilePath)) {
     write-host "Downloading $nugetZipUrl -> $outFilePath"
-    wget -Uri "$nugetZipUrl" -OutFile "$outFilePath"
+    (New-Object System.Net.WebClient).DownloadFile($nugetZipUrl, $outFilePath)
 }
 
 # It's possible for restore to run in parallel on the test machines.  As such


### PR DESCRIPTION
wget (alias for Invoke-WebRequest) attempts to update the powershell UI for every byte downloaded, which is very slow. Changing this to use WebClient.DownloadFile avoids this penalty and speeds up the download process significantly.