### PR TITLE
Pass Version46 to ToolLocationHelper to find default.win32manifest

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Shared/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/ManagedCompiler.cs
@@ -971,7 +971,18 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         string pathToDefaultManifest = ToolLocationHelper.GetPathToDotNetFrameworkFile
                                                        (
                                                            "default.win32manifest",
-                                                           TargetDotNetFrameworkVersion.VersionLatest
+
+                                                           // We are choosing to pass Version46 instead of VersionLatest. TargetDotNetFrameworkVersion
+                                                           // is an enum, and VersionLatest is not some sentinel value but rather a constant that is
+                                                           // equal to the highest version defined in the enum. Enum values, being constants, are baked
+                                                           // into consuming assembly, so specifying VersionLatest means not the latest version wherever
+                                                           // this code is running, but rather the latest version of the framework according to the
+                                                           // reference assembly with which this assembly was built. As of this writing, we are building
+                                                           // our bits on machines with Visual Studio 2015 that know about 4.6.1, so specifying
+                                                           // VersionLatest would bake in the enum value for 4.6.1. But we need to run on machines with
+                                                           // MSBuild that only know about Version46 (and no higher), so VersionLatest will fail there.
+                                                           // Explicitly passing Version46 prevents this problem.
+                                                           TargetDotNetFrameworkVersion.Version46
                                                        );
 
                         if (null == pathToDefaultManifest)


### PR DESCRIPTION
We are choosing to pass Version46 instead of VersionLatest. TargetDotNetFrameworkVersion is an enum, and VersionLatest is not some sentinel value but rather a constant that is equal to the highest
version defined in the enum. Enum values, being constants, are baked into consuming assembly, so specifying VersionLatest means not the latest version wherever this code is running, but rather the latest version of the framework according to the reference assembly with which this assembly was built. As of this writing, we are building our bits on machines with Visual Studio 2015 that know about 4.6.1, so specifying VersionLatest would bake in the enum value for 4.6.1. But we need to run on machines with MSBuild that only know about Version46 (and no higher), so VersionLatest will fail there.  Explicitly passing Version46 prevents this problem.