### PR TITLE
Show assembly name in editor dropdowns for Metadata as Source

### DIFF
--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceGeneratedFileInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceGeneratedFileInfo.cs
@@ -78,9 +78,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             var projectInfo = ProjectInfo.Create(
                 projectId,
                 VersionStamp.Default,
-                "MetadataAsSourceProject",
-                AssemblyIdentity.Name,
-                LanguageName,
+                name: AssemblyIdentity.Name,
+                assemblyName: AssemblyIdentity.Name,
+                language: LanguageName,
                 compilationOptions: compilationOptions,
                 documents: new[] { assemblyInfoDocument, generatedDocument },
                 metadataReferences: References);

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
@@ -275,16 +275,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 var semanticModel = await document.GetSemanticModelAsync();
                 return semanticModel.GetSymbolInfo(syntaxRoot.FindNode(testDocument.SelectedSpans.Single())).Symbol;
             }
-
-            private class GenerationResult
-            {
-                public readonly MetadataAsSourceFile File;
-
-                public GenerationResult(MetadataAsSourceFile file)
-                {
-                    this.File = file;
-                }
-            }
         }
     }
 }

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -699,6 +699,20 @@ End Class");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task TestWorkspaceContextHasReasonableProjectName()
+        {
+            using (var context = await TestContext.CreateAsync())
+            {
+                var compilation = await context.DefaultProject.GetCompilationAsync();
+                var result = await context.GenerateSourceAsync(compilation.ObjectType);
+                var openedDocument = context.GetDocument(result);
+
+                Assert.Equal(openedDocument.Project.AssemblyName, "mscorlib");
+                Assert.Equal(openedDocument.Project.Name, "mscorlib");
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
         public async Task TestReuseGenerateFromDifferentProject()
         {
             using (var context = await TestContext.CreateAsync())


### PR DESCRIPTION
Seems better than showing an unlocalized "MetadataAsSourceProject".

Before:
![image](https://cloud.githubusercontent.com/assets/201340/12664650/3ec96e3c-c5e6-11e5-83bc-13e0c9c32d0a.png)

After:
![image](https://cloud.githubusercontent.com/assets/201340/12664645/3213ee60-c5e6-11e5-869f-d2cd16090fde.png)

*Review:* @dotnet/roslyn-ide 