### PR TITLE
Fix #7182 where ContainsSkippedText was returning false incorrectly

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/StructuredTriviaSyntax.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/InternalSyntax/StructuredTriviaSyntax.vb
@@ -15,23 +15,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Partial Friend MustInherit Class StructuredTriviaSyntax
         Friend Sub New(reader As ObjectReader)
             MyBase.New(reader)
-            Me.SetFlags(NodeFlags.ContainsStructuredTrivia)
+            Initialize()
         End Sub
 
         Friend Sub New(ByVal kind As SyntaxKind)
             MyBase.New(kind)
-            Me.SetFlags(NodeFlags.ContainsStructuredTrivia)
+            Initialize()
         End Sub
 
         Friend Sub New(ByVal kind As SyntaxKind, context As ISyntaxFactoryContext)
             MyBase.New(kind)
-            Me.SetFlags(NodeFlags.ContainsStructuredTrivia)
+            Initialize()
             Me.SetFactoryContext(context)
         End Sub
 
         Friend Sub New(ByVal kind As SyntaxKind, ByVal errors As DiagnosticInfo(), ByVal annotations As SyntaxAnnotation())
             MyBase.New(kind, errors, annotations)
+            Initialize()
+        End Sub
+
+        Private Sub Initialize()
             Me.SetFlags(NodeFlags.ContainsStructuredTrivia)
+
+            If Kind = SyntaxKind.SkippedTokensTrivia Then
+                Me.SetFlags(NodeFlags.ContainsSkippedText)
+            End If
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/ManualTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/ManualTests.vb
@@ -225,5 +225,11 @@ End Module
             Dim token = tree.GetRoot().FindToken(text.Lines.Item(3).Start)
             Assert.Equal(">", token.ToString())
         End Sub
+        
+        <Fact, WorkItem(7182, "https://github.com/dotnet/roslyn/issues/7182")>
+        Public Sub WhenTextContainsTrailingTrivia_SyntaxNode_ContainsSkippedText_ReturnsTrue()
+            Dim parsedTypeName = SyntaxFactory.ParseTypeName("System.Collections.Generic.List(Of Integer), mscorlib")
+            Assert.True(parsedTypeName.ContainsSkippedText)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #7182
StructuredTriviaSyntax.vb now mirrors implementation in [StructuredTriviaSyntax.cs](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/StructuredTriviaSyntax.cs)
Also remove workaround for this bug in VisualBasicCodeModelService