### PR TITLE
Fix that the full bound tree is not cached for ArrowExpressionClauseSyntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1102,7 +1102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!alreadyInTree)
             {
-                if ((this.IsSpeculativeSemanticModel && syntax == _root) || syntax is StatementSyntax || syntax is ArrowExpressionClauseSyntax)
+                if (syntax == _root || syntax is StatementSyntax)
                 {
                     // Note: For speculative model we want to always cache the entire bound tree.
                     // If syntax is a statement, we need to add all its children.

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1102,7 +1102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!alreadyInTree)
             {
-                if ((this.IsSpeculativeSemanticModel && syntax == _root) || syntax is StatementSyntax)
+                if ((this.IsSpeculativeSemanticModel && syntax == _root) || syntax is StatementSyntax || syntax is ArrowExpressionClauseSyntax)
                 {
                     // Note: For speculative model we want to always cache the entire bound tree.
                     // If syntax is a statement, we need to add all its children.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -1755,10 +1755,12 @@ public class Example
 
             var nameSyntax = syntaxRoot.FindNode(TextSpan.FromBounds(130, 138));
             Assert.Equal("Lifetime", nameSyntax.ToString());
+            Assert.Equal("Lifetime.Persistent", nameSyntax.Parent.ToString());
 
             var actualSymbol = semanticModel.GetSymbolInfo(nameSyntax);
 
             Assert.Equal("Lifetime", actualSymbol.Symbol.ToTestDisplayString());
+            Assert.Equal(SymbolKind.NamedType, actualSymbol.Symbol.Kind);
         }
 
         #endregion Regression cases

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -1806,11 +1806,11 @@ public class Example
 
             var semanticModel = comp.GetSemanticModel(syntaxTree, false);
 
-            var nameSyntax = syntaxRoot.FindNode(TextSpan.FromBounds(130, 138));
-            Assert.Equal("Lifetime", nameSyntax.ToString());
-            Assert.Equal("Lifetime.Persistent", nameSyntax.Parent.ToString());
+            var memberAccess = syntaxRoot.DescendantNodes().Single(node => node.IsKind(SyntaxKind.SimpleMemberAccessExpression)) as MemberAccessExpressionSyntax;
+            Assert.Equal("Lifetime", memberAccess.Expression.ToString());
+            Assert.Equal("Lifetime.Persistent", memberAccess.ToString());
 
-            var actualSymbol = semanticModel.GetSymbolInfo(nameSyntax);
+            var actualSymbol = semanticModel.GetSymbolInfo(memberAccess.Expression);
 
             Assert.Equal("Lifetime", actualSymbol.Symbol.ToTestDisplayString());
             Assert.Equal(SymbolKind.NamedType, actualSymbol.Symbol.Kind);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -1753,10 +1753,12 @@ public class Example
 
             var semanticModel = comp.GetSemanticModel(syntaxTree, false);
 
-            var actualSymbol = semanticModel.GetSymbolInfo(syntaxRoot.FindNode(TextSpan.FromBounds(130, 138)));
-            var expectedSymbol = semanticModel.GetDeclaredSymbol(syntaxRoot.FindNode(TextSpan.FromBounds(0, 71)));
+            var nameSyntax = syntaxRoot.FindNode(TextSpan.FromBounds(130, 138));
+            Assert.Equal("Lifetime", nameSyntax.ToString());
 
-            Assert.Equal(expectedSymbol, actualSymbol.Symbol);
+            var actualSymbol = semanticModel.GetSymbolInfo(nameSyntax);
+
+            Assert.Equal("Lifetime", actualSymbol.Symbol.ToTestDisplayString());
         }
 
         #endregion Regression cases


### PR DESCRIPTION
An ArrowExpressionClauseSyntax is special because it has an expression as its direct child. Because of that the binder was not correctly caching all nodes of the bound tree and instead was falling back to binding decendand nodes by themself when asked for them. This fails if in the decendant nodes there is a color color case.

With this change the binder does cache all of the ArrowExpressionClauseSyntax's children including the correctly resolved symbols for a color color situation.

Fixes #5362.