### PR TITLE
EE test framework refactoring

### DIFF
--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb.Tests/TestHelpers/SymTestHelpers.cs
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb.Tests/TestHelpers/SymTestHelpers.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DiaSymReader.PortablePdb.UnitTests
     {
         public static ISymUnmanagedReader CreateSymReaderFromResource(KeyValuePair<byte[], byte[]> peAndPdb)
         {
-            return SymReaderFactory.CreateReader(new MemoryStream(peAndPdb.Value), metadataImporter: new SymMetadataImport(new MemoryStream(peAndPdb.Key)));
+            return SymReaderFactory.CreateReaderImpl(new MemoryStream(peAndPdb.Value), metadataImporter: new SymMetadataImport(new MemoryStream(peAndPdb.Key)));
         }
 
         public static void ValidateDocumentUrl(ISymUnmanagedDocument document, string url)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
@@ -8,8 +8,9 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using System;
 using Xunit;
 using Roslyn.Test.Utilities;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class AccessibilityTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
@@ -33,7 +33,7 @@ class C
     object Q { get { return 4; } }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "C");
             // Static field.
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
@@ -87,7 +87,7 @@ class C
     const int G = 2;
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "C");
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
                 CompileExpression(context, "F[G]"),
@@ -115,7 +115,7 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "C");
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
                 CompileExpression(context, "F(this)"),
@@ -149,7 +149,7 @@ class B : A
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "B");
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
                 CompileExpression(context, "base.F()"),
@@ -179,7 +179,7 @@ class A<T> where T : class
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "A.B");
             string error;
             var testData = new CompilationTestData();
@@ -230,7 +230,7 @@ namespace N
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "N.C");
             string error;
             var testData = new CompilationTestData();
@@ -271,7 +271,7 @@ class C
 {
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "C");
             string error;
             var testData = new CompilationTestData();
@@ -292,7 +292,7 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "C");
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
 @"{
@@ -321,7 +321,7 @@ class C
     object F = ""f"";
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "C");
             // No format specifiers.
             string error;
@@ -360,7 +360,7 @@ public class Derived : Base
 }
 ";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateTypeContext(runtime, "Derived");
             string error;
             var testData = new CompilationTestData();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
@@ -1,17 +1,14 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     /// <summary>
     /// Compile expressions at type-scope to support

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Debugger.Clr;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Test.Utilities;
-using System.Collections.Immutable;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DeclarationTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
@@ -14,7 +16,7 @@ using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DynamicTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -154,12 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(comp);
 
             var context = CreateMethodContext(runtime, "C.M");
             var testData = new CompilationTestData();
@@ -198,12 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(comp);
 
             var context = CreateMethodContext(runtime, "C.M");
             var testData = new CompilationTestData();
@@ -247,12 +237,7 @@ class Generic<T>
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            var runtime = CreateRuntimeInstance(comp);
 
             var context = CreateMethodContext(runtime, "C.M");
             var testData = new CompilationTestData();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -66,13 +66,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         }
 
         internal RuntimeInstance CreateRuntimeInstance(
+            ModuleInstance module,
             IEnumerable<MetadataReference> references,
-            ImmutableArray<byte> peImage,
-            ISymUnmanagedReader symReader,
-            string assemblyName = null,
             bool includeLocalSignatures = true)
         {
-            var instance = RuntimeInstance.Create(references, peImage, symReader, assemblyName, includeLocalSignatures);
+            var instance = RuntimeInstance.Create(module, references, includeLocalSignatures);
             _runtimeInstances.Add(instance);
             return instance;
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -67,10 +67,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 
         internal RuntimeInstance CreateRuntimeInstance(
             ModuleInstance module,
-            IEnumerable<MetadataReference> references,
-            bool includeLocalSignatures = true)
+            IEnumerable<MetadataReference> references)
         {
-            var instance = RuntimeInstance.Create(module, references, includeLocalSignatures);
+            var instance = RuntimeInstance.Create(module, references);
             _runtimeInstances.Add(instance);
             return instance;
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -7,21 +7,21 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.DiaSymReader;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Roslyn.Test.PdbUtilities;
-using Microsoft.CodeAnalysis.Emit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public abstract class ExpressionCompilerTestBase : CSharpTestBase, IDisposable
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -47,6 +47,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             _runtimeInstances.Free();
         }
 
+        internal RuntimeInstance CreateRuntimeInstance(IEnumerable<ModuleInstance> modules)
+        {
+            var instance = RuntimeInstance.Create(modules);
+            _runtimeInstances.Add(instance);
+            return instance;
+        }
+
         internal RuntimeInstance CreateRuntimeInstance(
             Compilation compilation,
             IEnumerable<MetadataReference> references = null,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 source,
                 options: TestOptions.DebugDll,
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0, debugFormat: 0);
             foreach (var module in runtime.Modules)
             {
                 Assert.Null(module.SymReader);
@@ -465,7 +465,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateMethodContext(runtime, methodName: "C.F");
             string error;
             var result = context.CompileExpression("x;", out error);
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(compilation0, includeSymbols: false);
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateMethodContext(runtime, methodName: "C.F");
             string error;
             // No format specifiers.
@@ -3930,8 +3930,7 @@ class C
                 source,
                 OutputKind.DynamicallyLinkedLibrary,
                 methodName: "C.M",
-                expr: "sizeof(S)",
-                includeSymbols: false);
+                expr: "sizeof(S)");
             testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        7 (0x7)
@@ -4154,8 +4153,8 @@ class C
                 source,
                 OutputKind.DynamicallyLinkedLibrary,
                 methodName: "C.M",
-                expr: "((D)(x => x + x))(1)",
-                includeSymbols: false);
+                expr: "((D)(x => x + x))(1)");
+
             testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"
 {
@@ -5577,8 +5576,7 @@ public class C
             byte[] exeBytes;
             byte[] pdbBytes;
             ImmutableArray<MetadataReference> unusedReferences;
-            var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
 
             var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef), exeBytes, SymReaderFactory.CreateReader(pdbBytes));
             var context = CreateMethodContext(runtime, "C.M");
@@ -5663,8 +5661,7 @@ public class Source
             byte[] exeBytes;
             byte[] pdbBytes;
             ImmutableArray<MetadataReference> unusedReferences;
-            var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
 
             var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef, libAv1Ref, libBv2Ref), exeBytes, SymReaderFactory.CreateReader(pdbBytes));
             var context = CreateMethodContext(runtime, "Source.Test");
@@ -5791,8 +5788,7 @@ public class C
             byte[] exeBytes;
             byte[] unusedPdbBytes;
             ImmutableArray<MetadataReference> references;
-            var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
 
             ISymUnmanagedReader symReader = new MockSymUnmanagedReader(ImmutableDictionary<int, MethodDebugInfoBytes>.Empty);
 
@@ -5829,8 +5825,7 @@ public class C
             byte[] exeBytes;
             byte[] unusedPdbBytes;
             ImmutableArray<MetadataReference> references;
-            var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
 
             var runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, NotImplementedSymUnmanagedReader.Instance);
             var evalContext = CreateMethodContext(runtime, "C.Main");

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -342,19 +342,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 options: TestOptions.DebugDll,
                 references: new MetadataReference[] { referenceA });
 
-            ImmutableArray<byte> exeBytes;
-            ImmutableArray<byte> pdbBytes;
-            compilationB.EmitAndGetReferences(out exeBytes, out pdbBytes);
             const int methodVersion = 1;
 
             var referencesB = new[] { MscorlibRef, referenceA };
-            var moduleB1 = ModuleInstance.Create(exeBytes, SymReaderFactory.CreateReader(pdbBytes));
-            var moduleB2 = ModuleInstance.Create(exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var moduleB = compilationB.ToModuleInstance();
 
             CSharpMetadataContext previous = default(CSharpMetadataContext);
             int startOffset;
             int endOffset;
-            var runtime = CreateRuntimeInstance(moduleB1, referencesB);
+            var runtime = CreateRuntimeInstance(moduleB, referencesB);
             ImmutableArray<MetadataBlock> typeBlocks;
             ImmutableArray<MetadataBlock> methodBlocks;
             Guid moduleVersionId;
@@ -421,7 +417,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 
             // With different references.
             var fewerReferences = new[] { MscorlibRef };
-            runtime = CreateRuntimeInstance(moduleB2, fewerReferences);
+            runtime = CreateRuntimeInstance(moduleB, fewerReferences);
             GetContextState(runtime, "C.F", out methodBlocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
             // Different references. No reuse.
@@ -1082,7 +1078,7 @@ class B : A
   }
 }";
             var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(source);
-            var runtime = CreateRuntimeInstance(new[] { module, MscorlibRef.ToModuleInstance() });
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var context = CreateMethodContext(runtime, methodName: "C.M");
 
             string error;
@@ -1125,7 +1121,7 @@ class B : A
   }
 }";
             var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(source);
-            var runtime = CreateRuntimeInstance(new[] { module, MscorlibRef.ToModuleInstance() });            
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });            
             var context = CreateMethodContext(runtime, "C.M");
 
             string error;
@@ -1167,7 +1163,7 @@ class B : A
 }
 ";
             var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(source);
-            var runtime = CreateRuntimeInstance(new[] { module, MscorlibRef.ToModuleInstance() });
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var context = CreateMethodContext(runtime, "C.M");
 
             string error;
@@ -4494,7 +4490,7 @@ class C
   }
 }";
             var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(source);
-            var runtime = CreateRuntimeInstance(new[] { module, MscorlibRef.ToModuleInstance() });
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var context = CreateMethodContext(runtime, methodName: "C.M");
 
             string error;
@@ -4663,7 +4659,7 @@ struct S
   }
 }";
             var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(source);
-            var runtime = CreateRuntimeInstance(new[] { module, MscorlibRef.ToModuleInstance() });
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var context = CreateMethodContext(runtime, methodName: "C.<>c__DisplayClass2.<Test>b__1");
 
             string error;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -7,11 +7,11 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.DiaSymReader;
 using Microsoft.VisualStudio.Debugger.Evaluation;
@@ -21,7 +21,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using CommonResources = Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests.Resources;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ExpressionCompilerTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -1,18 +1,17 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.DiaSymReader;
-using Roslyn.Test.Utilities;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
+using Microsoft.DiaSymReader;
+using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class HoistedStateMachineLocalTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
@@ -628,17 +628,10 @@ class C : I<int>
 
 } // end of class C
 ";
-
-            ImmutableArray<byte> ilBytes;
-            ImmutableArray<byte> ilPdbBytes;
-            EmitILToArray(ilSource, appendDefaultHeader: true, includePdb: true, assemblyBytes: out ilBytes, pdbBytes: out ilPdbBytes);
-
-            var runtime = CreateRuntimeInstance(
-                references: new[] { MscorlibRef },
-                peImage: ilBytes,
-                symReader: SymReaderFactory.CreateReader(ilPdbBytes));
-
+            var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var context = CreateMethodContext(runtime, "C.<I<System.Int32>.F>d__0.MoveNext");
+
             VerifyHasThis(context, "C", @"
 {
   // Code size        7 (0x7)
@@ -782,16 +775,8 @@ static class C
   }
 } // end of class C
 ";
-
-            ImmutableArray<byte> ilBytes;
-            ImmutableArray<byte> ilPdbBytes;
-            EmitILToArray(ilSource, appendDefaultHeader: true, includePdb: true, assemblyBytes: out ilBytes, pdbBytes: out ilPdbBytes);
-
-            var runtime = CreateRuntimeInstance(
-                references: new[] { MscorlibRef },
-                peImage: ilBytes,
-                symReader: SymReaderFactory.CreateReader(ilPdbBytes));
-
+            var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });            
             var context = CreateMethodContext(runtime, "C.<M>b__0");
             VerifyNoThis(context);
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
@@ -634,9 +634,8 @@ class C : I<int>
             EmitILToArray(ilSource, appendDefaultHeader: true, includePdb: true, assemblyBytes: out ilBytes, pdbBytes: out ilPdbBytes);
 
             var runtime = CreateRuntimeInstance(
-                assemblyName: GetUniqueName(),
-                references: ImmutableArray.Create(MscorlibRef),
-                exeBytes: ilBytes.ToArray(),
+                references: new[] { MscorlibRef },
+                peImage: ilBytes,
                 symReader: SymReaderFactory.CreateReader(ilPdbBytes));
 
             var context = CreateMethodContext(runtime, "C.<I<System.Int32>.F>d__0.MoveNext");
@@ -789,10 +788,9 @@ static class C
             EmitILToArray(ilSource, appendDefaultHeader: true, includePdb: true, assemblyBytes: out ilBytes, pdbBytes: out ilPdbBytes);
 
             var runtime = CreateRuntimeInstance(
-                assemblyName: GetUniqueName(),
-                references: ImmutableArray.Create(MscorlibRef),
-                exeBytes: ilBytes.ToArray(),
-                symReader: SymReaderFactory.CreateReader(ilPdbBytes.ToArray()));
+                references: new[] { MscorlibRef },
+                peImage: ilBytes,
+                symReader: SymReaderFactory.CreateReader(ilPdbBytes));
 
             var context = CreateMethodContext(runtime, "C.<M>b__0");
             VerifyNoThis(context);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Roslyn.Test.Utilities;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Xunit;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.PdbUtilities;
+using Roslyn.Test.Utilities;
+using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class HoistedThisTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class InstructionDecoderTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -2672,8 +2672,7 @@ class C
             byte[] exeBytes;
             byte[] pdbBytes;
             ImmutableArray<MetadataReference> unusedReferences;
-            var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
 
             var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef), exeBytes, SymReaderFactory.CreateReader(pdbBytes));
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -148,17 +148,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-            var runtime = CreateRuntimeInstance(
-                ExpressionCompilerUtilities.GenerateUniqueName(),
-                references,
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes),
-                includeLocalSignatures: false);
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            var runtime = CreateRuntimeInstance(comp, includeLocalSignatures: false);
+
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M",
@@ -556,12 +548,8 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
+            
+            var runtime = CreateRuntimeInstance(compilation0);
             var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
@@ -617,15 +605,9 @@ class P
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
+            var runtime = CreateRuntimeInstance(compilation0);
+            var context = CreateMethodContext(runtime, "C.M");
 
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
             var testData = new CompilationTestData();
             var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
             string typeName;
@@ -1654,20 +1636,9 @@ public struct B
                 options: TestOptions.DebugDll,
                 references: new[] { compilation0.EmitToImageReference() });
 
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation1.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(
-                ExpressionCompilerUtilities.GenerateUniqueName(),
-                ImmutableArray.Create(MscorlibRef), // no reference to compilation0
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
-
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            // no reference to compilation0
+            var runtime = CreateRuntimeInstance(compilation1, new[] { MscorlibRef });
+            var context = CreateMethodContext(runtime, "C.M");
 
             var testData = new CompilationTestData();
             var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
@@ -1707,15 +1678,8 @@ public struct B
                 options: TestOptions.DebugDll,
                 references: new[] { compilation0.EmitToImageReference() });
 
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation1.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-            var runtime = CreateRuntimeInstance(
-                ExpressionCompilerUtilities.GenerateUniqueName(),
-                ImmutableArray.Create(MscorlibRef), // no reference to compilation0
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+            // no reference to compilation0
+            var runtime = CreateRuntimeInstance(compilation1, new[] { MscorlibRef });
 
             var context = CreateMethodContext(
                 runtime,
@@ -1808,15 +1772,8 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, "C.M");
 
             var testData = new CompilationTestData();
             var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
@@ -1847,15 +1804,8 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, "C.M");
 
             var testData = new CompilationTestData();
 
@@ -1889,15 +1839,8 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-
-            var runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes));
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            var runtime = CreateRuntimeInstance(comp);
+            var context = CreateMethodContext(runtime, methodName: "C.M");
 
             string errorMessage;
             var testData = new CompilationTestData();
@@ -2669,12 +2612,9 @@ class C
             var libRef = CreateCompilationWithMscorlib(libSource).EmitToImageReference();
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemRef }, TestOptions.DebugDll);
 
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> unusedReferences;
-            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
-
-            var runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef), exeBytes, SymReaderFactory.CreateReader(pdbBytes));
+            var runtime = CreateRuntimeInstance(
+                comp, 
+                new[] { MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef });
 
             string typeName;
             var locals = ArrayBuilder<LocalAndMethod>.GetInstance();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.DiaSymReader;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
@@ -16,7 +16,7 @@ using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class LocalsTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ManagedAddressOfTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ManagedAddressOfTests.cs
@@ -3,12 +3,11 @@
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ManagedAddressOfTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MethodContextReuseConstraintsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MethodContextReuseConstraintsTests.cs
@@ -4,7 +4,7 @@ using System;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class MethodContextReuseConstraintsTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -694,9 +694,9 @@ class UseLinq
             var runtime = CreateRuntimeInstance(compilation, new[] { MscorlibRef });
             var context = CreateMethodContext(runtime, "C.M");
 
-            var systemCore = SystemCoreRef.ToModuleInstance(fullImage: null, symReader: null);
+            var systemCore = SystemCoreRef.ToModuleInstance();
             var fakeSystemLinq = CreateCompilationWithMscorlib45("", assemblyName: "System.Linq").
-                EmitToImageReference().ToModuleInstance(fullImage: null, symReader: null);
+                EmitToImageReference().ToModuleInstance();
 
             string errorMessage;
             CompilationTestData testData;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -747,8 +747,7 @@ class UseLinq
             byte[] exeBytes;
             byte[] pdbBytes;
             ImmutableArray<MetadataReference> unusedReferences;
-            var result = comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out pdbBytes, out unusedReferences);
 
             var runtime = CreateRuntimeInstance(GetUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes));
             return CreateMethodContext(runtime, methodName);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Debugger.Evaluation;
-using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Xunit;
-using Roslyn.Test.PdbUtilities;
+using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Roslyn.Test.PdbUtilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class MissingAssemblyTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -600,7 +600,7 @@ class C
             var context = CreateMethodContext(runtime, "C.M");
 
             var missingModule = runtime.Modules.First();
-            var missingIdentity = missingModule.MetadataReader.ReadAssemblyIdentityOrThrow();
+            var missingIdentity = missingModule.GetMetadataReader().ReadAssemblyIdentityOrThrow();
 
             var numRetries = 0;
             string errorMessage;
@@ -641,7 +641,7 @@ class C
             var context = CreateMethodContext(runtime, "C.M");
 
             var missingModule = runtime.Modules.First();
-            var missingIdentity = missingModule.MetadataReader.ReadAssemblyIdentityOrThrow();
+            var missingIdentity = missingModule.GetMetadataReader().ReadAssemblyIdentityOrThrow();
 
             var shouldSucceed = false;
             string errorMessage;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Roslyn.Test.Utilities;
-using System;
-using System.Collections.Immutable;
-using Xunit;
-using Roslyn.Test.PdbUtilities;
 using Microsoft.VisualStudio.Debugger.Evaluation;
+using Roslyn.Test.PdbUtilities;
+using Roslyn.Test.Utilities;
+using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class NoPIATests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
@@ -142,13 +142,13 @@ public interface I
             var moduleA = CreateCompilationWithMscorlib(
                 sourceA,
                 options: TestOptions.DebugDll,
-                references: new[] { modulePIA.MetadataReference.WithEmbedInteropTypes(true) }).ToModuleInstance();
+                references: new[] { modulePIA.GetReference().WithEmbedInteropTypes(true) }).ToModuleInstance();
 
             // csc /r:A.dll /r:PIA.dll B.cs
             var moduleB = CreateCompilationWithMscorlib(
                 sourceB,
                 options: TestOptions.DebugExe,
-                references: new[] { moduleA.MetadataReference, modulePIA.MetadataReference }).ToModuleInstance();
+                references: new[] { moduleA.GetReference(), modulePIA.GetReference() }).ToModuleInstance();
 
             var runtime = CreateRuntimeInstance(new[] { MscorlibRef.ToModuleInstance(), moduleA, modulePIA, moduleB });
             var context = CreateMethodContext(runtime, "A.M");

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
@@ -1026,7 +1026,7 @@ class B
             var moduleA = compilationA.ToModuleInstance();
 
             var assemblyNameB = "9BAC6622-86EB-4EC5-94A1-9A1E6D0C24B9";
-            var compilationB = CreateCompilationWithMscorlib(sourceB, options: TestOptions.DebugExe, references: new[] { moduleA.MetadataReference }, assemblyName: assemblyNameB);
+            var compilationB = CreateCompilationWithMscorlib(sourceB, options: TestOptions.DebugExe, references: new[] { moduleA.GetReference() }, assemblyName: assemblyNameB);
             var moduleB = compilationB.ToModuleInstance();
 
             var runtime = CreateRuntimeInstance(new[]

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
@@ -3,18 +3,17 @@
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.DiaSymReader;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class PseudoVariableTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -278,12 +278,12 @@ IL_0005:  ret
             ImmutableArray<AssemblyIdentity> expectedIdentities)
         {
             Assert.True(references.Contains(target));
-            var modules = references.SelectAsArray(r => r.ToModuleInstance(fullImage: null, symReader: null, includeLocalSignatures: false));
+            var modules = references.SelectAsArray(r => r.ToModuleInstance(includeLocalSignatures: false));
             using (var runtime = new RuntimeInstance(modules))
             {
                 var moduleVersionId = target.GetModuleVersionId();
                 var blocks = runtime.Modules.SelectAsArray(m => m.MetadataBlock);
-                var actualReferences = blocks.MakeAssemblyReferences(moduleVersionId, Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.CompilationExtensions.IdentityComparer);
+                var actualReferences = blocks.MakeAssemblyReferences(moduleVersionId, CompilationExtensions.IdentityComparer);
                 // Verify identities.
                 var actualIdentities = actualReferences.SelectAsArray(r => r.GetAssemblyIdentity());
                 AssertEx.Equal(expectedIdentities, actualIdentities);
@@ -333,114 +333,94 @@ public class B
         var x = new A();
     }
 }";
-            var assemblyNameA = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilationA = CreateCompilationWithMscorlibAndSystemCore(sourceA, options: TestOptions.DebugDll, assemblyName: assemblyNameA);
-            ImmutableArray<byte> exeBytesA;
-            ImmutableArray<byte> pdbBytesA;
-            ImmutableArray<MetadataReference> referencesA;
-            compilationA.EmitAndGetReferences(out exeBytesA, out pdbBytesA, out referencesA);
-            var referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display: assemblyNameA);
-            var identityA = referenceA.GetAssemblyIdentity();
-            var moduleA = referenceA.ToModuleInstance(exeBytesA.ToArray(), SymReaderFactory.CreateReader(pdbBytesA));
+            var compilationA = CreateCompilationWithMscorlibAndSystemCore(sourceA, options: TestOptions.DebugDll);
+            var identityA = compilationA.Assembly.Identity;
+            var moduleA = compilationA.ToModuleInstance();
 
-            var assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilationB = CreateCompilationWithMscorlibAndSystemCore(sourceB, options: TestOptions.DebugDll, assemblyName: assemblyNameB, references: new[] { referenceA });
-            ImmutableArray<byte> exeBytesB;
-            ImmutableArray<byte> pdbBytesB;
-            ImmutableArray<MetadataReference> referencesB;
-            compilationB.EmitAndGetReferences(out exeBytesB, out pdbBytesB, out referencesB);
-            var referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display: assemblyNameB);
-            var moduleB = referenceB.ToModuleInstance(exeBytesB.ToArray(), SymReaderFactory.CreateReader(pdbBytesB));
+            var compilationB = CreateCompilationWithMscorlibAndSystemCore(sourceB, options: TestOptions.DebugDll, references: new[] { moduleA.MetadataReference });
+            var moduleB = compilationB.ToModuleInstance();
 
-            var moduleBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
-            moduleBuilder.AddRange(referencesA.Select(r => r.ToModuleInstance(null, null)));
-            moduleBuilder.Add(moduleA);
-            moduleBuilder.Add(moduleB);
-            var modules = moduleBuilder.ToImmutableAndFree();
+            var runtime = CreateRuntimeInstance(new[] { MscorlibRef.ToModuleInstance(), SystemCoreRef.ToModuleInstance(), moduleA, moduleB });
+            ImmutableArray<MetadataBlock> blocks;
+            Guid moduleVersionId;
+            ISymUnmanagedReader symReader;
+            int typeToken;
+            int methodToken;
+            int localSignatureToken;
+            GetContextState(runtime, "B", out blocks, out moduleVersionId, out symReader, out typeToken, out localSignatureToken);
+            string errorMessage;
+            CompilationTestData testData;
+            var contextFactory = CreateTypeContextFactory(moduleVersionId, typeToken);
 
-            using (var runtime = new RuntimeInstance(modules))
-            {
-                ImmutableArray<MetadataBlock> blocks;
-                Guid moduleVersionId;
-                ISymUnmanagedReader symReader;
-                int typeToken;
-                int methodToken;
-                int localSignatureToken;
-                GetContextState(runtime, "B", out blocks, out moduleVersionId, out symReader, out typeToken, out localSignatureToken);
-                string errorMessage;
-                CompilationTestData testData;
-                var contextFactory = CreateTypeContextFactory(moduleVersionId, typeToken);
+            // Duplicate type in namespace, at type scope.
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.True(errorMessage.StartsWith("error CS0433: The type 'C1' exists in both "));
 
-                // Duplicate type in namespace, at type scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.True(errorMessage.StartsWith("error CS0433: The type 'C1' exists in both "));
+            GetContextState(runtime, "B.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
+            contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken);
 
-                GetContextState(runtime, "B.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
-                contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken);
+            // Duplicate type in namespace, at method scope.
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C1()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.True(errorMessage.StartsWith("error CS0433: The type 'C1' exists in both "));
 
-                // Duplicate type in namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C1()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.True(errorMessage.StartsWith("error CS0433: The type 'C1' exists in both "));
+            // Duplicate type in global namespace, at method scope.
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.True(errorMessage.StartsWith("error CS0433: The type 'C2' exists in both "));
 
-                // Duplicate type in global namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.True(errorMessage.StartsWith("error CS0433: The type 'C2' exists in both "));
+            // Duplicate extension method, at method scope.
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.Equal(errorMessage, "error CS0121: The call is ambiguous between the following methods or properties: 'N.E.F(A)' and 'N.E.F(A)'");
 
-                // Duplicate extension method, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.Equal(errorMessage, "error CS0121: The call is ambiguous between the following methods or properties: 'N.E.F(A)' and 'N.E.F(A)'");
+            // Same tests as above but in library that does not directly reference duplicates.
+            GetContextState(runtime, "A", out blocks, out moduleVersionId, out symReader, out typeToken, out localSignatureToken);
+            contextFactory = CreateTypeContextFactory(moduleVersionId, typeToken);
 
-                // Same tests as above but in library that does not directly reference duplicates.
-                GetContextState(runtime, "A", out blocks, out moduleVersionId, out symReader, out typeToken, out localSignatureToken);
-                contextFactory = CreateTypeContextFactory(moduleVersionId, typeToken);
-
-                // Duplicate type in namespace, at type scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.Null(errorMessage);
-                var methodData = testData.GetMethodData("<>x.<>m0");
-                methodData.VerifyIL(
+            // Duplicate type in namespace, at type scope.
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new N.C1()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.Null(errorMessage);
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            methodData.VerifyIL(
 @"{
-  // Code size        6 (0x6)
-  .maxstack  1
-  IL_0000:  newobj     ""N.C1..ctor()""
-  IL_0005:  ret
+// Code size        6 (0x6)
+.maxstack  1
+IL_0000:  newobj     ""N.C1..ctor()""
+IL_0005:  ret
 }");
-                Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName());
+            Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName());
 
-                GetContextState(runtime, "A.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
-                contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken);
+            GetContextState(runtime, "A.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
+            contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken);
 
-                // Duplicate type in global namespace, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.Null(errorMessage);
-                methodData = testData.GetMethodData("<>x.<>m0");
-                methodData.VerifyIL(
+            // Duplicate type in global namespace, at method scope.
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "new C2()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.Null(errorMessage);
+            methodData = testData.GetMethodData("<>x.<>m0");
+            methodData.VerifyIL(
 @"{
-  // Code size        6 (0x6)
-  .maxstack  1
-  .locals init (A V_0, //x
-                A V_1) //y
-  IL_0000:  newobj     ""C2..ctor()""
-  IL_0005:  ret
+// Code size        6 (0x6)
+.maxstack  1
+.locals init (A V_0, //x
+            A V_1) //y
+IL_0000:  newobj     ""C2..ctor()""
+IL_0005:  ret
 }");
-                Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName());
+            Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName());
 
-                // Duplicate extension method, at method scope.
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.Null(errorMessage);
-                methodData = testData.GetMethodData("<>x.<>m0");
-                methodData.VerifyIL(
+            // Duplicate extension method, at method scope.
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "x.F()", ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.Null(errorMessage);
+            methodData = testData.GetMethodData("<>x.<>m0");
+            methodData.VerifyIL(
 @"{
-  // Code size        7 (0x7)
-  .maxstack  1
-  .locals init (A V_0, //x
-                A V_1) //y
-  IL_0000:  ldloc.0
-  IL_0001:  call       ""A N.E.F(A)""
-  IL_0006:  ret
+// Code size        7 (0x7)
+.maxstack  1
+.locals init (A V_0, //x
+            A V_1) //y
+IL_0000:  ldloc.0
+IL_0001:  call       ""A N.E.F(A)""
+IL_0006:  ret
 }");
-                Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName());
-            }
+            Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityA.GetDisplayName());
         }
 
         /// <summary>
@@ -465,32 +445,15 @@ class C
 @"public class B : A
 {
 }";
-            var assemblyNameA = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilationA = CreateCompilation(
+            var moduleA = CreateCompilation(
                 sourceA,
-                references: new MetadataReference[] { SystemRuntimePP7Ref },
-                options: TestOptions.DebugDll,
-                assemblyName: assemblyNameA);
-            ImmutableArray<byte> exeBytesA;
-            ImmutableArray<byte> pdbBytesA;
-            ImmutableArray<MetadataReference> referencesA;
-            compilationA.EmitAndGetReferences(out exeBytesA, out pdbBytesA, out referencesA);
-            var referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display: assemblyNameA);
-            var identityA = referenceA.GetAssemblyIdentity();
-            var moduleA = referenceA.ToModuleInstance(exeBytesA.ToArray(), SymReaderFactory.CreateReader(pdbBytesA));
+                references: new[] { SystemRuntimePP7Ref },
+                options: TestOptions.DebugDll).ToModuleInstance();
 
-            var assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilationB = CreateCompilation(
+            var moduleB = CreateCompilation(
                 sourceB,
-                references: new MetadataReference[] { SystemRuntimePP7Ref, referenceA },
-                options: TestOptions.DebugDll,
-                assemblyName: assemblyNameB);
-            ImmutableArray<byte> exeBytesB;
-            ImmutableArray<byte> pdbBytesB;
-            ImmutableArray<MetadataReference> referencesB;
-            compilationB.EmitAndGetReferences(out exeBytesB, out pdbBytesB, out referencesB);
-            var referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display: assemblyNameB);
-            var moduleB = referenceB.ToModuleInstance(exeBytesB.ToArray(), SymReaderFactory.CreateReader(pdbBytesB));
+                references: new[] { SystemRuntimePP7Ref, moduleA.MetadataReference },
+                options: TestOptions.DebugDll).ToModuleInstance();
 
             // Include an empty assembly to verify that not all assemblies
             // with no references are treated as mscorlib.
@@ -498,48 +461,46 @@ class C
 
             // At runtime System.Runtime.dll contract assembly is replaced
             // by mscorlib.dll and System.Runtime.dll facade assemblies.
-            var moduleBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
-            moduleBuilder.Add(MscorlibFacadeRef.ToModuleInstance(null, null));
-            moduleBuilder.Add(SystemRuntimeFacadeRef.ToModuleInstance(null, null));
-            moduleBuilder.Add(moduleA);
-            moduleBuilder.Add(moduleB);
-            moduleBuilder.Add(referenceC.ToModuleInstance(null, null));
-            var modules = moduleBuilder.ToImmutableAndFree();
-
-            using (var runtime = new RuntimeInstance(modules))
+            var runtime = CreateRuntimeInstance(new[] 
             {
-                ImmutableArray<MetadataBlock> blocks;
-                Guid moduleVersionId;
-                ISymUnmanagedReader symReader;
-                int typeToken;
-                int localSignatureToken;
-                GetContextState(runtime, "C", out blocks, out moduleVersionId, out symReader, out typeToken, out localSignatureToken);
-                string errorMessage;
-                CompilationTestData testData;
-                int attempts = 0;
-                ExpressionCompiler.CreateContextDelegate contextFactory = (b, u) =>
-                {
-                    attempts++;
-                    return EvaluationContext.CreateTypeContext(
-                        ToCompilation(b, u, moduleVersionId),
-                        moduleVersionId,
-                        typeToken);
-                };
+                MscorlibFacadeRef.ToModuleInstance(),
+                SystemRuntimeFacadeRef.ToModuleInstance(),
+                moduleA,
+                moduleB,
+                referenceC.ToModuleInstance()
+            });
 
-                // Compile: [DebuggerDisplay("{new B()}")]
-                const string expr = "new B()";
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, expr, ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
-                Assert.Null(errorMessage);
-                Assert.Equal(2, attempts);
-                var methodData = testData.GetMethodData("<>x.<>m0");
-                methodData.VerifyIL(
+            ImmutableArray<MetadataBlock> blocks;
+            Guid moduleVersionId;
+            ISymUnmanagedReader symReader;
+            int typeToken;
+            int localSignatureToken;
+            GetContextState(runtime, "C", out blocks, out moduleVersionId, out symReader, out typeToken, out localSignatureToken);
+            string errorMessage;
+            CompilationTestData testData;
+            int attempts = 0;
+            ExpressionCompiler.CreateContextDelegate contextFactory = (b, u) =>
+            {
+                attempts++;
+                return EvaluationContext.CreateTypeContext(
+                    ToCompilation(b, u, moduleVersionId),
+                    moduleVersionId,
+                    typeToken);
+            };
+
+            // Compile: [DebuggerDisplay("{new B()}")]
+            const string expr = "new B()";
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, expr, ImmutableArray<Alias>.Empty, contextFactory, getMetaDataBytesPtr: null, errorMessage: out errorMessage, testData: out testData);
+            Assert.Null(errorMessage);
+            Assert.Equal(2, attempts);
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            methodData.VerifyIL(
 @"{
-  // Code size        6 (0x6)
-  .maxstack  1
-  IL_0000:  newobj     ""B..ctor()""
-  IL_0005:  ret
+// Code size        6 (0x6)
+.maxstack  1
+IL_0000:  newobj     ""B..ctor()""
+IL_0005:  ret
 }");
-            }
         }
 
         [WorkItem(1170032, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1170032")]
@@ -608,36 +569,34 @@ class C
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
             var reference = compilation.EmitToImageReference();
 
-            var modules = runtimeReferences.Add(reference).SelectAsArray(r => r.ToModuleInstance(null, null));
-            using (var runtime = new RuntimeInstance(modules))
-            {
-                var context = CreateMethodContext(runtime, "C.Main");
-                string errorMessage;
-                // { System.Console, mscorlib }
-                var testData = new CompilationTestData();
-                context.CompileExpression("typeof(System.Console)", out errorMessage, testData);
-                var methodData = testData.GetMethodData("<>x.<>m0");
-                methodData.VerifyIL(
+            var modules = runtimeReferences.Add(reference).SelectAsArray(r => r.ToModuleInstance());
+            var runtime = CreateRuntimeInstance(modules);
+            var context = CreateMethodContext(runtime, "C.Main");
+            string errorMessage;
+            // { System.Console, mscorlib }
+            var testData = new CompilationTestData();
+            context.CompileExpression("typeof(System.Console)", out errorMessage, testData);
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            methodData.VerifyIL(
 @"{
-  // Code size       11 (0xb)
-  .maxstack  1
-  IL_0000:  ldtoken    ""System.Console""
-  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000a:  ret
+// Code size       11 (0xb)
+.maxstack  1
+IL_0000:  ldtoken    ""System.Console""
+IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+IL_000a:  ret
 }");
-                // { mscorlib, System.ObjectModel }
-                testData = new CompilationTestData();
-                context.CompileExpression("(System.Collections.ObjectModel.ReadOnlyDictionary<object, object>)null", out errorMessage, testData);
-                methodData = testData.GetMethodData("<>x.<>m0");
-                methodData.VerifyIL(
+            // { mscorlib, System.ObjectModel }
+            testData = new CompilationTestData();
+            context.CompileExpression("(System.Collections.ObjectModel.ReadOnlyDictionary<object, object>)null", out errorMessage, testData);
+            methodData = testData.GetMethodData("<>x.<>m0");
+            methodData.VerifyIL(
 @"{
-  // Code size        2 (0x2)
-  .maxstack  1
-  IL_0000:  ldnull
-  IL_0001:  ret
+// Code size        2 (0x2)
+.maxstack  1
+IL_0000:  ldnull
+IL_0001:  ret
 }");
-                Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityObjectModel.GetDisplayName());
-            }
+            Assert.Equal(methodData.Method.ReturnType.ContainingAssembly.ToDisplayString(), identityObjectModel.GetDisplayName());
         }
 
         /// <summary>
@@ -657,94 +616,84 @@ public class B
     {
     }
 }";
-            var assemblyNameA = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilationA = CreateCompilationWithMscorlibAndSystemCore(sourceA, options: TestOptions.DebugDll, assemblyName: assemblyNameA);
-            ImmutableArray<byte> exeBytesA;
-            ImmutableArray<byte> pdbBytesA;
-            ImmutableArray<MetadataReference> referencesA;
-            compilationA.EmitAndGetReferences(out exeBytesA, out pdbBytesA, out referencesA);
-            var referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display: assemblyNameA);
-            var identityA = referenceA.GetAssemblyIdentity();
-            var moduleA = referenceA.ToModuleInstance(exeBytesA.ToArray(), SymReaderFactory.CreateReader(pdbBytesA));
+            var compilationA = CreateCompilationWithMscorlibAndSystemCore(sourceA, options: TestOptions.DebugDll);
+            var moduleA = compilationA.ToModuleInstance();
 
-            var assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilationB = CreateCompilationWithMscorlibAndSystemCore(sourceB, options: TestOptions.DebugDll, assemblyName: assemblyNameB, references: new[] { referenceA });
-            ImmutableArray<byte> exeBytesB;
-            ImmutableArray<byte> pdbBytesB;
-            ImmutableArray<MetadataReference> referencesB;
-            compilationB.EmitAndGetReferences(out exeBytesB, out pdbBytesB, out referencesB);
-            var referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display: assemblyNameB);
-            var moduleB = referenceB.ToModuleInstance(exeBytesB.ToArray(), SymReaderFactory.CreateReader(pdbBytesB));
+            var compilationB = CreateCompilationWithMscorlibAndSystemCore(sourceB, options: TestOptions.DebugDll, references: new[] { moduleA.MetadataReference });
+            var moduleB = compilationB.ToModuleInstance();
 
-            var moduleBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
-            moduleBuilder.AddRange(referencesA.Select(r => r.ToModuleInstance(null, null)));
-            moduleBuilder.Add(moduleA);
-            moduleBuilder.Add(moduleB);
-            moduleBuilder.Add(ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance(fullImage: null, symReader: null));
-            var modules = moduleBuilder.ToImmutableAndFree();
-
-            using (var runtime = new RuntimeInstance(modules))
+            var runtime = CreateRuntimeInstance(new[] 
             {
-                ImmutableArray<MetadataBlock> blocks;
-                Guid moduleVersionId;
-                ISymUnmanagedReader symReader;
-                int methodToken;
-                int localSignatureToken;
-                GetContextState(runtime, "B.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
-                var aliases = ImmutableArray.Create(
-                    ExceptionAlias(typeof(ArgumentException)),
-                    ReturnValueAlias(2, typeof(string)),
-                    ObjectIdAlias(1, typeof(object)));
-                int attempts = 0;
-                ExpressionCompiler.CreateContextDelegate contextFactory = (b, u) =>
-                {
-                    attempts++;
-                    return EvaluationContext.CreateMethodContext(
-                        ToCompilation(b, u, moduleVersionId),
-                        symReader,
-                        moduleVersionId,
-                        methodToken,
-                        methodVersion: 1,
-                        ilOffset: 0,
-                        localSignatureToken: localSignatureToken);
-                };
-                string errorMessage;
-                CompilationTestData testData;
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
-                    blocks,
-                    "(object)new A() ?? $exception ?? $1 ?? $ReturnValue2",
-                    aliases,
-                    contextFactory,
-                    getMetaDataBytesPtr: null,
-                    errorMessage: out errorMessage,
-                    testData: out testData);
-                Assert.Null(errorMessage);
-                Assert.Equal(2, attempts);
-                var methodData = testData.GetMethodData("<>x.<>m0");
-                methodData.VerifyIL(
+                MscorlibRef.ToModuleInstance(),
+                SystemCoreRef.ToModuleInstance(),
+                moduleA,
+                moduleB,
+                ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance()
+            });
+
+            ImmutableArray<MetadataBlock> blocks;
+            Guid moduleVersionId;
+            ISymUnmanagedReader symReader;
+            int methodToken;
+            int localSignatureToken;
+            GetContextState(runtime, "B.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
+
+            var aliases = ImmutableArray.Create(
+                ExceptionAlias(typeof(ArgumentException)),
+                ReturnValueAlias(2, typeof(string)),
+                ObjectIdAlias(1, typeof(object)));
+
+            int attempts = 0;
+            ExpressionCompiler.CreateContextDelegate contextFactory = (b, u) =>
+            {
+                attempts++;
+                return EvaluationContext.CreateMethodContext(
+                    ToCompilation(b, u, moduleVersionId),
+                    symReader,
+                    moduleVersionId,
+                    methodToken,
+                    methodVersion: 1,
+                    ilOffset: 0,
+                    localSignatureToken: localSignatureToken);
+            };
+
+            string errorMessage;
+            CompilationTestData testData;
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
+                blocks,
+                "(object)new A() ?? $exception ?? $1 ?? $ReturnValue2",
+                aliases,
+                contextFactory,
+                getMetaDataBytesPtr: null,
+                errorMessage: out errorMessage,
+                testData: out testData);
+
+            Assert.Null(errorMessage);
+            Assert.Equal(2, attempts);
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            methodData.VerifyIL(
 @"{
-  // Code size       49 (0x31)
-  .maxstack  2
-  IL_0000:  newobj     ""A..ctor()""
-  IL_0005:  dup
-  IL_0006:  brtrue.s   IL_0030
-  IL_0008:  pop
-  IL_0009:  call       ""System.Exception Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetException()""
-  IL_000e:  castclass  ""System.ArgumentException""
-  IL_0013:  dup
-  IL_0014:  brtrue.s   IL_0030
-  IL_0016:  pop
-  IL_0017:  ldstr      ""$1""
-  IL_001c:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetObjectByAlias(string)""
-  IL_0021:  dup
-  IL_0022:  brtrue.s   IL_0030
-  IL_0024:  pop
-  IL_0025:  ldc.i4.2
-  IL_0026:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(int)""
-  IL_002b:  castclass  ""string""
-  IL_0030:  ret
+// Code size       49 (0x31)
+.maxstack  2
+IL_0000:  newobj     ""A..ctor()""
+IL_0005:  dup
+IL_0006:  brtrue.s   IL_0030
+IL_0008:  pop
+IL_0009:  call       ""System.Exception Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetException()""
+IL_000e:  castclass  ""System.ArgumentException""
+IL_0013:  dup
+IL_0014:  brtrue.s   IL_0030
+IL_0016:  pop
+IL_0017:  ldstr      ""$1""
+IL_001c:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetObjectByAlias(string)""
+IL_0021:  dup
+IL_0022:  brtrue.s   IL_0030
+IL_0024:  pop
+IL_0025:  ldc.i4.2
+IL_0026:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(int)""
+IL_002b:  castclass  ""string""
+IL_0030:  ret
 }");
-            }
         }
 
         private static ExpressionCompiler.CreateContextDelegate CreateTypeContextFactory(

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -278,7 +278,7 @@ IL_0005:  ret
             ImmutableArray<AssemblyIdentity> expectedIdentities)
         {
             Assert.True(references.Contains(target));
-            var modules = references.SelectAsArray(r => r.ToModuleInstance(includeLocalSignatures: false));
+            var modules = references.SelectAsArray(r => r.ToModuleInstance());
             using (var runtime = new RuntimeInstance(modules))
             {
                 var moduleVersionId = target.GetModuleVersionId();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -4,18 +4,18 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.DiaSymReader;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Resources = Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests.Resources;
+using CommonResources = Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests.Resources;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ReferencedModulesTests : ExpressionCompilerTestBase
     {
@@ -510,7 +510,7 @@ class C
 
             // Include an empty assembly to verify that not all assemblies
             // with no references are treated as mscorlib.
-            var referenceC = AssemblyMetadata.CreateFromImage(Resources.Empty).GetReference();
+            var referenceC = AssemblyMetadata.CreateFromImage(CommonResources.Empty).GetReference();
 
             // At runtime System.Runtime.dll contract assembly is replaced
             // by mscorlib.dll and System.Runtime.dll facade assemblies.

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
@@ -110,15 +110,8 @@ class C
 
 } // end of class C
 ";
-            ImmutableArray<byte> exeBytes;
-            ImmutableArray<byte> pdbBytes;
-            EmitILToArray(ilSource, appendDefaultHeader: true, includePdb: true, assemblyBytes: out exeBytes, pdbBytes: out pdbBytes);
-
-            var runtime = CreateRuntimeInstance(
-                references: new[] { MscorlibRef },
-                peImage: exeBytes,
-                symReader: SymReaderFactory.CreateReader(pdbBytes));
-
+            var module = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var context = CreateMethodContext(runtime, methodName: "C.Test");
 
             Assert.Equal(DkmEvaluationResultAccessType.Private, GetResultProperties(context, "Private").AccessType);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.VisualStudio.Debugger.Evaluation;
-using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
-using Roslyn.Test.Utilities;
 using System.Collections.Immutable;
 using System.Linq;
-using Xunit;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Test.PdbUtilities;
+using Roslyn.Test.Utilities;
+using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ResultPropertiesTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
@@ -115,10 +115,10 @@ class C
             EmitILToArray(ilSource, appendDefaultHeader: true, includePdb: true, assemblyBytes: out exeBytes, pdbBytes: out pdbBytes);
 
             var runtime = CreateRuntimeInstance(
-                assemblyName: GetUniqueName(),
-                references: ImmutableArray.Create(MscorlibRef),
-                exeBytes: exeBytes.ToArray(),
+                references: new[] { MscorlibRef },
+                peImage: exeBytes,
                 symReader: SymReaderFactory.CreateReader(pdbBytes));
+
             var context = CreateMethodContext(runtime, methodName: "C.Test");
 
             Assert.Equal(DkmEvaluationResultAccessType.Private, GetResultProperties(context, "Private").AccessType);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -11,16 +11,15 @@ using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.DiaSymReader;
 using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class UsingDebugInfoTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -335,8 +335,7 @@ public class C
             byte[] exeBytes;
             byte[] unusedPdbBytes;
             ImmutableArray<MetadataReference> references;
-            var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
 
             var symReader = ExpressionCompilerTestHelpers.ConstructSymReaderWithImports(
                 exeBytes,
@@ -371,8 +370,7 @@ public class C
             byte[] exeBytes;
             byte[] unusedPdbBytes;
             ImmutableArray<MetadataReference> references;
-            var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
 
             var symReader = ExpressionCompilerTestHelpers.ConstructSymReaderWithImports(
                 exeBytes,
@@ -407,8 +405,7 @@ public class C
             byte[] exeBytes;
             byte[] unusedPdbBytes;
             ImmutableArray<MetadataReference> references;
-            var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
 
             ISymUnmanagedReader symReader;
             using (var peReader = new PEReader(ImmutableArray.Create(exeBytes)))
@@ -452,8 +449,7 @@ namespace N
             byte[] exeBytes;
             byte[] unusedPdbBytes;
             ImmutableArray<MetadataReference> references;
-            var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
 
             ISymUnmanagedReader symReader;
             using (var peReader = new PEReader(ImmutableArray.Create(exeBytes)))
@@ -497,8 +493,7 @@ namespace N
             byte[] exeBytes;
             byte[] unusedPdbBytes;
             ImmutableArray<MetadataReference> references;
-            var result = comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
-            Assert.True(result);
+            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
 
             ISymUnmanagedReader symReader;
             using (var peReader = new PEReader(ImmutableArray.Create(exeBytes)))
@@ -543,7 +538,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -576,7 +571,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -619,7 +614,7 @@ namespace A
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "A.C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single()).AsEnumerable().ToArray();
             Assert.Equal(2, importsList.Length);
 
@@ -655,7 +650,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -695,7 +690,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -725,7 +720,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -779,7 +774,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -828,7 +823,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -867,7 +862,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("X")) });
             comp.VerifyDiagnostics();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -912,7 +907,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("X")) });
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();
@@ -958,7 +953,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("global", "X")) });
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp, includeSymbols: true);
+            var runtime = CreateRuntimeInstance(comp);
             var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
             var imports = importsList.Single();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -340,7 +340,8 @@ public class C
                 "UACultureInfo TSystem.Globalization.CultureInfo, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", // Invalid - skipped.
                 "ASI USystem.IO"); // Valid.
 
-            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
+            var module = ModuleInstance.Create(peImage, symReader);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var evalContext = CreateMethodContext(runtime, "C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)); // Used to throw.
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -371,7 +372,8 @@ public class C
                 "AMy.Alias TSystem.Globalization.CultureInfo, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", // Invalid - skipped.
                 "ASI USystem.IO"); // Valid.
 
-            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
+            var module = ModuleInstance.Create(peImage, symReader);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var evalContext = CreateMethodContext(runtime, "C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)); // Used to throw.
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -408,7 +410,8 @@ public class C
                 }.ToImmutableDictionary());
             }
 
-            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
+            var module = ModuleInstance.Create(peImage, symReader);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var evalContext = CreateMethodContext(runtime, "C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -448,7 +451,8 @@ namespace N
                 }.ToImmutableDictionary());
             }
 
-            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
+            var module = ModuleInstance.Create(peImage, symReader);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var evalContext = CreateMethodContext(runtime, "N.C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -488,7 +492,8 @@ namespace N
                 }.ToImmutableDictionary());
             }
 
-            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
+            var module = ModuleInstance.Create(peImage, symReader);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
             var evalContext = CreateMethodContext(runtime, "N.C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
             var imports = compContext.NamespaceBinder.ImportChain.Single();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -866,9 +866,6 @@ class C
             Assert.Equal(SymbolKind.Namespace, targetSymbol.Kind);
             Assert.True(((NamespaceSymbol)targetSymbol).IsGlobalNamespace);
             Assert.Equal("System.Xml.Linq", targetSymbol.ContainingAssembly.Name);
-
-            var moduleInstance = runtime.Modules.Single(m => m.ModuleMetadata.Name.StartsWith("System.Xml.Linq", StringComparison.OrdinalIgnoreCase));
-            AssertEx.SetEqual(moduleInstance.MetadataReference.Properties.Aliases, "X");
         }
 
         [Fact]
@@ -1057,7 +1054,7 @@ public class C2 : C1
             var comp1 = CreateCompilation(source1, new[] { MscorlibRef_v20 }, TestOptions.DebugDll);
             var module1 = comp1.ToModuleInstance();
 
-            var comp2 = CreateCompilation(source2, new[] { MscorlibRef_v4_0_30316_17626, module1.MetadataReference }, TestOptions.DebugDll);
+            var comp2 = CreateCompilation(source2, new[] { MscorlibRef_v4_0_30316_17626, module1.GetReference() }, TestOptions.DebugDll);
             var module2 = comp2.ToModuleInstance();
 
             var runtime = CreateRuntimeInstance(new[] 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.DiaSymReader;
 using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
@@ -330,20 +331,16 @@ public class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source);
-
-            byte[] exeBytes;
-            byte[] unusedPdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
+            var peImage = comp.EmitToArray();
 
             var symReader = ExpressionCompilerTestHelpers.ConstructSymReaderWithImports(
-                exeBytes,
+                peImage,
                 "Main",
                 "USystem", // Valid.
                 "UACultureInfo TSystem.Globalization.CultureInfo, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", // Invalid - skipped.
                 "ASI USystem.IO"); // Valid.
 
-            var runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, symReader);
+            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
             var evalContext = CreateMethodContext(runtime, "C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)); // Used to throw.
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -365,20 +362,16 @@ public class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source);
-
-            byte[] exeBytes;
-            byte[] unusedPdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
+            var peImage = comp.EmitToArray();
 
             var symReader = ExpressionCompilerTestHelpers.ConstructSymReaderWithImports(
-                exeBytes,
+                peImage,
                 "Main",
                 "USystem", // Valid.
                 "AMy.Alias TSystem.Globalization.CultureInfo, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", // Invalid - skipped.
                 "ASI USystem.IO"); // Valid.
 
-            var runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, symReader);
+            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
             var evalContext = CreateMethodContext(runtime, "C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)); // Used to throw.
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -400,14 +393,10 @@ public class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source);
-
-            byte[] exeBytes;
-            byte[] unusedPdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
+            var peImage = comp.EmitToArray();
 
             ISymUnmanagedReader symReader;
-            using (var peReader = new PEReader(ImmutableArray.Create(exeBytes)))
+            using (var peReader = new PEReader(peImage))
             {
                 var metadataReader = peReader.GetMetadataReader();
                 var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
@@ -419,7 +408,7 @@ public class C
                 }.ToImmutableDictionary());
             }
 
-            var runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, symReader);
+            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
             var evalContext = CreateMethodContext(runtime, "C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -444,14 +433,10 @@ namespace N
 }
 ";
             var comp = CreateCompilationWithMscorlib(source);
-
-            byte[] exeBytes;
-            byte[] unusedPdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
+            var peImage = comp.EmitToArray();
 
             ISymUnmanagedReader symReader;
-            using (var peReader = new PEReader(ImmutableArray.Create(exeBytes)))
+            using (var peReader = new PEReader(peImage))
             {
                 var metadataReader = peReader.GetMetadataReader();
                 var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
@@ -463,7 +448,7 @@ namespace N
                 }.ToImmutableDictionary());
             }
 
-            var runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, symReader);
+            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
             var evalContext = CreateMethodContext(runtime, "N.C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -488,14 +473,10 @@ namespace N
 }
 ";
             var comp = CreateCompilationWithMscorlib(source);
-
-            byte[] exeBytes;
-            byte[] unusedPdbBytes;
-            ImmutableArray<MetadataReference> references;
-            comp.EmitAndGetReferences(out exeBytes, out unusedPdbBytes, out references);
+            var peImage = comp.EmitToArray();
 
             ISymUnmanagedReader symReader;
-            using (var peReader = new PEReader(ImmutableArray.Create(exeBytes)))
+            using (var peReader = new PEReader(peImage))
             {
                 var metadataReader = peReader.GetMetadataReader();
                 var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
@@ -507,7 +488,7 @@ namespace N
                 }.ToImmutableDictionary());
             }
 
-            var runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, symReader);
+            var runtime = CreateRuntimeInstance(new[] { MscorlibRef }, peImage, symReader);
             var evalContext = CreateMethodContext(runtime, "N.C.Main");
             var compContext = evalContext.CreateCompilationContext(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
             var imports = compContext.NamespaceBinder.ImportChain.Single();
@@ -1071,20 +1052,20 @@ public class C2 : C1
             ImmutableArray<MetadataReference> unused;
 
             var comp1 = CreateCompilation(source1, new[] { MscorlibRef_v20 }, TestOptions.DebugDll, assemblyName: "A");
-            byte[] dllBytes1;
-            byte[] pdbBytes1;
+            ImmutableArray<byte> dllBytes1;
+            ImmutableArray<byte> pdbBytes1;
             comp1.EmitAndGetReferences(out dllBytes1, out pdbBytes1, out unused);
             var ref1 = AssemblyMetadata.CreateFromImage(dllBytes1).GetReference(display: "A");
 
             var comp2 = CreateCompilation(source2, new[] { MscorlibRef_v4_0_30316_17626, ref1 }, TestOptions.DebugDll, assemblyName: "B");
-            byte[] dllBytes2;
-            byte[] pdbBytes2;
+            ImmutableArray<byte> dllBytes2;
+            ImmutableArray<byte> pdbBytes2;
             comp2.EmitAndGetReferences(out dllBytes2, out pdbBytes2, out unused);
             var ref2 = AssemblyMetadata.CreateFromImage(dllBytes2).GetReference(display: "B");
 
             var modulesBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
-            modulesBuilder.Add(ref1.ToModuleInstance(dllBytes1, SymReaderFactory.CreateReader(pdbBytes1)));
-            modulesBuilder.Add(ref2.ToModuleInstance(dllBytes2, SymReaderFactory.CreateReader(pdbBytes2)));
+            modulesBuilder.Add(ref1.ToModuleInstance(dllBytes1.ToArray(), SymReaderFactory.CreateReader(pdbBytes1)));
+            modulesBuilder.Add(ref2.ToModuleInstance(dllBytes2.ToArray(), SymReaderFactory.CreateReader(pdbBytes2)));
             modulesBuilder.Add(MscorlibRef_v4_0_30316_17626.ToModuleInstance(fullImage: null, symReader: null));
             modulesBuilder.Add(ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance(fullImage: null, symReader: null));
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.ExpressionEvaluator;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Debugger.Evaluation;
-using Roslyn.Test.PdbUtilities;
-using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Roslyn.Test.PdbUtilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 using Resources = Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests.Resources;
-using System.Reflection;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class WinMdTests : ExpressionCompilerTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
@@ -42,17 +42,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 options: TestOptions.DebugDll,
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
                 references: WinRtRefs);
+
             var runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage", "Windows.Foundation.Collections");
             Assert.True(runtimeAssemblies.Length >= 2);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-            var runtime = CreateRuntimeInstance(
-                ExpressionCompilerUtilities.GenerateUniqueName(),
-                ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies), // no reference to Windows.winmd
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+           
+            // no reference to Windows.winmd
+            var runtime = CreateRuntimeInstance(compilation0, new[] { MscorlibRef }.Concat(runtimeAssemblies));
+
             var context = CreateMethodContext(runtime, "C.M");
             string error;
             var testData = new CompilationTestData();
@@ -87,17 +83,13 @@ class C
                 options: TestOptions.DebugDll,
                 assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
                 references: WinRtRefs.Select(r => r.Display == "Windows" ? r.WithAliases(new[] { "X" }) : r));
+
             var runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage");
             Assert.True(runtimeAssemblies.Length >= 1);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-            var runtime = CreateRuntimeInstance(
-                ExpressionCompilerUtilities.GenerateUniqueName(),
-                ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies), // no reference to Windows.winmd
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
+
+            // no reference to Windows.winmd
+            var runtime = CreateRuntimeInstance(compilation0, new[] { MscorlibRef }.Concat(runtimeAssemblies));
+
             var context = CreateMethodContext(runtime, "C.M");
             string error;
             var testData = new CompilationTestData();
@@ -179,7 +171,8 @@ class C
     {
     }
 }";
-            var runtime = CreateRuntime(source, compileReferences, runtimeReferences);
+            var compilation0 = CreateCompilationWithMscorlib(source, compileReferences, TestOptions.DebugDll);
+            var runtime = CreateRuntimeInstance(compilation0, runtimeReferences);
             var context = CreateMethodContext(runtime, "C.M");
             string error;
             var testData = new CompilationTestData();
@@ -255,16 +248,17 @@ class C
     {
     }
 }";
-            var runtime = CreateRuntime(
-                source,
-                ImmutableArray.CreateRange(WinRtRefs),
+            var compilation = CreateCompilationWithMscorlib(source, ImmutableArray.CreateRange(WinRtRefs), TestOptions.DebugDll);
+            var runtime = CreateRuntimeInstance(
+                compilation,
                 ImmutableArray.Create(MscorlibRef).Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage", "Windows.Foundation.Collections")));
-            var context = CreateMethodContext(
-                runtime,
-                "C.M");
+
+            var context = CreateMethodContext(runtime, "C.M");
+
             var aliases = ImmutableArray.Create(
                 VariableAlias("s", "Windows.Storage.StorageFolder, Windows.Storage, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime"),
                 VariableAlias("d", "Windows.Foundation.DateTime, Windows.Foundation, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime"));
+
             string error;
             var testData = new CompilationTestData();
             context.CompileExpression(
@@ -305,10 +299,11 @@ class C
     {
     }
 }";
-            var runtime = CreateRuntime(
-                source,
-                ImmutableArray.CreateRange(WinRtRefs),
+            var compilation = CreateCompilationWithMscorlib(source, ImmutableArray.CreateRange(WinRtRefs), TestOptions.DebugDll);
+            var runtime = CreateRuntimeInstance(
+                compilation,
                 ImmutableArray.Create(MscorlibRef).Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Foundation", "Windows.UI", "Windows.UI.Xaml")));
+
             var context = CreateMethodContext(runtime, "C.M");
             string error;
             ResultProperties resultProperties;
@@ -339,9 +334,11 @@ class C
     {
     }
 }";
-            var runtime = CreateRuntime(source,
-                ImmutableArray.Create(WinRtRefs),
+            var compilation = CreateCompilationWithMscorlib(source, ImmutableArray.CreateRange(WinRtRefs), TestOptions.DebugDll);
+            var runtime = CreateRuntimeInstance(
+                compilation,
                 ImmutableArray.Create(MscorlibRef).Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI", "Windows.UI.Xaml")));
+
             string errorMessage;
             var testData = new CompilationTestData();
             ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
@@ -369,27 +366,6 @@ class C
   IL_0001:  callvirt   ""Windows.UI.Core.CoreDispatcher Windows.UI.Xaml.DependencyObject.Dispatcher.get""
   IL_0006:  ret
 }");
-        }
-
-        private RuntimeInstance CreateRuntime(
-            string source,
-            ImmutableArray<MetadataReference> compileReferences,
-            ImmutableArray<MetadataReference> runtimeReferences)
-        {
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
-                references: compileReferences);
-            byte[] exeBytes;
-            byte[] pdbBytes;
-            ImmutableArray<MetadataReference> references;
-            compilation0.EmitAndGetReferences(out exeBytes, out pdbBytes, out references);
-            return CreateRuntimeInstance(
-                ExpressionCompilerUtilities.GenerateUniqueName(),
-                runtimeReferences.AddIntrinsicAssembly(),
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes));
         }
 
         private static byte[] ToVersion1_3(byte[] bytes)

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/AccessibilityTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/AccessibilityTests.cs
@@ -10,7 +10,7 @@ using Roslyn.Test.Utilities;
 using System;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     internal class AccessibilityTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ArrayExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ArrayExpansionTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ArrayExpansionTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTestBase.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public abstract class CSharpResultProviderTestBase : ResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     internal class DebuggerBrowsableAttributeTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerDisplayAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerDisplayAttributeTests.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DebuggerDisplayAttributeTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerTypeProxyAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerTypeProxyAttributeTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DebuggerTypeProxyAttributeTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerVisualizerAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerVisualizerAttributeTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DebuggerVisualizerAttributeTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicFlagsCustomTypeInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicFlagsCustomTypeInfoTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DynamicFlagsCustomTypeInfoTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DynamicTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DynamicViewTests.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Xunit;
 using Roslyn.Test.Utilities;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class DynamicViewTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -15,7 +15,7 @@ using Microsoft.VisualStudio.Debugger.Symbols;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ExpansionTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FormatSpecifierTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FormatSpecifierTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class FormatSpecifierTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class FullNameTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FunctionPointerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FunctionPointerTests.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 using Xunit;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class FunctionPointerTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/NativeViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/NativeViewTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class NativeViewTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ObjectIdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ObjectIdTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using System;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ObjectIdTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
@@ -12,7 +12,7 @@ using System.Linq;
 using Xunit;
 using BindingFlags = System.Reflection.BindingFlags;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ResultsViewTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TypeNameFormatterTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TypeNameFormatterTests.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class TypeNameFormatterTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TypeVariablesExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TypeVariablesExpansionTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation;
 using System.Collections.Immutable;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class TypeVariablesExpansionTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     public class ValueFormattingTests : CSharpResultProviderTestBase
     {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/CustomDiagnosticFormatter.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/CustomDiagnosticFormatter.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Globalization;
 
-namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class CustomDiagnosticFormatter : DiagnosticFormatter
     {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -28,7 +28,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using PDB::Roslyn.Test.MetadataUtilities;
 
-namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class Scope
     {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -397,17 +397,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             }
         }
 
-        internal static ImmutableArray<MetadataReference> GetEmittedReferences(this Compilation compilation, ImmutableArray<byte> peImage)
+        internal static ImmutableArray<MetadataReference> GetEmittedReferences(Compilation compilation, MetadataReader mdReader)
         {
             // Determine the set of references that were actually used
             // and ignore any references that were dropped in emit.
-            HashSet<string> referenceNames;
-            using (var metadata = ModuleMetadata.CreateFromImage(peImage))
-            {
-                var reader = metadata.MetadataReader;
-                referenceNames = new HashSet<string>(reader.AssemblyReferences.Select(h => GetAssemblyReferenceName(reader, h)));
-            }
-
+            var referenceNames = new HashSet<string>(mdReader.AssemblyReferences.Select(h => GetAssemblyReferenceName(mdReader, h)));
             return ImmutableArray.CreateRange(compilation.References.Where(r => IsReferenced(r, referenceNames)));
         }
 
@@ -459,37 +453,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             return referenceNames.Contains(name);
         }
 
-        /// <summary>
-        /// Verify the set of module metadata blocks
-        /// contains all blocks referenced by the set.
-        /// </summary>
-        internal static void VerifyAllModules(this ImmutableArray<ModuleInstance> modules)
+        internal static ModuleInstance ToModuleInstance(this MetadataReference reference)
         {
-            var blocks = modules.SelectAsArray(m => m.MetadataBlock).SelectAsArray(b => ModuleMetadata.CreateFromMetadata(b.Pointer, b.Size));
-            var names = new HashSet<string>(blocks.Select(b => b.Name));
-            foreach (var block in blocks)
-            {
-                foreach (var name in block.GetModuleNames())
-                {
-                    Assert.True(names.Contains(name));
-                }
-            }
-        }
-
-        internal static ModuleMetadata GetModuleMetadata(this MetadataReference reference)
-        {
-            var metadata = ((MetadataImageReference)reference).GetMetadata();
-            var assemblyMetadata = metadata as AssemblyMetadata;
-            Assert.True((assemblyMetadata == null) || (assemblyMetadata.GetModules().Length == 1));
-            return (assemblyMetadata == null) ? (ModuleMetadata)metadata : assemblyMetadata.GetModules()[0];
-        }
-
-        internal static ModuleInstance ToModuleInstance(
-            this MetadataReference reference,
-            bool includeLocalSignatures = true)
-        {
-            var metadata = ((PortableExecutableReference)reference).GetMetadata();
-            return ModuleInstance.Create(metadata, default(ImmutableArray<byte>), null, includeLocalSignatures);
+            return ModuleInstance.Create((PortableExecutableReference)reference);
         }
 
         internal static ModuleInstance ToModuleInstance(
@@ -501,7 +467,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             var peImage = compilation.EmitToArray(new EmitOptions(debugInformationFormat: debugFormat), pdbStream: pdbStream);
             var symReader = (debugFormat != 0) ? SymReaderFactory.CreateReader(pdbStream, new PEReader(peImage)) : null;
 
-            return ModuleInstance.Create(AssemblyMetadata.CreateFromImage(peImage), peImage, symReader, includeLocalSignatures);
+            return ModuleInstance.Create(peImage, symReader, includeLocalSignatures);
         }
 
         internal static ModuleInstance GetModuleInstanceForIL(string ilSource)
@@ -509,21 +475,30 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             ImmutableArray<byte> peBytes;
             ImmutableArray<byte> pdbBytes;
             CommonTestBase.EmitILToArray(ilSource, appendDefaultHeader: true, includePdb: true, assemblyBytes: out peBytes, pdbBytes: out pdbBytes);
-            return ModuleInstance.Create(AssemblyMetadata.CreateFromImage(peBytes), peBytes, SymReaderFactory.CreateReader(pdbBytes), includeLocalSignatures: true);
+            return ModuleInstance.Create(peBytes, SymReaderFactory.CreateReader(pdbBytes), includeLocalSignatures: true);
         }
 
         internal static AssemblyIdentity GetAssemblyIdentity(this MetadataReference reference)
         {
-            var moduleMetadata = reference.GetModuleMetadata();
-            var reader = moduleMetadata.MetadataReader;
-            return reader.ReadAssemblyIdentityOrThrow();
+            using (var moduleMetadata = GetManifestModuleMetadata(reference))
+            {
+                return moduleMetadata.MetadataReader.ReadAssemblyIdentityOrThrow();
+            }
         }
 
         internal static Guid GetModuleVersionId(this MetadataReference reference)
         {
-            var moduleMetadata = reference.GetModuleMetadata();
-            var reader = moduleMetadata.MetadataReader;
-            return reader.GetModuleVersionIdOrThrow();
+            using (var moduleMetadata = GetManifestModuleMetadata(reference))
+            {
+                return moduleMetadata.MetadataReader.GetModuleVersionIdOrThrow();
+            }
+        }
+
+        private static ModuleMetadata GetManifestModuleMetadata(MetadataReference reference)
+        {
+            // make a copy to avoid disposing shared reference metadata:
+            var metadata = ((MetadataImageReference)reference).GetMetadata().Copy();
+            return (metadata as AssemblyMetadata)?.GetModules()[0] ?? (ModuleMetadata)metadata;
         }
 
         internal static void VerifyLocal<TMethodSymbol>(

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestUtilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestUtilities.csproj
@@ -74,6 +74,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="RuntimeInstance.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MethodDebugInfo.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MethodDebugInfo.cs
@@ -6,7 +6,7 @@ using Roslyn.Utilities;
 using Microsoft.DiaSymReader;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class MethodDebugInfoBytes
     {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MockSymUnmanaged.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/MockSymUnmanaged.cs
@@ -8,7 +8,7 @@ using Microsoft.DiaSymReader;
 using Roslyn.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class MockSymUnmanagedReader : ISymUnmanagedReader, ISymUnmanagedReader2, ISymUnmanagedReader3
     {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
@@ -10,24 +10,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
-    internal sealed class RuntimeInstance : IDisposable
-    {
-        internal RuntimeInstance(ImmutableArray<ModuleInstance> modules)
-        {
-            this.Modules = modules;
-        }
-
-        internal readonly ImmutableArray<ModuleInstance> Modules;
-
-        void IDisposable.Dispose()
-        {
-            foreach (var module in this.Modules)
-            {
-                module.Dispose();
-            }
-        }
-    }
-
     internal sealed class ModuleInstance : IDisposable
     {
         internal ModuleInstance(

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             MetadataReference metadataReference,
             ModuleMetadata moduleMetadata,
             Guid moduleVersionId,
-            byte[] fullImage,
+            ImmutableArray<byte> fullImage,
             byte[] metadataOnly,
             object symReader,
             bool includeLocalSignatures)
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
         internal readonly MetadataReference MetadataReference;
         internal readonly ModuleMetadata ModuleMetadata;
         internal readonly Guid ModuleVersionId;
-        internal readonly byte[] FullImage;
+        internal readonly ImmutableArray<byte> FullImage;
         internal readonly byte[] MetadataOnly;
         internal readonly GCHandle MetadataHandle;
         internal readonly object SymReader;

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ModuleInstance.cs
@@ -8,7 +8,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class ModuleInstance : IDisposable
     {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NotImplementedSymUnmanaged.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NotImplementedSymUnmanaged.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.SymbolStore;
 using System.Runtime.InteropServices.ComTypes;
 using Microsoft.DiaSymReader;
 
-namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class NotImplementedSymUnmanagedReader : ISymUnmanagedReader, ISymUnmanagedReader2, ISymUnmanagedReader3
     {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/RuntimeInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/RuntimeInstance.cs
@@ -11,16 +11,16 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using System.IO;
 using System.Reflection.PortableExecutable;
 
-namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class RuntimeInstance : IDisposable
     {
+        internal readonly ImmutableArray<ModuleInstance> Modules;
+
         internal RuntimeInstance(ImmutableArray<ModuleInstance> modules)
         {
             this.Modules = modules;
         }
-
-        internal readonly ImmutableArray<ModuleInstance> Modules;
 
         void IDisposable.Dispose()
         {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/RuntimeInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/RuntimeInstance.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+extern alias PDB;
+
+using System;
+using System.Linq;
+using System.Collections.Immutable;
+using Microsoft.DiaSymReader;
+using PDB::Roslyn.Test.PdbUtilities;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using System.IO;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.CodeAnalysis.ExpressionEvaluator
+{
+    internal sealed class RuntimeInstance : IDisposable
+    {
+        internal RuntimeInstance(ImmutableArray<ModuleInstance> modules)
+        {
+            this.Modules = modules;
+        }
+
+        internal readonly ImmutableArray<ModuleInstance> Modules;
+
+        void IDisposable.Dispose()
+        {
+            foreach (var module in this.Modules)
+            {
+                module.Dispose();
+            }
+        }
+
+        internal static RuntimeInstance Create(Compilation compilation, DebugInformationFormat debugFormat = 0)
+        {
+            var pdbStream = (debugFormat != 0) ? new MemoryStream() : null;
+            var peImage = compilation.EmitToArray(new EmitOptions(debugInformationFormat: debugFormat), pdbStream: pdbStream);
+            var symReader = (debugFormat != 0) ? SymReaderFactory.CreateReader(pdbStream, new PEReader(peImage)) : null;
+            var references = compilation.GetEmittedReferences(peImage).AddIntrinsicAssembly();
+
+            return Create(compilation.AssemblyName, references, peImage, symReader);
+        }
+
+        internal static RuntimeInstance Create(
+            string assemblyName,
+            ImmutableArray<MetadataReference> references,
+            ImmutableArray<byte> peImage,
+            ISymUnmanagedReader symReaderOpt,
+            bool includeLocalSignatures = true)
+        {
+            var exeReference = AssemblyMetadata.CreateFromImage(peImage).GetReference(display: assemblyName);
+            var modulesBuilder = ArrayBuilder<ModuleInstance>.GetInstance();
+            // Create modules for the references
+            modulesBuilder.AddRange(references.Select(r => r.ToModuleInstance(fullImage: null, symReader: null, includeLocalSignatures: includeLocalSignatures)));
+            // Create a module for the exe.
+            modulesBuilder.Add(exeReference.ToModuleInstance(peImage.ToArray(), symReaderOpt, includeLocalSignatures: includeLocalSignatures));
+
+            var modules = modulesBuilder.ToImmutableAndFree();
+            modules.VerifyAllModules();
+
+            return new RuntimeInstance(modules);
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/RuntimeInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/RuntimeInstance.cs
@@ -37,43 +37,30 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             DebugInformationFormat debugFormat = 0,
             bool includeLocalSignatures = true)
         {
-            var exeModuleInstance = compilation.ToModuleInstance(debugFormat, includeLocalSignatures);
+            var module = compilation.ToModuleInstance(debugFormat, includeLocalSignatures);
 
             if (references == null)
             {
-                references = compilation.GetEmittedReferences(exeModuleInstance.FullImage);
+                references = compilation.GetEmittedReferences(module.FullImage);
             }
 
             references = references.Concat(new[] { ExpressionCompilerTestHelpers.IntrinsicAssemblyReference });
 
-            return Create(references, exeModuleInstance, includeLocalSignatures);
+            return Create(module, references, includeLocalSignatures);
         }
 
         internal static RuntimeInstance Create(
+            ModuleInstance module,
             IEnumerable<MetadataReference> references,
-            ModuleInstance exeModuleInstance,
             bool includeLocalSignatures = true)
         {
             // Create modules for the references and the program
             var modules = ImmutableArray.CreateRange(
                 references.Select(r => r.ToModuleInstance(includeLocalSignatures: includeLocalSignatures)).
-                Concat(new[] { exeModuleInstance }));
+                Concat(new[] { module }));
 
             modules.VerifyAllModules();
             return new RuntimeInstance(modules);
-        }
-
-        // TODO: remove
-        internal static RuntimeInstance Create(
-            IEnumerable<MetadataReference> references,
-            ImmutableArray<byte> peImage,
-            ISymUnmanagedReader symReaderOpt,
-            string assemblyName = null,
-            bool includeLocalSignatures = true)
-        {
-            var exeReference = AssemblyMetadata.CreateFromImage(peImage).GetReference(display: assemblyName);
-            var exeModuleInstance = exeReference.ToModuleInstance(peImage, symReaderOpt, includeLocalSignatures: includeLocalSignatures);
-            return Create(references, exeModuleInstance, includeLocalSignatures);
         }
     }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/AccessibilityTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/AccessibilityTests.vb
@@ -3,14 +3,13 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
-Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class AccessibilityTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.vb
@@ -1,13 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.CodeGen
-Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class DebuggerDisplayAttributeTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.vb
@@ -32,7 +32,7 @@ Public Class Derived
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim runtime = CreateRuntimeInstance(comp, includeSymbols:=False)
+            Dim runtime = CreateRuntimeInstance(comp)
             Dim context = CreateTypeContext(runtime, "Derived")
             Dim errorMessage As String = Nothing
             Dim testData As New CompilationTestData()

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DeclarationTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DeclarationTests.vb
@@ -3,15 +3,14 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.VisualStudio.Debugger.Clr
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class DeclarationTests
         Inherits ExpressionCompilerTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
@@ -408,7 +408,7 @@ End Namespace
         Private Shared Function MakeAssemblyReaders(runtimeInstance As RuntimeInstance) As ImmutableArray(Of AssemblyReaders)
             Return ImmutableArray.CreateRange(runtimeInstance.Modules.
                 Where(Function(instance) instance.SymReader IsNot Nothing).
-                Select(Function(instance) New AssemblyReaders(instance.MetadataReader, instance.SymReader)))
+                Select(Function(instance) New AssemblyReaders(instance.GetMetadataReader(), instance.SymReader)))
         End Function
 
         Private Shared Sub CheckDteeMethodDebugInfo(methodDebugInfo As MethodDebugInfo, ParamArray namespaceNames As String())

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
@@ -274,14 +274,6 @@ End Namespace
         Public Sub FalseModule_Nested()
             ' NOTE: VB only allows top-level module types.
             Dim ilSource = "
-.assembly 'IL' {} 
-
-.assembly extern mscorlib 
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
-  .ver 4:0:0:0
-} 
-
 .assembly extern Microsoft.VisualBasic { } 
 
 .class public auto ansi N1.Outer
@@ -326,14 +318,6 @@ End Namespace
         Public Sub FalseModule_Generic()
             ' NOTE: VB only allows non-generic module types.
             Dim ilSource = "
-.assembly 'IL' {} 
-
-.assembly extern mscorlib 
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
-  .ver 4:0:0:0
-} 
-
 .assembly extern Microsoft.VisualBasic { } 
 
 .class public auto ansi sealed N1.M`1<T>
@@ -359,14 +343,6 @@ End Namespace
         Public Sub FalseModule_Interface()
             ' NOTE: VB only allows non-interface module types.
             Dim ilSource = "
-.assembly 'IL' {} 
-
-.assembly extern mscorlib 
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
-  .ver 4:0:0:0
-} 
-
 .assembly extern Microsoft.VisualBasic { } 
 
 .class interface private abstract auto ansi I

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
@@ -2,17 +2,16 @@
 
 Imports System.Collections.Immutable
 Imports System.IO
-Imports System.Reflection.Metadata
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.DiaSymReader
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class DteeTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/DteeTests.vb
@@ -115,8 +115,8 @@ End Namespace
         <Fact>
         Public Sub DteeEntryPointImportsIgnored()
             Dim comp = CreateCompilationWithMscorlib({s_dteeEntryPointSource}, options:=TestOptions.DebugDll, assemblyName:=GetUniqueName())
-            Dim compModuleInstance = GetModuleInstance(comp)
-            Dim corlibModuleReference = MscorlibRef.ToModuleInstance(Nothing, Nothing)
+            Dim compModuleInstance = comp.ToModuleInstance()
+            Dim corlibModuleReference = MscorlibRef.ToModuleInstance()
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(compModuleInstance, corlibModuleReference))
             Dim lazyAssemblyReaders = MakeLazyAssemblyReaders(runtimeInstance)
@@ -153,16 +153,16 @@ Class C2
     End Sub
 End Class
 "
-            Dim comp1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll.WithRootNamespace("root1"), assemblyName:=GetUniqueName())
-            Dim compModuleInstance1 = GetModuleInstance(comp1)
+            Dim comp1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll.WithRootNamespace("root1"))
+            Dim compModuleInstance1 = comp1.ToModuleInstance()
 
-            Dim comp2 = CreateCompilationWithMscorlib({source2}, options:=TestOptions.DebugDll.WithRootNamespace("root2"), assemblyName:=GetUniqueName())
-            Dim compModuleInstance2 = GetModuleInstance(comp2)
+            Dim comp2 = CreateCompilationWithMscorlib({source2}, options:=TestOptions.DebugDll.WithRootNamespace("root2"))
+            Dim compModuleInstance2 = comp2.ToModuleInstance()
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 compModuleInstance1,
                 compModuleInstance2,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance()))
 
             Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
             CheckDteeMethodDebugInfo(methodDebugInfo, "root1", "root2")
@@ -208,16 +208,16 @@ Namespace N7
 End Namespace
 "
             Dim comp1 = CreateCompilationWithMscorlib({source1}, {MsvbRef}, options:=TestOptions.DebugDll, assemblyName:=GetUniqueName())
-            Dim compModuleInstance1 = GetModuleInstance(comp1)
+            Dim compModuleInstance1 = comp1.ToModuleInstance()
 
             Dim comp2 = CreateCompilationWithMscorlib({source2}, {MsvbRef}, options:=TestOptions.DebugDll, assemblyName:=GetUniqueName())
-            Dim compModuleInstance2 = GetModuleInstance(comp2)
+            Dim compModuleInstance2 = comp2.ToModuleInstance()
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 compModuleInstance1,
                 compModuleInstance2,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing),
-                MsvbRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance(),
+                MsvbRef.ToModuleInstance()))
 
             Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
             CheckDteeMethodDebugInfo(methodDebugInfo, "N1", "N2.N3", "N5.N6")
@@ -226,12 +226,12 @@ End Namespace
         <Fact>
         Public Sub ImportStrings_NoMethods()
             Dim comp = CreateCompilationWithMscorlib({""}, {MsvbRef}, options:=TestOptions.DebugDll.WithRootNamespace("root"), assemblyName:=GetUniqueName())
-            Dim compModuleInstance = GetModuleInstance(comp)
+            Dim compModuleInstance = comp.ToModuleInstance()
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 compModuleInstance,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing),
-                MsvbRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance(),
+                MsvbRef.ToModuleInstance()))
 
             ' Since there are no methods in the assembly, there is no import custom debug info, so we
             ' have no way to find the root namespace.
@@ -255,16 +255,16 @@ Namespace N2
 End Namespace
 "
             Dim comp1 = CreateCompilationWithMscorlib({source1}, {MsvbRef}, options:=TestOptions.ReleaseDll, assemblyName:=GetUniqueName())
-            Dim compModuleInstance1 = GetModuleInstance(comp1)
+            Dim compModuleInstance1 = comp1.ToModuleInstance(debugFormat:=Nothing)
 
             Dim comp2 = CreateCompilationWithMscorlib({source2}, {MsvbRef}, options:=TestOptions.DebugDll, assemblyName:=GetUniqueName())
-            Dim compModuleInstance2 = GetModuleInstance(comp2)
+            Dim compModuleInstance2 = comp2.ToModuleInstance()
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 compModuleInstance1,
                 compModuleInstance2,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing),
-                MsvbRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance(),
+                MsvbRef.ToModuleInstance()))
 
             Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
             CheckDteeMethodDebugInfo(methodDebugInfo, "N2")
@@ -311,12 +311,12 @@ End Namespace
   }
 } // end of class N1.Outer
 "
-            Dim ilModuleInstance = GetModuleInstanceForIL(ilSource)
+            Dim ilModuleInstance = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource)
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 ilModuleInstance,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing),
-                MsvbRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance(),
+                MsvbRef.ToModuleInstance()))
 
             Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
             CheckDteeMethodDebugInfo(methodDebugInfo)
@@ -344,12 +344,12 @@ End Namespace
 
 } // end of class M
 "
-            Dim ilModuleInstance = GetModuleInstanceForIL(ilSource)
+            Dim ilModuleInstance = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource)
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 ilModuleInstance,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing),
-                MsvbRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance(),
+                MsvbRef.ToModuleInstance()))
 
             Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
             CheckDteeMethodDebugInfo(methodDebugInfo)
@@ -376,12 +376,12 @@ End Namespace
 
 } // end of class I
 "
-            Dim ilModuleInstance = GetModuleInstanceForIL(ilSource)
+            Dim ilModuleInstance = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource)
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 ilModuleInstance,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing),
-                MsvbRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance(),
+                MsvbRef.ToModuleInstance()))
 
             Dim methodDebugInfo = EvaluationContext.SynthesizeMethodDebugInfoForDtee(MakeAssemblyReaders(runtimeInstance))
             CheckDteeMethodDebugInfo(methodDebugInfo)
@@ -418,20 +418,20 @@ End Namespace
 "
 
             Dim dteeComp = CreateCompilationWithMscorlib({s_dteeEntryPointSource}, options:=TestOptions.DebugDll, assemblyName:=GetUniqueName())
-            Dim dteeModuleInstance = GetModuleInstance(dteeComp)
+            Dim dteeModuleInstance = dteeComp.ToModuleInstance()
 
             Dim comp1 = CreateCompilationWithMscorlib({source1}, {MsvbRef}, options:=TestOptions.DebugDll.WithRootNamespace("root"), assemblyName:=GetUniqueName())
-            Dim compModuleInstance1 = GetModuleInstance(comp1)
+            Dim compModuleInstance1 = comp1.ToModuleInstance()
 
             Dim comp2 = CreateCompilationWithMscorlib({source2}, {MsvbRef}, options:=TestOptions.DebugDll.WithRootNamespace("root"), assemblyName:=GetUniqueName())
-            Dim compModuleInstance2 = GetModuleInstance(comp2)
+            Dim compModuleInstance2 = comp2.ToModuleInstance()
 
             Dim runtimeInstance = CreateRuntimeInstance(ImmutableArray.Create(
                 dteeModuleInstance,
                 compModuleInstance1,
                 compModuleInstance2,
-                MscorlibRef.ToModuleInstance(Nothing, Nothing),
-                MsvbRef.ToModuleInstance(Nothing, Nothing)))
+                MscorlibRef.ToModuleInstance(),
+                MsvbRef.ToModuleInstance()))
             Dim lazyAssemblyReaders = MakeLazyAssemblyReaders(runtimeInstance)
 
             Dim evalContext = CreateMethodContext(runtimeInstance, s_dteeEntryPointName, lazyAssemblyReaders:=lazyAssemblyReaders)
@@ -465,34 +465,6 @@ End Namespace
             Return ImmutableArray.CreateRange(runtimeInstance.Modules.
                 Where(Function(instance) instance.SymReader IsNot Nothing).
                 Select(Function(instance) New AssemblyReaders(instance.MetadataReader, instance.SymReader)))
-        End Function
-
-        Private Shared Function GetModuleInstance(comp As VisualBasicCompilation) As ModuleInstance
-            Dim makePdb = comp.Options.OptimizationLevel = OptimizationLevel.Debug
-
-            Dim peBytes As Byte()
-            Dim pdbBytes As Byte()
-            Using pdbStream = If(makePdb, New MemoryStream(), Nothing)
-                Using peStream As New MemoryStream()
-                    Dim emitResult = comp.Emit(peStream, pdbStream)
-                    AssertNoErrors(emitResult.Diagnostics)
-                    Assert.True(emitResult.Success)
-
-                    peBytes = peStream.ToArray()
-                    pdbBytes = pdbStream?.ToArray()
-                End Using
-            End Using
-            Assert.Equal(makePdb, pdbBytes IsNot Nothing)
-            Dim compRef = AssemblyMetadata.CreateFromImage(peBytes).GetReference()
-            Return compRef.ToModuleInstance(peBytes, If(makePdb, SymReaderFactory.CreateReader(pdbBytes), Nothing))
-        End Function
-
-        Private Shared Function GetModuleInstanceForIL(ilSource As String) As ModuleInstance
-            Dim peBytes As ImmutableArray(Of Byte) = Nothing
-            Dim pdbBytes As ImmutableArray(Of Byte) = Nothing
-            EmitILToArray(ilSource, appendDefaultHeader:=False, includePdb:=True, assemblyBytes:=peBytes, pdbBytes:=pdbBytes)
-            Dim compRef = AssemblyMetadata.CreateFromImage(peBytes).GetReference()
-            Return compRef.ToModuleInstance(peBytes.ToArray(), SymReaderFactory.CreateReader(pdbBytes))
         End Function
 
         Private Shared Sub CheckDteeMethodDebugInfo(methodDebugInfo As MethodDebugInfo, ParamArray namespaceNames As String())

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -64,10 +64,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
         Friend Function CreateRuntimeInstance(
             [module] As ModuleInstance,
-            Optional references As IEnumerable(Of MetadataReference) = Nothing,
-            Optional includeLocalSignatures As Boolean = True) As RuntimeInstance
+            Optional references As IEnumerable(Of MetadataReference) = Nothing) As RuntimeInstance
 
-            Dim instance = RuntimeInstance.Create([module], references, includeLocalSignatures)
+            Dim instance = RuntimeInstance.Create([module], references)
             _runtimeInstances.Add(instance)
             Return instance
         End Function

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -45,6 +45,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
             _runtimeInstances.Free()
         End Sub
 
+        Friend Function CreateRuntimeInstance(modules As IEnumerable(Of ModuleInstance)) As RuntimeInstance
+            Dim instance = RuntimeInstance.Create(modules)
+            _runtimeInstances.Add(instance)
+            Return instance
+        End Function
+
         Friend Function CreateRuntimeInstance(
             compilation As Compilation,
             Optional references As IEnumerable(Of MetadataReference) = Nothing,
@@ -64,12 +70,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
             Optional includeLocalSignatures As Boolean = True) As RuntimeInstance
 
             Dim instance = RuntimeInstance.Create(references, exeBytes, symReader, assemblyName, includeLocalSignatures)
-            _runtimeInstances.Add(instance)
-            Return instance
-        End Function
-
-        Friend Function CreateRuntimeInstance(modules As ImmutableArray(Of ModuleInstance)) As RuntimeInstance
-            Dim instance = New RuntimeInstance(modules)
             _runtimeInstances.Add(instance)
             Return instance
         End Function

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -63,13 +63,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
         End Function
 
         Friend Function CreateRuntimeInstance(
-            references As IEnumerable(Of MetadataReference),
-            exeBytes As ImmutableArray(Of Byte),
-            symReader As ISymUnmanagedReader,
-            Optional assemblyName As String = Nothing,
+            [module] As ModuleInstance,
+            Optional references As IEnumerable(Of MetadataReference) = Nothing,
             Optional includeLocalSignatures As Boolean = True) As RuntimeInstance
 
-            Dim instance = RuntimeInstance.Create(references, exeBytes, symReader, assemblyName, includeLocalSignatures)
+            Dim instance = RuntimeInstance.Create([module], references, includeLocalSignatures)
             _runtimeInstances.Add(instance)
             Return instance
         End Function

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -9,19 +9,20 @@ Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
 Imports Microsoft.VisualStudio.Debugger.Clr
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
-Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public MustInherit Class ExpressionCompilerTestBase
         Inherits BasicTestBase
         Implements IDisposable

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -47,21 +47,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
         Friend Function CreateRuntimeInstance(
             compilation As Compilation,
-            Optional debugFormat As DebugInformationFormat = DebugInformationFormat.Pdb) As RuntimeInstance
+            Optional references As IEnumerable(Of MetadataReference) = Nothing,
+            Optional debugFormat As DebugInformationFormat = DebugInformationFormat.Pdb,
+            Optional includeLocalSignatures As Boolean = True) As RuntimeInstance
 
-            Dim instance = RuntimeInstance.Create(compilation, debugFormat)
+            Dim instance = RuntimeInstance.Create(compilation, references, debugFormat, includeLocalSignatures)
             _runtimeInstances.Add(instance)
             Return instance
         End Function
 
         Friend Function CreateRuntimeInstance(
-            assemblyName As String,
-            references As ImmutableArray(Of MetadataReference),
-            exeBytes As Byte(),
+            references As IEnumerable(Of MetadataReference),
+            exeBytes As ImmutableArray(Of Byte),
             symReader As ISymUnmanagedReader,
+            Optional assemblyName As String = Nothing,
             Optional includeLocalSignatures As Boolean = True) As RuntimeInstance
 
-            Dim instance = RuntimeInstance.Create(assemblyName, references, exeBytes.ToImmutableArray(), symReader, includeLocalSignatures)
+            Dim instance = RuntimeInstance.Create(references, exeBytes, symReader, assemblyName, includeLocalSignatures)
             _runtimeInstances.Add(instance)
             Return instance
         End Function
@@ -190,7 +192,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
                 {MscorlibRef_v4_0_30316_17626, SystemRef, MsvbRef},
                 options:=If(outputKind = OutputKind.DynamicallyLinkedLibrary, TestOptions.DebugDll, TestOptions.DebugExe))
 
-            Dim runtime = CreateRuntimeInstance(compilation0, If(includeSymbols, DebugInformationFormat.Pdb, Nothing))
+            Dim runtime = CreateRuntimeInstance(compilation0, debugFormat:=If(includeSymbols, DebugInformationFormat.Pdb, Nothing))
             Dim context = CreateMethodContext(runtime, methodName, atLineNumber)
             Dim testData = New CompilationTestData()
             Dim missingAssemblyIdentities As ImmutableArray(Of AssemblyIdentity) = Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -256,13 +256,9 @@ End Class"
             Dim referenceA = compA.EmitToImageReference()
 
             Dim compB = CreateCompilationWithMscorlib({sourceB}, options:=TestOptions.DebugDll, references:={referenceA})
-            Dim exeBytes As ImmutableArray(Of Byte) = Nothing
-            Dim pdbBytes As ImmutableArray(Of Byte) = Nothing
-            compB.EmitAndGetReferences(exeBytes, pdbBytes)
 
             Dim referencesB = {MscorlibRef, referenceA}
-            Dim moduleB1 = ModuleInstance.Create(exeBytes, SymReaderFactory.CreateReader(pdbBytes))
-            Dim moduleB2 = ModuleInstance.Create(exeBytes, SymReaderFactory.CreateReader(pdbBytes))
+            Dim moduleB = compB.ToModuleInstance()
 
             Const methodVersion = 1
 
@@ -270,7 +266,7 @@ End Class"
             Dim startOffset = 0
             Dim endOffset = 0
 
-            Dim runtime = CreateRuntimeInstance(moduleB1, referencesB)
+            Dim runtime = CreateRuntimeInstance(moduleB, referencesB)
 
             Dim typeBlocks As ImmutableArray(Of MetadataBlock) = Nothing
             Dim methodBlocks As ImmutableArray(Of MetadataBlock) = Nothing
@@ -332,7 +328,7 @@ End Class"
 
             ' With different references.
             Dim fewerReferences = {MscorlibRef}
-            runtime = CreateRuntimeInstance(moduleB2, fewerReferences)
+            runtime = CreateRuntimeInstance(moduleB, fewerReferences)
             methodBlocks = Nothing
             moduleVersionId = Nothing
             symReader = Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -6,9 +6,10 @@ Imports System.IO
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
@@ -17,7 +18,7 @@ Imports Roslyn.Test.Utilities
 Imports Xunit
 Imports CommonResources = Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests.Resources
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class ExpressionCompilerTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -196,7 +196,7 @@ Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim runtime = CreateRuntimeInstance(comp, includeSymbols:=False)
+            Dim runtime = CreateRuntimeInstance(comp, debugFormat:=Nothing)
             For Each moduleInstance In runtime.Modules
                 Assert.Null(moduleInstance.SymReader)
             Next
@@ -405,7 +405,7 @@ Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim runtime = CreateRuntimeInstance(comp, includeSymbols:=False)
+            Dim runtime = CreateRuntimeInstance(comp)
             Dim context = CreateMethodContext(runtime, methodName:="C.F")
             Dim errorMessage As String = Nothing
 
@@ -3730,8 +3730,7 @@ End Class
             Dim exeBytes As Byte() = Nothing
             Dim pdbBytes As Byte() = Nothing
             Dim unusedReferences As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
 
             Dim runtime = CreateRuntimeInstance(GetUniqueName(), ImmutableArray.Create(MscorlibRef), exeBytes, SymReaderFactory.CreateReader(pdbBytes))
             Dim context = CreateMethodContext(runtime, "C.M")
@@ -3862,8 +3861,7 @@ End Class
             Dim exeBytes As Byte() = Nothing
             Dim unusedPdbBytes As Byte() = Nothing
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, unusedPdbBytes, references)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, unusedPdbBytes, references)
 
             Dim symReader As ISymUnmanagedReader = New MockSymUnmanagedReader(ImmutableDictionary(Of Integer, MethodDebugInfoBytes).Empty)
 
@@ -3898,8 +3896,7 @@ End Class
             Dim exeBytes As Byte() = Nothing
             Dim unusedPdbBytes As Byte() = Nothing
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, unusedPdbBytes, references)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, unusedPdbBytes, references)
 
             Dim runtime = CreateRuntimeInstance("assemblyName", references, exeBytes, NotImplementedSymUnmanagedReader.Instance)
             Dim evalContext = CreateMethodContext(runtime, "C.Main")

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
@@ -3,14 +3,15 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class HoistedMeTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
@@ -482,15 +482,8 @@ End Module
 } // end of class C
 "
 
-            Dim ilBytes As ImmutableArray(Of Byte) = Nothing
-            Dim ilPdbBytes As ImmutableArray(Of Byte) = Nothing
-            EmitILToArray(ilSource, appendDefaultHeader:=True, includePdb:=True, assemblyBytes:=ilBytes, pdbBytes:=ilPdbBytes)
-
-            Dim runtime = CreateRuntimeInstance(
-                references:={MscorlibRef},
-                exeBytes:=ilBytes,
-                symReader:=SymReaderFactory.CreateReader(ilPdbBytes))
-
+            Dim ilModule = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource)
+            Dim runtime = CreateRuntimeInstance(ilModule, {MscorlibRef})
             Dim context = CreateMethodContext(runtime, "C._Lambda$__1")
             VerifyNoMe(context)
         End Sub

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedMeTests.vb
@@ -487,10 +487,9 @@ End Module
             EmitILToArray(ilSource, appendDefaultHeader:=True, includePdb:=True, assemblyBytes:=ilBytes, pdbBytes:=ilPdbBytes)
 
             Dim runtime = CreateRuntimeInstance(
-                assemblyName:=GetUniqueName(),
-                references:=ImmutableArray.Create(MscorlibRef),
-                exeBytes:=ilBytes.ToArray(),
-                symReader:=SymReaderFactory.CreateReader(ilPdbBytes.ToArray()))
+                references:={MscorlibRef},
+                exeBytes:=ilBytes,
+                symReader:=SymReaderFactory.CreateReader(ilPdbBytes))
 
             Dim context = CreateMethodContext(runtime, "C._Lambda$__1")
             VerifyNoMe(context)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/HoistedStateMachineLocalTests.vb
@@ -3,13 +3,13 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class HoistedStateMachineLocalTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
@@ -198,8 +198,7 @@ End Class
             Dim exeBytes As Byte() = Nothing
             Dim unusedPdbBytes As Byte() = Nothing
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, unusedPdbBytes, references)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, unusedPdbBytes, references)
 
             Dim symReader = ExpressionCompilerTestHelpers.ConstructSymReaderWithImports(
                 exeBytes,
@@ -238,8 +237,7 @@ End Class
             Dim exeBytes As Byte() = Nothing
             Dim unusedPdbBypes As Byte() = Nothing
             Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, unusedPdbBypes, references)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, unusedPdbBypes, references)
 
             Dim symReader = ExpressionCompilerTestHelpers.ConstructSymReaderWithImports(
                 exeBytes,
@@ -337,7 +335,7 @@ End Namespace
             Dim aliases As Dictionary(Of String, AliasAndImportsClausePosition) = Nothing
             Dim xmlNamespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition) = Nothing
 
-            Dim runtime = CreateRuntimeInstance(comp, includeSymbols:=True)
+            Dim runtime = CreateRuntimeInstance(comp)
             GetImports(
                 runtime,
                 "root.N.C.M",
@@ -387,7 +385,7 @@ End Namespace
                 Dim aliases As Dictionary(Of String, AliasAndImportsClausePosition) = Nothing
                 Dim xmlNamespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition) = Nothing
 
-                Dim runtime = CreateRuntimeInstance(comp, includeSymbols:=True)
+                Dim runtime = CreateRuntimeInstance(comp)
                 GetImports(
                     runtime,
                     "N.C.M",
@@ -444,7 +442,7 @@ End Namespace
             Dim aliases As Dictionary(Of String, AliasAndImportsClausePosition) = Nothing
             Dim xmlNamespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition) = Nothing
 
-            Dim runtime = CreateRuntimeInstance(comp, includeSymbols:=True)
+            Dim runtime = CreateRuntimeInstance(comp)
             GetImports(
                 runtime,
                 "root.N.C.M",

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
@@ -202,7 +202,8 @@ End Class
                 "@FA:O=1", ' Invalid
                 "@FA:SC=System.Collections") ' Valid
 
-            Dim runtime = CreateRuntimeInstance({MscorlibRef}, exeBytes, symReader)
+            Dim exeModule = ModuleInstance.Create(exeBytes, symReader)
+            Dim runtime = CreateRuntimeInstance(exeModule, {MscorlibRef})
             Dim evalContext = CreateMethodContext(runtime, "C.Main")
             Dim compContext = evalContext.CreateCompilationContext(SyntaxHelpers.ParseDebuggerExpression("Nothing", consumeFullText:=True)) ' Used to throw.
 
@@ -237,7 +238,8 @@ End Class
                 "@FA:S.I=System.IO", ' Invalid
                 "@FA:SC=System.Collections") ' Valid
 
-            Dim runtime = CreateRuntimeInstance({MscorlibRef}, exeBytes, symReader)
+            Dim exeModule = ModuleInstance.Create(exeBytes, symReader)
+            Dim runtime = CreateRuntimeInstance(exeModule, {MscorlibRef})
             Dim evalContext = CreateMethodContext(runtime, "C.Main")
             Dim compContext = evalContext.CreateCompilationContext(SyntaxHelpers.ParseDebuggerExpression("Nothing", consumeFullText:=True)) ' Used to throw.
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
@@ -5,20 +5,18 @@ Imports System.IO
 Imports System.Reflection
 Imports System.Reflection.Metadata
 Imports System.Reflection.Metadata.Ecma335
-Imports System.Reflection.PortableExecutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.CodeGen
-Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class ImportsDebugInfoTests
         Inherits ExpressionCompilerTestBase
 
@@ -124,8 +122,8 @@ End Namespace
                     compilation.Emit(exebits, pdbbits)
 
                     exebits.Position = 0
-                    Using metadata = modulemetadata.CreateFromStream(exebits, leaveOpen:=True)
-                        Dim [module] = metadata.module
+                    Using metadata = ModuleMetadata.CreateFromStream(exebits, leaveOpen:=True)
+                        Dim [module] = metadata.Module
                         Dim metadataReader = [module].MetadataReader
                         Dim methodHandle = metadataReader.MethodDefinitions.Single(Function(mh) metadataReader.GetString(metadataReader.GetMethodDefinition(mh).Name) = methodName)
                         Dim methodToken = metadataReader.GetToken(methodHandle)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ImportDebugInfoTests.vb
@@ -478,10 +478,10 @@ Public Class C2 : Inherits C1
 End Class
 "
 
-            Dim comp1 = CreateCompilationWithReferences(VisualBasicSyntaxTree.ParseText(source1), {MscorlibRef_v20}, TestOptions.DebugDll, assemblyName:="A")
+            Dim comp1 = CreateCompilationWithReferences(VisualBasicSyntaxTree.ParseText(source1), {MscorlibRef_v20}, TestOptions.DebugDll)
             Dim module1 = comp1.ToModuleInstance()
 
-            Dim comp2 = CreateCompilationWithReferences(VisualBasicSyntaxTree.ParseText(source2), {MscorlibRef_v4_0_30316_17626, module1.MetadataReference}, TestOptions.DebugDll, assemblyName:="B")
+            Dim comp2 = CreateCompilationWithReferences(VisualBasicSyntaxTree.ParseText(source2), {MscorlibRef_v4_0_30316_17626, module1.GetReference()}, TestOptions.DebugDll)
             Dim module2 = comp2.ToModuleInstance()
 
             Dim runtime = CreateRuntimeInstance({module1, module2, MscorlibRef_v4_0_30316_17626.ToModuleInstance(), ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance()})

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
@@ -1,15 +1,15 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Reflection.Metadata.Ecma335
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
-Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     '// TODO: constructors
     '// TODO: keyword identifiers

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -2647,8 +2647,7 @@ End Class
             Dim exeBytes As Byte() = Nothing
             Dim pdbBytes As Byte() = Nothing
             Dim unusedReferences As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
 
             ' Referencing SystemCoreRef and SystemXmlLinqRef will cause Microsoft.VisualBasic.Embedded to be compiled
             ' and it depends on EditorBrowsableAttribute.

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -3,15 +3,16 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class LocalsTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -244,15 +244,13 @@ End Class"
     End Sub
 End Class"
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes), includeLocalSignatures:=False)
+            Dim runtime = CreateRuntimeInstance(comp, includeLocalSignatures:=False)
+
             Dim context = CreateMethodContext(
                 runtime,
                 methodName:="C.M",
                 atLineNumber:=999)
+
             Dim testData = New CompilationTestData()
             Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
             Dim typeName As String = Nothing
@@ -558,14 +556,9 @@ Class C
     End Sub
 End Class"
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugExe)
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
-            Dim context = CreateMethodContext(
-                runtime,
-                methodName:="C.M")
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C.M")
+
             Dim testData = New CompilationTestData()
             Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
             Dim typeName As String = Nothing
@@ -614,14 +607,10 @@ Class P
     End Sub
 End Class"
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugExe)
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
-            Dim context = CreateMethodContext(
-                runtime,
-                methodName:="C.M")
+
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C.M")
+
             Dim testData = New CompilationTestData()
             Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
             Dim typeName As String = Nothing
@@ -1695,19 +1684,10 @@ End Structure"
 End Class"
             Dim comp0 = CreateCompilationWithMscorlib({source0}, options:=TestOptions.DebugDll)
             Dim comp1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll, references:={comp0.EmitToImageReference()})
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            comp1.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim runtime = CreateRuntimeInstance(
-                ExpressionCompilerUtilities.GenerateUniqueName(),
-                ImmutableArray.Create(MscorlibRef), ' no reference to compilation0
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
 
-            Dim context = CreateMethodContext(
-                runtime,
-                methodName:="C.M")
+            ' no reference to compilation0
+            Dim runtime = CreateRuntimeInstance(comp1, {MscorlibRef})
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Dim testData = New CompilationTestData()
             Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
@@ -1772,15 +1752,9 @@ Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
 
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
-            Dim context = CreateMethodContext(
-                runtime,
-                methodName:="C.M")
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Dim errorMessage As String = Nothing
             context.CompileAssignment("d", "Nothing", errorMessage, formatter:=DebuggerDiagnosticFormatter.Instance)
@@ -1821,15 +1795,8 @@ Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, references)
-
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes, exeBytes))
-            Dim context = CreateMethodContext(
-                runtime,
-                methodName:="C.M")
+            Dim runtime = CreateRuntimeInstance(comp)
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Dim errorMessage As String = Nothing
             context.CompileAssignment("d", "Nothing", errorMessage, formatter:=DebuggerDiagnosticFormatter.Instance)
@@ -2645,15 +2612,9 @@ End Class
             Dim libRef = CreateCompilationWithMscorlib({libSource}, options:=TestOptions.DebugDll).EmitToImageReference()
             Dim comp = CreateCompilationWithReferences({VisualBasicSyntaxTree.ParseText(source)}, {MscorlibRef, SystemRef}, TestOptions.DebugDll)
 
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim unusedReferences As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
-
             ' Referencing SystemCoreRef and SystemXmlLinqRef will cause Microsoft.VisualBasic.Embedded to be compiled
             ' and it depends on EditorBrowsableAttribute.
-            Dim runtimeReferences = ImmutableArray.Create(MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef)
-            Dim runtime = CreateRuntimeInstance(GetUniqueName(), runtimeReferences, exeBytes, SymReaderFactory.CreateReader(pdbBytes))
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef})
 
             Dim typeName As String = Nothing
             Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -87,7 +87,8 @@ End Class
 "
             Dim libRef = CreateCompilationWithMscorlib({libSource}, {}, TestOptions.DebugDll, assemblyName:="Lib").EmitToImageReference()
             Dim comp = CreateCompilationWithMscorlib({source}, {libRef}, TestOptions.DebugDll)
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", MscorlibRef)
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef})
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Const expectedError = "error BC30652: Reference required to assembly 'Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'Missing'. Add one to your project."
             Dim expectedMissingAssemblyIdentity = New AssemblyIdentity("Lib")
@@ -177,8 +178,8 @@ Public Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, {SystemRef, SystemCoreRef, SystemXmlRef, SystemXmlLinqRef}, TestOptions.DebugDll)
-            comp.AssertNoErrors()
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", MscorlibRef)
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef})
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Const expectedError = "error BC31190: XML literals and XML axis properties are not available. Add references to System.Xml, System.Xml.Linq, and System.Core or other assemblies declaring System.Linq.Enumerable, System.Xml.Linq.XElement, System.Xml.Linq.XName, System.Xml.Linq.XAttribute and System.Xml.Linq.XNamespace types."
 
@@ -213,7 +214,8 @@ Public Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", MscorlibRef)
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef})
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Const expectedError = "error BC35000: Requested operation is not available because the runtime library function 'Microsoft.VisualBasic.CompilerServices.Operators.CompareObjectEqual' is not defined."
             Dim expectedMissingAssemblyIdentity = EvaluationContextBase.MicrosoftVisualBasicIdentity
@@ -247,9 +249,13 @@ End Class
 "
 
             Dim comp = CreateCompilationWithReferences({VisualBasicSyntaxTree.ParseText(source)}, {MscorlibRef}.Concat(WinRtRefs), TestOptions.DebugDll)
+
             Dim runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI")
             Assert.True(runtimeAssemblies.Any())
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies))
+
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef}.Concat(runtimeAssemblies))
+            Dim context = CreateMethodContext(runtime, "C.M")
+
             Dim globalNamespace = context.Compilation.GlobalNamespace
 
             Dim expectedIdentity = New AssemblyIdentity("Windows.Storage", contentType:=AssemblyContentType.WindowsRuntime)
@@ -285,8 +291,8 @@ Public Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, {SystemCoreRef}, TestOptions.DebugDll)
-            comp.AssertNoErrors()
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", MscorlibRef)
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef})
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Const expectedErrorTemplate = "error BC30456: '{0}' is not a member of 'Integer()'."
             Dim expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity
@@ -334,20 +340,9 @@ Public Class C
 End Class
 "
             Dim comp = CreateCompilationWithMscorlib({source}, {}, TestOptions.DebugDll)
+            Dim runtime = CreateRuntimeInstance(comp, {CSharpRef})
+            Dim context = CreateMethodContext(runtime, "C.M")
 
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim unusedReferences As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
-
-            Dim runtime = CreateRuntimeInstance(
-                GetUniqueName(),
-                ImmutableArray.Create(CSharpRef, ExpressionCompilerTestHelpers.IntrinsicAssemblyReference),
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
-            Dim context = CreateMethodContext(
-                runtime,
-                "C.M")
             Dim aliases = ImmutableArray.Create(ExceptionAlias("Microsoft.CSharp.RuntimeBinder.RuntimeBinderException, Microsoft.CSharp, Version = 4.0.0.0, Culture = neutral, PublicKeyToken = b03f5f7f11d50a3a", stowed:=True))
 
             Const expectedError = "error BC30002: Type 'System.Void' is not defined."
@@ -385,7 +380,9 @@ End Class
             Dim comp = CreateCompilationWithReferences({VisualBasicSyntaxTree.ParseText(source)}, {MscorlibRef}.Concat(WinRtRefs), TestOptions.DebugDll)
             Dim runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage")
             Assert.True(runtimeAssemblies.Any())
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies))
+
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef}.Concat(runtimeAssemblies))
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Const expectedError = "error BC30456: 'UI' is not a member of 'Windows'."
             Dim expectedMissingAssemblyIdentity = New AssemblyIdentity("Windows.UI", contentType:=System.Reflection.AssemblyContentType.WindowsRuntime)
@@ -423,7 +420,9 @@ End Class
             Dim comp = CreateCompilationWithReferences({VisualBasicSyntaxTree.ParseText(source)}, {MscorlibRef}.Concat(WinRtRefs), TestOptions.DebugDll)
             Dim runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI")
             Assert.True(runtimeAssemblies.Any())
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies))
+
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef}.Concat(runtimeAssemblies))
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Const expectedError = "error BC30456: 'Xaml' is not a member of 'Windows.UI'."
             Dim expectedMissingAssemblyIdentity = New AssemblyIdentity("Windows.UI.Xaml", contentType:=System.Reflection.AssemblyContentType.WindowsRuntime)
@@ -456,9 +455,12 @@ End Class
 "
 
             Dim comp = CreateCompilationWithReferences({VisualBasicSyntaxTree.ParseText(source)}, {MscorlibRef}.Concat(WinRtRefs), TestOptions.DebugDll)
+
             Dim runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage")
             Assert.True(runtimeAssemblies.Any())
-            Dim context = CreateMethodContextWithReferences(comp, "C.M", ImmutableArray.Create(MscorlibRef).Concat(runtimeAssemblies))
+
+            Dim runtime = CreateRuntimeInstance(comp, {MscorlibRef}.Concat(runtimeAssemblies))
+            Dim context = CreateMethodContext(runtime, "C.M")
 
             Const expectedError = "error BC30002: Type 'Windows.UI.Colors' is not defined."
             Dim expectedMissingAssemblyIdentity = New AssemblyIdentity("Windows.UI", contentType:=System.Reflection.AssemblyContentType.WindowsRuntime)
@@ -531,14 +533,13 @@ Class UseLinq
 End Class"
 
             Dim compilation = CreateCompilationWithMscorlib({source}, references:={SystemCoreRef})
-            Dim exeBytes() As Byte = Nothing, pdbBytes() As Byte = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            compilation.EmitAndGetReferences(exeBytes, pdbBytes, references)
-            Dim systemCore = SystemCoreRef.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing)
-            Dim referencesWithoutSystemCore = references.Where(Function(r) r IsNot SystemCoreRef).ToImmutableArray()
-            Dim runtime = CreateRuntimeInstance(ExpressionCompilerUtilities.GenerateUniqueName(), referencesWithoutSystemCore.AddIntrinsicAssembly(), exeBytes, symReader:=Nothing)
+
+            Dim runtime = CreateRuntimeInstance(compilation, {MscorlibRef})
             Dim context = CreateMethodContext(runtime, "C.Main")
-            Dim fakeSystemLinq = CreateCompilationWithMscorlib({""}, options:=TestOptions.ReleaseDll, assemblyName:="System.Linq").EmitToImageReference().ToModuleInstance(fullImage:=Nothing, symReader:=Nothing)
+
+            Dim systemCore = SystemCoreRef.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing)
+            Dim fakeSystemLinq = CreateCompilationWithMscorlib({""}, options:=TestOptions.ReleaseDll, assemblyName:="System.Linq").
+                EmitToImageReference().ToModuleInstance(fullImage:=Nothing, symReader:=Nothing)
 
             Dim errorMessage As String = Nothing
             Dim testData As CompilationTestData = Nothing
@@ -569,20 +570,6 @@ End Class"
 
             Assert.Equal(2, retryCount)
         End Sub
-
-        Private Function CreateMethodContextWithReferences(comp As Compilation, methodName As String, ParamArray references As MetadataReference()) As EvaluationContext
-            Return CreateMethodContextWithReferences(comp, methodName, ImmutableArray.CreateRange(references))
-        End Function
-
-        Private Function CreateMethodContextWithReferences(comp As Compilation, methodName As String, references As ImmutableArray(Of MetadataReference)) As EvaluationContext
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim unusedReferences As ImmutableArray(Of MetadataReference) = Nothing
-            comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
-
-            Dim runtime = CreateRuntimeInstance(GetUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes))
-            Return CreateMethodContext(runtime, methodName)
-        End Function
 
         Private Shared Function GetMissingAssemblyIdentities(code As ERRID, ParamArray arguments() As Object) As ImmutableArray(Of AssemblyIdentity)
             Return GetMissingAssemblyIdentities(code, arguments, globalNamespace:=Nothing)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -538,8 +538,7 @@ End Class"
             Dim context = CreateMethodContext(runtime, "C.Main")
 
             Dim systemCore = SystemCoreRef.ToModuleInstance()
-            Dim fakeSystemLinq = CreateCompilationWithMscorlib({""}, options:=TestOptions.ReleaseDll, assemblyName:="System.Linq").
-                EmitToImageReference().ToModuleInstance()
+            Dim fakeSystemLinq = CreateCompilationWithMscorlib({""}, options:=TestOptions.ReleaseDll, assemblyName:="System.Linq").ToModuleInstance()
 
             Dim errorMessage As String = Nothing
             Dim testData As CompilationTestData = Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -336,8 +336,7 @@ End Class
             Dim exeBytes As Byte() = Nothing
             Dim pdbBytes As Byte() = Nothing
             Dim unusedReferences As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
 
             Dim runtime = CreateRuntimeInstance(
                 GetUniqueName(),
@@ -577,8 +576,7 @@ End Class"
             Dim exeBytes As Byte() = Nothing
             Dim pdbBytes As Byte() = Nothing
             Dim unusedReferences As ImmutableArray(Of MetadataReference) = Nothing
-            Dim result = comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
-            Assert.True(result)
+            comp.EmitAndGetReferences(exeBytes, pdbBytes, unusedReferences)
 
             Dim runtime = CreateRuntimeInstance(GetUniqueName(), references, exeBytes, SymReaderFactory.CreateReader(pdbBytes))
             Return CreateMethodContext(runtime, methodName)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -496,7 +496,7 @@ End Class
             Dim context = CreateMethodContext(runtime, "C.M")
 
             Dim missingModule = runtime.Modules.First()
-            Dim missingIdentity = missingModule.MetadataReader.ReadAssemblyIdentityOrThrow()
+            Dim missingIdentity = missingModule.GetMetadataReader().ReadAssemblyIdentityOrThrow()
 
             Dim numRetries = 0
             Dim errorMessage As String = Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -537,9 +537,9 @@ End Class"
             Dim runtime = CreateRuntimeInstance(compilation, {MscorlibRef})
             Dim context = CreateMethodContext(runtime, "C.Main")
 
-            Dim systemCore = SystemCoreRef.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing)
+            Dim systemCore = SystemCoreRef.ToModuleInstance()
             Dim fakeSystemLinq = CreateCompilationWithMscorlib({""}, options:=TestOptions.ReleaseDll, assemblyName:="System.Linq").
-                EmitToImageReference().ToModuleInstance(fullImage:=Nothing, symReader:=Nothing)
+                EmitToImageReference().ToModuleInstance()
 
             Dim errorMessage As String = Nothing
             Dim testData As CompilationTestData = Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -4,16 +4,18 @@ Imports System.Collections.Immutable
 Imports System.Reflection
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class MissingAssemblyTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/NoPIATests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/NoPIATests.vb
@@ -2,11 +2,12 @@
 
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class NoPIATests
         Inherits ExpressionCompilerTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
@@ -808,37 +808,31 @@ Class C
         Dim o As New A(Of Object)()
     End Sub
 End Class"
-            Dim assemblyNameA = "397300B1-A"
-            Dim publicKeyA = ImmutableArray.CreateRange(Of Byte)({&H00, &H24, &H00, &H00, &H04, &H80, &H00, &H00, &H94, &H00, &H00, &H00, &H06, &H02, &H00, &H00, &H00, &H24, &H00, &H00, &H52, &H53, &H41, &H31, &H00, &H04, &H00, &H00, &H01, &H00, &H01, &H00, &HED, &HD3, &H22, &HCB, &H6B, &HF8, &HD4, &HA2, &HFC, &HCC, &H87, &H37, &H04, &H06, &H04, &HCE, &HE7, &HB2, &HA6, &HF8, &H4A, &HEE, &HF3, &H19, &HDF, &H5B, &H95, &HE3, &H7A, &H6A, &H28, &H24, &HA4, &H0A, &H83, &H83, &HBD, &HBA, &HF2, &HF2, &H52, &H20, &HE9, &HAA, &H3B, &HD1, &HDD, &HE4, &H9A, &H9A, &H9C, &HC0, &H30, &H8F, &H01, &H40, &H06, &HE0, &H2B, &H95, &H62, &H89, &H2A, &H34, &H75, &H22, &H68, &H64, &H6E, &H7C, &H2E, &H83, &H50, &H5A, &HCE, &H7B, &H0B, &HE8, &HF8, &H71, &HE6, &HF7, &H73, &H8E, &HEB, &H84, &HD2, &H73, &H5D, &H9D, &HBE, &H5E, &HF5, &H90, &HF9, &HAB, &H0A, &H10, &H7E, &H23, &H48, &HF4, &HAD, &H70, &H2E, &HF7, &HD4, &H51, &HD5, &H8B, &H3A, &HF7, &HCA, &H90, &H4C, &HDC, &H80, &H19, &H26, &H65, &HC9, &H37, &HBD, &H52, &H81, &HF1, &H8B, &HCD})
+            Const assemblyNameA = "397300B1-A"
+            Const assemblyNameB = "397300B1-B"
+
+            Dim publicKeyA = ImmutableArray.CreateRange(Of Byte)({&H0, &H24, &H0, &H0, &H4, &H80, &H0, &H0, &H94, &H0, &H0, &H0, &H6, &H2, &H0, &H0, &H0, &H24, &H0, &H0, &H52, &H53, &H41, &H31, &H0, &H4, &H0, &H0, &H1, &H0, &H1, &H0, &HED, &HD3, &H22, &HCB, &H6B, &HF8, &HD4, &HA2, &HFC, &HCC, &H87, &H37, &H4, &H6, &H4, &HCE, &HE7, &HB2, &HA6, &HF8, &H4A, &HEE, &HF3, &H19, &HDF, &H5B, &H95, &HE3, &H7A, &H6A, &H28, &H24, &HA4, &HA, &H83, &H83, &HBD, &HBA, &HF2, &HF2, &H52, &H20, &HE9, &HAA, &H3B, &HD1, &HDD, &HE4, &H9A, &H9A, &H9C, &HC0, &H30, &H8F, &H1, &H40, &H6, &HE0, &H2B, &H95, &H62, &H89, &H2A, &H34, &H75, &H22, &H68, &H64, &H6E, &H7C, &H2E, &H83, &H50, &H5A, &HCE, &H7B, &HB, &HE8, &HF8, &H71, &HE6, &HF7, &H73, &H8E, &HEB, &H84, &HD2, &H73, &H5D, &H9D, &HBE, &H5E, &HF5, &H90, &HF9, &HAB, &HA, &H10, &H7E, &H23, &H48, &HF4, &HAD, &H70, &H2E, &HF7, &HD4, &H51, &HD5, &H8B, &H3A, &HF7, &HCA, &H90, &H4C, &HDC, &H80, &H19, &H26, &H65, &HC9, &H37, &HBD, &H52, &H81, &HF1, &H8B, &HCD})
+
             Dim compilationA1 = CreateCompilation(
                 New AssemblyIdentity(assemblyNameA, New Version(1, 1, 1, 1), cultureName:="", publicKeyOrToken:=publicKeyA, hasPublicKey:=True),
                 {sourceA},
                 references:={MscorlibRef_v20},
                 options:=TestOptions.DebugDll.WithDelaySign(True))
-            Dim referenceA1 = compilationA1.EmitToImageReference()
-            Dim assemblyNameB = "397300B1-B"
+
             Dim compilationB1 = CreateCompilation(
                 New AssemblyIdentity(assemblyNameB, New Version(1, 2, 2, 2)),
                 {sourceB},
-                references:={MscorlibRef_v20, referenceA1},
+                references:={MscorlibRef_v20, compilationA1.EmitToImageReference()},
                 options:=TestOptions.DebugDll)
 
             ' Use mscorlib v4.0.0.0 and A v2.1.2.1 at runtime.
-            Dim exeBytes As Byte() = Nothing
-            Dim pdbBytes As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            compilationB1.EmitAndGetReferences(exeBytes, pdbBytes, references)
             Dim compilationA2 = CreateCompilation(
                 New AssemblyIdentity(assemblyNameA, New Version(2, 1, 2, 1), cultureName:="", publicKeyOrToken:=publicKeyA, hasPublicKey:=True),
                 {sourceA},
                 references:={MscorlibRef_v20},
                 options:=TestOptions.DebugDll.WithDelaySign(True))
-            Dim referenceA2 = compilationA2.EmitToImageReference()
-            Dim runtime = CreateRuntimeInstance(
-                assemblyNameB,
-                ImmutableArray.Create(MscorlibRef, referenceA2).AddIntrinsicAssembly(),
-                exeBytes,
-                SymReaderFactory.CreateReader(pdbBytes))
+
+            Dim runtime = CreateRuntimeInstance(compilationB1, {MscorlibRef, compilationA2.EmitToImageReference()})
 
             ' GetType(Exception), GetType(A(Of B(Of Object))), GetType(B(Of A(Of Object)()))
             Dim context = CreateMethodContext(
@@ -911,24 +905,24 @@ Class B
 End Class"
             Dim assemblyNameA = "0B93FF0B-31A2-47C8-B24D-16A2D77AB5C5"
             Dim compilationA = CreateCompilationWithMscorlibAndVBRuntime(MakeSources(sourceA, assemblyName:=assemblyNameA), options:=TestOptions.DebugDll)
-            Dim exeA As Byte() = Nothing
-            Dim pdbA As Byte() = Nothing
+            Dim exeA As ImmutableArray(Of Byte) = Nothing
+            Dim pdbA As ImmutableArray(Of Byte) = Nothing
             Dim referencesA As ImmutableArray(Of MetadataReference) = Nothing
             compilationA.EmitAndGetReferences(exeA, pdbA, referencesA)
             Dim referenceA = AssemblyMetadata.CreateFromImage(exeA).GetReference()
 
             Dim assemblyNameB = "9BBC6622-86EB-4EC5-94A1-9A1E6D0C24B9"
             Dim compilationB = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(MakeSources(sourceB, assemblyName:=assemblyNameB), options:=TestOptions.DebugDll, additionalRefs:={referenceA})
-            Dim exeB As Byte() = Nothing
-            Dim pdbB As Byte() = Nothing
+            Dim exeB As ImmutableArray(Of Byte) = Nothing
+            Dim pdbB As ImmutableArray(Of Byte) = Nothing
             Dim referencesB As ImmutableArray(Of MetadataReference) = Nothing
             compilationB.EmitAndGetReferences(exeB, pdbB, referencesB)
             Dim referenceB = AssemblyMetadata.CreateFromImage(exeB).GetReference()
 
             Dim modulesBuilder = ArrayBuilder(Of ModuleInstance).GetInstance()
             modulesBuilder.Add(MscorlibRef.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing))
-            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage:=exeA, symReader:=SymReaderFactory.CreateReader(pdbA)))
-            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage:=exeB, symReader:=SymReaderFactory.CreateReader(pdbB)))
+            modulesBuilder.Add(referenceA.ToModuleInstance(fullImage:=exeA.ToArray(), symReader:=SymReaderFactory.CreateReader(pdbA)))
+            modulesBuilder.Add(referenceB.ToModuleInstance(fullImage:=exeB.ToArray(), symReader:=SymReaderFactory.CreateReader(pdbB)))
             modulesBuilder.Add(ExpressionCompilerTestHelpers.IntrinsicAssemblyReference.ToModuleInstance(fullImage:=Nothing, symReader:=Nothing))
 
             Using runtime = New RuntimeInstance(modulesBuilder.ToImmutableAndFree())

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
@@ -908,7 +908,7 @@ End Class"
             Dim moduleA = compilationA.ToModuleInstance()
 
             Dim assemblyNameB = "9BBC6622-86EB-4EC5-94A1-9A1E6D0C24B9"
-            Dim compilationB = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(MakeSources(sourceB, assemblyName:=assemblyNameB), options:=TestOptions.DebugDll, additionalRefs:={moduleA.MetadataReference})
+            Dim compilationB = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(MakeSources(sourceB, assemblyName:=assemblyNameB), options:=TestOptions.DebugDll, additionalRefs:={moduleA.GetReference()})
             Dim moduleB = compilationB.ToModuleInstance()
 
             Dim runtime = CreateRuntimeInstance(

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/PseudoVariableTests.vb
@@ -3,8 +3,10 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
 Imports Microsoft.VisualStudio.Debugger.Clr
 Imports Microsoft.VisualStudio.Debugger.Evaluation
@@ -12,7 +14,7 @@ Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class PseudoVariableTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -1,17 +1,18 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
-Imports System.Linq
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class ReferencedModulesTests
         Inherits ExpressionCompilerTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -38,7 +38,7 @@ End Class"
 End Class"
             ' Assembly A, multiple versions, strong name.
             Dim assemblyNameA = ExpressionCompilerUtilities.GenerateUniqueName()
-            Dim publicKeyA = ImmutableArray.CreateRange(Of Byte)({&H00, &H24, &H00, &H00, &H04, &H80, &H00, &H00, &H94, &H00, &H00, &H00, &H06, &H02, &H00, &H00, &H00, &H24, &H00, &H00, &H52, &H53, &H41, &H31, &H00, &H04, &H00, &H00, &H01, &H00, &H01, &H00, &HED, &HD3, &H22, &HCB, &H6B, &HF8, &HD4, &HA2, &HFC, &HCC, &H87, &H37, &H04, &H06, &H04, &HCE, &HE7, &HB2, &HA6, &HF8, &H4A, &HEE, &HF3, &H19, &HDF, &H5B, &H95, &HE3, &H7A, &H6A, &H28, &H24, &HA4, &H0A, &H83, &H83, &HBD, &HBA, &HF2, &HF2, &H52, &H20, &HE9, &HAA, &H3B, &HD1, &HDD, &HE4, &H9A, &H9A, &H9C, &HC0, &H30, &H8F, &H01, &H40, &H06, &HE0, &H2B, &H95, &H62, &H89, &H2A, &H34, &H75, &H22, &H68, &H64, &H6E, &H7C, &H2E, &H83, &H50, &H5A, &HCE, &H7B, &H0B, &HE8, &HF8, &H71, &HE6, &HF7, &H73, &H8E, &HEB, &H84, &HD2, &H73, &H5D, &H9D, &HBE, &H5E, &HF5, &H90, &HF9, &HAB, &H0A, &H10, &H7E, &H23, &H48, &HF4, &HAD, &H70, &H2E, &HF7, &HD4, &H51, &HD5, &H8B, &H3A, &HF7, &HCA, &H90, &H4C, &HDC, &H80, &H19, &H26, &H65, &HC9, &H37, &HBD, &H52, &H81, &HF1, &H8B, &HCD})
+            Dim publicKeyA = ImmutableArray.CreateRange(Of Byte)({&H0, &H24, &H0, &H0, &H4, &H80, &H0, &H0, &H94, &H0, &H0, &H0, &H6, &H2, &H0, &H0, &H0, &H24, &H0, &H0, &H52, &H53, &H41, &H31, &H0, &H4, &H0, &H0, &H1, &H0, &H1, &H0, &HED, &HD3, &H22, &HCB, &H6B, &HF8, &HD4, &HA2, &HFC, &HCC, &H87, &H37, &H4, &H6, &H4, &HCE, &HE7, &HB2, &HA6, &HF8, &H4A, &HEE, &HF3, &H19, &HDF, &H5B, &H95, &HE3, &H7A, &H6A, &H28, &H24, &HA4, &HA, &H83, &H83, &HBD, &HBA, &HF2, &HF2, &H52, &H20, &HE9, &HAA, &H3B, &HD1, &HDD, &HE4, &H9A, &H9A, &H9C, &HC0, &H30, &H8F, &H1, &H40, &H6, &HE0, &H2B, &H95, &H62, &H89, &H2A, &H34, &H75, &H22, &H68, &H64, &H6E, &H7C, &H2E, &H83, &H50, &H5A, &HCE, &H7B, &HB, &HE8, &HF8, &H71, &HE6, &HF7, &H73, &H8E, &HEB, &H84, &HD2, &H73, &H5D, &H9D, &HBE, &H5E, &HF5, &H90, &HF9, &HAB, &HA, &H10, &H7E, &H23, &H48, &HF4, &HAD, &H70, &H2E, &HF7, &HD4, &H51, &HD5, &H8B, &H3A, &HF7, &HCA, &H90, &H4C, &HDC, &H80, &H19, &H26, &H65, &HC9, &H37, &HBD, &H52, &H81, &HF1, &H8B, &HCD})
             Dim compilationAS1 = CreateCompilation(
                 New AssemblyIdentity(assemblyNameA, New Version(1, 1, 1, 1), cultureName:="", publicKeyOrToken:=publicKeyA, hasPublicKey:=True),
                 {sourceA},
@@ -56,7 +56,7 @@ End Class"
 
             ' Assembly B, multiple versions, strong name.
             Dim assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName()
-            Dim publicKeyB = ImmutableArray.CreateRange(Of Byte)({&H00, &H24, &H00, &H00, &H04, &H80, &H00, &H00, &H94, &H00, &H00, &H00, &H06, &H02, &H00, &H00, &H00, &H24, &H00, &H00, &H53, &H52, &H41, &H31, &H00, &H04, &H00, &H00, &H01, &H00, &H01, &H00, &HED, &HD3, &H22, &HCB, &H6B, &HF8, &HD4, &HA2, &HFC, &HCC, &H87, &H37, &H04, &H06, &H04, &HCE, &HE7, &HB2, &HA6, &HF8, &H4A, &HEE, &HF3, &H19, &HDF, &H5B, &H95, &HE3, &H7A, &H6A, &H28, &H24, &HA4, &H0A, &H83, &H83, &HBD, &HBA, &HF2, &HF2, &H52, &H20, &HE9, &HAA, &H3B, &HD1, &HDD, &HE4, &H9A, &H9A, &H9C, &HC0, &H30, &H8F, &H01, &H40, &H06, &HE0, &H2B, &H95, &H62, &H89, &H2A, &H34, &H75, &H22, &H68, &H64, &H6E, &H7C, &H2E, &H83, &H50, &H5A, &HCE, &H7B, &H0B, &HE8, &HF8, &H71, &HE6, &HF7, &H73, &H8E, &HEB, &H84, &HD2, &H73, &H5D, &H9D, &HBE, &H5E, &HF5, &H90, &HF9, &HAB, &H0A, &H10, &H7E, &H23, &H48, &HF4, &HAD, &H70, &H2E, &HF7, &HD4, &H51, &HD5, &H8B, &H3A, &HF7, &HCA, &H90, &H4C, &HDC, &H80, &H19, &H26, &H65, &HC9, &H37, &HBD, &H52, &H81, &HF1, &H8B, &HCD})
+            Dim publicKeyB = ImmutableArray.CreateRange(Of Byte)({&H0, &H24, &H0, &H0, &H4, &H80, &H0, &H0, &H94, &H0, &H0, &H0, &H6, &H2, &H0, &H0, &H0, &H24, &H0, &H0, &H53, &H52, &H41, &H31, &H0, &H4, &H0, &H0, &H1, &H0, &H1, &H0, &HED, &HD3, &H22, &HCB, &H6B, &HF8, &HD4, &HA2, &HFC, &HCC, &H87, &H37, &H4, &H6, &H4, &HCE, &HE7, &HB2, &HA6, &HF8, &H4A, &HEE, &HF3, &H19, &HDF, &H5B, &H95, &HE3, &H7A, &H6A, &H28, &H24, &HA4, &HA, &H83, &H83, &HBD, &HBA, &HF2, &HF2, &H52, &H20, &HE9, &HAA, &H3B, &HD1, &HDD, &HE4, &H9A, &H9A, &H9C, &HC0, &H30, &H8F, &H1, &H40, &H6, &HE0, &H2B, &H95, &H62, &H89, &H2A, &H34, &H75, &H22, &H68, &H64, &H6E, &H7C, &H2E, &H83, &H50, &H5A, &HCE, &H7B, &HB, &HE8, &HF8, &H71, &HE6, &HF7, &H73, &H8E, &HEB, &H84, &HD2, &H73, &H5D, &H9D, &HBE, &H5E, &HF5, &H90, &HF9, &HAB, &HA, &H10, &H7E, &H23, &H48, &HF4, &HAD, &H70, &H2E, &HF7, &HD4, &H51, &HD5, &H8B, &H3A, &HF7, &HCA, &H90, &H4C, &HDC, &H80, &H19, &H26, &H65, &HC9, &H37, &HBD, &H52, &H81, &HF1, &H8B, &HCD})
             Dim compilationBS1 = CreateCompilation(
                 New AssemblyIdentity(assemblyNameB, New Version(1, 1, 1, 1), cultureName:="", publicKeyOrToken:=publicKeyB, hasPublicKey:=True),
                 {sourceB},
@@ -73,73 +73,57 @@ End Class"
             Dim identityBS2 = referenceBS2.GetAssemblyIdentity()
 
             ' Assembly C, multiple versions, not strong name.
-            Dim assemblyNameC = ExpressionCompilerUtilities.GenerateUniqueName()
             Dim compilationCN1 = CreateCompilation(
-                New AssemblyIdentity(assemblyNameC, New Version(1, 1, 1, 1)),
+                New AssemblyIdentity("C", New Version(1, 1, 1, 1)),
                 {sourceC},
                 references:={MscorlibRef, referenceBS1},
                 options:=TestOptions.DebugDll)
-            Dim exeBytesC1 As Byte() = Nothing
-            Dim pdbBytesC1 As Byte() = Nothing
-            Dim references As ImmutableArray(Of MetadataReference) = Nothing
-            compilationCN1.EmitAndGetReferences(exeBytesC1, pdbBytesC1, references)
-            Dim compilationCN2 = CreateCompilation(
-                New AssemblyIdentity(assemblyNameC, New Version(2, 1, 1, 1)),
-                {sourceC},
-                references:={MscorlibRef, referenceBS2},
-                options:=TestOptions.DebugDll)
-            Dim exeBytesC2 As Byte() = Nothing
-            Dim pdbBytesC2 As Byte() = Nothing
-            compilationCN1.EmitAndGetReferences(exeBytesC2, pdbBytesC2, references)
 
             ' Duplicate assemblies, target module referencing BS1.
-            Using runtime = CreateRuntimeInstance(
-                assemblyNameC,
-                ImmutableArray.Create(MscorlibRef, referenceAS1, referenceAS2, referenceBS2, referenceBS1, referenceBS2),
-                exeBytesC1,
-                SymReaderFactory.CreateReader(pdbBytesC1))
+            Dim runtime = CreateRuntimeInstance(
+                compilationCN1,
+                {MscorlibRef, referenceAS1, referenceAS2, referenceBS2, referenceBS1, referenceBS2})
 
-                Dim typeBlocks As ImmutableArray(Of MetadataBlock) = Nothing
-                Dim methodBlocks As ImmutableArray(Of MetadataBlock) = Nothing
-                Dim moduleVersionId As Guid = Nothing
-                Dim symReader As ISymUnmanagedReader = Nothing
-                Dim typeToken = 0
-                Dim methodToken = 0
-                Dim localSignatureToken = 0
-                GetContextState(runtime, "C", typeBlocks, moduleVersionId, symReader, typeToken, localSignatureToken)
-                GetContextState(runtime, "C.M", methodBlocks, moduleVersionId, symReader, methodToken, localSignatureToken)
+            Dim typeBlocks As ImmutableArray(Of MetadataBlock) = Nothing
+            Dim methodBlocks As ImmutableArray(Of MetadataBlock) = Nothing
+            Dim moduleVersionId As Guid = Nothing
+            Dim symReader As ISymUnmanagedReader = Nothing
+            Dim typeToken = 0
+            Dim methodToken = 0
+            Dim localSignatureToken = 0
+            GetContextState(runtime, "C", typeBlocks, moduleVersionId, symReader, typeToken, localSignatureToken)
+            GetContextState(runtime, "C.M", methodBlocks, moduleVersionId, symReader, methodToken, localSignatureToken)
 
-                ' Compile expression with type context.
-                Dim context = EvaluationContext.CreateTypeContext(
-                    Nothing,
-                    typeBlocks,
-                    moduleVersionId,
-                    typeToken)
-                Dim errorMessage As String = Nothing
-                ' A is ambiguous since there were no explicit references to AS1 or AS2.
-                context.CompileExpression("New A()", errorMessage)
-                Assert.Equal(errorMessage, "error BC30554: 'A' is ambiguous.")
-                ' Ideally, B should be resolved to BS1.
-                context.CompileExpression("New B()", errorMessage)
-                Assert.Equal(errorMessage, "error BC30554: 'B' is ambiguous.")
+            ' Compile expression with type context.
+            Dim context = EvaluationContext.CreateTypeContext(
+                Nothing,
+                typeBlocks,
+                moduleVersionId,
+                typeToken)
+            Dim errorMessage As String = Nothing
+            ' A is ambiguous since there were no explicit references to AS1 or AS2.
+            context.CompileExpression("New A()", errorMessage)
+            Assert.Equal(errorMessage, "error BC30554: 'A' is ambiguous.")
+            ' Ideally, B should be resolved to BS1.
+            context.CompileExpression("New B()", errorMessage)
+            Assert.Equal(errorMessage, "error BC30554: 'B' is ambiguous.")
 
-                ' Compile expression with method context.
-                Dim previous = New VisualBasicMetadataContext(typeBlocks, context)
-                context = EvaluationContext.CreateMethodContext(
-                    previous,
-                    methodBlocks,
-                    MakeDummyLazyAssemblyReaders(),
-                    symReader,
-                    moduleVersionId,
-                    methodToken,
-                    methodVersion:=1,
-                    ilOffset:=0,
-                    localSignatureToken:=localSignatureToken)
-                Assert.Equal(previous.Compilation, context.Compilation) ' re-use type context compilation
-                ' Ideally, B should be resolved to BS1.
-                context.CompileExpression("New B()", errorMessage)
-                Assert.Equal(errorMessage, "error BC30554: 'B' is ambiguous.")
-            End Using
+            ' Compile expression with method context.
+            Dim previous = New VisualBasicMetadataContext(typeBlocks, context)
+            context = EvaluationContext.CreateMethodContext(
+                previous,
+                methodBlocks,
+                MakeDummyLazyAssemblyReaders(),
+                symReader,
+                moduleVersionId,
+                methodToken,
+                methodVersion:=1,
+                ilOffset:=0,
+                localSignatureToken:=localSignatureToken)
+            Assert.Equal(previous.Compilation, context.Compilation) ' re-use type context compilation
+            ' Ideally, B should be resolved to BS1.
+            context.CompileExpression("New B()", errorMessage)
+            Assert.Equal(errorMessage, "error BC30554: 'B' is ambiguous.")
         End Sub
 
         <Fact>
@@ -192,25 +176,25 @@ End Class"
                 MakeSources(sourceA, assemblyName:=assemblyNameA),
                 options:=TestOptions.DebugDll,
                 additionalRefs:={SystemCoreRef})
-            Dim exeBytesA As Byte() = Nothing
-            Dim pdbBytesA As Byte() = Nothing
+            Dim exeBytesA As ImmutableArray(Of Byte) = Nothing
+            Dim pdbBytesA As ImmutableArray(Of Byte) = Nothing
             Dim referencesA As ImmutableArray(Of MetadataReference) = Nothing
             compilationA.EmitAndGetReferences(exeBytesA, pdbBytesA, referencesA)
             Dim referenceA = AssemblyMetadata.CreateFromImage(exeBytesA).GetReference(display:=assemblyNameA)
             Dim identityA = referenceA.GetAssemblyIdentity()
-            Dim moduleA = referenceA.ToModuleInstance(exeBytesA, SymReaderFactory.CreateReader(pdbBytesA))
+            Dim moduleA = referenceA.ToModuleInstance(exeBytesA.ToArray(), SymReaderFactory.CreateReader(pdbBytesA))
 
             Dim assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName()
             Dim compilationB = CreateCompilationWithMscorlibAndVBRuntime(
                 MakeSources(sourceB, assemblyName:=assemblyNameB),
                 options:=TestOptions.DebugDll,
                 additionalRefs:={SystemCoreRef, referenceA})
-            Dim exeBytesB As Byte() = Nothing
-            Dim pdbBytesB As Byte() = Nothing
+            Dim exeBytesB As ImmutableArray(Of Byte) = Nothing
+            Dim pdbBytesB As ImmutableArray(Of Byte) = Nothing
             Dim referencesB As ImmutableArray(Of MetadataReference) = Nothing
             compilationB.EmitAndGetReferences(exeBytesB, pdbBytesB, referencesB)
             Dim referenceB = AssemblyMetadata.CreateFromImage(exeBytesB).GetReference(display:=assemblyNameB)
-            Dim moduleB = referenceB.ToModuleInstance(exeBytesB, SymReaderFactory.CreateReader(pdbBytesB))
+            Dim moduleB = referenceB.ToModuleInstance(exeBytesB.ToArray(), SymReaderFactory.CreateReader(pdbBytesB))
 
             Dim moduleBuilder = ArrayBuilder(Of ModuleInstance).GetInstance()
             moduleBuilder.AddRange(referencesA.Select(Function(r) r.ToModuleInstance(Nothing, Nothing)))
@@ -319,72 +303,59 @@ Class C
         F()
     End Sub
 End Class"
-            Dim assemblyNameA = ExpressionCompilerUtilities.GenerateUniqueName()
-            Dim compilationA1 = CreateCompilation(
-                New AssemblyIdentity(assemblyNameA, New Version(1, 1, 1, 1)),
+            Dim referenceA1 = CreateCompilation(
+                New AssemblyIdentity("A", New Version(1, 1, 1, 1)),
                 {sourceA},
                 options:=TestOptions.DebugDll,
-                references:={MscorlibRef, SystemRef, MsvbRef})
-            Dim referenceA1 = compilationA1.EmitToImageReference()
+                references:={MscorlibRef, SystemRef, MsvbRef}).EmitToImageReference()
 
-            Dim compilationA2 = CreateCompilation(
-                New AssemblyIdentity(assemblyNameA, New Version(2, 1, 1, 2)),
+            Dim referenceA2 = CreateCompilation(
+                New AssemblyIdentity("A", New Version(2, 1, 1, 2)),
                 {sourceA},
                 options:=TestOptions.DebugDll,
-                references:={MscorlibRef, SystemRef, MsvbRef})
-            Dim referenceA2 = compilationA2.EmitToImageReference()
+                references:={MscorlibRef, SystemRef, MsvbRef}).EmitToImageReference()
 
-            Dim assemblyNameB = ExpressionCompilerUtilities.GenerateUniqueName()
             Dim compilationB = CreateCompilation(
-                New AssemblyIdentity(assemblyNameB, New Version(1, 1, 1, 1)),
+                New AssemblyIdentity("B", New Version(1, 1, 1, 1)),
                 {sourceB},
                 options:=TestOptions.DebugDll,
                 references:={MscorlibRef, referenceA1})
-            Dim exeBytesB As Byte() = Nothing
-            Dim pdbBytesB As Byte() = Nothing
-            Dim referencesB As ImmutableArray(Of MetadataReference) = Nothing
-            compilationB.EmitAndGetReferences(exeBytesB, pdbBytesB, referencesB)
 
-            Using runtime = CreateRuntimeInstance(
-                assemblyNameB,
-                ImmutableArray.Create(MscorlibRef, SystemRef, MsvbRef, referenceA1, referenceA2),
-                exeBytesB,
-                SymReaderFactory.CreateReader(pdbBytesB))
+            Dim runtime = CreateRuntimeInstance(compilationB, {MscorlibRef, SystemRef, MsvbRef, referenceA1, referenceA2})
 
-                Dim blocks As ImmutableArray(Of MetadataBlock) = Nothing
-                Dim moduleVersionId As Guid = Nothing
-                Dim symReader As ISymUnmanagedReader = Nothing
-                Dim typeToken = 0
-                Dim methodToken = 0
-                Dim localSignatureToken = 0
-                GetContextState(runtime, "C.M", blocks, moduleVersionId, symReader, methodToken, localSignatureToken)
+            Dim blocks As ImmutableArray(Of MetadataBlock) = Nothing
+            Dim moduleVersionId As Guid = Nothing
+            Dim symReader As ISymUnmanagedReader = Nothing
+            Dim typeToken = 0
+            Dim methodToken = 0
+            Dim localSignatureToken = 0
+            GetContextState(runtime, "C.M", blocks, moduleVersionId, symReader, methodToken, localSignatureToken)
 
-                Dim context = EvaluationContext.CreateMethodContext(
-                    Nothing,
-                    blocks,
-                    MakeDummyLazyAssemblyReaders(),
-                    symReader,
-                    moduleVersionId,
-                    methodToken,
-                    methodVersion:=1,
-                    ilOffset:=0,
-                    localSignatureToken:=localSignatureToken)
-                Dim errorMessage As String = Nothing
-                context.CompileExpression("F()", errorMessage)
-                Assert.Equal(errorMessage, "error BC30562: 'F' is ambiguous between declarations in Modules 'N.M, N.M'.")
+            Dim context = EvaluationContext.CreateMethodContext(
+                Nothing,
+                blocks,
+                MakeDummyLazyAssemblyReaders(),
+                symReader,
+                moduleVersionId,
+                methodToken,
+                methodVersion:=1,
+                ilOffset:=0,
+                localSignatureToken:=localSignatureToken)
+            Dim errorMessage As String = Nothing
+            context.CompileExpression("F()", errorMessage)
+            Assert.Equal(errorMessage, "error BC30562: 'F' is ambiguous between declarations in Modules 'N.M, N.M'.")
 
-                Dim testData As New CompilationTestData()
-                Dim contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken)
-                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "F()", ImmutableArray(Of [Alias]).Empty, contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
-                Assert.Null(errorMessage)
-                testData.GetMethodData("<>x.<>m0").VerifyIL(
+            Dim testData As New CompilationTestData()
+            Dim contextFactory = CreateMethodContextFactory(moduleVersionId, symReader, methodToken, localSignatureToken)
+            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(blocks, "F()", ImmutableArray(Of [Alias]).Empty, contextFactory, getMetaDataBytesPtr:=Nothing, errorMessage:=errorMessage, testData:=testData)
+            Assert.Null(errorMessage)
+            testData.GetMethodData("<>x.<>m0").VerifyIL(
 "{
-  // Code size        6 (0x6)
-  .maxstack  1
-  IL_0000:  call       ""Function N.M.F() As Object""
-  IL_0005:  ret
+// Code size        6 (0x6)
+.maxstack  1
+IL_0000:  call       ""Function N.M.F() As Object""
+IL_0005:  ret
 }")
-            End Using
         End Sub
 
         <WorkItem(1170032, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1170032")>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
@@ -105,15 +105,8 @@ End Class
 
 } // end of class C
 "
-            Dim exeBytes As ImmutableArray(Of Byte) = Nothing
-            Dim pdbBytes As ImmutableArray(Of Byte) = Nothing
-            EmitILToArray(ilSource, appendDefaultHeader:=True, includePdb:=True, assemblyBytes:=exeBytes, pdbBytes:=pdbBytes)
-
-            Dim runtime = CreateRuntimeInstance(
-                references:={MscorlibRef},
-                exeBytes:=exeBytes,
-                symReader:=SymReaderFactory.CreateReader(pdbBytes))
-
+            Dim ilModule = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource)
+            Dim runtime = CreateRuntimeInstance(ilModule, {MscorlibRef})
             Dim context = CreateMethodContext(runtime, "C.Test")
 
             Assert.Equal(DkmEvaluationResultAccessType.Private, GetResultProperties(context, "[Private]").AccessType)
@@ -260,15 +253,8 @@ End Class
 
 } // end of class C
 "
-            Dim exeBytes As ImmutableArray(Of Byte) = Nothing
-            Dim pdbBytes As ImmutableArray(Of Byte) = Nothing
-            EmitILToArray(ilSource, appendDefaultHeader:=True, includePdb:=True, assemblyBytes:=exeBytes, pdbBytes:=pdbBytes)
-
-            Dim runtime = CreateRuntimeInstance(
-                references:={MscorlibRef},
-                exeBytes:=exeBytes,
-                symReader:=SymReaderFactory.CreateReader(pdbBytes))
-
+            Dim ilModule = ExpressionCompilerTestHelpers.GetModuleInstanceForIL(ilSource)
+            Dim runtime = CreateRuntimeInstance(ilModule, {MscorlibRef})
             Dim context = CreateMethodContext(runtime, methodName:="C.Test")
 
             Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "F").ModifierFlags)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
@@ -3,13 +3,15 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class ResultPropertiesTests
         Inherits ExpressionCompilerTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ResultPropertiesTests.vb
@@ -110,11 +110,11 @@ End Class
             EmitILToArray(ilSource, appendDefaultHeader:=True, includePdb:=True, assemblyBytes:=exeBytes, pdbBytes:=pdbBytes)
 
             Dim runtime = CreateRuntimeInstance(
-                assemblyName:=GetUniqueName(),
-                references:=ImmutableArray.Create(MscorlibRef),
-                exeBytes:=exeBytes.ToArray(),
+                references:={MscorlibRef},
+                exeBytes:=exeBytes,
                 symReader:=SymReaderFactory.CreateReader(pdbBytes))
-            Dim context = CreateMethodContext(runtime, methodName:="C.Test")
+
+            Dim context = CreateMethodContext(runtime, "C.Test")
 
             Assert.Equal(DkmEvaluationResultAccessType.Private, GetResultProperties(context, "[Private]").AccessType)
             Assert.Equal(DkmEvaluationResultAccessType.Protected, GetResultProperties(context, "[Protected]").AccessType)
@@ -265,10 +265,10 @@ End Class
             EmitILToArray(ilSource, appendDefaultHeader:=True, includePdb:=True, assemblyBytes:=exeBytes, pdbBytes:=pdbBytes)
 
             Dim runtime = CreateRuntimeInstance(
-                assemblyName:=GetUniqueName(),
-                references:=ImmutableArray.Create(MscorlibRef),
-                exeBytes:=exeBytes.ToArray(),
+                references:={MscorlibRef},
+                exeBytes:=exeBytes,
                 symReader:=SymReaderFactory.CreateReader(pdbBytes))
+
             Dim context = CreateMethodContext(runtime, methodName:="C.Test")
 
             Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "F").ModifierFlags)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StatementTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StatementTests.vb
@@ -4,14 +4,13 @@ Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
-Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class StatementTests
         Inherits ExpressionCompilerTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StaticLocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/StaticLocalsTests.vb
@@ -3,13 +3,13 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.DiaSymReader
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class StaticLocalsTests
         Inherits ExpressionCompilerTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/WinMdTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/WinMdTests.vb
@@ -4,15 +4,16 @@ Imports System.Collections.Immutable
 Imports System.Reflection.Metadata
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
-Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
-Imports Resources = Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests.Resources
+Imports CommonResources = Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests.Resources
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class WinMdTests
         Inherits ExpressionCompilerTestBase
@@ -64,15 +65,15 @@ End Class"
             CompileTimeAndRuntimeAssemblies(
                 ImmutableArray.Create(
                     MscorlibRef,
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.Windows)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.LibraryA)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(Resources.LibraryB).GetReference()),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.Windows)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.LibraryA)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(CommonResources.LibraryB).GetReference()),
                 ImmutableArray.Create(
                     MscorlibRef,
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.Windows_Data)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.Windows_Storage)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.LibraryA)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(Resources.LibraryB).GetReference()),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.Windows_Data)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.Windows_Storage)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.LibraryA)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(CommonResources.LibraryB).GetReference()),
                 "Windows.Storage")
         End Sub
 
@@ -81,15 +82,15 @@ End Class"
             CompileTimeAndRuntimeAssemblies(
                 ImmutableArray.Create(
                     MscorlibRef,
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.Windows)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.LibraryA)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(Resources.LibraryB).GetReference()),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.Windows)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.LibraryA)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(CommonResources.LibraryB).GetReference()),
                 ImmutableArray.Create(
                     MscorlibRef,
-                    AssemblyMetadata.CreateFromImage(ToVersion1_4(Resources.Windows_Data)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_4(Resources.Windows_Storage)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_3(Resources.LibraryA)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(Resources.LibraryB).GetReference()),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_4(CommonResources.Windows_Data)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_4(CommonResources.Windows_Storage)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_3(CommonResources.LibraryA)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(CommonResources.LibraryB).GetReference()),
                 "Windows.Storage")
         End Sub
 
@@ -98,15 +99,15 @@ End Class"
             CompileTimeAndRuntimeAssemblies(
                 ImmutableArray.Create(
                     MscorlibRef,
-                    AssemblyMetadata.CreateFromImage(ToVersion1_4(Resources.Windows_Data)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_4(Resources.Windows_Storage)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_4(Resources.LibraryA)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(Resources.LibraryB).GetReference()),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_4(CommonResources.Windows_Data)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_4(CommonResources.Windows_Storage)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_4(CommonResources.LibraryA)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(CommonResources.LibraryB).GetReference()),
                 ImmutableArray.Create(
                     MscorlibRef,
-                    AssemblyMetadata.CreateFromImage(ToVersion1_4(Resources.Windows)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(ToVersion1_4(Resources.LibraryA)).GetReference(),
-                    AssemblyMetadata.CreateFromImage(Resources.LibraryB).GetReference()),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_4(CommonResources.Windows)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(ToVersion1_4(CommonResources.LibraryA)).GetReference(),
+                    AssemblyMetadata.CreateFromImage(CommonResources.LibraryB).GetReference()),
                 "Windows")
         End Sub
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ArrayExpansionTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ArrayExpansionTests.vb
@@ -3,7 +3,7 @@
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class ArrayExpansionTests : Inherits VisualBasicResultProviderTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/DebuggerTypeProxyAttributeTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/DebuggerTypeProxyAttributeTests.vb
@@ -5,7 +5,7 @@ Imports Microsoft.VisualStudio.Debugger.Clr
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class DebuggerTypeProxyAttributeTests
         Inherits VisualBasicResultProviderTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/DynamicViewTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/DynamicViewTests.vb
@@ -9,7 +9,7 @@ Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class DynamicViewTests : Inherits VisualBasicResultProviderTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ExpansionTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ExpansionTests.vb
@@ -9,7 +9,7 @@ Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class ExpansionTests : Inherits VisualBasicResultProviderTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/FormatSpecifierTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/FormatSpecifierTests.vb
@@ -5,7 +5,7 @@ Imports Microsoft.VisualStudio.Debugger.Clr
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class FormatSpecifierTests
         Inherits VisualBasicResultProviderTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/FullNameTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/FullNameTests.vb
@@ -7,7 +7,7 @@ Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class FullNameTests : Inherits VisualBasicResultProviderTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/Helpers/TestTypeExtensions.vb
@@ -5,7 +5,7 @@ Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Module TestTypeExtensions
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ObjectIdTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ObjectIdTests.vb
@@ -6,7 +6,7 @@ Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class ObjectIdTests
         Inherits VisualBasicResultProviderTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ResultsViewTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ResultsViewTests.vb
@@ -7,7 +7,7 @@ Imports System.Reflection
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class ResultsViewTests
         Inherits VisualBasicResultProviderTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/TypeNameFormatterTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/TypeNameFormatterTests.vb
@@ -9,7 +9,7 @@ Imports Roslyn.Test.Utilities
 Imports Xunit
 Imports Type = Microsoft.VisualStudio.Debugger.Metadata.Type
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class TypeNameFormatterTests : Inherits VisualBasicResultProviderTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/TypeVariablesExpansionTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/TypeVariablesExpansionTests.vb
@@ -6,7 +6,7 @@ Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports System.Collections.Immutable
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class TypeVariablesExpansionTests
         Inherits VisualBasicResultProviderTestBase

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ValueFormatterTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ValueFormatterTests.vb
@@ -6,7 +6,7 @@ Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Xunit
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class ValueFormatterTests : Inherits VisualBasicResultProviderTestBase
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/VisualBasicResultProviderTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/VisualBasicResultProviderTestBase.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 
     Public Class VisualBasicResultProviderTestBase : Inherits ResultProviderTestBase
 

--- a/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
@@ -56,33 +56,30 @@ namespace Roslyn.Test.PdbUtilities
 
         public static ISymUnmanagedReader CreateReader(byte[] pdbImage, byte[] peImageOpt = null)
         {
-            return CreateReader(new MemoryStream(pdbImage), (peImageOpt != null) ? new MemoryStream(peImageOpt) : null);
+            return CreateReader(new MemoryStream(pdbImage), (peImageOpt != null) ? new PEReader(new MemoryStream(peImageOpt)) : null);
         }
 
         public static ISymUnmanagedReader CreateReader(ImmutableArray<byte> pdbImage, ImmutableArray<byte> peImageOpt = default(ImmutableArray<byte>))
         {
-            return CreateReader(new MemoryStream(pdbImage.ToArray()), peImageOpt.IsDefault ? null : new MemoryStream(peImageOpt.ToArray()));
+            return CreateReader(new MemoryStream(pdbImage.ToArray()), (peImageOpt.IsDefault) ? null : new PEReader(peImageOpt));
         }
 
         public static ISymUnmanagedReader CreateReader(Stream pdbStream, Stream peStreamOpt = null)
         {
-            if (peStreamOpt != null)
-            {
-                var peReader = new PEReader(peStreamOpt);
-                return CreateReader(pdbStream, peReader.GetMetadataReader(), peReader);
-            }
-            else
-            {
-                return CreateReader(pdbStream, null, null);
-            }
+            return CreateReader(pdbStream, (peStreamOpt != null) ? new PEReader(peStreamOpt) : null);
+        }
+
+        public static ISymUnmanagedReader CreateReader(Stream pdbStream, PEReader peReaderOpt)
+        {
+            return CreateReader(pdbStream, peReaderOpt?.GetMetadataReader(), peReaderOpt);
         }
 
         public static ISymUnmanagedReader CreateReader(Stream pdbStream, MetadataReader metadataReaderOpt, IDisposable metadataMemoryOwnerOpt)
         {
-            return CreateReader(pdbStream, metadataImporter: new DummyMetadataImport(metadataReaderOpt, metadataMemoryOwnerOpt));
+            return CreateReaderImpl(pdbStream, metadataImporter: new DummyMetadataImport(metadataReaderOpt, metadataMemoryOwnerOpt));
         }
 
-        public static ISymUnmanagedReader CreateReader(Stream pdbStream, object metadataImporter)
+        public static ISymUnmanagedReader CreateReaderImpl(Stream pdbStream, object metadataImporter)
         {
             pdbStream.Position = 0;
             bool isPortable = pdbStream.ReadByte() == 'B' && pdbStream.ReadByte() == 'S' && pdbStream.ReadByte() == 'J' && pdbStream.ReadByte() == 'B';

--- a/src/Test/Utilities/Shared/FX/PinnedBlob.cs
+++ b/src/Test/Utilities/Shared/FX/PinnedBlob.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+using Roslyn.Utilities;
+
+namespace Roslyn.Test.Utilities
+{
+    internal class PinnedBlob : IDisposable
+    {
+        private GCHandle _bytes; // non-readonly as Free() mutates to prevent double-free.
+        public readonly IntPtr Pointer;
+        public readonly int Size;
+
+        public PinnedBlob(ImmutableArray<byte> blob)
+            : this(blob.DangerousGetUnderlyingArray())
+        {
+        }
+
+        public unsafe PinnedBlob(byte[] blob)
+        {
+            _bytes = GCHandle.Alloc(blob, GCHandleType.Pinned);
+            Pointer = _bytes.AddrOfPinnedObject();
+            Size = blob.Length;
+        }
+
+        public void Dispose()
+        {
+            _bytes.Free();
+        }
+    }
+}

--- a/src/Test/Utilities/Shared/TestUtilities.projitems
+++ b/src/Test/Utilities/Shared/TestUtilities.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FX\ImmutableArrayTestExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\MonoHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\ObjectReference.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FX\PinnedBlob.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\PinnedMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\RegexExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\StringExtensions.cs" />


### PR DESCRIPTION
The current design of EE tests doesn't allow for running all/most tests against both native and portable PDB. This PR is gonna be a series of refactorings that will enable us to do so.

