### PR TITLE
More WorkItem attribute cleanup

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -974,7 +974,7 @@ public class C
             CompileAndVerify(source, new[] { SystemCoreRef });
         }
 
-        [Fact, WorkItem(16, "unknown")]
+        [Fact, WorkItem(16, "http://roslyn.codeplex.com/workitem/16")]
         public void RemoveAtOfKeywordAsDynamicMemberName()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -6634,7 +6634,6 @@ True");
 }");
         }
 
-        [WorkItem(1, "unknown")]
         [Fact]
         public void Bug1()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
@@ -679,7 +679,7 @@ class Program
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "E").WithArguments("E"));
         }
 
-        [WorkItem(9142, "unknown")]
+        [WorkItem(9145, "http://vstfdevdiv:8080/DevDiv_Projects/Roslyn/_workitems/edit/9145")]
         [Fact]
         public void Bug9145()
         {

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingDelegateCreationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingDelegateCreationTests.vb
@@ -1243,7 +1243,7 @@ End Class
             CompileAndVerify(source, "all working here")
         End Sub
 
-        <Fact, WorkItem(17302)>
+        <Fact>
         Public Sub InvalidDelegateRelaxationForSharednessMismatch()
             Dim compilationDef = <compilation>
                                      <file name="a.vb"><![CDATA[
@@ -1272,7 +1272,7 @@ End Module
             CompileAndVerify(compilation, expectedOutput:="2")
         End Sub
 
-        <Fact, WorkItem(17302)>
+        <Fact>
         Public Sub InvalidDelegateRelaxationForSharednessMismatch_2()
             Dim compilationDef = <compilation>
                                      <file name="a.vb"><![CDATA[
@@ -1314,7 +1314,7 @@ BC30518: Overload resolution failed because no accessible 'Foo' can be called wi
                                            </expected>)
         End Sub
 
-        <Fact, WorkItem(17302)>
+        <Fact>
         Public Sub InvalidDelegateRelaxationForMyClassMismatch()
             Dim compilationDef = <compilation>
                                      <file name="a.vb"><![CDATA[

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
@@ -143,7 +143,7 @@ public enum Foo
                 hideAdvancedMembers: false);
         }
 
-        [WorkItem(8540099)]
+        [WorkItem(854099, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/854099")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task NotInComment()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/BoolKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/BoolKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ByteKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ByteKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/CharKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/CharKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DecimalKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DecimalKeywordRecommenderTests.cs
@@ -586,14 +586,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DoubleKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DoubleKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DynamicKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DynamicKeywordRecommenderTests.cs
@@ -539,14 +539,12 @@ $$");
 }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/FloatKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/FloatKeywordRecommenderTests.cs
@@ -558,14 +558,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/IntKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/IntKeywordRecommenderTests.cs
@@ -654,14 +654,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/LongKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/LongKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ObjectKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ObjectKeywordRecommenderTests.cs
@@ -592,14 +592,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SByteKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SByteKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ShortKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ShortKeywordRecommenderTests.cs
@@ -585,7 +585,6 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StringKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StringKeywordRecommenderTests.cs
@@ -641,7 +641,6 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UIntKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UIntKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ULongKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ULongKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
@@ -585,14 +585,12 @@ class C { }
 ");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/VoidKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VoidKeywordRecommenderTests.cs
@@ -631,14 +631,12 @@ $$");
     static void Method1(void* p1 = default($$");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsync()
         {
             await VerifyKeywordAsync(@"class c { async $$ }");
         }
 
-        [WorkItem(18374)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterAsyncAsType()
         {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -2589,7 +2589,6 @@ class C
             });
         }
 
-        [WorkItem(947, "unknown")]
         [Fact]
         public void DuplicateEditorBrowsableAttributes()
         {

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -2578,7 +2578,6 @@ End Class"
             locals.Free()
         End Sub
 
-        <WorkItem(947, "unknown")>
         <Fact>
         Public Sub DuplicateEditorBrowsableAttributes()
             Const libSource = "

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -519,7 +519,6 @@ End Class
             Assert.Equal($"error BC30652: Reference required to assembly '{missingIdentity}' containing the type 'MissingType'. Add one to your project.", errorMessage)
         End Sub
 
-        <WorkItem(2547, "unknown")>
         <Fact>
         Public Sub TryDifferentLinqLibraryOnRetry()
             Dim source = "

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -82,7 +82,7 @@ Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
         }
 
         [Fact]
-        [WorkItem(7133)]
+        [WorkItem(7133, "http://github.com/dotnet/roslyn/issues/7133")]
         public void TestDisplayResultsWithCurrentUICulture()
         {
             var runner = CreateRunner(input:
@@ -455,7 +455,6 @@ Type ""#help"" for more information.
 > ", runner.Console.Out.ToString());
         }
 
-        [WorkItem(5748, "unknown")]
         [Fact]
         public void RelativePath()
         {

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -130,7 +130,7 @@ Type ""#help"" for more information.
         End Sub
 
         <Fact()>
-        <WorkItem(7133)>
+        <WorkItem(7133, "https://github.com/dotnet/roslyn/issues/7133")>
         Public Sub TestDisplayResultsWithCurrentUICulture()
             Dim runner = CreateRunner(args:={}, input:="Imports System.Globalization
 System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.GetCultureInfo(""en-GB"")

--- a/src/Test/Utilities/Shared/Assert/WorkItemAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/WorkItemAttribute.cs
@@ -23,11 +23,6 @@ namespace Roslyn.Test.Utilities
             get { return _description; }
         }
 
-        public WorkItemAttribute(int id)
-            : this(id, string.Empty)
-        {
-        }
-
         public WorkItemAttribute(int id, string description)
         {
             _id = id;

--- a/src/VisualStudio/Core/Test/Progression/ContainsChildrenGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/ContainsChildrenGraphQueryTests.vb
@@ -107,7 +107,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
             End Using
         End Function
 
-        <WorkItem(165369, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems#_a=edit&id=165369")>
+        <WorkItem(165369, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/165369")>
         <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
         Public Async Function ContainsChildrenForNodeWithRelativeUriPath() As Task
             Using testState = Await ProgressionTestState.CreateAsync(

--- a/src/VisualStudio/Core/Test/RQName/RQNameTests.vb
+++ b/src/VisualStudio/Core/Test/RQName/RQNameTests.vb
@@ -177,7 +177,6 @@ class MyClass
 
 
         <Fact, Trait(Traits.Feature, Traits.Features.RQName)>
-        <WorkItem(7924037)>
         Public Async Function TestRQNameForAnonymousTypeReturnsNull() As Task
             Dim markup = <Text><![CDATA[
 class Program


### PR DESCRIPTION
This change does the following:

- Deletes the constructor WorkItem(int) leaving only WorkItem(int, string).
- Fixes up many occurences where the URL of the bug was missing / incorrect.
- Removes several WorkItem attributes that had invalid bug ids