### PR TITLE
Bug Fix 5607: VB Parenthesis overtyping

### DIFF
--- a/src/EditorFeatures/Test/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/Test/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
         internal void CheckOverType(IBraceCompletionSession session, bool allowOverType = true)
         {
             var preClosingPoint = session.ClosingPoint.GetPoint(session.SubjectBuffer.CurrentSnapshot);
-            Assert.Equal(preClosingPoint.Subtract(1).GetChar(), session.ClosingBrace);
+            Assert.Equal(session.ClosingBrace, preClosingPoint.Subtract(1).GetChar());
 
             bool handled;
             session.PreOverType(out handled);

--- a/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticParenthesesCompletion.vb
+++ b/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticParenthesesCompletion.vb
@@ -301,6 +301,58 @@ End Class</code>
             End Using
         End Function
 
+        <WorkItem(5607, "https://github.com/dotnet/roslyn/issues/5607")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)>
+        Public Async Function TestOverTypeAfterIntegerLiteral() As Task
+            Dim code = <code>Imports System.Collections.Generic
+Class C
+    Sub Method()
+        Dim lines As New List(Of String)
+        lines.RemoveAt$$
+    End Sub
+End Class</code>
+
+            Using session = Await CreateSessionAsync(code)
+                Assert.NotNull(session)
+                CheckStart(session.Session)
+                Type(session.Session, "0")
+                CheckOverType(session.Session)
+            End Using
+        End Function
+
+        <WorkItem(5607, "https://github.com/dotnet/roslyn/issues/5607")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)>
+        Public Async Function TestOverTypeAfterDateLiteral() As Task
+            Dim code = <code>Class C
+    Sub Method()
+        Test(#1AM#)$$
+    End Sub
+    Sub Test(d As Date)
+    End Sub
+End Class</code>
+
+            Using session = Await CreateSessionAsync(code)
+                Assert.NotNull(session)
+                CheckOverType(session.Session)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)>
+        Public Async Function TestOverTypeAfterStringLiteral() As Task
+            Dim code = <code>Class C
+    Sub Method()
+        Console.Write$$
+    End Sub
+End Class</code>
+
+            Using session = Await CreateSessionAsync(code)
+                Assert.NotNull(session)
+                CheckStart(session.Session)
+                Type(session.Session, """a""")
+                CheckOverType(session.Session)
+            End Using
+        End Function
+
         Friend Overloads Function CreateSessionAsync(code As XElement) As Threading.Tasks.Task(Of Holder)
             Return CreateSessionAsync(code.NormalizedValue())
         End Function

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions.vb
@@ -114,6 +114,13 @@ recurse:
                 Return True
             End If
 
+            ' If it is a numeric literal, all checks are done and we're okay. 
+            If token.IsKind(SyntaxKind.IntegerLiteralToken, SyntaxKind.DecimalLiteralToken,
+                            SyntaxKind.DateLiteralToken, SyntaxKind.FloatingLiteralToken) Then
+                Return False
+            End If
+
+            ' For char or string literals, check if we're at the end of an incomplete literal.
             Dim lastChar = If(token.IsKind(SyntaxKind.CharacterLiteralToken), "'", """")
 
             Return AtEndOfIncompleteStringOrCharLiteral(token, position, lastChar)


### PR DESCRIPTION
Fixes #5607

The bug was that automatic brace completion will not overtype close
parenthesis if the close parenthesis token was preceded by a numeric
literal. The bug was in `IsEntirelyWithinStringOrCharOrNumericLiteral`,
where we were imposing checks meant for chars and strings on numeric
literals, which was likely introduced in PR #1763. This change addresses
it by not enforcing checks meant for chars/strings on numeric literals.