### PR TITLE
fix test failures caused by localization

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
             catch (ArgumentException argException)
             {
-                Assert.Equal(CodeAnalysisResources.NullValueInPathMap + "\r\nParameter name: pathMap", argException.Message);
+                Assert.Equal(new ArgumentException(CodeAnalysisResources.NullValueInPathMap, "pathMap").Message, argException.Message);
             }
 
             // Empty pathmap value doesn't throw
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
             catch (ArgumentException argExeption)
             {
-                Assert.Equal(CodeAnalysisResources.AbsolutePathExpected + "\r\nParameter name: baseDirectory", argExeption.Message);
+                Assert.Equal(new ArgumentException(CodeAnalysisResources.AbsolutePathExpected, "baseDirectory").Message, argExeption.Message);
             }
         }
     }

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -1150,7 +1150,7 @@ Console.Write(Task.Run(() => { Thread.CurrentThread.Join(100); return 42; }).Con
 
             Assert.Equal("", output);
             Assert.DoesNotContain("Unexpected", error, StringComparison.OrdinalIgnoreCase);
-            Assert.True(error.StartsWith("System.Exception: Exception of type 'System.Exception' was thrown."));
+            Assert.True(error.StartsWith(new Exception().ToString()));
         }
 
         #region Submission result printing - null/void/value.

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -181,7 +181,7 @@ Type ""#help"" for more information.
 5
 > div(10, 0)
 «Red»
-Attempted to divide by zero.
+{new System.DivideByZeroException().Message}
 «DarkRed»
   + Submission#0.div(Int32 a, Int32 b)
 «Gray»


### PR DESCRIPTION
With these changes `msbuild BuildAndTest.proj` compiles without any failing tests on my german machine.