### PR TITLE
explicitly list analyzer exceptions when they fail a test

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -75,7 +75,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         /// </summary>
         private void AssertNoAnalyzerExceptionDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
-            Assert.Equal(0, diagnostics.Count(diag => diag.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.AnalyzerException)));
+            var analyzerExceptionDiagnostics = diagnostics.Where(diag => diag.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.AnalyzerException));
+
+            // using `Assert.True()` because it allows a custom message to help diagnose the problem
+            Assert.True(analyzerExceptionDiagnostics.Count() == 0,
+                $"Found analyzer exception diagnostics: {string.Join(", ", analyzerExceptionDiagnostics)}");
         }
     }
 }

--- a/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.UnitTests.Diagnostics;
 using Roslyn.Utilities;
 using Xunit;
 using System.Collections.Concurrent;
+using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 {
@@ -76,10 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         private void AssertNoAnalyzerExceptionDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
             var analyzerExceptionDiagnostics = diagnostics.Where(diag => diag.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.AnalyzerException));
-
-            // using `Assert.True()` because it allows a custom message to help diagnose the problem
-            Assert.True(analyzerExceptionDiagnostics.Count() == 0,
-                $"Found analyzer exception diagnostics: {string.Join(", ", analyzerExceptionDiagnostics)}");
+            AssertEx.Empty(analyzerExceptionDiagnostics, "Found analyzer exception diagnostics");
         }
     }
 }

--- a/src/Test/Utilities/Shared/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Shared/Assert/AssertEx.cs
@@ -489,5 +489,15 @@ namespace Roslyn.Test.Utilities
 
             return "file://" + compareCmd;
         }
+
+        public static void Empty<T>(IEnumerable<T> items, string message = "")
+        {
+            // realize the list in case it can't be traversed twice via .Count()/.Any() and .Select()
+            var list = items.ToList();
+            if (list.Count != 0)
+            {
+                Fail($"Expected 0 items but found {list.Count}: {message}\r\nItems:\r\n    {string.Join("\r\n    ", list)}");
+            }
+        }
     }
 }


### PR DESCRIPTION
While investigating flaky tests I found that whoever wrote this helper method <sub>it was me</sub> didn't think it prudent to actually list the analyzer diagnostics that failed the test.  This fixes that so that flaky test investigation is hopefully easier.

@dotnet/roslyn-ide @dotnet/roslyn-infrastructure