### PR TITLE
Address backward compatibility issues around intrinsic aliases.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -412,6 +412,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(lookupResult.IsClear)
 
                 Dim sourceModule = binder.Compilation.SourceModule
+
+                ' Handle a case of being able to refer to System.Int32 through System.Integer.
+                ' Same for other intrinsic types with intrinsic name different from emitted name.
+                If (options And LookupOptions.AllowIntrinsicAliases) <> 0 AndAlso arity = 0 Then
+                    Dim containingNs = container.ContainingNamespace
+
+                    If containingNs IsNot Nothing AndAlso containingNs.IsGlobalNamespace AndAlso CaseInsensitiveComparison.Equals(container.Name, "System") Then
+                        Dim specialType = GetTypeForIntrinsicAlias(name)
+
+                        If specialType <> SpecialType.None Then
+                            Dim candidate = binder.Compilation.GetSpecialType(specialType)
+
+                            ' Intrinsic alias works only if type is available
+                            If Not candidate.IsErrorType() Then
+                                lookupResult.MergeMembersOfTheSameNamespace(binder.CheckViability(candidate, arity, options, Nothing, useSiteDiagnostics), sourceModule, options)
+                            End If
+                        End If
+                    End If
+                End If
+
 #If DEBUG Then
                 Dim haveSeenNamespace As Boolean = False
 #End If
@@ -429,6 +449,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     lookupResult.MergeMembersOfTheSameNamespace(currentResult, sourceModule, options)
                 Next
             End Sub
+
+            Public Shared Function GetTypeForIntrinsicAlias(possibleAlias As String) As SpecialType
+                Dim aliasAsKeyword As SyntaxKind = SyntaxFacts.GetKeywordKind(possibleAlias)
+
+                Select Case aliasAsKeyword
+                    Case SyntaxKind.DateKeyword
+                        Return SpecialType.System_DateTime
+                    Case SyntaxKind.UShortKeyword
+                        Return SpecialType.System_UInt16
+                    Case SyntaxKind.ShortKeyword
+                        Return SpecialType.System_Int16
+                    Case SyntaxKind.UIntegerKeyword
+                        Return SpecialType.System_UInt32
+                    Case SyntaxKind.IntegerKeyword
+                        Return SpecialType.System_Int32
+                    Case SyntaxKind.ULongKeyword
+                        Return SpecialType.System_UInt64
+                    Case SyntaxKind.LongKeyword
+                        Return SpecialType.System_Int64
+                    Case Else
+                        Return SpecialType.None
+                End Select
+            End Function
 
             ''' <summary>
             ''' Lookup a member name in modules of a namespace, 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -646,7 +646,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If Not fieldName.HasErrors Then
 
                     ' no need to use the memberInitializerBinder here, because there is no MemberAccessExpression 
-                    target = BindMemberAccess(fieldName, variableOrTempPlaceholder, fieldName, False, False, memberBindingDiagnostics)
+                    target = BindMemberAccess(fieldName, variableOrTempPlaceholder, fieldName, False, memberBindingDiagnostics)
                     diagnostics.AddRange(memberBindingDiagnostics)
 
                     Dim identifierName As String = fieldName.Identifier.ValueText

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupOptions.vb
@@ -142,6 +142,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Ignore duplicate types from the cor library.
         ''' </summary>
         IgnoreCorLibraryDuplicatedTypes = 1 << 17
+
+        ''' <summary>
+        ''' Handle a case of being able to refer to System.Int32 through System.Integer.
+        ''' Same for other intrinsic types with intrinsic name different from emitted name.
+        ''' </summary>
+        AllowIntrinsicAliases = 1 << 18
     End Enum
 
     Friend Module LookupOptionExtensions


### PR DESCRIPTION
Fixes #8238.

@dotnet/roslyn-compiler Please review.