### PR TITLE
Switch most C# EE tests to helpers that excercise both Windows and Portable PDBs

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
@@ -139,17 +139,16 @@ internal class C : B
                 options: TestOptions.DebugDll,
                 assemblyName: Guid.NewGuid().ToString("D"));
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("this.M(this.P)", out error, testData);
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("this.M(this.P)", out error, testData);
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+    @"
 {
   // Code size       13 (0xd)
   .maxstack  2
@@ -161,6 +160,7 @@ internal class C : B
   IL_000c:  ret
 }
 ");
+            });
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
@@ -29,47 +29,50 @@ class C
     static int P { get { return 3; } }
     object Q { get { return 4; } }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "C");
-            // Static field.
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                CompileExpression(context, "F"),
-@"{
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "C");
+                // Static field.
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    CompileExpression(context, "F"),
+    @"{
   // Code size        6 (0x6)
   .maxstack  1
   IL_0000:  ldsfld     ""object C.F""
   IL_0005:  ret
 }");
-            // Instance field.
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                CompileExpression(context, "G"),
-@"{
+                // Instance field.
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    CompileExpression(context, "G"),
+    @"{
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.G""
   IL_0006:  ret
 }");
-            // Static property.
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                CompileExpression(context, "P"),
-@"{
+                // Static property.
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    CompileExpression(context, "P"),
+    @"{
   // Code size        6 (0x6)
   .maxstack  1
   IL_0000:  call       ""int C.P.get""
   IL_0005:  ret
 }");
-            // Instance property.
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                CompileExpression(context, "Q"),
-@"{
+                // Instance property.
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    CompileExpression(context, "Q"),
+    @"{
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  callvirt   ""object C.Q.get""
   IL_0006:  ret
 }");
+            });
         }
 
         [Fact]
@@ -84,11 +87,12 @@ class C
     const int G = 2;
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "C");
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                CompileExpression(context, "F[G]"),
-@"{
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "C");
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    CompileExpression(context, "F[G]"),
+    @"{
   // Code size       12 (0xc)
   .maxstack  2
   IL_0000:  ldstr      ""str""
@@ -96,6 +100,7 @@ class C
   IL_0006:  call       ""char string.this[int].get""
   IL_000b:  ret
 }");
+            });
         }
 
         [Fact]
@@ -112,17 +117,19 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "C");
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                CompileExpression(context, "F(this)"),
-@"{
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "C");
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    CompileExpression(context, "F(this)"),
+    @"{
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  call       ""object C.F(C)""
   IL_0006:  ret
 }");
+            });
         }
 
         [Fact]
@@ -146,17 +153,19 @@ class B : A
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "B");
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                CompileExpression(context, "base.F()"),
-@"{
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "B");
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    CompileExpression(context, "base.F()"),
+    @"{
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  call       ""object A.F()""
   IL_0006:  ret
 }");
+            });
         }
 
         [Fact]
@@ -176,15 +185,16 @@ class A<T> where T : class
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "A.B");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("F(default(T), default(U))", out error, testData);
-            string actualIL = testData.GetMethodData("<>x<T, U>.<>m0").GetMethodIL();
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                actualIL,
-@"{
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "A.B");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("F(default(T), default(U))", out error, testData);
+                string actualIL = testData.GetMethodData("<>x<T, U>.<>m0").GetMethodIL();
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    actualIL,
+    @"{
   // Code size       24 (0x18)
   .maxstack  2
   .locals init (T V_0,
@@ -198,15 +208,16 @@ class A<T> where T : class
   IL_0012:  call       ""object A<T>.B<U>.F<T, U>(T, U)""
   IL_0017:  ret
 }");
-            // Verify generated type is generic, but method is not.
-            using (var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(result.Assembly)))
-            {
-                var reader = metadata.MetadataReader;
-                var typeDef = reader.GetTypeDef(result.TypeName);
-                reader.CheckTypeParameters(typeDef.GetGenericParameters(), "T", "U");
-                var methodDef = reader.GetMethodDef(typeDef, result.MethodName);
-                reader.CheckTypeParameters(methodDef.GetGenericParameters());
-            }
+                // Verify generated type is generic, but method is not.
+                using (var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(result.Assembly)))
+                {
+                    var reader = metadata.MetadataReader;
+                    var typeDef = reader.GetTypeDef(result.TypeName);
+                    reader.CheckTypeParameters(typeDef.GetGenericParameters(), "T", "U");
+                    var methodDef = reader.GetMethodDef(typeDef, result.MethodName);
+                    reader.CheckTypeParameters(methodDef.GetGenericParameters());
+                }
+            });
         }
 
         [Fact]
@@ -227,16 +238,17 @@ namespace N
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "N.C");
-            string error;
-            var testData = new CompilationTestData();
-            // Expression compilation should succeed without imports.
-            var result = context.CompileExpression("typeof(N.C) ?? typeof(C)", out error, testData);
-            Assert.Null(error);
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                testData.GetMethodData("<>x.<>m0").GetMethodIL(),
-@"{
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "N.C");
+                string error;
+                var testData = new CompilationTestData();
+                // Expression compilation should succeed without imports.
+                var result = context.CompileExpression("typeof(N.C) ?? typeof(C)", out error, testData);
+                Assert.Null(error);
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                    testData.GetMethodData("<>x.<>m0").GetMethodIL(),
+    @"{
   // Code size       25 (0x19)
   .maxstack  2
   IL_0000:  ldtoken    ""N.C""
@@ -248,14 +260,15 @@ namespace N
   IL_0013:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_0018:  ret
 }");
-            // Expression compilation should fail using imports since there are no symbols.
-            context = CreateTypeContext(runtime, "N.C");
-            testData = new CompilationTestData();
-            result = context.CompileExpression("typeof(A.C) ?? typeof(B) ?? typeof(C)", out error, testData);
-            Assert.Equal(error, "error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)");
-            testData = new CompilationTestData();
-            result = context.CompileExpression("typeof(B) ?? typeof(C)", out error, testData);
-            Assert.Equal(error, "error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)");
+                // Expression compilation should fail using imports since there are no symbols.
+                context = CreateTypeContext(runtime, "N.C");
+                testData = new CompilationTestData();
+                result = context.CompileExpression("typeof(A.C) ?? typeof(B) ?? typeof(C)", out error, testData);
+                Assert.Equal(error, "error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)");
+                testData = new CompilationTestData();
+                result = context.CompileExpression("typeof(B) ?? typeof(C)", out error, testData);
+                Assert.Equal(error, "error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)");
+            });
         }
 
         [Fact]
@@ -268,12 +281,14 @@ class C
 {
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "C");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("$ReturnValue", out error, testData);
-            Assert.Equal(error, "error CS0103: The name '$ReturnValue' does not exist in the current context");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "C");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("$ReturnValue", out error, testData);
+                Assert.Equal(error, "error CS0103: The name '$ReturnValue' does not exist in the current context");
+            });
         }
 
         [Fact]
@@ -289,10 +304,11 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "C");
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-@"{
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "C");
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(
+    @"{
   // Code size       29 (0x1d)
   .maxstack  3
   IL_0000:  newobj     ""<>x.<>c__DisplayClass0_0..ctor()""
@@ -304,7 +320,8 @@ class C
   IL_0017:  call       ""object C.F(System.Func<object>)""
   IL_001c:  ret
 }",
-            CompileExpression(context, "F(() => this.o)"));
+                CompileExpression(context, "F(() => this.o)"));
+            });
         }
 
         [Fact]
@@ -318,19 +335,21 @@ class C
     object F = ""f"";
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "C");
-            // No format specifiers.
-            string error;
-            var result = context.CompileExpression("F", out error);
-            Assert.NotNull(result.Assembly);
-            Assert.Null(result.FormatSpecifiers);
-            // Format specifiers.
-            result = context.CompileExpression("F, nq,ac", out error);
-            Assert.NotNull(result.Assembly);
-            Assert.Equal(result.FormatSpecifiers.Count, 2);
-            Assert.Equal(result.FormatSpecifiers[0], "nq");
-            Assert.Equal(result.FormatSpecifiers[1], "ac");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "C");
+                // No format specifiers.
+                string error;
+                var result = context.CompileExpression("F", out error);
+                Assert.NotNull(result.Assembly);
+                Assert.Null(result.FormatSpecifiers);
+                // Format specifiers.
+                result = context.CompileExpression("F, nq,ac", out error);
+                Assert.NotNull(result.Assembly);
+                Assert.Equal(result.FormatSpecifiers.Count, 2);
+                Assert.Equal(result.FormatSpecifiers[0], "nq");
+                Assert.Equal(result.FormatSpecifiers[1], "ac");
+            });
         }
 
         [Fact]
@@ -357,22 +376,24 @@ public class Derived : Base
 }
 ";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateTypeContext(runtime, "Derived");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("GetDebuggerDisplay()", out error, testData);
-            Assert.Null(error);
-            var actualIL = testData.GetMethodData("<>x.<>m0").GetMethodIL();
-            var expectedIL =
-@"{
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateTypeContext(runtime, "Derived");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("GetDebuggerDisplay()", out error, testData);
+                Assert.Null(error);
+                var actualIL = testData.GetMethodData("<>x.<>m0").GetMethodIL();
+                var expectedIL =
+    @"{
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  callvirt   ""string Derived.GetDebuggerDisplay()""
   IL_0006:  ret
 }";
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL);
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL);
+            });
         }
 
         private static string CompileExpression(EvaluationContext context, string expr)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
-using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -37,26 +36,28 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x01);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
-@"{
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x01);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
+    @"{
   // Code size        2 (0x2)
   .maxstack  1
   .locals init (dynamic V_0) //d
   IL_0000:  ldloc.0
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -76,26 +77,28 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x02);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
-@"{
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x02);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
+    @"{
   // Code size        2 (0x2)
   .maxstack  1
   .locals init (dynamic[] V_0) //d
   IL_0000:  ldloc.0
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -115,26 +118,28 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x02);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
-@"{
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x02);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
+    @"{
   // Code size        2 (0x2)
   .maxstack  1
   .locals init (System.Collections.Generic.List<dynamic> V_0) //d
   IL_0000:  ldloc.0
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -154,26 +159,27 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x01);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
-@"{
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x01);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+    @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldnull
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -193,26 +199,27 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x02);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x02);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldnull
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -237,26 +244,27 @@ class Generic<T>
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x02);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x02);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldnull
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(4106, "https://github.com/dotnet/roslyn/issues/4106")]
@@ -280,30 +288,28 @@ class Generic<T>
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(2, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "a", null); // Dynamic info ignored because ambiguous.
+                VerifyCustomTypeInfo(locals[1], "b", 0x01);
+                locals.Free();
 
-            var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(2, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "a", null); // Dynamic info ignored because ambiguous.
-            VerifyCustomTypeInfo(locals[1], "b", 0x01);
-            locals.Free();
-
-            context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(2, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "b", 0x02);
-            VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
-            locals.Free();
+                context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(2, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "b", 0x02);
+                VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
+                locals.Free();
+            });
         }
 
         [WorkItem(4106, "https://github.com/dotnet/roslyn/issues/4106")]
@@ -327,30 +333,28 @@ class Generic<T>
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(2, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "a", null);
+                VerifyCustomTypeInfo(locals[1], "b", 0x01);
+                locals.Free();
 
-            var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(2, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "a", null);
-            VerifyCustomTypeInfo(locals[1], "b", 0x01);
-            locals.Free();
-
-            context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(2, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "b", null);
-            VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
-            locals.Free();
+                context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(2, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "b", null);
+                VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
+                locals.Free();
+            });
         }
 
         [WorkItem(4106, "https://github.com/dotnet/roslyn/issues/4106")]
@@ -382,42 +386,40 @@ class Generic<T>
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "e", null);
+                VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
+                VerifyCustomTypeInfo(locals[2], "b", 0x01);
+                locals.Free();
 
-            var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "e", null);
-            VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
-            VerifyCustomTypeInfo(locals[2], "b", 0x01);
-            locals.Free();
+                context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "e", null);
+                VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
+                VerifyCustomTypeInfo(locals[2], "c", null); // Dynamic info ignored because ambiguous.
+                locals.Free();
 
-            context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "e", null);
-            VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
-            VerifyCustomTypeInfo(locals[2], "c", null); // Dynamic info ignored because ambiguous.
-            locals.Free();
-
-            context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 999);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "e", null);
-            VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
-            VerifyCustomTypeInfo(locals[2], "c", null); // Dynamic info ignored because ambiguous.
-            locals.Free();
+                context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 999);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "e", null);
+                VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
+                VerifyCustomTypeInfo(locals[2], "c", null); // Dynamic info ignored because ambiguous.
+                locals.Free();
+            });
         }
 
         [WorkItem(4106, "https://github.com/dotnet/roslyn/issues/4106")]
@@ -448,41 +450,39 @@ class Generic<T>
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "e", null);
+                VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
+                VerifyCustomTypeInfo(locals[2], "c", null);
+                locals.Free();
 
-            var context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 799);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "e", null);
-            VerifyCustomTypeInfo(locals[1], "a", null); // Dynamic info ignored because ambiguous.
-            VerifyCustomTypeInfo(locals[2], "c", null);
-            locals.Free();
+                context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(2, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "e", null);
+                VerifyCustomTypeInfo(locals[1], "b", 0x02);
+                locals.Free();
 
-            context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 899);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(2, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "e", null);
-            VerifyCustomTypeInfo(locals[1], "b", 0x02);
-            locals.Free();
-
-            context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 999);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "e", null);
-            VerifyCustomTypeInfo(locals[1], "a", null);
-            VerifyCustomTypeInfo(locals[2], "c", null); // Dynamic info ignored because ambiguous.
-            locals.Free();
+                context = CreateMethodContext(runtime, methodName: "C.M", atLineNumber: 999);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "e", null);
+                VerifyCustomTypeInfo(locals[1], "a", null);
+                VerifyCustomTypeInfo(locals[2], "c", null); // Dynamic info ignored because ambiguous.
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -499,22 +499,21 @@ class Generic<T>
         dynamic d = null;
 	}
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, methodName: "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(4, locals.Count);
-            VerifyCustomTypeInfo(locals[0], "c123456789012345678901234567890123456789012345678901234567890123", null); // dynamic info dropped
-            VerifyCustomTypeInfo(locals[1], "d", 0x01);
-            VerifyCustomTypeInfo(locals[2], "a123456789012345678901234567890123456789012345678901234567890123", null); // dynamic info dropped
-            VerifyCustomTypeInfo(locals[3], "b", 0x01);
-            locals.Free();
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(4, locals.Count);
+                VerifyCustomTypeInfo(locals[0], "c123456789012345678901234567890123456789012345678901234567890123", null); // dynamic info dropped
+                VerifyCustomTypeInfo(locals[1], "d", 0x01);
+                VerifyCustomTypeInfo(locals[2], "a123456789012345678901234567890123456789012345678901234567890123", null); // dynamic info dropped
+                VerifyCustomTypeInfo(locals[3], "b", 0x01);
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -533,25 +532,27 @@ class Generic<T>
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x01);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x01);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -570,25 +571,27 @@ class Generic<T>
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x02);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
-@"{
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x02);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
+    @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -607,25 +610,27 @@ class Generic<T>
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
-            VerifyCustomTypeInfo(locals[0], "d", 0x02);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
-@"{
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
+                VerifyCustomTypeInfo(locals[0], "d", 0x02);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
+    @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(1087216, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1087216")]
@@ -653,53 +658,54 @@ public class Outer<T, U>
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasDynamicAttribute(method);
-            VerifyCustomTypeInfo(locals[0], "d", 0x04, 0x03);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
-@"{
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasDynamicAttribute(method);
+                VerifyCustomTypeInfo(locals[0], "d", 0x04, 0x03);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
+    @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
 
-            string error;
-            var result = context.CompileExpression("d", out error);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, 0x04, 0x03);
+                string error;
+                var result = context.CompileExpression("d", out error);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, 0x04, 0x03);
 
-            // Note that the method produced by CompileAssignment returns void
-            // so there is never custom type info.
-            result = context.CompileAssignment("d", "d", out error);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, null);
+                // Note that the method produced by CompileAssignment returns void
+                // so there is never custom type info.
+                result = context.CompileAssignment("d", "d", out error);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, null);
 
-            ResultProperties resultProperties;
-            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            testData = new CompilationTestData();
-            result = context.CompileExpression(
-                "var dd = d;",
-                DkmEvaluationFlags.None,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, null);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"{
+                ResultProperties resultProperties;
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                testData = new CompilationTestData();
+                result = context.CompileExpression(
+                    "var dd = d;",
+                    DkmEvaluationFlags.None,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, null);
+                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+    @"{
   // Code size       57 (0x39)
   .maxstack  7
   IL_0000:  ldtoken    ""Outer<dynamic[], object[]>.Inner<Outer<object, dynamic>[], dynamic>""
@@ -724,7 +730,8 @@ public class Outer<T, U>
   IL_0037:  stind.ref
   IL_0038:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -737,45 +744,43 @@ public class Outer<T, U>
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 "C.M");
-            var aliases = ImmutableArray.Create(
-                Alias(
-                    DkmClrAliasKind.Variable,
-                    "d1",
-                    "d1",
-                    typeof(object).AssemblyQualifiedName,
-                    MakeCustomTypeInfo(true)),
-                Alias(
-                    DkmClrAliasKind.Variable,
-                    "d2",
-                    "d2",
-                    typeof(Dictionary<Dictionary<dynamic, Dictionary<object[], dynamic[]>>, object>).AssemblyQualifiedName,
-                    MakeCustomTypeInfo(false, false, true, false, false, false, false, true, false)));
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var diagnostics = DiagnosticBag.GetInstance();
+                var aliases = ImmutableArray.Create(
+                    Alias(
+                        DkmClrAliasKind.Variable,
+                        "d1",
+                        "d1",
+                        typeof(object).AssemblyQualifiedName,
+                        MakeCustomTypeInfo(true)),
+                    Alias(
+                        DkmClrAliasKind.Variable,
+                        "d2",
+                        "d2",
+                        typeof(Dictionary<Dictionary<dynamic, Dictionary<object[], dynamic[]>>, object>).AssemblyQualifiedName,
+                        MakeCustomTypeInfo(false, false, true, false, false, false, false, true, false)));
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var diagnostics = DiagnosticBag.GetInstance();
 
-            var testData = new CompilationTestData();
-            context.CompileGetLocals(
-                locals,
-                argumentsOnly: false,
-                aliases: aliases,
-                diagnostics: diagnostics,
-                typeName: out typeName,
-                testData: testData);
-            diagnostics.Free();
-            Assert.Equal(locals.Count, 2);
+                var testData = new CompilationTestData();
+                context.CompileGetLocals(
+                    locals,
+                    argumentsOnly: false,
+                    aliases: aliases,
+                    diagnostics: diagnostics,
+                    typeName: out typeName,
+                    testData: testData);
+                diagnostics.Free();
+                Assert.Equal(locals.Count, 2);
 
-            VerifyCustomTypeInfo(locals[0], "d1", 0x01);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d1", expectedILOpt:
-@"{
+                VerifyCustomTypeInfo(locals[0], "d1", 0x01);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d1", expectedILOpt:
+    @"{
   // Code size       11 (0xb)
   .maxstack  1
   IL_0000:  ldstr      ""d1""
@@ -783,9 +788,9 @@ public class Outer<T, U>
   IL_000a:  ret
 }");
 
-            VerifyCustomTypeInfo(locals[1], "d2", 0x84, 0x00); // Note: read flags right-to-left in each byte: 0010 0001 0(000 0000)
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "d2", expectedILOpt:
-@"{
+                VerifyCustomTypeInfo(locals[1], "d2", 0x84, 0x00); // Note: read flags right-to-left in each byte: 0010 0001 0(000 0000)
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "d2", expectedILOpt:
+    @"{
   // Code size       16 (0x10)
   .maxstack  1
   IL_0000:  ldstr      ""d2""
@@ -793,7 +798,8 @@ public class Outer<T, U>
   IL_000a:  castclass  ""System.Collections.Generic.Dictionary<System.Collections.Generic.Dictionary<dynamic, System.Collections.Generic.Dictionary<object[], dynamic[]>>, object>""
   IL_000f:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         private static CustomTypeInfo MakeCustomTypeInfo(params bool[] flags)
@@ -815,16 +821,18 @@ public class Outer<T, U>
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            var method = testData.Methods.Single().Value.Method;
-            AssertHasNoDynamicAttribute(method);
-            locals.Free();
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                var method = testData.Methods.Single().Value.Method;
+                AssertHasNoDynamicAttribute(method);
+                locals.Free();
+            });
         }
 
         private static void AssertHasDynamicAttribute(IMethodSymbol method)
@@ -855,16 +863,17 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            var result = context.CompileExpression("d.M()", out error, testData);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, 0x01);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.Equal(TypeKind.Dynamic, methodData.Method.ReturnType.TypeKind);
-            methodData.VerifyIL(@"
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                var result = context.CompileExpression("d.M()", out error, testData);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, 0x01);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.Equal(TypeKind.Dynamic, methodData.Method.ReturnType.TypeKind);
+                methodData.VerifyIL(@"
 {
   // Code size       77 (0x4d)
   .maxstack  9
@@ -895,6 +904,7 @@ class C
   IL_004c:  ret
 }
 ");
+            });
         }
 
         [WorkItem(1160855, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1160855")]
@@ -921,15 +931,16 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            var result = context.CompileExpression("G(async () => await d())", out error, testData);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, null);
-            var methodData = testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()");
-            methodData.VerifyIL(@"
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                var result = context.CompileExpression("G(async () => await d())", out error, testData);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, null);
+                var methodData = testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()");
+                methodData.VerifyIL(@"
 {
   // Code size      539 (0x21b)
   .maxstack  10
@@ -1123,6 +1134,7 @@ class C
   IL_021a:  ret
 }
 ");
+            });
         }
 
         [WorkItem(1072296, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072296")]
@@ -1141,15 +1153,15 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-
-            var context = CreateMethodContext(runtime, "C.Foo");
-            var testData = new CompilationTestData();
-            string error;
-            var result = context.CompileAssignment("a", "() => Foo(x)", out error, testData);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, null);
-            testData.GetMethodData("<>x.<>c.<<>m0>b__0_0").VerifyIL(@"
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.Foo");
+                var testData = new CompilationTestData();
+                string error;
+                var result = context.CompileAssignment("a", "() => Foo(x)", out error, testData);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, null);
+                testData.GetMethodData("<>x.<>c.<<>m0>b__0_0").VerifyIL(@"
 {
   // Code size      106 (0x6a)
   .maxstack  9
@@ -1187,13 +1199,13 @@ class C
   IL_0069:  ret
 }");
 
-            context = CreateMethodContext(runtime, "C.<>c.<Foo>b__1_0");
-            testData = new CompilationTestData();
-            result = context.CompileExpression("Foo(x)", out error, testData);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, 0x01);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            methodData.VerifyIL(@"
+                context = CreateMethodContext(runtime, "C.<>c.<Foo>b__1_0");
+                testData = new CompilationTestData();
+                result = context.CompileExpression("Foo(x)", out error, testData);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, 0x01);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                methodData.VerifyIL(@"
 {
   // Code size      102 (0x66)
   .maxstack  9
@@ -1230,6 +1242,7 @@ class C
   IL_0060:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, System.Type, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, System.Type, dynamic)""
   IL_0065:  ret
 }");
+            });
         }
 
         [WorkItem(1095613, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1095613")]
@@ -1252,15 +1265,15 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef, CSharpRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            var result = context.CompileExpression("Foo(x)", out error, testData);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, 0x01);
-            testData.GetMethodData("<>c.<>m0()").VerifyIL(@"
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                var result = context.CompileExpression("Foo(x)", out error, testData);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, 0x01);
+                testData.GetMethodData("<>c.<>m0()").VerifyIL(@"
 {
   // Code size      166 (0xa6)
   .maxstack  11
@@ -1313,10 +1326,10 @@ class C
   IL_00a4:  stloc.0
   IL_00a5:  ret
 }");
-            result = context.CompileExpression("Foo(y)", out error, testData);
-            Assert.Null(error);
-            VerifyCustomTypeInfo(result, 0x01);
-            testData.GetMethodData("<>c.<>m0()").VerifyIL(@"
+                result = context.CompileExpression("Foo(y)", out error, testData);
+                Assert.Null(error);
+                VerifyCustomTypeInfo(result, 0x01);
+                testData.GetMethodData("<>c.<>m0()").VerifyIL(@"
 {
   // Code size      166 (0xa6)
   .maxstack  11
@@ -1369,6 +1382,7 @@ class C
   IL_00a4:  stloc.0
   IL_00a5:  ret
 }");
+            });
         }
 
         private static void VerifyCustomTypeInfo(LocalAndMethod localAndMethod, string expectedName, params byte[] expectedBytes)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -47,6 +47,42 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             _runtimeInstances.Free();
         }
 
+        // TODO: remove -- workaround for bugs in Portable PDB handling in EE
+        internal static void WithRuntimeInstancePortableBug(Compilation compilation, Action<RuntimeInstance> validator)
+        {
+            WithRuntimeInstancePortableBug(compilation, null, validator);
+        }
+
+        // TODO: remove -- workaround for bugs in Portable PDB handling in EE
+        internal static void WithRuntimeInstancePortableBug(Compilation compilation, IEnumerable<MetadataReference> references, Action<RuntimeInstance> validator)
+        {
+            using (var instance = RuntimeInstance.Create(compilation, references, DebugInformationFormat.Pdb, true))
+            {
+                validator(instance);
+            }
+        }
+
+        internal static void WithRuntimeInstance(Compilation compilation, Action<RuntimeInstance> validator)
+        {
+            WithRuntimeInstance(compilation, null, true, validator);
+        }
+
+        internal static void WithRuntimeInstance(Compilation compilation, IEnumerable<MetadataReference> references, Action<RuntimeInstance> validator)
+        {
+            WithRuntimeInstance(compilation, references, true, validator);
+        }
+
+        internal static void WithRuntimeInstance(Compilation compilation, IEnumerable<MetadataReference> references, bool includeLocalSignatures, Action<RuntimeInstance> validator)
+        {
+            foreach (var debugFormat in new[] { DebugInformationFormat.Pdb, DebugInformationFormat.PortablePdb })
+            {
+                using (var instance = RuntimeInstance.Create(compilation, references, debugFormat, includeLocalSignatures))
+                {
+                    validator(instance);
+                }
+            }
+        }
+
         internal RuntimeInstance CreateRuntimeInstance(IEnumerable<ModuleInstance> modules)
         {
             var instance = RuntimeInstance.Create(modules);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -39,52 +39,50 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                ImmutableArray<MetadataBlock> blocks;
+                Guid moduleVersionId;
+                ISymUnmanagedReader symReader;
+                int methodToken;
+                int localSignatureToken;
+                GetContextState(runtime, "C.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
-            ImmutableArray<MetadataBlock> blocks;
-            Guid moduleVersionId;
-            ISymUnmanagedReader symReader;
-            int methodToken;
-            int localSignatureToken;
-            GetContextState(runtime, "C.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
+                uint ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader);
+                var context = EvaluationContext.CreateMethodContext(
+                    default(CSharpMetadataContext),
+                    blocks,
+                    symReader,
+                    moduleVersionId,
+                    methodToken: methodToken,
+                    methodVersion: 1,
+                    ilOffset: ilOffset,
+                    localSignatureToken: localSignatureToken);
 
-            uint ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader);
-            var context = EvaluationContext.CreateMethodContext(
-                default(CSharpMetadataContext),
-                blocks,
-                symReader,
-                moduleVersionId,
-                methodToken: methodToken,
-                methodVersion: 1,
-                ilOffset: ilOffset,
-                localSignatureToken: localSignatureToken);
+                string error;
+                var result = context.CompileExpression("1", out error);
+                var mvid1 = result.Assembly.GetModuleVersionId();
+                var name1 = result.Assembly.GetAssemblyName();
+                Assert.NotEqual(mvid1, Guid.Empty);
 
-            string error;
-            var result = context.CompileExpression("1", out error);
-            var mvid1 = result.Assembly.GetModuleVersionId();
-            var name1 = result.Assembly.GetAssemblyName();
-            Assert.NotEqual(mvid1, Guid.Empty);
+                context = EvaluationContext.CreateMethodContext(
+                    new CSharpMetadataContext(blocks, context),
+                    blocks,
+                    symReader,
+                    moduleVersionId,
+                    methodToken: methodToken,
+                    methodVersion: 1,
+                    ilOffset: ilOffset,
+                    localSignatureToken: localSignatureToken);
 
-            context = EvaluationContext.CreateMethodContext(
-                new CSharpMetadataContext(blocks, context),
-                blocks,
-                symReader,
-                moduleVersionId,
-                methodToken: methodToken,
-                methodVersion: 1,
-                ilOffset: ilOffset,
-                localSignatureToken: localSignatureToken);
-
-            result = context.CompileExpression("2", out error);
-            var mvid2 = result.Assembly.GetModuleVersionId();
-            var name2 = result.Assembly.GetAssemblyName();
-            Assert.NotEqual(mvid2, Guid.Empty);
-            Assert.NotEqual(mvid2, mvid1);
-            Assert.NotEqual(name2.FullName, name1.FullName);
+                result = context.CompileExpression("2", out error);
+                var mvid2 = result.Assembly.GetModuleVersionId();
+                var name2 = result.Assembly.GetAssemblyName();
+                Assert.NotEqual(mvid2, Guid.Empty);
+                Assert.NotEqual(mvid2, mvid1);
+                Assert.NotEqual(name2.FullName, name1.FullName);
+            });
         }
 
         [Fact]
@@ -95,18 +93,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     static void M() { }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var result = context.CompileExpression("M(", out error);
-            Assert.Null(result);
-            Assert.Equal(error, "error CS1026: ) expected");
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var result = context.CompileExpression("M(", out error);
+                Assert.Null(result);
+                Assert.Equal(error, "error CS1026: ) expected");
+            });
         }
 
         /// <summary>
@@ -127,30 +122,27 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     static void M() { }
 }";
-                var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                    source,
-                    options: TestOptions.DebugDll,
-                    assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-                var runtime = CreateRuntimeInstance(compilation0);
-                var context = CreateMethodContext(
-                    runtime,
-                    methodName: "C.M");
-                ResultProperties resultProperties;
-                string error;
-                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-                var result = context.CompileExpression(
-                    "M(",
-                    DkmEvaluationFlags.TreatAsExpression,
-                    NoAliases,
-                    CustomDiagnosticFormatter.Instance,
-                    out resultProperties,
-                    out error,
-                    out missingAssemblyIdentities,
-                    preferredUICulture: null,
-                    testData: null);
-                Assert.Null(result);
-                Assert.Equal(error, "LCID=1031, Code=1026");
-                Assert.Empty(missingAssemblyIdentities);
+                var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+                WithRuntimeInstance(compilation0, runtime =>
+                {
+                    var context = CreateMethodContext(runtime, "C.M");
+                    ResultProperties resultProperties;
+                    string error;
+                    ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                    var result = context.CompileExpression(
+                        "M(",
+                        DkmEvaluationFlags.TreatAsExpression,
+                        NoAliases,
+                        CustomDiagnosticFormatter.Instance,
+                        out resultProperties,
+                        out error,
+                        out missingAssemblyIdentities,
+                        preferredUICulture: null,
+                        testData: null);
+                    Assert.Null(result);
+                    Assert.Equal(error, "LCID=1031, Code=1026");
+                    Assert.Empty(missingAssemblyIdentities);
+                });
             }
             finally
             {
@@ -171,22 +163,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
     static void M() { }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            // (1,2): warning CS0078: The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
-            const string expr = "0l";
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression(expr, out error, testData);
-            Assert.NotNull(result.Assembly);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                // (1,2): warning CS0078: The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
+                const string expr = "0l";
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression(expr, out error, testData);
+                Assert.NotNull(result.Assembly);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        3 (0x3)
   .maxstack  1
@@ -194,6 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0001:  conv.i8
   IL_0002:  ret
 }");
+            });
         }
 
         /// <summary>
@@ -460,34 +449,35 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, methodName: "C.F");
-            string error;
-            var result = context.CompileExpression("x;", out error);
-            Assert.Null(error);
-            result = context.CompileExpression("x \t;\t ", out error);
-            Assert.Null(error);
-            // Multiple semicolons: not supported.
-            result = context.CompileExpression("x;;", out error);
-            Assert.Equal(error, "error CS1073: Unexpected token ';'");
-            // // comments.
-            result = context.CompileExpression("x;//", out error);
-            Assert.Equal(error, "error CS0726: ';//' is not a valid format specifier");
-            result = context.CompileExpression("x//;", out error);
-            Assert.Null(error);
-            // /*...*/ comments.
-            result = context.CompileExpression("x/*...*/", out error);
-            Assert.Null(error);
-            result = context.CompileExpression("x/*;*/", out error);
-            Assert.Null(error);
-            result = context.CompileExpression("x;/*...*/", out error);
-            Assert.Equal(error, "error CS0726: ';/*...*/' is not a valid format specifier");
-            result = context.CompileExpression("x/*...*/;", out error);
-            Assert.Null(error);
-            // Trailing semicolon, no expression.
-            result = context.CompileExpression(" ; ", out error);
-            Assert.Equal(error, "error CS1733: Expected expression");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.F");
+                string error;
+                var result = context.CompileExpression("x;", out error);
+                Assert.Null(error);
+                result = context.CompileExpression("x \t;\t ", out error);
+                Assert.Null(error);
+                // Multiple semicolons: not supported.
+                result = context.CompileExpression("x;;", out error);
+                Assert.Equal(error, "error CS1073: Unexpected token ';'");
+                // // comments.
+                result = context.CompileExpression("x;//", out error);
+                Assert.Equal(error, "error CS0726: ';//' is not a valid format specifier");
+                result = context.CompileExpression("x//;", out error);
+                Assert.Null(error);
+                // /*...*/ comments.
+                result = context.CompileExpression("x/*...*/", out error);
+                Assert.Null(error);
+                result = context.CompileExpression("x/*;*/", out error);
+                Assert.Null(error);
+                result = context.CompileExpression("x;/*...*/", out error);
+                Assert.Equal(error, "error CS0726: ';/*...*/' is not a valid format specifier");
+                result = context.CompileExpression("x/*...*/;", out error);
+                Assert.Null(error);
+                // Trailing semicolon, no expression.
+                result = context.CompileExpression(" ; ", out error);
+                Assert.Equal(error, "error CS1733: Expected expression");
+            });
         }
 
         [Fact]
@@ -502,60 +492,61 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, methodName: "C.F");
-            string error;
-            // No format specifiers.
-            var result = context.CompileExpression("x", out error);
-            CheckFormatSpecifiers(result);
-            // Format specifiers on expression.
-            result = context.CompileExpression("x,", out error);
-            Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
-            result = context.CompileExpression("x,,", out error);
-            Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
-            result = context.CompileExpression("x y", out error);
-            Assert.Equal(error, "error CS0726: 'y' is not a valid format specifier");
-            result = context.CompileExpression("x yy zz", out error);
-            Assert.Equal(error, "error CS0726: 'yy' is not a valid format specifier");
-            result = context.CompileExpression("x,,y", out error);
-            Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
-            result = context.CompileExpression("x,yy,zz,ww", out error);
-            CheckFormatSpecifiers(result, "yy", "zz", "ww");
-            result = context.CompileExpression("x, y z", out error);
-            Assert.Equal(error, "error CS0726: 'z' is not a valid format specifier");
-            result = context.CompileExpression("x, y  ,  z  ", out error);
-            CheckFormatSpecifiers(result, "y", "z");
-            result = context.CompileExpression("x, y, z,", out error);
-            Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
-            result = context.CompileExpression("x,y,z;w", out error);
-            Assert.Equal(error, "error CS0726: 'z;w' is not a valid format specifier");
-            result = context.CompileExpression("x, y;, z", out error);
-            Assert.Equal(error, "error CS0726: 'y;' is not a valid format specifier");
-            // Format specifiers after // comment: ignored.
-            result = context.CompileExpression("x // ,f", out error);
-            CheckFormatSpecifiers(result);
-            // Format specifiers after /*...*/ comment.
-            result = context.CompileExpression("x /*,f*/, g, h", out error);
-            CheckFormatSpecifiers(result, "g", "h");
-            // Format specifiers on assignment value.
-            result = context.CompileAssignment("x", "null, y", out error);
-            Assert.Null(result);
-            Assert.Equal(error, "error CS1073: Unexpected token ','");
-            // Trailing semicolon, no format specifiers.
-            result = context.CompileExpression("x; ", out error);
-            CheckFormatSpecifiers(result);
-            // Format specifiers, no expression.
-            result = context.CompileExpression(",f", out error);
-            Assert.Equal(error, "error CS1525: Invalid expression term ','");
-            // Format specifiers before semicolon: not supported.
-            result = context.CompileExpression("x,f;\t", out error);
-            Assert.Equal(error, "error CS1073: Unexpected token ','");
-            // Format specifiers after semicolon: not supported.
-            result = context.CompileExpression("x;,f", out error);
-            Assert.Equal(error, "error CS0726: ';' is not a valid format specifier");
-            result = context.CompileExpression("x; f, g", out error);
-            Assert.Equal(error, "error CS0726: ';' is not a valid format specifier");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.F");
+                string error;
+                // No format specifiers.
+                var result = context.CompileExpression("x", out error);
+                CheckFormatSpecifiers(result);
+                // Format specifiers on expression.
+                result = context.CompileExpression("x,", out error);
+                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                result = context.CompileExpression("x,,", out error);
+                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                result = context.CompileExpression("x y", out error);
+                Assert.Equal(error, "error CS0726: 'y' is not a valid format specifier");
+                result = context.CompileExpression("x yy zz", out error);
+                Assert.Equal(error, "error CS0726: 'yy' is not a valid format specifier");
+                result = context.CompileExpression("x,,y", out error);
+                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                result = context.CompileExpression("x,yy,zz,ww", out error);
+                CheckFormatSpecifiers(result, "yy", "zz", "ww");
+                result = context.CompileExpression("x, y z", out error);
+                Assert.Equal(error, "error CS0726: 'z' is not a valid format specifier");
+                result = context.CompileExpression("x, y  ,  z  ", out error);
+                CheckFormatSpecifiers(result, "y", "z");
+                result = context.CompileExpression("x, y, z,", out error);
+                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                result = context.CompileExpression("x,y,z;w", out error);
+                Assert.Equal(error, "error CS0726: 'z;w' is not a valid format specifier");
+                result = context.CompileExpression("x, y;, z", out error);
+                Assert.Equal(error, "error CS0726: 'y;' is not a valid format specifier");
+                // Format specifiers after // comment: ignored.
+                result = context.CompileExpression("x // ,f", out error);
+                CheckFormatSpecifiers(result);
+                // Format specifiers after /*...*/ comment.
+                result = context.CompileExpression("x /*,f*/, g, h", out error);
+                CheckFormatSpecifiers(result, "g", "h");
+                // Format specifiers on assignment value.
+                result = context.CompileAssignment("x", "null, y", out error);
+                Assert.Null(result);
+                Assert.Equal(error, "error CS1073: Unexpected token ','");
+                // Trailing semicolon, no format specifiers.
+                result = context.CompileExpression("x; ", out error);
+                CheckFormatSpecifiers(result);
+                // Format specifiers, no expression.
+                result = context.CompileExpression(",f", out error);
+                Assert.Equal(error, "error CS1525: Invalid expression term ','");
+                // Format specifiers before semicolon: not supported.
+                result = context.CompileExpression("x,f;\t", out error);
+                Assert.Equal(error, "error CS1073: Unexpected token ','");
+                // Format specifiers after semicolon: not supported.
+                result = context.CompileExpression("x;,f", out error);
+                Assert.Equal(error, "error CS0726: ';' is not a valid format specifier");
+                result = context.CompileExpression("x; f, g", out error);
+                Assert.Equal(error, "error CS0726: ';' is not a valid format specifier");
+            });
         }
 
         private static void CheckFormatSpecifiers(CompileResult result, params string[] formatSpecifiers)
@@ -592,21 +583,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.F",
-                atLineNumber: 999);
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.F", atLineNumber: 999);
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("a[0]", out error, testData);
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("a[0]", out error, testData);
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        4 (0x4)
   .maxstack  2
@@ -619,6 +605,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0002:  ldelem.i4
   IL_0003:  ret
 }");
+            });
         }
 
         [Fact]
@@ -641,16 +628,14 @@ class B : A
     {
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "B.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("this.F() ?? this.G ?? this.P", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "B.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("this.F() ?? this.G ?? this.P", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       27 (0x1b)
   .maxstack  2
@@ -668,9 +653,9 @@ class B : A
   IL_0015:  callvirt   ""object B.P.get""
   IL_001a:  ret
 }");
-            testData = new CompilationTestData();
-            result = context.CompileExpression("F(this.F)", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData = new CompilationTestData();
+                result = context.CompileExpression("F(this.F)", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       19 (0x13)
   .maxstack  2
@@ -681,9 +666,9 @@ class B : A
   IL_000d:  call       ""object B.F(System.Func<object>)""
   IL_0012:  ret
 }");
-            testData = new CompilationTestData();
-            result = context.CompileExpression("F(new System.Func<object>(this.F))", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData = new CompilationTestData();
+                result = context.CompileExpression("F(new System.Func<object>(this.F))", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       19 (0x13)
   .maxstack  2
@@ -694,6 +679,7 @@ class B : A
   IL_000d:  call       ""object B.F(System.Func<object>)""
   IL_0012:  ret
 }");
+            });
         }
 
         [Fact]
@@ -716,16 +702,15 @@ class B : A
     {
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "B.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("base.F() ?? base.G ?? base.P", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "B.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("base.F() ?? base.G ?? base.P", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       27 (0x1b)
   .maxstack  2
@@ -743,9 +728,9 @@ class B : A
   IL_0015:  call       ""object A.P.get""
   IL_001a:  ret
 }");
-            testData = new CompilationTestData();
-            result = context.CompileExpression("F(base.F)", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData = new CompilationTestData();
+                result = context.CompileExpression("F(base.F)", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       18 (0x12)
   .maxstack  2
@@ -755,9 +740,9 @@ class B : A
   IL_000c:  call       ""object B.F(System.Func<object>)""
   IL_0011:  ret
 }");
-            testData = new CompilationTestData();
-            result = context.CompileExpression("F(new System.Func<object>(base.F))", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData = new CompilationTestData();
+                result = context.CompileExpression("F(new System.Func<object>(base.F))", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       18 (0x12)
   .maxstack  2
@@ -767,6 +752,7 @@ class B : A
   IL_000c:  call       ""object B.F(System.Func<object>)""
   IL_0011:  ret
 }");
+            });
         }
 
         /// <summary>
@@ -1262,22 +1248,16 @@ class B : A
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.UnsafeDebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.UnsafeDebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M", atLineNumber: 999);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M",
-                atLineNumber: 999);
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("(int)p1[0] + p2[0] + ((int*)p3)[0]", out error, testData);
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("(int)p1[0] + p2[0] + ((int*)p3)[0]", out error, testData);
-
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       11 (0xb)
   .maxstack  2
@@ -1299,6 +1279,7 @@ class B : A
   IL_0009:  add
   IL_000a:  ret
 }");
+            });
         }
 
         [WorkItem(1034549, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1034549")]
@@ -1313,22 +1294,18 @@ class B : A
         int x = 0;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileAssignment(
-                target: "x",
-                expr: "1",
-                error: out error,
-                testData: testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileAssignment(
+                    target: "x",
+                    expr: "1",
+                    error: out error,
+                    testData: testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        3 (0x3)
   .maxstack  1
@@ -1337,13 +1314,13 @@ class B : A
   IL_0001:  stloc.0
   IL_0002:  ret
 }");
-            // Assign to a local, as above, but in an expression.
-            testData = new CompilationTestData();
-            context.CompileExpression(
-                expr: "x = 1",
-                error: out error,
-                testData: testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                // Assign to a local, as above, but in an expression.
+                testData = new CompilationTestData();
+                context.CompileExpression(
+                    expr: "x = 1",
+                    error: out error,
+                    testData: testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        4 (0x4)
   .maxstack  2
@@ -1353,6 +1330,7 @@ class B : A
   IL_0002:  stloc.0
   IL_0003:  ret
 }");
+            });
         }
 
         [Fact]
@@ -1371,22 +1349,18 @@ class B : A
         int y;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileAssignment(
-                target: "this.a[F(x)]",
-                expr: "this.a[y]",
-                error: out error,
-                testData: testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileAssignment(
+                    target: "this.a[F(x)]",
+                    expr: "this.a[y]",
+                    error: out error,
+                    testData: testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       22 (0x16)
   .maxstack  4
@@ -1402,6 +1376,7 @@ class B : A
   IL_0014:  stelem.ref
   IL_0015:  ret
 }");
+            });
         }
 
         [Fact]
@@ -1467,28 +1442,30 @@ class C
             var compilation0 = CreateCompilationWithMscorlib(
                 source,
                 options: TestOptions.DebugDll,
-                references: new[] { SystemCoreRef, CSharpRef },
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+                references: new[] { SystemCoreRef, CSharpRef });
+
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
-            CheckResultFlags(context, "o.F()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            // Calls to methods are reported as having side effects, even if
-            // the method is marked [Pure]. This matches the native EE.
-            CheckResultFlags(context, "o.G()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "o.P", DkmClrCompilationResultFlags.None);
-            CheckResultFlags(context, "o.P = 2", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "((dynamic)o).G()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "(Action)(() => { })", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "++i", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "--i", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "i++", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "i--", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "i += 2", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "i *= 3", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "new C() { P = 1 }", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "new C() { P = H() }", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "o.F()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                // Calls to methods are reported as having side effects, even if
+                // the method is marked [Pure]. This matches the native EE.
+                CheckResultFlags(context, "o.G()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "o.P", DkmClrCompilationResultFlags.None);
+                CheckResultFlags(context, "o.P = 2", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "((dynamic)o).G()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "(Action)(() => { })", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "++i", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "--i", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "i++", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "i--", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "i += 2", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "i *= 3", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "new C() { P = 1 }", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "new C() { P = H() }", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+            });
         }
 
         [Fact]
@@ -1519,36 +1496,36 @@ class C
             var compilation0 = CreateCompilationWithMscorlib(
                 source,
                 options: TestOptions.DebugDll,
-                references: new[] { SystemCoreRef, CSharpRef },
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+                references: new[] { SystemCoreRef, CSharpRef });
 
-            CheckResultFlags(context, "F", DkmClrCompilationResultFlags.None);
-            CheckResultFlags(context, "RF", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "CF", DkmClrCompilationResultFlags.ReadOnlyResult);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            // Note: flags are always None in error cases.
-            // CheckResultFlags(context, "E", DkmClrCompilationResultFlags.None); // TODO: DevDiv #1055825
-            CheckResultFlags(context, "CE", DkmClrCompilationResultFlags.None, "error CS0079: The event 'C.CE' can only appear on the left hand side of += or -=");
+                CheckResultFlags(context, "F", DkmClrCompilationResultFlags.None);
+                CheckResultFlags(context, "RF", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "CF", DkmClrCompilationResultFlags.ReadOnlyResult);
 
-            CheckResultFlags(context, "RP", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "WP", DkmClrCompilationResultFlags.None, "error CS0154: The property or indexer 'C.WP' cannot be used in this context because it lacks the get accessor");
-            CheckResultFlags(context, "RWP", DkmClrCompilationResultFlags.None);
+                // Note: flags are always None in error cases.
+                // CheckResultFlags(context, "E", DkmClrCompilationResultFlags.None); // TODO: DevDiv #1055825
+                CheckResultFlags(context, "CE", DkmClrCompilationResultFlags.None, "error CS0079: The event 'C.CE' can only appear on the left hand side of += or -=");
 
-            CheckResultFlags(context, "this[1]", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "this[1, 2]", DkmClrCompilationResultFlags.None, "error CS0154: The property or indexer 'C.this[int, int]' cannot be used in this context because it lacks the get accessor");
-            CheckResultFlags(context, "this[1, 2, 3]", DkmClrCompilationResultFlags.None);
+                CheckResultFlags(context, "RP", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "WP", DkmClrCompilationResultFlags.None, "error CS0154: The property or indexer 'C.WP' cannot be used in this context because it lacks the get accessor");
+                CheckResultFlags(context, "RWP", DkmClrCompilationResultFlags.None);
 
-            CheckResultFlags(context, "M()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "this[1]", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "this[1, 2]", DkmClrCompilationResultFlags.None, "error CS0154: The property or indexer 'C.this[int, int]' cannot be used in this context because it lacks the get accessor");
+                CheckResultFlags(context, "this[1, 2, 3]", DkmClrCompilationResultFlags.None);
 
-            CheckResultFlags(context, "null", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "1", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "M", DkmClrCompilationResultFlags.None, "error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?");
-            CheckResultFlags(context, "typeof(C)", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "new C()", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "M()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+
+                CheckResultFlags(context, "null", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "1", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "M", DkmClrCompilationResultFlags.None, "error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?");
+                CheckResultFlags(context, "typeof(C)", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "new C()", DkmClrCompilationResultFlags.ReadOnlyResult);
+            });
         }
 
         [Fact]
@@ -1570,21 +1547,21 @@ class C
             var compilation0 = CreateCompilationWithMscorlib(
                 source,
                 options: TestOptions.DebugDll,
-                references: new[] { SystemCoreRef, CSharpRef },
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+                references: new[] { SystemCoreRef, CSharpRef });
 
-            CheckResultFlags(context, "RF", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "RF[0]", DkmClrCompilationResultFlags.None);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            CheckResultFlags(context, "RP", DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "RP[0]", DkmClrCompilationResultFlags.None);
+                CheckResultFlags(context, "RF", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "RF[0]", DkmClrCompilationResultFlags.None);
 
-            CheckResultFlags(context, "M()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
-            CheckResultFlags(context, "M()[0]", DkmClrCompilationResultFlags.PotentialSideEffect);
+                CheckResultFlags(context, "RP", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "RP[0]", DkmClrCompilationResultFlags.None);
+
+                CheckResultFlags(context, "M()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "M()[0]", DkmClrCompilationResultFlags.PotentialSideEffect);
+            });
         }
 
         private static void CheckResultFlags(EvaluationContext context, string expr, DkmClrCompilationResultFlags expectedFlags, string expectedError = null)
@@ -1615,26 +1592,25 @@ class C
     {
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.M");
-            ResultProperties resultProperties;
-            string error;
-            context.CompileExpression("x", out resultProperties, out error);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult);
-            context.CompileExpression("y", out resultProperties, out error);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.None);
-            context.CompileExpression("(bool)y", out resultProperties, out error);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult);
-            context.CompileExpression("!y", out resultProperties, out error);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.ReadOnlyResult);
-            context.CompileExpression("false", out resultProperties, out error);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult);
-            context.CompileExpression("F()", out resultProperties, out error);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult | DkmClrCompilationResultFlags.PotentialSideEffect);
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                ResultProperties resultProperties;
+                string error;
+                context.CompileExpression("x", out resultProperties, out error);
+                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult);
+                context.CompileExpression("y", out resultProperties, out error);
+                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.None);
+                context.CompileExpression("(bool)y", out resultProperties, out error);
+                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult);
+                context.CompileExpression("!y", out resultProperties, out error);
+                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.ReadOnlyResult);
+                context.CompileExpression("false", out resultProperties, out error);
+                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult);
+                context.CompileExpression("F()", out resultProperties, out error);
+                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult | DkmClrCompilationResultFlags.PotentialSideEffect);
+            });
         }
 
         /// <summary>
@@ -1734,22 +1710,21 @@ class C
         object o;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileAssignment(
-                target: "o",
-                expr: "M",
-                error: out error,
-                testData: testData);
-            Assert.Equal(error, "error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileAssignment(
+                    target: "o",
+                    expr: "M",
+                    error: out error,
+                    testData: testData);
+                Assert.Equal(error, "error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?");
+            });
         }
 
         [Fact]
@@ -1764,16 +1739,14 @@ class C
         const int y = 2;
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("x[y]", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("x[y]", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       12 (0xc)
   .maxstack  2
@@ -1782,6 +1755,7 @@ class C
   IL_0006:  call       ""char string.this[int].get""
   IL_000b:  ret
 }");
+            });
         }
 
         [Fact]
@@ -1795,22 +1769,21 @@ class C
         const int x = 1;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileAssignment(
-                target: "x",
-                expr: "2",
-                error: out error,
-                testData: testData);
-            Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileAssignment(
+                    target: "x",
+                    expr: "2",
+                    error: out error,
+                    testData: testData);
+                Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+            });
         }
 
         [Fact]
@@ -1831,22 +1804,20 @@ class C
         y = default(T);
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M1");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileAssignment(
-                target: "x",
-                expr: "2",
-                error: out error,
-                testData: testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileAssignment(
+                    target: "x",
+                    expr: "2",
+                    error: out error,
+                    testData: testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        4 (0x4)
   .maxstack  2
@@ -1855,16 +1826,16 @@ class C
   IL_0002:  stind.i4
   IL_0003:  ret
 }");
-            context = CreateMethodContext(
-                runtime,
-                methodName: "C.M2");
-            testData = new CompilationTestData();
-            context.CompileAssignment(
-                target: "y",
-                expr: "default(T)",
-                error: out error,
-                testData: testData);
-            testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.M2");
+                testData = new CompilationTestData();
+                context.CompileAssignment(
+                    target: "y",
+                    expr: "default(T)",
+                    error: out error,
+                    testData: testData);
+                testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
 @"{
   // Code size        8 (0x8)
   .maxstack  1
@@ -1872,12 +1843,13 @@ class C
   IL_0001:  initobj    ""T""
   IL_0007:  ret
 }");
-            testData = new CompilationTestData();
-            context.CompileExpression(
-                expr: "F(() => y)",
-                error: out error,
-                testData: testData);
-            Assert.Equal(error, "error CS1628: Cannot use ref or out parameter 'y' inside an anonymous method, lambda expression, or query expression");
+                testData = new CompilationTestData();
+                context.CompileExpression(
+                    expr: "F(() => y)",
+                    error: out error,
+                    testData: testData);
+                Assert.Equal(error, "error CS1628: Cannot use ref or out parameter 'y' inside an anonymous method, lambda expression, or query expression");
+            });
         }
 
         [Fact]
@@ -1942,23 +1914,21 @@ class C
     {
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression(
-                "@0x123 ?? @0xa1b2c3 ?? (object)$exception ?? @0XA1B2C3.GetHashCode()",
-                DkmEvaluationFlags.TreatAsExpression,
-                ImmutableArray.Create(ExceptionAlias()),
-                out error,
-                testData);
-            Assert.Null(error);
-            Assert.Equal(testData.Methods.Count, 1);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+                    "@0x123 ?? @0xa1b2c3 ?? (object)$exception ?? @0XA1B2C3.GetHashCode()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    ImmutableArray.Create(ExceptionAlias()),
+                    out error,
+                    testData);
+                Assert.Null(error);
+                Assert.Equal(testData.Methods.Count, 1);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       61 (0x3d)
   .maxstack  2
@@ -1985,12 +1955,13 @@ class C
   IL_0037:  box        ""int""
   IL_003c:  ret
 }");
-            testData = new CompilationTestData();
-            // Report overflow, even though native EE does not.
-            context.CompileExpression(
-                "@0xffff0000ffff0000ffff0000",
-                out error, testData);
-            Assert.Equal(error, "error CS1021: Integral constant is too large");
+                testData = new CompilationTestData();
+                // Report overflow, even though native EE does not.
+                context.CompileExpression(
+                    "@0xffff0000ffff0000ffff0000",
+                    out error, testData);
+                Assert.Equal(error, "error CS1021: Integral constant is too large");
+            });
         }
 
         [WorkItem(986227, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/986227")]
@@ -2006,18 +1977,15 @@ class C<T>
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression(
-                expr:
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+                    expr:
 @"((Func<E<T>>)(() =>
 {
     E<T> e1 = null;
@@ -2034,26 +2002,26 @@ class C<T>
     }
     return e1;
 }))()",
-                error: out error,
-                testData: testData);
+                    error: out error,
+                    testData: testData);
 
-            var methodData = testData.GetMethodData("<>x<T>.<>c.<<>m0>b__0_0");
-            var method = (MethodSymbol)methodData.Method;
-            var containingType = method.ContainingType;
-            var returnType = (NamedTypeSymbol)method.ReturnType;
-            // Return type E<T> with type argument T from <>c<T>.
-            Assert.Equal(returnType.TypeArguments[0].ContainingSymbol, containingType.ContainingType);
-            var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
-            Assert.Equal(1, locals.Length);
-            // All locals of type E<T> with type argument T from <>c<T>.
-            foreach (var local in locals)
-            {
-                var localType = (NamedTypeSymbol)local.Type;
-                var typeArg = localType.TypeArguments[0];
-                Assert.Equal(typeArg.ContainingSymbol, containingType.ContainingType);
-            }
+                var methodData = testData.GetMethodData("<>x<T>.<>c.<<>m0>b__0_0");
+                var method = (MethodSymbol)methodData.Method;
+                var containingType = method.ContainingType;
+                var returnType = (NamedTypeSymbol)method.ReturnType;
+                // Return type E<T> with type argument T from <>c<T>.
+                Assert.Equal(returnType.TypeArguments[0].ContainingSymbol, containingType.ContainingType);
+                var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
+                Assert.Equal(1, locals.Length);
+                // All locals of type E<T> with type argument T from <>c<T>.
+                foreach (var local in locals)
+                {
+                    var localType = (NamedTypeSymbol)local.Type;
+                    var typeArg = localType.TypeArguments[0];
+                    Assert.Equal(typeArg.ContainingSymbol, containingType.ContainingType);
+                }
 
-            methodData.VerifyIL(
+                methodData.VerifyIL(
 @"{
   // Code size       23 (0x17)
   .maxstack  1
@@ -2080,6 +2048,7 @@ class C<T>
   IL_0015:  ldloc.0
   IL_0016:  ret
 }");
+            });
         }
 
         [WorkItem(986227, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/986227")]
@@ -2095,37 +2064,33 @@ class C<T>
         T t;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression(
-                expr: "new T() { F = 1 }",
-                error: out error,
-                testData: testData);
-
-            var methodData = testData.GetMethodData("<>x.<>m0<T>()");
-            var method = (MethodSymbol)methodData.Method;
-            var returnType = method.ReturnType;
-            Assert.Equal(returnType.TypeKind, TypeKind.TypeParameter);
-            Assert.Equal(returnType.ContainingSymbol, method);
-
-            var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
-            // The original local of type T from <>m0<T>.
-            Assert.Equal(locals.Length, 1);
-            foreach (var local in locals)
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
             {
-                var localType = (TypeSymbol)local.Type;
-                Assert.Equal(localType.ContainingSymbol, method);
-            }
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+                    expr: "new T() { F = 1 }",
+                    error: out error,
+                    testData: testData);
 
-            methodData.VerifyIL(
+                var methodData = testData.GetMethodData("<>x.<>m0<T>()");
+                var method = (MethodSymbol)methodData.Method;
+                var returnType = method.ReturnType;
+                Assert.Equal(returnType.TypeKind, TypeKind.TypeParameter);
+                Assert.Equal(returnType.ContainingSymbol, method);
+
+                var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
+                // The original local of type T from <>m0<T>.
+                Assert.Equal(locals.Length, 1);
+                foreach (var local in locals)
+                {
+                    var localType = (TypeSymbol)local.Type;
+                    Assert.Equal(localType.ContainingSymbol, method);
+                }
+
+                methodData.VerifyIL(
 @"{
   // Code size       23 (0x17)
   .maxstack  3
@@ -2138,6 +2103,7 @@ class C<T>
   IL_0011:  stfld      ""object C.F""
   IL_0016:  ret
 }");
+            });
         }
 
         [Fact]
@@ -2151,22 +2117,19 @@ class C<T>
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileAssignment(
-                target: "o",
-                expr: string.Format("new {{ {0} = 1 }}", longName),
-                error: out error,
-                testData: testData);
-            Assert.Equal(error, string.Format("error CS7013: Name '<{0}>i__Field' exceeds the maximum length allowed in metadata.", longName));
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileAssignment(
+                    target: "o",
+                    expr: string.Format("new {{ {0} = 1 }}", longName),
+                    error: out error,
+                    testData: testData);
+                Assert.Equal(error, string.Format("error CS7013: Name '<{0}>i__Field' exceeds the maximum length allowed in metadata.", longName));
+            });
         }
 
         /// <summary>
@@ -2183,22 +2146,19 @@ class C<T>
         object o;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileAssignment(
-                target: "o",
-                expr: "M()",
-                error: out error,
-                testData: testData);
-            Assert.Equal(error, "error CS0029: Cannot implicitly convert type 'void' to 'object'");
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileAssignment(
+                    target: "o",
+                    expr: "M()",
+                    error: out error,
+                    testData: testData);
+                Assert.Equal(error, "error CS0029: Cannot implicitly convert type 'void' to 'object'");
+            });
         }
 
         [Fact]
@@ -2211,22 +2171,18 @@ class C<T>
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.UnsafeDebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileAssignment(
-                target: "p[1]",
-                expr: "p[0] + 1",
-                error: out error,
-                testData: testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.UnsafeDebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileAssignment(
+                    target: "p[1]",
+                    expr: "p[0] + 1",
+                    error: out error,
+                    testData: testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        9 (0x9)
   .maxstack  3
@@ -2240,6 +2196,7 @@ class C<T>
   IL_0007:  stind.i4
   IL_0008:  ret
 }");
+            });
         }
 
         /// <remarks>
@@ -2270,12 +2227,14 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.UnsafeDebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.Main");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("G(async() => await F())", out error, testData);
-            Assert.Null(error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.Main");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("G(async() => await F())", out error, testData);
+                Assert.Null(error);
+            });
         }
 
         /// <remarks>
@@ -2304,18 +2263,20 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.UnsafeDebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.Main");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression(@"G(async() => 
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.Main");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression(@"G(async() => 
 {
     unsafe 
     {
         return await F();
     }
 })", out error, testData);
-            Assert.Null(error);
+                Assert.Null(error);
+            });
         }
 
         /// <summary>
@@ -2433,19 +2394,15 @@ class C
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "A.B.M1");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("(object)t ?? (object)w ?? typeof(V) ?? typeof(X)", out error, testData);
-            var methodData = testData.GetMethodData("<>x<T, U, V>.<>m0<W, X>");
-            methodData.VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "A.B.M1");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("(object)t ?? (object)w ?? typeof(V) ?? typeof(X)", out error, testData);
+                var methodData = testData.GetMethodData("<>x<T, U, V>.<>m0<W, X>");
+                methodData.VerifyIL(
 @"{
   // Code size       45 (0x2d)
   .maxstack  2
@@ -2470,22 +2427,23 @@ class C
   IL_0027:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_002c:  ret
 }");
-            // Verify generated type and method are generic.
-            Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Generic);
-            var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(result.Assembly));
-            var reader = metadata.MetadataReader;
-            var typeDef = reader.GetTypeDef(result.TypeName);
-            reader.CheckTypeParameters(typeDef.GetGenericParameters(), "T", "U", "V");
-            var methodDef = reader.GetMethodDef(typeDef, result.MethodName);
-            reader.CheckTypeParameters(methodDef.GetGenericParameters(), "W", "X");
+                // Verify generated type and method are generic.
+                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Generic);
+                var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(result.Assembly));
+                var reader = metadata.MetadataReader;
+                var typeDef = reader.GetTypeDef(result.TypeName);
+                reader.CheckTypeParameters(typeDef.GetGenericParameters(), "T", "U", "V");
+                var methodDef = reader.GetMethodDef(typeDef, result.MethodName);
+                reader.CheckTypeParameters(methodDef.GetGenericParameters(), "W", "X");
 
-            context = CreateMethodContext(
-                runtime,
-                methodName: "A.B.M2");
-            testData = new CompilationTestData();
-            context.CompileExpression("(object)t ?? typeof(T) ?? typeof(U)", out error, testData);
-            methodData = testData.GetMethodData("<>x<T, U, V>.<>m0");
-            Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Default);
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "A.B.M2");
+                testData = new CompilationTestData();
+                context.CompileExpression("(object)t ?? typeof(T) ?? typeof(U)", out error, testData);
+                methodData = testData.GetMethodData("<>x<T, U, V>.<>m0");
+                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Default);
+            });
         }
 
         [Fact]
@@ -2504,19 +2462,15 @@ class C<T>
         return u;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("F(() => this.M(u))", out error, testData);
-            var methodData = testData.GetMethodData("<>x<T>.<>m0<U>");
-            methodData.VerifyIL(@"
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("F(() => this.M(u))", out error, testData);
+                var methodData = testData.GetMethodData("<>x<T>.<>m0<U>");
+                methodData.VerifyIL(@"
 {
   // Code size       36 (0x24)
   .maxstack  3
@@ -2533,7 +2487,8 @@ class C<T>
   IL_001e:  call       ""U C<T>.F<U>(System.Func<U>)""
   IL_0023:  ret
 }");
-            Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Generic);
+                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Generic);
+            });
         }
 
         [WorkItem(976847, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/976847")]
@@ -2547,19 +2502,15 @@ class C<T>
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("new System.ArgIterator(__arglist)", out error, testData);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            methodData.VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("new System.ArgIterator(__arglist)", out error, testData);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                methodData.VerifyIL(
 @"{
   // Code size        8 (0x8)
   .maxstack  1
@@ -2567,7 +2518,8 @@ class C<T>
   IL_0002:  newobj     ""System.ArgIterator..ctor(System.RuntimeArgumentHandle)""
   IL_0007:  ret
 }");
-            Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.ExtraArguments);
+                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.ExtraArguments);
+            });
         }
 
         [Fact]
@@ -2911,24 +2863,22 @@ class B : A
         F(() => base.F(y));
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "B.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("F(() => this.F(x))", out error, testData);
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("F(() => this.F(x))", out error, testData);
 
-            // Note there are duplicate local names (one from the original
-            // display class, the other from the new display class in each case).
-            // That is expected since we do not rename old locals nor do we
-            // offset numbering of new locals. Having duplicate local names
-            // in the PDB should be harmless though.
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                // Note there are duplicate local names (one from the original
+                // display class, the other from the new display class in each case).
+                // That is expected since we do not rename old locals nor do we
+                // offset numbering of new locals. Having duplicate local names
+                // in the PDB should be harmless though.
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       29 (0x1d)
   .maxstack  3
@@ -2942,7 +2892,7 @@ class B : A
   IL_0017:  call       ""void B.F(System.Func<object>)""
   IL_001c:  ret
 }");
-            testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<>m0>b__0").VerifyIL(
+                testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<>m0>b__0").VerifyIL(
 @"{
   // Code size       28 (0x1c)
   .maxstack  2
@@ -2955,9 +2905,9 @@ class B : A
   IL_0016:  callvirt   ""object B.F(object)""
   IL_001b:  ret
 }");
-            testData = new CompilationTestData();
-            context.CompileExpression("F(() => base.F(y))", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData = new CompilationTestData();
+                context.CompileExpression("F(() => base.F(y))", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       29 (0x1d)
   .maxstack  3
@@ -2971,7 +2921,7 @@ class B : A
   IL_0017:  call       ""void B.F(System.Func<object>)""
   IL_001c:  ret
 }");
-            testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<>m0>b__0").VerifyIL(
+                testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<>m0>b__0").VerifyIL(
 @"{
   // Code size       28 (0x1c)
   .maxstack  2
@@ -2984,6 +2934,7 @@ class B : A
   IL_0016:  call       ""object A.F(object)""
   IL_001b:  ret
 }");
+            });
         }
 
         [WorkItem(994485, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/994485")]
@@ -3008,18 +2959,14 @@ class C
     }
 }
 ";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("e.HasValue", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("e.HasValue", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -3032,6 +2979,7 @@ class C
   IL_0006:  call       ""bool E?.HasValue.get""
   IL_000b:  ret
 }");
+            });
         }
 
         [Fact]
@@ -3072,22 +3020,17 @@ class B : A
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "B.M",
-                atLineNumber: 999);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "B.M", atLineNumber: 999);
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("this.F(y)", out error, testData);
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("this.F(y)", out error, testData);
 
-            testData.GetMethodData("<>x.<>m0<T>").VerifyIL(@"
+                testData.GetMethodData("<>x.<>m0<T>").VerifyIL(@"
 {
   // Code size       23 (0x17)
   .maxstack  2
@@ -3104,10 +3047,10 @@ class B : A
   IL_0011:  callvirt   ""object B.F(object)""
   IL_0016:  ret
 }");
-            testData = new CompilationTestData();
-            context.CompileExpression("base.F(x)", out error, testData);
+                testData = new CompilationTestData();
+                context.CompileExpression("base.F(x)", out error, testData);
 
-            testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
+                testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
 @"{
   // Code size       18 (0x12)
   .maxstack  2
@@ -3123,6 +3066,7 @@ class B : A
   IL_000c:  call       ""object A.F(object)""
   IL_0011:  ret
 }");
+            });
         }
 
         [Fact]
@@ -3349,20 +3293,16 @@ class B : A
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll.WithModuleName("MODULE"),
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("new [] { 1, 2, 3, 4, 5 }", out error, testData);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.Equal(methodData.Method.ReturnType.ToDisplayString(), "int[]");
-            methodData.VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll.WithModuleName("MODULE"));
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("new [] { 1, 2, 3, 4, 5 }", out error, testData);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.Equal(methodData.Method.ReturnType.ToDisplayString(), "int[]");
+                methodData.VerifyIL(
 @"{
   // Code size       18 (0x12)
   .maxstack  3
@@ -3373,6 +3313,7 @@ class B : A
   IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  ret
 }");
+            });
         }
 
         // Scenario from the lambda / anonymous type milestone.
@@ -3395,18 +3336,14 @@ class Program
         var o = mgr.Reports.Where(e => e.Salary < 100).Select(e => new { e.Name, e.Salary }).First();
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "Program.F");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("mgr.Reports.Where(e => e.Salary < 100).Select(e => new { e.Name, e.Salary }).First()", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "Program.F");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("mgr.Reports.Where(e => e.Salary < 100).Select(e => new { e.Name, e.Salary }).First()", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       84 (0x54)
   .maxstack  3
@@ -3436,6 +3373,7 @@ class Program
   IL_004e:  call       ""<anonymous type: string Name, int Salary> System.Linq.Enumerable.First<<anonymous type: string Name, int Salary>>(System.Collections.Generic.IEnumerable<<anonymous type: string Name, int Salary>>)""
   IL_0053:  ret
 }");
+            });
         }
 
         [Fact]
@@ -3455,18 +3393,14 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("F(() => o + 1)", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("F(() => o + 1)", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size      100 (0x64)
   .maxstack  3
@@ -3495,6 +3429,7 @@ class C
   IL_005e:  call       ""object C.F(System.Linq.Expressions.Expression<System.Func<object>>)""
   IL_0063:  ret
 }");
+            });
         }
 
         /// <summary>
@@ -3518,18 +3453,15 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("F(() => null ?? new object())", out error, testData);
-            Assert.Equal(error, "error CS0845: An expression tree lambda may not contain a coalescing operator with a null literal left-hand side");
+            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("F(() => null ?? new object())", out error, testData);
+                Assert.Equal(error, "error CS0845: An expression tree lambda may not contain a coalescing operator with a null literal left-hand side");
+            });
         }
 
         [WorkItem(935651, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/935651")]
@@ -3582,30 +3514,27 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            ResultProperties resultProperties;
-            string error;
-            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            var result = context.CompileExpression(
-                "o.First()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(error, "error CS1061: 'object[]' does not contain a definition for 'First' and no extension method 'First' accepting a first argument of type 'object[]' could be found (are you missing a using directive or an assembly reference?)");
-            AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
+                ResultProperties resultProperties;
+                string error;
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                var result = context.CompileExpression(
+                    "o.First()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(error, "error CS1061: 'object[]' does not contain a definition for 'First' and no extension method 'First' accepting a first argument of type 'object[]' could be found (are you missing a using directive or an assembly reference?)");
+                AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
+            });
         }
 
         [Fact]
@@ -3619,21 +3548,17 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
+            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
 
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("E.First(o)", out error, testData);
-            Assert.Null(error);
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("E.First(o)", out error, testData);
+                Assert.Null(error);
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -3641,12 +3566,13 @@ class C
   IL_0001:  call       ""object System.Linq.Enumerable.First<object>(System.Collections.Generic.IEnumerable<object>)""
   IL_0006:  ret
 }");
+            });
         }
 
         [Fact]
         public void NetModuleReference()
         {
-            var source0 =
+            var sourceNetModule =
 @"class A
 {
 }";
@@ -3657,33 +3583,23 @@ class C
     {
     }
 }";
-            var assembly0Name = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilation0 = CreateCompilationWithMscorlib(
-                source0,
-                options: TestOptions.DebugModule,
-                assemblyName: assembly0Name);
-            var netModule0 = ModuleMetadata.CreateFromImage(compilation0.EmitToArray()).GetReference(display: assembly0Name);
-            var assembly1Name = ExpressionCompilerUtilities.GenerateUniqueName();
-            var compilation1 = CreateCompilationWithMscorlib(
-                source1,
-                options: TestOptions.DebugDll,
-                assemblyName: assembly1Name,
-                references: new MetadataReference[] { netModule0 });
+            var netModuleRef = CreateCompilationWithMscorlib(sourceNetModule, options: TestOptions.DebugModule).EmitToImageReference();
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll, references: new[] { netModuleRef });
 
-            var runtime = CreateRuntimeInstance(compilation1);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "B.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("this", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"{
+            WithRuntimeInstance(compilation1, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "B.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("this", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
+            });
         }
 
         /// <summary>
@@ -3779,56 +3695,57 @@ class C
                 referenceN2, // From D2
             };
 
-            var runtime = CreateRuntimeInstance(compilation, references);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(compilation, references, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            // Expression references ambiguous modules.
-            ResultProperties resultProperties;
-            string error;
-            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            context.CompileExpression(
-                "x.F0 + y.F0",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
-            Assert.Equal("error CS7079: The type 'A0' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
+                // Expression references ambiguous modules.
+                ResultProperties resultProperties;
+                string error;
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                context.CompileExpression(
+                    "x.F0 + y.F0",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
+                Assert.Equal("error CS7079: The type 'A0' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
 
-            context.CompileExpression(
-                "y.F0",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
-            Assert.Equal("error CS7079: The type 'A0' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
+                context.CompileExpression(
+                    "y.F0",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
+                Assert.Equal("error CS7079: The type 'A0' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
 
-            context.CompileExpression(
-                "z.F1",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Empty(missingAssemblyIdentities);
-            Assert.Equal("error CS7079: The type 'A1' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
+                context.CompileExpression(
+                    "z.F1",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Empty(missingAssemblyIdentities);
+                Assert.Equal("error CS7079: The type 'A1' is defined in a module that has not been added. You must add the module '" + assemblyName + "_N0.netmodule'.", error);
 
-            // Expression does not reference ambiguous modules.
-            var testData = new CompilationTestData();
-            context.CompileExpression("w.F2", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                // Expression does not reference ambiguous modules.
+                var testData = new CompilationTestData();
+                context.CompileExpression("w.F2", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       11 (0xb)
   .maxstack  1
@@ -3836,6 +3753,7 @@ class C
   IL_0005:  ldfld      ""int A2.F2""
   IL_000a:  ret
 }");
+            });
         }
 
         [Fact]
@@ -4320,25 +4238,21 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("checked(2147483647 + 1)", out error, testData);
-            Assert.Equal("error CS0220: The operation overflows at compile time in checked mode", error);
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("checked(2147483647 + 1)", out error, testData);
+                Assert.Equal("error CS0220: The operation overflows at compile time in checked mode", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("unchecked(2147483647 + 1)", out error, testData);
-            Assert.Null(error);
+                testData = new CompilationTestData();
+                context.CompileExpression("unchecked(2147483647 + 1)", out error, testData);
+                Assert.Null(error);
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        6 (0x6)
   .maxstack  1
@@ -4346,17 +4260,18 @@ class C
   IL_0005:  ret
 }");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("2147483647 + 1", out error, testData);
-            Assert.Null(error);
+                testData = new CompilationTestData();
+                context.CompileExpression("2147483647 + 1", out error, testData);
+                Assert.Null(error);
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        6 (0x6)
   .maxstack  1
   IL_0000:  ldc.i4     0x80000000
   IL_0005:  ret
 }");
+            });
         }
 
         [WorkItem(1012956, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1012956")]
@@ -4371,28 +4286,24 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("u = 2147483647 + 1", out error, testData);
-            Assert.Equal("error CS0031: Constant value '-2147483648' cannot be converted to a 'uint'", error);
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("u = 2147483647 + 1", out error, testData);
+                Assert.Equal("error CS0031: Constant value '-2147483648' cannot be converted to a 'uint'", error);
 
-            testData = new CompilationTestData();
-            context.CompileAssignment("u", "2147483647 + 1", out error, testData);
-            Assert.Equal("error CS0031: Constant value '-2147483648' cannot be converted to a 'uint'", error);
+                testData = new CompilationTestData();
+                context.CompileAssignment("u", "2147483647 + 1", out error, testData);
+                Assert.Equal("error CS0031: Constant value '-2147483648' cannot be converted to a 'uint'", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("u = 2147483647 + 1u", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData = new CompilationTestData();
+                context.CompileExpression("u = 2147483647 + 1u", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        9 (0x9)
   .maxstack  2
@@ -4402,10 +4313,10 @@ class C
   IL_0008:  ret
 }");
 
-            testData = new CompilationTestData();
-            context.CompileAssignment("u", "2147483647 + 1u", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData = new CompilationTestData();
+                context.CompileAssignment("u", "2147483647 + 1u", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        8 (0x8)
   .maxstack  1
@@ -4413,6 +4324,7 @@ class C
   IL_0005:  starg.s    V_1
   IL_0007:  ret
 }");
+            });
         }
 
         [WorkItem(1016530, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1016530")]
@@ -4450,22 +4362,19 @@ class C
         object o = 1;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileAssignment(
-                target: "o",
-                expr: "(System.Func<object>)(() => 2))(",
-                error: out error,
-                testData: testData);
-            Assert.Equal("error CS1073: Unexpected token ')'", error);
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileAssignment(
+                    target: "o",
+                    expr: "(System.Func<object>)(() => 2))(",
+                    error: out error,
+                    testData: testData);
+                Assert.Equal("error CS1073: Unexpected token ')'", error);
+            });
         }
 
         [WorkItem(1015887, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1015887")]
@@ -4557,18 +4466,16 @@ struct S
         yield return this; // Until iterators always capture 'this', do it explicitly.
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.Equal(SpecialType.System_Int32, methodData.Method.ReturnType.SpecialType);
-            methodData.VerifyIL(@"
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.Equal(SpecialType.System_Int32, methodData.Method.ReturnType.SpecialType);
+                methodData.VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -4578,6 +4485,7 @@ struct S
   IL_0006:  ret
 }
 ");
+            });
         }
 
         [WorkItem(1024137, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1024137")]
@@ -4595,18 +4503,16 @@ struct S
         yield return this; // Until iterators always capture 'this', do it explicitly.
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("t", out error, testData);
-            var methodData = testData.GetMethodData("<>x<T>.<>m0");
-            Assert.Equal("T", methodData.Method.ReturnType.Name);
-            methodData.VerifyIL(@"
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("t", out error, testData);
+                var methodData = testData.GetMethodData("<>x<T>.<>m0");
+                Assert.Equal("T", methodData.Method.ReturnType.Name);
+                methodData.VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -4616,6 +4522,7 @@ struct S
   IL_0006:  ret
 }
 ");
+            });
         }
 
         [WorkItem(1028808, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1028808")]
@@ -4693,18 +4600,16 @@ struct S
     {
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("this?.F()", out error, testData);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.Equal(((MethodSymbol)methodData.Method).ReturnType.ToDisplayString(), "int?");
-            methodData.VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("this?.F()", out error, testData);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.Equal(((MethodSymbol)methodData.Method).ReturnType.ToDisplayString(), "int?");
+                methodData.VerifyIL(
 @"{
   // Code size       25 (0x19)
   .maxstack  1
@@ -4721,16 +4626,16 @@ struct S
   IL_0018:  ret
 }");
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("(new C())?.G()?.F()", out error, testData);
-            methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.Equal(((MethodSymbol)methodData.Method).ReturnType.ToDisplayString(), "int?");
+                testData = new CompilationTestData();
+                result = context.CompileExpression("(new C())?.G()?.F()", out error, testData);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.Equal(((MethodSymbol)methodData.Method).ReturnType.ToDisplayString(), "int?");
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("G()?.M()", out error, testData);
-            methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.True(((MethodSymbol)methodData.Method).ReturnsVoid);
-            methodData.VerifyIL(
+                testData = new CompilationTestData();
+                result = context.CompileExpression("G()?.M()", out error, testData);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.True(((MethodSymbol)methodData.Method).ReturnsVoid);
+                methodData.VerifyIL(
 @"{
   // Code size       17 (0x11)
   .maxstack  2
@@ -4743,6 +4648,7 @@ struct S
   IL_000b:  call       ""void C.M()""
   IL_0010:  ret
 }");
+            });
         }
 
         [Fact]
@@ -4763,18 +4669,16 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib45(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.Main");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("F()", out error, testData);
-            // Currently, the name of the evaluation method is used for
-            // [CallerMemberName] so "F()" will generate "[] [<>m0] [1]".
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.Main");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("F()", out error, testData);
+                // Currently, the name of the evaluation method is used for
+                // [CallerMemberName] so "F()" will generate "[] [<>m0] [1]".
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       17 (0x11)
   .maxstack  3
@@ -4784,6 +4688,7 @@ class C
   IL_000b:  call       ""object C.F(string, string, int)""
   IL_0010:  ret
 }");
+            });
         }
 
         [Fact]
@@ -4820,34 +4725,36 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("X")) });
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("SXL.LoadOptions.None.ToString()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("SXL.LoadOptions.None.ToString()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("LO.None.ToString()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                testData = new CompilationTestData();
+                result = context.CompileExpression("LO.None.ToString()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("LoadOptions.None.ToString()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                testData = new CompilationTestData();
+                result = context.CompileExpression("LoadOptions.None.ToString()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("X.System.Xml.Linq.LoadOptions.None.ToString()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                testData = new CompilationTestData();
+                result = context.CompileExpression("X.System.Xml.Linq.LoadOptions.None.ToString()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("X::System.Xml.Linq.LoadOptions.None.ToString()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                testData = new CompilationTestData();
+                result = context.CompileExpression("X::System.Xml.Linq.LoadOptions.None.ToString()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+            });
         }
 
         [Fact]
@@ -4884,19 +4791,21 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("global", "X")) });
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("A.LoadOptions.None.ToString()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("A.LoadOptions.None.ToString()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("B.LoadOptions.None.ToString()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                testData = new CompilationTestData();
+                result = context.CompileExpression("B.LoadOptions.None.ToString()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+            });
         }
 
         [Fact]
@@ -4923,14 +4832,16 @@ class C
                     SystemXmlLinqRef.WithAliases(ImmutableArray.Create("X")),
                     SystemXmlRef.WithAliases(ImmutableArray.Create("X"))
                 });
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("new X::System.Xml.XmlDocument()", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("new X::System.Xml.XmlDocument()", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        6 (0x6)
   .maxstack  1
@@ -4940,10 +4851,10 @@ class C
 }
 ");
 
-            testData = new CompilationTestData();
-            result = context.CompileExpression("X::System.Xml.Linq.LoadOptions.None", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                result = context.CompileExpression("X::System.Xml.Linq.LoadOptions.None", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -4952,6 +4863,7 @@ class C
   IL_0001:  ret
 }
 ");
+            });
         }
 
         [Fact]
@@ -4968,27 +4880,27 @@ class C
     }
 }
 ";
-
             var comp = CreateCompilationWithMscorlib(source);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var actionType = context.Compilation.GetWellKnownType(WellKnownType.System_Action);
+                var actionType = context.Compilation.GetWellKnownType(WellKnownType.System_Action);
 
-            ResultProperties resultProperties;
-            string error;
-            CompilationTestData testData;
-            CompileResult result;
-            CompilationTestData.MethodData methodData;
+                ResultProperties resultProperties;
+                string error;
+                CompilationTestData testData;
+                CompileResult result;
+                CompilationTestData.MethodData methodData;
 
-            // Inspect the value.
-            testData = new CompilationTestData();
-            result = context.CompileExpression("E", out resultProperties, out error, testData);
-            Assert.Null(error);
-            Assert.Equal(DkmClrCompilationResultFlags.None, resultProperties.Flags);
-            methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.Equal(actionType, methodData.Method.ReturnType);
-            methodData.VerifyIL(@"
+                // Inspect the value.
+                testData = new CompilationTestData();
+                result = context.CompileExpression("E", out resultProperties, out error, testData);
+                Assert.Null(error);
+                Assert.Equal(DkmClrCompilationResultFlags.None, resultProperties.Flags);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.Equal(actionType, methodData.Method.ReturnType);
+                methodData.VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -4998,14 +4910,14 @@ class C
 }
 ");
 
-            // Invoke the delegate.
-            testData = new CompilationTestData();
-            result = context.CompileExpression("E()", out resultProperties, out error, testData);
-            Assert.Null(error);
-            Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
-            methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.True(methodData.Method.ReturnsVoid);
-            methodData.VerifyIL(@"
+                // Invoke the delegate.
+                testData = new CompilationTestData();
+                result = context.CompileExpression("E()", out resultProperties, out error, testData);
+                Assert.Null(error);
+                Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.True(methodData.Method.ReturnsVoid);
+                methodData.VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -5016,14 +4928,14 @@ class C
 }
 ");
 
-            // Assign to the event.
-            testData = new CompilationTestData();
-            result = context.CompileExpression("E = null", out resultProperties, out error, testData);
-            Assert.Null(error);
-            Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
-            methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.Equal(actionType, methodData.Method.ReturnType);
-            methodData.VerifyIL(@"
+                // Assign to the event.
+                testData = new CompilationTestData();
+                result = context.CompileExpression("E = null", out resultProperties, out error, testData);
+                Assert.Null(error);
+                Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.Equal(actionType, methodData.Method.ReturnType);
+                methodData.VerifyIL(@"
 {
   // Code size       11 (0xb)
   .maxstack  3
@@ -5038,14 +4950,14 @@ class C
 }
 ");
 
-            // Event (compound) assignment.
-            testData = new CompilationTestData();
-            result = context.CompileExpression("E += null", out resultProperties, out error, testData);
-            Assert.Null(error);
-            Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
-            methodData = testData.GetMethodData("<>x.<>m0");
-            Assert.True(methodData.Method.ReturnsVoid);
-            methodData.VerifyIL(@"
+                // Event (compound) assignment.
+                testData = new CompilationTestData();
+                result = context.CompileExpression("E += null", out resultProperties, out error, testData);
+                Assert.Null(error);
+                Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
+                methodData = testData.GetMethodData("<>x.<>m0");
+                Assert.True(methodData.Method.ReturnsVoid);
+                methodData.VerifyIL(@"
 {
   // Code size        8 (0x8)
   .maxstack  2
@@ -5055,6 +4967,7 @@ class C
   IL_0007:  ret
 }
 ");
+            });
         }
 
         [Fact]
@@ -5216,25 +5129,26 @@ class C
 }";
 
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            var testData = new CompilationTestData();
-            ResultProperties resultProperties;
-            string error;
-            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            context.CompileExpression(
-                "from c in \"ABC\" select c",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData);
-            Assert.Equal(new AssemblyIdentity("System.Core"), missingAssemblyIdentities.Single());
-            Assert.Equal(error, "error CS1935: Could not find an implementation of the query pattern for source type 'string'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                ResultProperties resultProperties;
+                string error;
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                context.CompileExpression(
+                    "from c in \"ABC\" select c",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData);
+                Assert.Equal(new AssemblyIdentity("System.Core"), missingAssemblyIdentities.Single());
+                Assert.Equal(error, "error CS1935: Could not find an implementation of the query pattern for source type 'string'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?");
+            });
         }
 
         [WorkItem(1079762, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1079762")]
@@ -5253,26 +5167,25 @@ class C
         F(z => z != null && x != null, 3);
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.<>c__DisplayClass1_0.<M>b__0");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("z", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<>c__DisplayClass1_0.<M>b__0");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("z", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-            testData = new CompilationTestData();
-            context.CompileExpression("y", out error, testData);
-            Assert.Equal(error, "error CS0103: The name 'y' does not exist in the current context");
+                testData = new CompilationTestData();
+                context.CompileExpression("y", out error, testData);
+                Assert.Equal(error, "error CS0103: The name 'y' does not exist in the current context");
+            });
         }
 
         [WorkItem(1079762, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1079762")]
@@ -5287,25 +5200,24 @@ class C
         System.Func<object, bool> f = z => z != null;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.<>c.<M>b__0_0");
-            ResultProperties resultProperties;
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("z", out resultProperties, out error, testData);
-            Assert.Null(error);
-            Assert.Equal(DkmClrCompilationResultFlags.None, resultProperties.Flags);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<>c.<M>b__0_0");
+                ResultProperties resultProperties;
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("z", out resultProperties, out error, testData);
+                Assert.Null(error);
+                Assert.Equal(DkmClrCompilationResultFlags.None, resultProperties.Flags);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
+            });
         }
 
         [WorkItem(1084059, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1084059")]
@@ -5322,19 +5234,17 @@ class C
         Max(1, 2);
     }
 }";
-            var comp = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
-            ResultProperties resultProperties;
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("Min(1, 2)", out resultProperties, out error, testData);
-            Assert.Null(error);
-            Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                ResultProperties resultProperties;
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("Min(1, 2)", out resultProperties, out error, testData);
+                Assert.Null(error);
+                Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        8 (0x8)
   .maxstack  2
@@ -5343,6 +5253,7 @@ class C
   IL_0002:  call       ""int System.Math.Min(int, int)""
   IL_0007:  ret
 }");
+            });
         }
 
         [WorkItem(1014763, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1014763")]
@@ -5359,17 +5270,15 @@ class C
         return tt;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.I");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("typeof(T)", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0<T>").VerifyIL(@"
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.I");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("typeof(T)", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0<T>").VerifyIL(@"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -5378,6 +5287,7 @@ class C
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ret
 }");
+            });
         }
 
         [WorkItem(1014763, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1014763")]
@@ -5397,17 +5307,15 @@ class C
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.<I>d__0.MoveNext");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("typeof(T)", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T>.<>m0").VerifyIL(@"
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<I>d__0.MoveNext");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("typeof(T)", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T>.<>m0").VerifyIL(@"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -5416,6 +5324,7 @@ class C
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ret
 }");
+            });
         }
 
         [WorkItem(1085642, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1085642")]
@@ -5480,43 +5389,45 @@ public class C
             var libRef = CreateCompilationWithMscorlib(libSource, assemblyName: "Lib").EmitToImageReference();
             var comp = CreateCompilationWithMscorlib(source, new[] { libRef }, TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef });
-            var context = CreateMethodContext(runtime, "C.M");
-
-            var expectedError = "error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.";
-            var expectedMissingAssemblyIdentity = new AssemblyIdentity("Lib");
-
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
-
-            Action<string> verify = expr =>
+            WithRuntimeInstance(comp, new[] { MscorlibRef }, runtime =>
             {
-                context.CompileExpression(
-                    expr,
-                    DkmEvaluationFlags.TreatAsExpression,
-                    NoAliases,
-                    DebuggerDiagnosticFormatter.Instance,
-                    out resultProperties,
-                    out actualError,
-                    out actualMissingAssemblyIdentities,
-                    EnsureEnglishUICulture.PreferredOrNull,
-                    testData: null);
-                Assert.Equal(expectedError, actualError);
-                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
-            };
+                var context = CreateMethodContext(runtime, "C.M");
 
-            verify("M(null)");
-            verify("field");
-            verify("field.Method");
-            verify("parameter");
-            verify("parameter.Method");
-            verify("local");
-            verify("local.Method");
+                var expectedError = "error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.";
+                var expectedMissingAssemblyIdentity = new AssemblyIdentity("Lib");
 
-            // Note that even expressions that don't require the missing type will fail because
-            // the method we synthesize refers to the original locals and parameters.
-            verify("0");
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+
+                Action<string> verify = expr =>
+                {
+                    context.CompileExpression(
+                        expr,
+                        DkmEvaluationFlags.TreatAsExpression,
+                        NoAliases,
+                        DebuggerDiagnosticFormatter.Instance,
+                        out resultProperties,
+                        out actualError,
+                        out actualMissingAssemblyIdentities,
+                        EnsureEnglishUICulture.PreferredOrNull,
+                        testData: null);
+                    Assert.Equal(expectedError, actualError);
+                    Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                };
+
+                verify("M(null)");
+                verify("field");
+                verify("field.Method");
+                verify("parameter");
+                verify("parameter.Method");
+                verify("local");
+                verify("local.Method");
+
+                // Note that even expressions that don't require the missing type will fail because
+                // the method we synthesize refers to the original locals and parameters.
+                verify("0");
+            });
         }
 
         [WorkItem(1089688, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1089688")]
@@ -5560,18 +5471,19 @@ public class Source
                 // warning CS1701: Assuming assembly reference 'B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' used by 'A' matches identity 'B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2' of 'B', you may need to supply runtime policy
                 Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin).WithArguments("B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "A", "B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2", "B").WithLocation(1, 1));
 
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef, libAv1Ref, libBv2Ref });
-            var context = CreateMethodContext(runtime, "Source.Test");
+            WithRuntimeInstance(comp, new[] { MscorlibRef, libAv1Ref, libBv2Ref }, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "Source.Test");
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("new A()", out error, testData);
-            Assert.Null(error);
-            var methodData = testData.GetMethodData("<>x.<>m0");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("new A()", out error, testData);
+                Assert.Null(error);
+                var methodData = testData.GetMethodData("<>x.<>m0");
 
-            // Even though the method's return type has a use-site warning, we are able to evaluate the expression.
-            Assert.Equal(ErrorCode.WRN_UnifyReferenceMajMin, (ErrorCode)((MethodSymbol)methodData.Method).ReturnType.GetUseSiteDiagnostic().Code);
-            methodData.VerifyIL(@"
+                // Even though the method's return type has a use-site warning, we are able to evaluate the expression.
+                Assert.Equal(ErrorCode.WRN_UnifyReferenceMajMin, (ErrorCode)((MethodSymbol)methodData.Method).ReturnType.GetUseSiteDiagnostic().Code);
+                methodData.VerifyIL(@"
 {
   // Code size        6 (0x6)
   .maxstack  1
@@ -5579,6 +5491,7 @@ public class Source
   IL_0000:  newobj     ""A..ctor()""
   IL_0005:  ret
 }");
+            });
         }
 
         [WorkItem(1090458, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1090458")]
@@ -5601,12 +5514,14 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.Main");
-            ResultProperties resultProperties;
-            string error;
-            context.CompileExpression("c.P", out resultProperties, out error);
-            Assert.Null(error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.Main");
+                ResultProperties resultProperties;
+                string error;
+                context.CompileExpression("c.P", out resultProperties, out error);
+                Assert.Null(error);
+            });
         }
 
         [WorkItem(1090458, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1090458")]
@@ -5660,12 +5575,14 @@ namespace Windows.Foundation.Metadata
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.Main");
-            ResultProperties resultProperties;
-            string error;
-            context.CompileExpression("c.P", out resultProperties, out error);
-            Assert.Null(error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.Main");
+                ResultProperties resultProperties;
+                string error;
+                context.CompileExpression("c.P", out resultProperties, out error);
+                Assert.Null(error);
+            });
         }
 
         [WorkItem(1089591, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1089591")]
@@ -5754,14 +5671,15 @@ public class C<T>
 }
 ";
             var comp = CreateCompilationWithMscorlib45(source);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.<>c__0.<M>b__0_0");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<>c__0.<M>b__0_0");
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("typeof(U)", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("typeof(U)", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -5770,6 +5688,7 @@ public class C<T>
   IL_000a:  ret
 }
 ");
+            });
         }
 
         [WorkItem(1136085, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1136085")]
@@ -5786,11 +5705,12 @@ public class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(source);
-            var runtime = CreateRuntimeInstance(compilation);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstancePortableBug(compilation, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var expectedIL = @"
+                string error;
+                var expectedIL = @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -5799,24 +5719,25 @@ public class C
   IL_000a:  ret
 }";
 
-            var testData = new CompilationTestData();
-            context.CompileExpression("typeof(Action<>)", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                var testData = new CompilationTestData();
+                context.CompileExpression("typeof(Action<>)", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("typeof(Action<>  )", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                testData = new CompilationTestData();
+                context.CompileExpression("typeof(Action<>  )", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
 
-            context.CompileExpression("typeof(Action<Action<>>)", out error, testData);
-            Assert.Equal("error CS7003: Unexpected use of an unbound generic name", error);
+                context.CompileExpression("typeof(Action<Action<>>)", out error, testData);
+                Assert.Equal("error CS7003: Unexpected use of an unbound generic name", error);
 
-            context.CompileExpression("typeof(Action<Action< > > )", out error);
-            Assert.Equal("error CS7003: Unexpected use of an unbound generic name", error);
+                context.CompileExpression("typeof(Action<Action< > > )", out error);
+                Assert.Equal("error CS7003: Unexpected use of an unbound generic name", error);
 
-            context.CompileExpression("typeof(Action<>a)", out error);
-            Assert.Equal("error CS1026: ) expected", error);
+                context.CompileExpression("typeof(Action<>a)", out error);
+                Assert.Equal("error CS1026: ) expected", error);
+            });
         }
 
         [WorkItem(1068138, "DevDiv")]
@@ -5930,16 +5851,14 @@ class C
         var q = new[] { new C() }.AsQueryable();
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileExpression("q.Where(c => true)", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileExpression("q.Where(c => true)", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       64 (0x40)
   .maxstack  6
@@ -5966,6 +5885,7 @@ class C
   IL_003a:  call       ""System.Linq.IQueryable<C> System.Linq.Queryable.Where<C>(System.Linq.IQueryable<C>, System.Linq.Expressions.Expression<System.Func<C, bool>>)""
   IL_003f:  ret
 }");
+            });
         }
 
         /// <summary>
@@ -5986,16 +5906,14 @@ class C
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib45(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileExpression("F(async () => new C())", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileExpression("F(async () => new C())", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       37 (0x25)
   .maxstack  2
@@ -6011,6 +5929,7 @@ class C
   IL_001f:  call       ""void C.F<C>(System.Func<System.Threading.Tasks.Task<C>>)""
   IL_0024:  ret
 }");
+            });
         }
 
         [Fact]
@@ -6027,14 +5946,15 @@ class C
     }
 }";
             var comp = CreateCompilationWithMscorlib45(source);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("M(() => x)", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("M(() => x)", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       32 (0x20)
   .maxstack  3
@@ -6052,6 +5972,7 @@ class C
   IL_001a:  callvirt   ""void C.M(System.Func<int>)""
   IL_001f:  ret
 }");
+            });
         }
 
         [WorkItem(3309, "https://github.com/dotnet/roslyn/issues/3309")]
@@ -6094,32 +6015,29 @@ class C
         int y;
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                ImmutableArray<MetadataBlock> blocks;
+                Guid moduleVersionId;
+                ISymUnmanagedReader symReader;
+                int methodToken;
+                int localSignatureToken;
+                GetContextState(runtime, "C.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
-            ImmutableArray<MetadataBlock> blocks;
-            Guid moduleVersionId;
-            ISymUnmanagedReader symReader;
-            int methodToken;
-            int localSignatureToken;
-            GetContextState(runtime, "C.M", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
+                var context = EvaluationContext.CreateMethodContext(
+                    blocks.ToCompilation(),
+                    symReader,
+                    moduleVersionId,
+                    methodToken: methodToken,
+                    methodVersion: 1,
+                    ilOffset: ExpressionCompilerTestHelpers.NoILOffset,
+                    localSignatureToken: localSignatureToken);
 
-            var context = EvaluationContext.CreateMethodContext(
-                blocks.ToCompilation(),
-                symReader,
-                moduleVersionId,
-                methodToken: methodToken,
-                methodVersion: 1,
-                ilOffset: ExpressionCompilerTestHelpers.NoILOffset,
-                localSignatureToken: localSignatureToken);
-
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("x + y", out error, testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("x + y", out error, testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        4 (0x4)
   .maxstack  2
@@ -6130,31 +6048,32 @@ class C
   IL_0003:  ret
 }");
 
-            // Verify the context is re-used for ILOffset == 0.
-            var previous = context;
-            context = EvaluationContext.CreateMethodContext(
-                new CSharpMetadataContext(blocks, previous),
-                blocks,
-                symReader,
-                moduleVersionId,
-                methodToken: methodToken,
-                methodVersion: 1,
-                ilOffset: 0,
-                localSignatureToken: localSignatureToken);
-            Assert.Same(previous, context);
+                // Verify the context is re-used for ILOffset == 0.
+                var previous = context;
+                context = EvaluationContext.CreateMethodContext(
+                    new CSharpMetadataContext(blocks, previous),
+                    blocks,
+                    symReader,
+                    moduleVersionId,
+                    methodToken: methodToken,
+                    methodVersion: 1,
+                    ilOffset: 0,
+                    localSignatureToken: localSignatureToken);
+                Assert.Same(previous, context);
 
-            // Verify the context is re-used for NoILOffset.
-            previous = context;
-            context = EvaluationContext.CreateMethodContext(
-                new CSharpMetadataContext(blocks, previous),
-                blocks,
-                symReader,
-                moduleVersionId,
-                methodToken: methodToken,
-                methodVersion: 1,
-                ilOffset: ExpressionCompilerTestHelpers.NoILOffset,
-                localSignatureToken: localSignatureToken);
-            Assert.Same(previous, context);
+                // Verify the context is re-used for NoILOffset.
+                previous = context;
+                context = EvaluationContext.CreateMethodContext(
+                    new CSharpMetadataContext(blocks, previous),
+                    blocks,
+                    symReader,
+                    moduleVersionId,
+                    methodToken: methodToken,
+                    methodVersion: 1,
+                    ilOffset: ExpressionCompilerTestHelpers.NoILOffset,
+                    localSignatureToken: localSignatureToken);
+                Assert.Same(previous, context);
+            });
         }
 
         [WorkItem(4098, "https://github.com/dotnet/roslyn/issues/4098")]
@@ -6172,19 +6091,15 @@ class C
         var useLinq = list.Last();
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("from x in list from y in list where x > 0 select new { x, y };", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("from x in list from y in list where x > 0 select new { x, y };", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size      140 (0x8c)
   .maxstack  4
@@ -6232,6 +6147,7 @@ class C
   IL_0086:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: int x, int y>> System.Linq.Enumerable.Select<<anonymous type: int x, int y>, <anonymous type: int x, int y>>(System.Collections.Generic.IEnumerable<<anonymous type: int x, int y>>, System.Func<<anonymous type: int x, int y>, <anonymous type: int x, int y>>)""
   IL_008b:  ret
 }");
+            });
         }
 
         [WorkItem(2501, "https://github.com/dotnet/roslyn/issues/2501")]
@@ -6257,17 +6173,16 @@ class C
             var compilation0 = CreateCompilationWithMscorlib45(
                 source,
                 options: TestOptions.DebugDll,
-                references: new[] { SystemCoreRef },
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "N.C.<>c.<<M>b__0_0>d.MoveNext");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("c.Where(n => n > 0)", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                references: new[] { SystemCoreRef });
+
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "N.C.<>c.<<M>b__0_0>d.MoveNext");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("c.Where(n => n > 0)", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       43 (0x2b)
   .maxstack  3
@@ -6287,6 +6202,7 @@ class C
   IL_0025:  call       ""System.Collections.Generic.IEnumerable<int> System.Linq.Enumerable.Where<int>(System.Collections.Generic.IEnumerable<int>, System.Func<int, bool>)""
   IL_002a:  ret
 }");
+            });
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedStateMachineLocalTests.cs
@@ -105,47 +105,48 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                EvaluationContext context;
+                CompilationTestData testData;
+                string error;
 
-            EvaluationContext context;
-            CompilationTestData testData;
-            string error;
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 500);
+                context.CompileExpression("x", out error);
+                Assert.Equal(expectedError, error);
 
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 500);
-            context.CompileExpression("x", out error);
-            Assert.Equal(expectedError, error);
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 550);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 550);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 600);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 600);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 650);
+                context.CompileExpression("x", out error);
+                Assert.Equal(expectedError, error);
 
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 650);
-            context.CompileExpression("x", out error);
-            Assert.Equal(expectedError, error);
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 700);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 700);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 750);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 750);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
-
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 800);
-            context.CompileExpression("x", out error);
-            Assert.Equal(expectedError, error);
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 800);
+                context.CompileExpression("x", out error);
+                Assert.Equal(expectedError, error);
+            });
         }
 
         [Fact]
@@ -210,47 +211,48 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                EvaluationContext context;
+                CompilationTestData testData;
+                string error;
 
-            EvaluationContext context;
-            CompilationTestData testData;
-            string error;
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 500);
+                context.CompileExpression("x", out error);
+                Assert.Equal(expectedError, error);
 
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 500);
-            context.CompileExpression("x", out error);
-            Assert.Equal(expectedError, error);
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 550);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 550);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 600);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 600);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__1"));
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 650);
+                context.CompileExpression("x", out error);
+                Assert.Equal(expectedError, error);
 
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 650);
-            context.CompileExpression("x", out error);
-            Assert.Equal(expectedError, error);
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 700);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 700);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
+                testData = new CompilationTestData();
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 750);
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
 
-            testData = new CompilationTestData();
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 750);
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(string.Format(expectedIlTemplate, "<x>5__2"));
-
-            context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 800);
-            context.CompileExpression("x", out error);
-            Assert.Equal(expectedError, error);
+                context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext", atLineNumber: 800);
+                context.CompileExpression("x", out error);
+                Assert.Equal(expectedError, error);
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -259,25 +261,26 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "/*instance*/", "1");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -289,7 +292,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch");
+                AssertEx.SetEqual(GetLocalNames(context), "ch");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -298,22 +302,23 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "/*instance*/", "x");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -327,10 +332,10 @@ class C
 }
 ");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -342,7 +347,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "x");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "x");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -351,19 +357,20 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "/*instance*/", "u.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("u", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("u", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -377,13 +384,13 @@ class C
 }
 ");
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -395,7 +402,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "u");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "u");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -404,25 +412,26 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "/*instance*/", "ch.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -434,7 +443,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch");
+                AssertEx.SetEqual(GetLocalNames(context), "ch");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -443,16 +453,17 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "/*instance*/", "t.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            testData = new CompilationTestData();
-            context.CompileExpression("t", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("t", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -466,16 +477,16 @@ class C
 }
 ");
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -487,7 +498,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "this", "ch");
+                AssertEx.SetEqual(GetLocalNames(context), "this", "ch");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -496,16 +508,17 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "/*instance*/", "x + t.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            testData = new CompilationTestData();
-            context.CompileExpression("t", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("t", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       17 (0x11)
   .maxstack  1
@@ -520,13 +533,13 @@ class C
 }
 ");
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -540,10 +553,10 @@ class C
 }
 ");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -555,7 +568,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "this", "ch", "x");
+                AssertEx.SetEqual(GetLocalNames(context), "this", "ch", "x");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -564,25 +578,26 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "static", "1");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -594,7 +609,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch");
+                AssertEx.SetEqual(GetLocalNames(context), "ch");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -603,22 +619,23 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "static", "x");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -632,10 +649,10 @@ class C
 }
 ");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -647,7 +664,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "x");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "x");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -656,19 +674,20 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "static", "u.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("u", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("u", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -682,13 +701,13 @@ class C
 }
 ");
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -700,7 +719,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "u");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "u");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -709,25 +729,26 @@ class C
         {
             var source = string.Format(asyncLambdaSourceTemplate, "static", "ch.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D.t'", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -739,7 +760,8 @@ class C
   IL_0006:  ret
 }
 ");
-            AssertEx.SetEqual(GetLocalNames(context), "ch");
+                AssertEx.SetEqual(GetLocalNames(context), "ch");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -748,25 +770,26 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "/*instance*/", "1");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -779,12 +802,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -793,22 +817,23 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "/*instance*/", "x");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -822,10 +847,10 @@ class C
 }
 ");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -838,12 +863,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "x", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "x", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -852,19 +878,20 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "/*instance*/", "u.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("u", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("u", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -878,13 +905,13 @@ class C
 }
 ");
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -897,12 +924,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "u", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "u", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -911,25 +939,26 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "/*instance*/", "ch.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -942,12 +971,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -956,16 +986,17 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "/*instance*/", "t.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            testData = new CompilationTestData();
-            context.CompileExpression("t", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("t", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -979,16 +1010,16 @@ class C
 }
 ");
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -1001,12 +1032,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "this", "ch", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "this", "ch", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -1015,16 +1047,17 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "/*instance*/", "x + t.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            testData = new CompilationTestData();
-            context.CompileExpression("t", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("t", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       17 (0x11)
   .maxstack  1
@@ -1039,13 +1072,13 @@ class C
 }
 ");
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -1059,10 +1092,10 @@ class C
 }
 ");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -1075,12 +1108,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "this", "ch", "x", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "this", "ch", "x", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -1089,25 +1123,26 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "static", "1");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -1120,12 +1155,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -1134,22 +1170,23 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "static", "x");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -1163,10 +1200,10 @@ class C
 }
 ");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -1179,12 +1216,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "x", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "x", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -1193,19 +1231,20 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "static", "u.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__DisplayClass1_0.<<M>b__0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("u", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("u", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size       12 (0xc)
   .maxstack  1
@@ -1219,13 +1258,13 @@ class C
 }
 ");
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -1238,12 +1277,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "u", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "u", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1112496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1112496")]
@@ -1252,25 +1292,26 @@ class C
         {
             var source = string.Format(genericAsyncLambdaSourceTemplate, "static", "ch.GetHashCode()");
             var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, assemblyName: GetUniqueName());
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "D.<>c__1.<<M>b__1_0>d.MoveNext");
 
-            string error;
-            CompilationTestData testData;
+                string error;
+                CompilationTestData testData;
 
-            context.CompileExpression("t", out error);
-            Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
+                context.CompileExpression("t", out error);
+                Assert.Equal("error CS0120: An object reference is required for the non-static field, method, or property 'D<T>.t'", error);
 
-            context.CompileExpression("u", out error);
-            Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
+                context.CompileExpression("u", out error);
+                Assert.Equal("error CS0103: The name 'u' does not exist in the current context", error);
 
-            context.CompileExpression("x", out error);
-            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
+                context.CompileExpression("x", out error);
+                Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("ch", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
+                testData = new CompilationTestData();
+                context.CompileExpression("ch", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x<T, U>.<>m0").VerifyIL(@"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -1283,12 +1324,13 @@ class C
 }
 ");
 
-            context.CompileExpression("typeof(T)", out error);
-            Assert.Null(error);
-            context.CompileExpression("typeof(U)", out error);
-            Assert.Null(error);
+                context.CompileExpression("typeof(T)", out error);
+                Assert.Null(error);
+                context.CompileExpression("typeof(U)", out error);
+                Assert.Null(error);
 
-            AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+                AssertEx.SetEqual(GetLocalNames(context), "ch", "<>TypeVariables");
+            });
         }
 
         [WorkItem(1134746, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1134746")]
@@ -1313,48 +1355,49 @@ class C
         }
     }
 }";
-            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                ImmutableArray<MetadataBlock> blocks;
+                Guid moduleVersionId;
+                ISymUnmanagedReader symReader;
+                int methodToken;
+                int localSignatureToken;
+                GetContextState(runtime, "C.<M>d__0.MoveNext", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
 
-            ImmutableArray<MetadataBlock> blocks;
-            Guid moduleVersionId;
-            ISymUnmanagedReader symReader;
-            int methodToken;
-            int localSignatureToken;
-            GetContextState(runtime, "C.<M>d__0.MoveNext", out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
+                uint ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber: 100);
+                var context = EvaluationContext.CreateMethodContext(
+                    default(CSharpMetadataContext),
+                    blocks,
+                    symReader,
+                    moduleVersionId,
+                    methodToken: methodToken,
+                    methodVersion: 1,
+                    ilOffset: ilOffset,
+                    localSignatureToken: localSignatureToken);
 
-            uint ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber: 100);
-            var context = EvaluationContext.CreateMethodContext(
-                default(CSharpMetadataContext),
-                blocks,
-                symReader,
-                moduleVersionId,
-                methodToken: methodToken,
-                methodVersion: 1,
-                ilOffset: ilOffset,
-                localSignatureToken: localSignatureToken);
+                string error;
+                context.CompileExpression("x", out error);
+                Assert.Null(error);
+                context.CompileExpression("y", out error);
+                Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
 
-            string error;
-            context.CompileExpression("x", out error);
-            Assert.Null(error);
-            context.CompileExpression("y", out error);
-            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+                ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber: 200);
+                context = EvaluationContext.CreateMethodContext(
+                    new CSharpMetadataContext(blocks, context),
+                    blocks,
+                    symReader,
+                    moduleVersionId,
+                    methodToken: methodToken,
+                    methodVersion: 1,
+                    ilOffset: ilOffset,
+                    localSignatureToken: localSignatureToken);
 
-            ilOffset = ExpressionCompilerTestHelpers.GetOffset(methodToken, symReader, atLineNumber: 200);
-            context = EvaluationContext.CreateMethodContext(
-                new CSharpMetadataContext(blocks, context),
-                blocks,
-                symReader,
-                moduleVersionId,
-                methodToken: methodToken,
-                methodVersion: 1,
-                ilOffset: ilOffset,
-                localSignatureToken: localSignatureToken);
-
-            context.CompileExpression("x", out error);
-            Assert.Null(error);
-            context.CompileExpression("y", out error);
-            Assert.Null(error);
+                context.CompileExpression("x", out error);
+                Assert.Null(error);
+                context.CompileExpression("y", out error);
+                Assert.Null(error);
+            });
         }
 
         private static string[] GetLocalNames(EvaluationContext context)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -31,17 +31,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.NotNull(assembly);
-            Assert.Equal(assembly.Count, 0);
-            Assert.Equal(locals.Count, 0);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.Equal(assembly.Count, 0);
+                Assert.Equal(locals.Count, 0);
+            });
         }
 
         [Fact]
@@ -63,21 +63,19 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M",
-                atLineNumber: 999);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M", atLineNumber: 999);
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.NotNull(assembly);
-            Assert.NotEqual(assembly.Count, 0);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
 
-            Assert.Equal(locals.Count, 4);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+                Assert.Equal(locals.Count, 4);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -88,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "a", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "a", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -99,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "b", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "b", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -111,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0001:  ret
 }
 ");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "c", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "c", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -122,7 +120,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0000:  ldloc.3
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         /// <summary>
@@ -149,44 +148,45 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp, includeLocalSignatures: false);
 
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M",
-                atLineNumber: 999);
+            WithRuntimeInstance(comp, references: null, includeLocalSignatures: false, validator: runtime =>
+            {
+                var context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.M",
+                    atLineNumber: 999);
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "a", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "a", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
 
-            string error;
-            testData = new CompilationTestData();
-            context.CompileExpression("b", out error, testData);
-            Assert.Equal(error, "error CS0103: The name 'b' does not exist in the current context");
+                string error;
+                testData = new CompilationTestData();
+                context.CompileExpression("b", out error, testData);
+                Assert.Equal(error, "error CS0103: The name 'b' does not exist in the current context");
 
-            testData = new CompilationTestData();
-            context.CompileExpression("a[1]", out error, testData);
-            string actualIL = testData.GetMethodData("<>x.<>m0").GetMethodIL();
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(actualIL,
+                testData = new CompilationTestData();
+                context.CompileExpression("a[1]", out error, testData);
+                string actualIL = testData.GetMethodData("<>x.<>m0").GetMethodIL();
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(actualIL,
 @"{
   // Code size        4 (0x4)
   .maxstack  2
@@ -195,6 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0002:  ldelem.i4
   IL_0003:  ret
 }");
+            });
         }
 
         [Fact]
@@ -207,47 +208,44 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     {
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugDll,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                "C.M");
-            var aliases = ImmutableArray.Create(
-                ExceptionAlias(typeof(System.IO.IOException)),
-                ReturnValueAlias(2, typeof(string)),
-                ReturnValueAlias(),
-                ObjectIdAlias(2, typeof(bool)),
-                VariableAlias("o", "C"));
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var diagnostics = DiagnosticBag.GetInstance();
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var testData = new CompilationTestData();
-            context.CompileGetLocals(
-                locals,
-                argumentsOnly: true,
-                aliases: aliases,
-                diagnostics: diagnostics,
-                typeName: out typeName,
-                testData: testData);
-            Assert.Equal(locals.Count, 1);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "o");
-            locals.Clear();
+                var aliases = ImmutableArray.Create(
+                    ExceptionAlias(typeof(System.IO.IOException)),
+                    ReturnValueAlias(2, typeof(string)),
+                    ReturnValueAlias(),
+                    ObjectIdAlias(2, typeof(bool)),
+                    VariableAlias("o", "C"));
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var diagnostics = DiagnosticBag.GetInstance();
 
-            testData = new CompilationTestData();
-            context.CompileGetLocals(
-                locals,
-                argumentsOnly: false,
-                aliases: aliases,
-                diagnostics: diagnostics,
-                typeName: out typeName,
-                testData: testData);
-            diagnostics.Free();
-            Assert.Equal(locals.Count, 7);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "$exception", "Error", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                var testData = new CompilationTestData();
+                context.CompileGetLocals(
+                    locals,
+                    argumentsOnly: true,
+                    aliases: aliases,
+                    diagnostics: diagnostics,
+                    typeName: out typeName,
+                    testData: testData);
+                Assert.Equal(locals.Count, 1);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "o");
+                locals.Clear();
+
+                testData = new CompilationTestData();
+                context.CompileGetLocals(
+                    locals,
+                    argumentsOnly: false,
+                    aliases: aliases,
+                    diagnostics: diagnostics,
+                    typeName: out typeName,
+                    testData: testData);
+                diagnostics.Free();
+                Assert.Equal(locals.Count, 7);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "$exception", "Error", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size       11 (0xb)
   .maxstack  1
@@ -255,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0005:  castclass  ""System.IO.IOException""
   IL_000a:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "$ReturnValue2", "Method M2 returned", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "$ReturnValue2", "Method M2 returned", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size       12 (0xc)
   .maxstack  1
@@ -264,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0006:  castclass  ""string""
   IL_000b:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "$ReturnValue", "Method M returned", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "$ReturnValue", "Method M returned", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -272,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0001:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(int)""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "$2", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "$2", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size       16 (0x10)
   .maxstack  1
@@ -281,7 +279,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_000a:  unbox.any  ""bool""
   IL_000f:  ret
 }");
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "o", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "o", expectedILOpt:
 @"{
   // Code size       16 (0x10)
   .maxstack  1
@@ -290,21 +288,22 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_000a:  castclass  ""C""
   IL_000f:  ret
 }");
-            VerifyLocal(testData, typeName, locals[5], "<>m5", "this", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[5], "<>m5", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[6], "<>m6", "o", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[6], "<>m6", "o", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -318,32 +317,31 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "@this", expectedILOpt: // Native EE uses "this" rather than "@this".
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "@this", expectedILOpt: // Native EE uses "this" rather than "@this".
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -358,18 +356,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: true, typeName: out typeName, testData: testData);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: true, typeName: out typeName, testData: testData);
-
-            Assert.Equal(locals.Count, 1);
-            VerifyLocal(testData, typeName, locals[0], "<>m0<T>", "x", expectedILOpt:
+                Assert.Equal(locals.Count, 1);
+                VerifyLocal(testData, typeName, locals[0], "<>m0<T>", "x", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -377,8 +373,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0000:  ldarg.1
   IL_0001:  ret
 }",
-                expectedGeneric: true);
-            locals.Free();
+                    expectedGeneric: true);
+                locals.Free();
+            });
         }
 
         /// <summary>
@@ -405,19 +402,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.F", atLineNumber: 999);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.F",
-                atLineNumber: 999);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "args", expectedILOpt:
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "args", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -431,7 +425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0001:  ldfld      ""object[] C.<>c__DisplayClass0_0.args""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
 @"{
   // Code size        3 (0x3)
   .maxstack  1
@@ -444,7 +438,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0000:  ldloc.s    V_5
   IL_0002:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(928113, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/928113")]
@@ -472,19 +467,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.F",
-                atLineNumber: 888);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.F", atLineNumber: 888);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
 {
 // Code size        2 (0x2)
 .maxstack  1
@@ -494,7 +486,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 IL_0000:  ldc.i4.3
 IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -504,21 +496,21 @@ IL_0001:  ret
   IL_0000:  ldnull
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
 
-            context = CreateMethodContext(
-                runtime,
-                methodName: "C.F",
-                atLineNumber: 999);
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 5);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "u");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "z", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.F",
+                    atLineNumber: 999);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 5);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "u");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "v", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "z", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
 // Code size        6 (0x6)
 .maxstack  1
@@ -528,7 +520,8 @@ IL_0001:  ret
 IL_0000:  ldstr      ""str""
 IL_0005:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -548,22 +541,20 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
-            
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 2);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 2);
 
-            var method = (MethodSymbol)testData.GetMethodData("<>x.<>m0").Method;
-            Assert.Equal(method.Parameters[0].Type, method.ReturnType);
+                var method = (MethodSymbol)testData.GetMethodData("<>x.<>m0").Method;
+                Assert.Equal(method.Parameters[0].Type, method.ReturnType);
 
-            VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -571,17 +562,18 @@ class C
   IL_0001:  ret
 }");
 
-            method = (MethodSymbol)testData.GetMethodData("<>x.<>m1").Method;
-            Assert.Equal(method.Parameters[0].Type, method.ReturnType);
+                method = (MethodSymbol)testData.GetMethodData("<>x.<>m1").Method;
+                Assert.Equal(method.Parameters[0].Type, method.ReturnType);
 
-            VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldc.i4.1
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -605,43 +597,44 @@ class P
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 3);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 3);
 
-            VerifyLocal(testData, "<>x<T>", locals[0], "<>m0<U>", "t", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, "<>x<T>", locals[0], "<>m0<U>", "t", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldc.i4.0
   IL_0001:  ret
 }",
-                expectedGeneric: true);
+                    expectedGeneric: true);
 
-            VerifyLocal(testData, "<>x<T>", locals[1], "<>m1<U>", "u", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, "<>x<T>", locals[1], "<>m1<U>", "u", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldc.i4.0
   IL_0001:  ret
 }",
-                expectedGeneric: true);
+                    expectedGeneric: true);
 
-            VerifyLocal(testData, "<>x<T>", locals[2], "<>m2<U>", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, "<>x<T>", locals[2], "<>m2<U>", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size        6 (0x6)
   .maxstack  1
   IL_0000:  newobj     ""<>c__TypeVariables<T, U>..ctor()""
   IL_0005:  ret
 }",
-                expectedGeneric: true);
+                    expectedGeneric: true);
 
-            testData.GetMethodData("<>c__TypeVariables<T, U>..ctor").VerifyIL(
+                testData.GetMethodData("<>c__TypeVariables<T, U>..ctor").VerifyIL(
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -650,7 +643,8 @@ class P
   IL_0006:  ret
 }");
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -676,18 +670,18 @@ class P
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M",
                 atLineNumber: 999);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -699,7 +693,7 @@ class P
   IL_0001:  ldfld      ""C C.<>c__DisplayClass1_0.<>4__this""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "x", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -711,7 +705,7 @@ class P
   IL_0001:  ldfld      ""C C.<>c__DisplayClass1_0.x""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "z", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "z", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -722,7 +716,7 @@ class P
   IL_0000:  ldloc.3
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "y", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "y", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -734,7 +728,7 @@ class P
   IL_0001:  ldfld      ""C C.<>c__DisplayClass1_0.y""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "w", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "w", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -746,8 +740,9 @@ class P
   IL_0001:  ldfld      ""int C.<>c__DisplayClass1_1.w""
   IL_0006:  ret
 }");
-            Assert.Equal(locals.Count, 5);
-            locals.Free();
+                Assert.Equal(locals.Count, 5);
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -772,17 +767,15 @@ class P
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<>c__DisplayClass1_1.<M>b__0");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c__DisplayClass1_1.<M>b__0");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -792,7 +785,7 @@ class P
   IL_0001:  ldfld      ""C C.<>c__DisplayClass1_1.<>4__this""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "_1", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "_1", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -801,7 +794,7 @@ class P
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -811,7 +804,7 @@ class P
   IL_0001:  ldfld      ""object C.<>c__DisplayClass1_0.y""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "x", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -821,8 +814,9 @@ class P
   IL_0001:  ldfld      ""object C.<>c__DisplayClass1_1.x""
   IL_0006:  ret
 }");
-            Assert.Equal(locals.Count, 4);
-            locals.Free();
+                Assert.Equal(locals.Count, 4);
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -856,18 +850,17 @@ class C
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c.<Main>b__0_0");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<>c.<Main>b__0_0");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x2", expectedILOpt:
-@"
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x2", expectedILOpt:
+    @"
 {
   // Code size        7 (0x7)
   .maxstack  1
@@ -878,22 +871,22 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_0.x2""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "x3");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "x4");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "x1");
-            Assert.Equal(locals.Count, 4);
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "x3");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "x4");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "x1");
+                Assert.Equal(locals.Count, 4);
 
-            locals.Free();
+                locals.Free();
 
-            context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c__DisplayClass0_0.<Main>b__1");
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.<>c__DisplayClass0_0.<Main>b__1");
 
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "y2", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "y2", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -904,10 +897,10 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_1.y2""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y3");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "y1");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "x2");
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "x3", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y3");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y1");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "x2");
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "x3", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -918,19 +911,19 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_0.x3""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[5], "<>m5", "x4");
-            Assert.Equal(locals.Count, 6);
-            locals.Free();
+                VerifyLocal(testData, typeName, locals[5], "<>m5", "x4");
+                Assert.Equal(locals.Count, 6);
+                locals.Free();
 
-            context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c__DisplayClass0_1.<Main>b__2");
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.<>c__DisplayClass0_1.<Main>b__2");
 
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "z2", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "z2", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -941,11 +934,11 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_2.z2""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "z1");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "y2");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "y3");
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "x2");
-            VerifyLocal(testData, typeName, locals[5], "<>m5", "x3", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "z1");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y2");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "y3");
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "x2");
+                VerifyLocal(testData, typeName, locals[5], "<>m5", "x3", expectedILOpt:
 @"{
   // Code size       12 (0xc)
   .maxstack  1
@@ -957,20 +950,20 @@ class C
   IL_0006:  ldfld      ""object C.<>c__DisplayClass0_0.x3""
   IL_000b:  ret
 }");
-            VerifyLocal(testData, typeName, locals[6], "<>m6", "x4");
-            Assert.Equal(locals.Count, 7);
-            locals.Free();
+                VerifyLocal(testData, typeName, locals[6], "<>m6", "x4");
+                Assert.Equal(locals.Count, 7);
+                locals.Free();
 
-            context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c__DisplayClass0_2.<Main>b__3");
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.<>c__DisplayClass0_2.<Main>b__3");
 
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "w1");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "z2", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "w1");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "z2", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -980,11 +973,11 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_2.z2""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "y2");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "y3");
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "x2");
-            VerifyLocal(testData, typeName, locals[5], "<>m5", "x3");
-            VerifyLocal(testData, typeName, locals[6], "<>m6", "x4", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y2");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "y3");
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "x2");
+                VerifyLocal(testData, typeName, locals[5], "<>m5", "x3");
+                VerifyLocal(testData, typeName, locals[6], "<>m6", "x4", expectedILOpt:
 @"{
   // Code size       17 (0x11)
   .maxstack  1
@@ -996,8 +989,9 @@ class C
   IL_000b:  ldfld      ""object C.<>c__DisplayClass0_0.x4""
   IL_0010:  ret
 }");
-            Assert.Equal(locals.Count, 7);
-            locals.Free();
+                Assert.Equal(locals.Count, 7);
+                locals.Free();
+            });
         }
 
         /// <summary>
@@ -1024,32 +1018,32 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c__DisplayClass0_0.<M>b__0");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(3, locals.Count);
-            VerifyLocal(testData, "<>x<T>", locals[0], "<>m0", "y");
-            VerifyLocal(testData, "<>x<T>", locals[1], "<>m1", "x");
-            VerifyLocal(testData, "<>x<T>", locals[2], "<>m2", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-            locals.Free();
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<>c__DisplayClass0_0.<M>b__0");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(3, locals.Count);
+                VerifyLocal(testData, "<>x<T>", locals[0], "<>m0", "y");
+                VerifyLocal(testData, "<>x<T>", locals[1], "<>m1", "x");
+                VerifyLocal(testData, "<>x<T>", locals[2], "<>m2", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                locals.Free();
 
-            context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c__DisplayClass0_1.<M>b__1");
-            testData = new CompilationTestData();
-            locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 4);
-            VerifyLocal(testData, "<>x<T>", locals[0], "<>m0", "z");
-            VerifyLocal(testData, "<>x<T>", locals[1], "<>m1", "y");
-            VerifyLocal(testData, "<>x<T>", locals[2], "<>m2", "x");
-            VerifyLocal(testData, "<>x<T>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-            locals.Free();
+                context = CreateMethodContext(
+                    runtime,
+                    methodName: "C.<>c__DisplayClass0_1.<M>b__1");
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 4);
+                VerifyLocal(testData, "<>x<T>", locals[0], "<>m0", "z");
+                VerifyLocal(testData, "<>x<T>", locals[1], "<>m1", "y");
+                VerifyLocal(testData, "<>x<T>", locals[2], "<>m2", "x");
+                VerifyLocal(testData, "<>x<T>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1069,17 +1063,16 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "A.B.M");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "A.B.M");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            Assert.Equal(locals.Count, 6);
-            VerifyLocal(testData, "<>x<T, U, V>", locals[0], "<>m0<W>", "this", expectedILOpt:
+                Assert.Equal(locals.Count, 6);
+                VerifyLocal(testData, "<>x<T, U, V>", locals[0], "<>m0<W>", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1090,16 +1083,16 @@ class C
   IL_0001:  ldobj      ""A<T>.B<U, V>""
   IL_0006:  ret
 }",
-                expectedGeneric: true);
-            var method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m0<W>").Method;
-            var containingType = method.ContainingType;
-            var returnType = (NamedTypeSymbol)method.ReturnType;
-            Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[0]);
-            Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[1]);
-            returnType = returnType.ContainingType;
-            Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments[0]);
+                    expectedGeneric: true);
+                var method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m0<W>").Method;
+                var containingType = method.ContainingType;
+                var returnType = (NamedTypeSymbol)method.ReturnType;
+                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[0]);
+                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[1]);
+                returnType = returnType.ContainingType;
+                Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments[0]);
 
-            VerifyLocal(testData, "<>x<T, U, V>", locals[1], "<>m1<W>", "o", expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U, V>", locals[1], "<>m1<W>", "o", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -1109,15 +1102,15 @@ class C
   IL_0000:  ldarg.1
   IL_0001:  ret
 }",
-                expectedGeneric: true);
-            method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m1<W>").Method;
-            // method.ReturnType: A<U>.B<V, object>[]
-            returnType = (NamedTypeSymbol)((ArrayTypeSymbol)method.ReturnType).ElementType;
-            Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[0]);
-            returnType = returnType.ContainingType;
-            Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[0]);
+                    expectedGeneric: true);
+                method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m1<W>").Method;
+                // method.ReturnType: A<U>.B<V, object>[]
+                returnType = (NamedTypeSymbol)((ArrayTypeSymbol)method.ReturnType).ElementType;
+                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[0]);
+                returnType = returnType.ContainingType;
+                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[0]);
 
-            VerifyLocal(testData, "<>x<T, U, V>", locals[2], "<>m2<W>", "t", expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U, V>", locals[2], "<>m2<W>", "t", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -1127,12 +1120,12 @@ class C
   IL_0000:  ldloc.0
   IL_0001:  ret
 }",
-                expectedGeneric: true);
-            method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m2<W>").Method;
-            containingType = method.ContainingType;
-            Assert.Equal(containingType.TypeParameters[0], method.ReturnType);
+                    expectedGeneric: true);
+                method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m2<W>").Method;
+                containingType = method.ContainingType;
+                Assert.Equal(containingType.TypeParameters[0], method.ReturnType);
 
-            VerifyLocal(testData, "<>x<T, U, V>", locals[3], "<>m3<W>", "u", expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U, V>", locals[3], "<>m3<W>", "u", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -1142,12 +1135,12 @@ class C
   IL_0000:  ldloc.1
   IL_0001:  ret
 }",
-                expectedGeneric: true);
-            method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m3<W>").Method;
-            containingType = method.ContainingType;
-            Assert.Equal(containingType.TypeParameters[1], method.ReturnType);
+                    expectedGeneric: true);
+                method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m3<W>").Method;
+                containingType = method.ContainingType;
+                Assert.Equal(containingType.TypeParameters[1], method.ReturnType);
 
-            VerifyLocal(testData, "<>x<T, U, V>", locals[4], "<>m4<W>", "w", expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U, V>", locals[4], "<>m4<W>", "w", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -1157,11 +1150,11 @@ class C
   IL_0000:  ldloc.2
   IL_0001:  ret
 }",
-                expectedGeneric: true);
-            method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m4<W>").Method;
-            Assert.Equal(method.TypeParameters[0], method.ReturnType);
+                    expectedGeneric: true);
+                method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m4<W>").Method;
+                Assert.Equal(method.TypeParameters[0], method.ReturnType);
 
-            VerifyLocal(testData, "<>x<T, U, V>", locals[5], "<>m5<W>", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U, V>", locals[5], "<>m5<W>", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size        6 (0x6)
   .maxstack  1
@@ -1171,23 +1164,24 @@ class C
   IL_0000:  newobj     ""<>c__TypeVariables<T, U, V, W>..ctor()""
   IL_0005:  ret
 }",
-                expectedGeneric: true);
-            method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m5<W>").Method;
-            returnType = (NamedTypeSymbol)method.ReturnType;
-            Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments[0]);
-            Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[1]);
-            Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[2]);
-            Assert.Equal(method.TypeParameters[0], returnType.TypeArguments[3]);
+                    expectedGeneric: true);
+                method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m5<W>").Method;
+                returnType = (NamedTypeSymbol)method.ReturnType;
+                Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments[0]);
+                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[1]);
+                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[2]);
+                Assert.Equal(method.TypeParameters[0], returnType.TypeArguments[3]);
 
-            // Verify <>c__TypeVariables type was emitted (#976772).
-            using (var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(assembly)))
-            {
-                var reader = metadata.MetadataReader;
-                var typeDef = reader.GetTypeDef("<>c__TypeVariables");
-                reader.CheckTypeParameters(typeDef.GetGenericParameters(), "T", "U", "V", "W");
-            }
+                // Verify <>c__TypeVariables type was emitted (#976772).
+                using (var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(assembly)))
+                {
+                    var reader = metadata.MetadataReader;
+                    var typeDef = reader.GetTypeDef("<>c__TypeVariables");
+                    reader.CheckTypeParameters(typeDef.GetGenericParameters(), "T", "U", "V", "W");
+                }
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1204,20 +1198,18 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<>c__DisplayClass0_0.<M>b__0");
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<>c__DisplayClass0_0.<M>b__0");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-
-            Assert.Equal(locals.Count, 3);
-            VerifyLocal(testData, "<>x<T, U>", locals[0], "<>m0", "t");
-            VerifyLocal(testData, "<>x<T, U>", locals[1], "<>m1", "u", expectedILOpt:
+                Assert.Equal(locals.Count, 3);
+                VerifyLocal(testData, "<>x<T, U>", locals[0], "<>m0", "t");
+                VerifyLocal(testData, "<>x<T, U>", locals[1], "<>m1", "u", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1226,14 +1218,15 @@ class C
   IL_0001:  ldfld      ""U C<T>.<>c__DisplayClass0_0<U>.u""
   IL_0006:  ret
 }",
-                expectedGeneric: false);
-            VerifyLocal(testData, "<>x<T, U>", locals[2], "<>m2", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                    expectedGeneric: false);
+                VerifyLocal(testData, "<>x<T, U>", locals[2], "<>m2", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
 
-            var method = (MethodSymbol)testData.GetMethodData("<>x<T, U>.<>m1").Method;
-            var containingType = method.ContainingType;
-            Assert.Equal(containingType.TypeParameters[1], method.ReturnType);
+                var method = (MethodSymbol)testData.GetMethodData("<>x<T, U>.<>m1").Method;
+                var containingType = method.ContainingType;
+                Assert.Equal(containingType.TypeParameters[1], method.ReturnType);
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1258,18 +1251,15 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<F>d__2.MoveNext",
-                atLineNumber: 999);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, "<>x", locals[0], "<>m0", "this", expectedILOpt:
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<F>d__2.MoveNext", atLineNumber: 999);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1278,7 +1268,7 @@ class C
   IL_0001:  ldfld      ""C C.<F>d__2.<>4__this""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x", locals[1], "<>m1", "o", expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "o", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1287,7 +1277,8 @@ class C
   IL_0001:  ldfld      ""object C.<F>d__2.<o>5__3""
   IL_0006:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1310,18 +1301,19 @@ class C
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "C.<F>d__0.MoveNext",
                 atLineNumber: 999);
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, "<>x<T>", locals[0], "<>m0", "o", expectedILOpt:
+                VerifyLocal(testData, "<>x<T>", locals[0], "<>m0", "o", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1332,7 +1324,7 @@ class C
   IL_0001:  ldfld      ""T[] C.<F>d__0<T>.o""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x<T>", locals[1], "<>m1", "i", expectedILOpt:
+                VerifyLocal(testData, "<>x<T>", locals[1], "<>m1", "i", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1343,7 +1335,7 @@ class C
   IL_0001:  ldfld      ""int C.<F>d__0<T>.<i>5__1""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x<T>", locals[2], "<>m2", "t", expectedILOpt:
+                VerifyLocal(testData, "<>x<T>", locals[2], "<>m2", "t", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1354,9 +1346,10 @@ class C
   IL_0001:  ldfld      ""T C.<F>d__0<T>.<t>5__2""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x<T>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-            Assert.Equal(locals.Count, 4);
-            locals.Free();
+                VerifyLocal(testData, "<>x<T>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                Assert.Equal(locals.Count, 4);
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1378,17 +1371,16 @@ struct S<T> where T : class
                 options: TestOptions.DebugDll,
                 references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef });
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "S.<F>d__1.MoveNext");
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "S.<F>d__1.MoveNext");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, "<>x<T, U>", locals[0], "<>m0", "this", expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U>", locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1399,7 +1391,7 @@ struct S<T> where T : class
   IL_0001:  ldfld      ""S<T> S<T>.<F>d__1<U>.<>4__this""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x<T, U>", locals[1], "<>m1", "y", expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U>", locals[1], "<>m1", "y", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1410,7 +1402,7 @@ struct S<T> where T : class
   IL_0001:  ldfld      ""U S<T>.<F>d__1<U>.y""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x<T, U>", locals[2], "<>m2", "z", expectedILOpt:
+                VerifyLocal(testData, "<>x<T, U>", locals[2], "<>m2", "z", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1421,10 +1413,11 @@ struct S<T> where T : class
   IL_0001:  ldfld      ""T S<T>.<F>d__1<U>.<z>5__1""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x<T, U>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
+                VerifyLocal(testData, "<>x<T, U>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
 
-            Assert.Equal(locals.Count, 4);
-            locals.Free();
+                Assert.Equal(locals.Count, 4);
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1449,17 +1442,16 @@ class C
                 options: TestOptions.DebugDll,
                 references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef });
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<M>d__1.MoveNext");
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-            VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1473,7 +1465,7 @@ class C
   IL_0001:  ldfld      ""object C.<M>d__1.x""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1487,8 +1479,9 @@ class C
   IL_0001:  ldfld      ""object C.<M>d__1.<y>5__1""
   IL_0006:  ret
 }");
-            Assert.Equal(locals.Count, 2);
-            locals.Free();
+                Assert.Equal(locals.Count, 2);
+                locals.Free();
+            });
         }
 
         [WorkItem(995976, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/995976")]
@@ -1521,16 +1514,15 @@ class C
                 options: TestOptions.DebugDll,
                 references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef });
 
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<M>d__2.MoveNext");
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__2.MoveNext");
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1543,7 +1535,7 @@ class C
   IL_0001:  ldfld      ""int C.<M>d__2.x""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
 @"{
   // Code size       12 (0xc)
   .maxstack  1
@@ -1557,7 +1549,8 @@ class C
   IL_0006:  ldfld      ""int C.<>c__DisplayClass2_0.y""
   IL_000b:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(2240, "https://github.com/dotnet/roslyn/issues/2240")]
@@ -1577,15 +1570,16 @@ class C
         };
     }
 }";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            var context = CreateMethodContext(runtime, methodName: "C.<>c.<<M>b__0_0>d.MoveNext");
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var testData = new CompilationTestData();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
+            var compilation0 = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.<>c.<<M>b__0_0>d.MoveNext");
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var testData = new CompilationTestData();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1595,7 +1589,7 @@ class C
   IL_0001:  ldfld      ""int C.<>c.<<M>b__0_0>d.x""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1605,7 +1599,8 @@ class C
   IL_0001:  ldfld      ""int C.<>c.<<M>b__0_0>d.<y>5__1""
   IL_0006:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(996571, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/996571")]
@@ -1637,20 +1632,22 @@ public struct B
                 references: new[] { compilation0.EmitToImageReference() });
 
             // no reference to compilation0
-            var runtime = CreateRuntimeInstance(compilation1, new[] { MscorlibRef });
-            var context = CreateMethodContext(runtime, "C.M");
-
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData, expectedDiagnostics: new[]
+            WithRuntimeInstance(compilation1, new[] { MscorlibRef }, runtime =>
             {
-                // error CS0012: The type 'A' is defined in an assembly that is not referenced. You must add a reference to assembly 'Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("A", "Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
-            });
+                var context = CreateMethodContext(runtime, "C.M");
 
-            Assert.Equal(locals.Count, 0);
-            locals.Free();
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData, expectedDiagnostics: new[]
+                {
+                    // error CS0012: The type 'A' is defined in an assembly that is not referenced. You must add a reference to assembly 'Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                    Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("A", "Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                });
+
+                Assert.Equal(locals.Count, 0);
+                locals.Free();
+            });
         }
 
         [WorkItem(996571, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/996571")]
@@ -1679,24 +1676,23 @@ public struct B
                 references: new[] { compilation0.EmitToImageReference() });
 
             // no reference to compilation0
-            var runtime = CreateRuntimeInstance(compilation1, new[] { MscorlibRef });
-
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData, expectedDiagnostics: new[]
+            WithRuntimeInstance(compilation1, new[] { MscorlibRef }, runtime =>
             {
-                // error CS0012: The type 'I' is defined in an assembly that is not referenced. You must add a reference to assembly 'Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("I", "Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
-            });
+                var context = CreateMethodContext(runtime, "C.M");
 
-            Assert.Equal(locals.Count, 0);
-            locals.Free();
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData, expectedDiagnostics: new[]
+                {
+                    // error CS0012: The type 'I' is defined in an assembly that is not referenced. You must add a reference to assembly 'Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                    Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("I", "Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                });
+
+                Assert.Equal(locals.Count, 0);
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1715,20 +1711,20 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(
                 runtime,
                 methodName: "C.M",
                 atLineNumber: 999);
 
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("o = null", out error, testData);
-            Assert.Null(error); // In regular code, there would be an error about modifying a lock local.
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("o = null", out error, testData);
+                Assert.Null(error); // In regular code, there would be an error about modifying a lock local.
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        5 (0x5)
   .maxstack  2
@@ -1741,11 +1737,11 @@ class C
   IL_0004:  ret
 }");
 
-            testData = new CompilationTestData();
-            context.CompileAssignment("o", "null", out error, testData);
-            Assert.Null(error); // In regular code, there would be an error about modifying a lock local.
+                testData = new CompilationTestData();
+                context.CompileAssignment("o", "null", out error, testData);
+                Assert.Null(error); // In regular code, there would be an error about modifying a lock local.
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        4 (0x4)
   .maxstack  1
@@ -1756,6 +1752,7 @@ class C
   IL_0001:  starg.s    V_1
   IL_0003:  ret
 }");
+            });
         }
 
         [WorkItem(1015887, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1015887")]
@@ -1771,22 +1768,24 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size       10 (0xa)
   .maxstack  1
   IL_0000:  ldc.r8     2.74745778612482E-266
   IL_0009:  ret
 }");
+            });
         }
 
         [WorkItem(1015887, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1015887")]
@@ -1803,17 +1802,18 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var testData = new CompilationTestData();
+                var testData = new CompilationTestData();
 
-            string error;
-            context.CompileAssignment("c", "(byte)(b + 3)", out error, testData);
-            Assert.Null(error);
+                string error;
+                context.CompileAssignment("c", "(byte)(b + 3)", out error, testData);
+                Assert.Null(error);
 
-            testData.GetMethodData("<>x.<>m0").VerifyIL(@"
+                testData.GetMethodData("<>x.<>m0").VerifyIL(@"
 {
   // Code size        3 (0x3)
   .maxstack  1
@@ -1823,6 +1823,7 @@ class C
   IL_0002:  ret
 }
 ");
+            });
         }
 
         [WorkItem(1015887, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1015887")]
@@ -1838,20 +1839,21 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.M");
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.M");
 
-            string errorMessage;
-            var testData = new CompilationTestData();
-            context.CompileAssignment("d", "Nothing", out errorMessage, testData);
-            Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", errorMessage);
+                string errorMessage;
+                var testData = new CompilationTestData();
+                context.CompileAssignment("d", "Nothing", out errorMessage, testData);
+                Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", errorMessage);
 
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(1, locals.Count);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(1, locals.Count);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size       12 (0xc)
   .maxstack  5
@@ -1863,6 +1865,7 @@ class C
   IL_0006:  newobj     ""decimal..ctor(int, int, int, bool, byte)""
   IL_000b:  ret
 }");
+            });
         }
 
         [Fact, WorkItem(1022165, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1022165"), WorkItem(1028883, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1028883"), WorkItem(1034204, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1034204")]
@@ -1879,20 +1882,19 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.NotNull(assembly);
-            Assert.NotEqual(assembly.Count, 0);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
 
-            Assert.Equal(locals.Count, 5);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt: @"
+                Assert.Equal(locals.Count, 5);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -1902,7 +1904,7 @@ class C
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "@null", expectedILOpt: @"
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "@null", expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -1912,7 +1914,7 @@ class C
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "@this", expectedILOpt: @"
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "@this", expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -1922,7 +1924,7 @@ class C
   IL_0000:  ldloc.0
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "@true", expectedILOpt: @"
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "@true", expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -1932,7 +1934,7 @@ class C
   IL_0000:  ldloc.1
   IL_0001:  ret
 }");
-            VerifyLocal(testData, typeName, locals[4], "<>m4", "@namespace", expectedILOpt: @"
+                VerifyLocal(testData, typeName, locals[4], "<>m4", "@namespace", expectedILOpt: @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -1942,7 +1944,8 @@ class C
   IL_0000:  ldloc.2
   IL_0001:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact]
@@ -1968,30 +1971,30 @@ static class C
 }";
 
             var compilation0 = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<F>d__0.MoveNext");
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext");
 
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.NotNull(assembly);
-            Assert.NotEqual(assembly.Count, 0);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
 
-            Assert.Equal(locals.Count, 1);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: expectedIL);
-            Assert.Equal(SpecialType.System_Int32, testData.GetMethodData(typeName + ".<>m0").Method.ReturnType.SpecialType);
-            locals.Free();
+                Assert.Equal(locals.Count, 1);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: expectedIL);
+                Assert.Equal(SpecialType.System_Int32, testData.GetMethodData(typeName + ".<>m0").Method.ReturnType.SpecialType);
+                locals.Free();
 
-            testData = new CompilationTestData();
-            string error;
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            methodData.VerifyIL(expectedIL);
-            Assert.Equal(SpecialType.System_Int32, methodData.Method.ReturnType.SpecialType);
+                testData = new CompilationTestData();
+                string error;
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                methodData.VerifyIL(expectedIL);
+                Assert.Equal(SpecialType.System_Int32, methodData.Method.ReturnType.SpecialType);
+            });
         }
 
         [Fact, WorkItem(1063254, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063254")]
@@ -2028,12 +2031,13 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            string displayClassName;
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            var ilTemplate = @"
+            WithRuntimeInstance(compilation, runtime =>
+            {
+                string displayClassName;
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                var ilTemplate = @"
 {{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2043,44 +2047,45 @@ class C
   IL_0006:  ret
 }}";
 
-            // M1(int, int)
-            displayClassName = "<M1>d__0";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "y"));
-            locals.Clear();
+                // M1(int, int)
+                displayClassName = "<M1>d__0";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "y"));
+                locals.Clear();
 
-            // M1(int, float)
-            displayClassName = "<M1>d__1";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", displayClassName, "y"));
-            locals.Clear();
+                // M1(int, float)
+                displayClassName = "<M1>d__1";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", displayClassName, "y"));
+                locals.Clear();
 
-            // M2(int, float)
-            displayClassName = "<M2>d__2";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", displayClassName, "y"));
-            locals.Clear();
+                // M2(int, float)
+                displayClassName = "<M2>d__2";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", displayClassName, "y"));
+                locals.Clear();
 
-            // M2(int, T)
-            displayClassName = "<M2>d__3";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            typeName += "<T>";
-            displayClassName += "<T>";
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "T", displayClassName, "y"));
-            locals.Clear();
+                // M2(int, T)
+                displayClassName = "<M2>d__3";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                typeName += "<T>";
+                displayClassName += "<T>";
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "T", displayClassName, "y"));
+                locals.Clear();
 
-            // M2(int, int)
-            displayClassName = "<M2>d__4";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "y"));
-            locals.Clear();
+                // M2(int, int)
+                displayClassName = "<M2>d__4";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "x"));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "int", displayClassName, "y"));
+                locals.Clear();
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact, WorkItem(1063254, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063254")]
@@ -2117,12 +2122,13 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            string displayClassName;
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            var ilTemplate = @"
+            WithRuntimeInstance(compilation, runtime =>
+            {
+                string displayClassName;
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                var ilTemplate = @"
 {{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2134,39 +2140,40 @@ class C
   IL_0006:  ret
 }}";
 
-            // M1(int)
-            displayClassName = "<M1>d__0";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", "int", displayClassName, "x"));
-            locals.Clear();
+                // M1(int)
+                displayClassName = "<M1>d__0";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", "int", displayClassName, "x"));
+                locals.Clear();
 
-            // M1(int, float)
-            displayClassName = "<M1>d__1";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "float", "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", "float", displayClassName, "y"));
-            locals.Clear();
+                // M1(int, float)
+                displayClassName = "<M1>d__1";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "float", "int", displayClassName, "x"));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", "float", displayClassName, "y"));
+                locals.Clear();
 
-            // M2(int, float)
-            displayClassName = "<M2>d__2";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "float", "int", displayClassName, "x"));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", "float", displayClassName, "y"));
-            locals.Clear();
+                // M2(int, float)
+                displayClassName = "<M2>d__2";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "float", "int", displayClassName, "x"));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(ilTemplate, "float", "float", displayClassName, "y"));
+                locals.Clear();
 
-            // M2(T)
-            displayClassName = "<M2>d__3";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "T", "T", displayClassName + "<T>", "x"));
-            locals.Clear();
+                // M2(T)
+                displayClassName = "<M2>d__3";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "T", "T", displayClassName + "<T>", "x"));
+                locals.Clear();
 
-            // M2(int)
-            displayClassName = "<M2>d__4";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", "int", displayClassName, "x"));
-            locals.Clear();
+                // M2(int)
+                displayClassName = "<M2>d__4";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(ilTemplate, "int", "int", displayClassName, "x"));
+                locals.Clear();
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact, WorkItem(1063254, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063254")]
@@ -2189,19 +2196,20 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            string displayClassName;
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            var voidRetILTemplate = @"
+            WithRuntimeInstance(compilation, runtime =>
+            {
+                string displayClassName;
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                var voidRetILTemplate = @"
 {{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.{0}
   IL_0001:  ret
 }}";
-            var funcILTemplate = @"
+                var funcILTemplate = @"
 {{
   // Code size        2 (0x2)
   .maxstack  1
@@ -2209,37 +2217,38 @@ class C
   IL_0001:  ret
 }}";
 
-            // y => x.ToString()
-            displayClassName = "<>c__DisplayClass0_0";
-            GetLocals(runtime, "C." + displayClassName + ".<M1>b__0", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "y", expectedILOpt: string.Format(voidRetILTemplate, 1));
-            locals.Clear();
+                // y => x.ToString()
+                displayClassName = "<>c__DisplayClass0_0";
+                GetLocals(runtime, "C." + displayClassName + ".<M1>b__0", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "y", expectedILOpt: string.Format(voidRetILTemplate, 1));
+                locals.Clear();
 
-            // z => x
-            displayClassName = "<>c__DisplayClass0_0";
-            GetLocals(runtime, "C." + displayClassName + ".<M1>b__1", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "z", expectedILOpt: string.Format(funcILTemplate, 1));
-            locals.Clear();
+                // z => x
+                displayClassName = "<>c__DisplayClass0_0";
+                GetLocals(runtime, "C." + displayClassName + ".<M1>b__1", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "z", expectedILOpt: string.Format(funcILTemplate, 1));
+                locals.Clear();
 
-            // y => y.ToString()
-            displayClassName = "<>c__1";
-            GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_0", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "y", expectedILOpt: string.Format(voidRetILTemplate, 1));
-            locals.Clear();
+                // y => y.ToString()
+                displayClassName = "<>c__1";
+                GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_0", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "y", expectedILOpt: string.Format(voidRetILTemplate, 1));
+                locals.Clear();
 
-            // z => z
-            displayClassName = "<>c__1";
-            GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_1", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "z", expectedILOpt: string.Format(funcILTemplate, 1));
-            locals.Clear();
+                // z => z
+                displayClassName = "<>c__1";
+                GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_1", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "z", expectedILOpt: string.Format(funcILTemplate, 1));
+                locals.Clear();
 
-            // t => t
-            displayClassName = "<>c__1";
-            GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_2", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "t", expectedILOpt: string.Format(funcILTemplate, 1));
-            locals.Clear();
+                // t => t
+                displayClassName = "<>c__1";
+                GetLocals(runtime, "C." + displayClassName + ".<M2>b__1_2", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "t", expectedILOpt: string.Format(funcILTemplate, 1));
+                locals.Clear();
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact, WorkItem(1063254, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063254")]
@@ -2273,11 +2282,12 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            var voidRetILTemplate = @"
+            WithRuntimeInstance(compilation, runtime =>
+            {
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                var voidRetILTemplate = @"
 {{
   // Code size        2 (0x2)
   .maxstack  1
@@ -2285,7 +2295,7 @@ class C
   IL_0000:  ldarg.{1}
   IL_0001:  ret
 }}";
-            var funcILTemplate = @"
+                var funcILTemplate = @"
 {{
   // Code size        2 (0x2)
   .maxstack  1
@@ -2294,7 +2304,7 @@ class C
   IL_0000:  ldarg.{1}
   IL_0001:  ret
 }}";
-            var refParamILTemplate = @"
+                var refParamILTemplate = @"
 {{
   // Code size        3 (0x3)
   .maxstack  1
@@ -2305,37 +2315,38 @@ class C
   IL_0002:  ret
 }}";
 
-            // M1(int, int)
-            GetLocals(runtime, "C.M1(Int32,Int32)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(voidRetILTemplate, "int", 1));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(voidRetILTemplate, "int", 2));
-            locals.Clear();
+                // M1(int, int)
+                GetLocals(runtime, "C.M1(Int32,Int32)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(voidRetILTemplate, "int", 1));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(voidRetILTemplate, "int", 2));
+                locals.Clear();
 
-            // M1(int, string)
-            GetLocals(runtime, "C.M1(Int32,String)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(funcILTemplate, "string", 1));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(funcILTemplate, "string", 2));
-            locals.Clear();
+                // M1(int, string)
+                GetLocals(runtime, "C.M1(Int32,String)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(funcILTemplate, "string", 1));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(funcILTemplate, "string", 2));
+                locals.Clear();
 
-            // M2(int, string)
-            GetLocals(runtime, "C.M2(Int32,String)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(voidRetILTemplate, "string", 0));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(voidRetILTemplate, "string", 1));
-            locals.Clear();
+                // M2(int, string)
+                GetLocals(runtime, "C.M2(Int32,String)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(voidRetILTemplate, "string", 0));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(voidRetILTemplate, "string", 1));
+                locals.Clear();
 
-            // M2(int, T)
-            GetLocals(runtime, "C.M2(Int32,T)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0<T>", "x", expectedILOpt: string.Format(funcILTemplate, "T", 0), expectedGeneric: true);
-            VerifyLocal(testData, typeName, locals[1], "<>m1<T>", "y", expectedILOpt: string.Format(funcILTemplate, "T", 1), expectedGeneric: true);
-            locals.Clear();
+                // M2(int, T)
+                GetLocals(runtime, "C.M2(Int32,T)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0<T>", "x", expectedILOpt: string.Format(funcILTemplate, "T", 0), expectedGeneric: true);
+                VerifyLocal(testData, typeName, locals[1], "<>m1<T>", "y", expectedILOpt: string.Format(funcILTemplate, "T", 1), expectedGeneric: true);
+                locals.Clear();
 
-            // M2(int, int)
-            GetLocals(runtime, "C.M2(Int32,Int32)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(funcILTemplate, "int", 0));
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(refParamILTemplate, "int", 1));
-            locals.Clear();
+                // M2(int, int)
+                GetLocals(runtime, "C.M2(Int32,Int32)", argumentsOnly: true, locals: locals, count: 2, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: string.Format(funcILTemplate, "int", 0));
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: string.Format(refParamILTemplate, "int", 1));
+                locals.Clear();
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [Fact, WorkItem(1063254, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063254")]
@@ -2384,12 +2395,13 @@ class C<T>
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            string displayClassName;
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            var iteratorILTemplate = @"
+            WithRuntimeInstance(compilation, runtime =>
+            {
+                string displayClassName;
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                var iteratorILTemplate = @"
 {{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2398,7 +2410,7 @@ class C<T>
   IL_0001:  ldfld      ""{0} C<T>.{1}.{2}""
   IL_0006:  ret
 }}";
-            var asyncILTemplate = @"
+                var asyncILTemplate = @"
 {{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2410,51 +2422,52 @@ class C<T>
   IL_0006:  ret
 }}";
 
-            // M1()
-            displayClassName = "<M1>d__0";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
-            locals.Clear();
+                // M1()
+                displayClassName = "<M1>d__0";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
+                locals.Clear();
 
-            // M1(int)
-            displayClassName = "<M1>d__1";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(iteratorILTemplate, "int", displayClassName, "x"));
-            locals.Clear();
+                // M1(int)
+                displayClassName = "<M1>d__1";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(iteratorILTemplate, "int", displayClassName, "x"));
+                locals.Clear();
 
-            // M2(int)
-            displayClassName = "<M2>d__2";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(iteratorILTemplate, "int", displayClassName, "x"));
-            locals.Clear();
+                // M2(int)
+                displayClassName = "<M2>d__2";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(iteratorILTemplate, "int", displayClassName, "x"));
+                locals.Clear();
 
-            // M2()
-            displayClassName = "<M2>d__3";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
-            locals.Clear();
+                // M2()
+                displayClassName = "<M2>d__3";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
+                locals.Clear();
 
-            // M3()
-            displayClassName = "<M3>d__4";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
-            locals.Clear();
+                // M3()
+                displayClassName = "<M3>d__4";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
+                locals.Clear();
 
-            // M3(int)
-            displayClassName = "<M3>d__5";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
-            locals.Clear();
+                // M3(int)
+                displayClassName = "<M3>d__5";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
+                locals.Clear();
 
-            // M4(int)
-            displayClassName = "<M4>d__6";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
-            locals.Clear();
+                // M4(int)
+                displayClassName = "<M4>d__6";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName + "<T, T>", locals[0], "<>m0", "x", expectedILOpt: string.Format(asyncILTemplate, "T", displayClassName + "<T>", "x"));
+                locals.Clear();
 
-            // M4()
-            displayClassName = "<M4>d__7";
-            GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
-            locals.Clear();
+                // M4()
+                displayClassName = "<M4>d__7";
+                GetLocals(runtime, "C." + displayClassName + ".MoveNext", argumentsOnly: true, locals: locals, count: 0, typeName: out typeName, testData: out testData);
+                locals.Clear();
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(1115030, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1115030")]
@@ -2484,17 +2497,15 @@ class C
         }
     }
 }";
-            var compilation0 = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<M>d__1.MoveNext",
-                atLineNumber: 999);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "o", expectedILOpt:
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+            WithRuntimeInstancePortableBug(compilation, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext", atLineNumber: 999);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "o", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2504,7 +2515,7 @@ class C
   IL_0001:  ldfld      ""object C.<M>d__1.<o>5__1""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "e", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "e", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2514,7 +2525,8 @@ class C
   IL_0001:  ldfld      ""System.Exception C.<M>d__1.<e>5__2""
   IL_0006:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(1115030, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1115030")]
@@ -2546,16 +2558,14 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.<M>d__1.MoveNext",
-                atLineNumber: 999);
-            var testData = new CompilationTestData();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "o", expectedILOpt:
+            WithRuntimeInstancePortableBug(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext", atLineNumber: 999);
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "o", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2565,7 +2575,7 @@ class C
   IL_0001:  ldfld      ""object C.<M>d__1.<o>5__1""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "e", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "e", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2575,7 +2585,8 @@ class C
   IL_0001:  ldfld      ""System.Exception C.<M>d__1.<e>5__2""
   IL_0006:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(947, "unknown")]
@@ -2612,16 +2623,15 @@ class C
             var libRef = CreateCompilationWithMscorlib(libSource).EmitToImageReference();
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemRef }, TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(
-                comp, 
-                new[] { MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef });
-
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            GetLocals(runtime, "C.M", argumentsOnly: false, locals: locals, count: 1, typeName: out typeName, testData: out testData);
-            Assert.Equal("this", locals.Single().LocalName);
-            locals.Free();
+            WithRuntimeInstance(comp, new[] { MscorlibRef, SystemRef, SystemCoreRef, SystemXmlLinqRef, libRef }, runtime =>
+            {
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                GetLocals(runtime, "C.M", argumentsOnly: false, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                Assert.Equal("this", locals.Single().LocalName);
+                locals.Free();
+            });
         }
 
         [WorkItem(2089, "https://github.com/dotnet/roslyn/issues/2089")]
@@ -2647,14 +2657,15 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            var context = CreateMethodContext(runtime, "C.<M>d__2.MoveNext()");
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var testData = new CompilationTestData();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, "<>x", locals[0], "<>m0", "this", expectedILOpt:
+            WithRuntimeInstance(compilation, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__2.MoveNext()");
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var testData = new CompilationTestData();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -2666,7 +2677,7 @@ class C
   IL_0001:  ldfld      ""C C.<M>d__2.<>4__this""
   IL_0006:  ret
 }");
-            VerifyLocal(testData, "<>x", locals[1], "<>m1", "s", expectedILOpt:
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "s", expectedILOpt:
 @"{
   // Code size       12 (0xc)
   .maxstack  1
@@ -2679,7 +2690,8 @@ class C
   IL_0006:  ldfld      ""string C.<>c__DisplayClass2_0.s""
   IL_000b:  ret
 }");
-            locals.Free();
+                locals.Free();
+            });
         }
 
         [WorkItem(2336, "https://github.com/dotnet/roslyn/issues/2336")]
@@ -2698,16 +2710,18 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation);
-            var context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext()", atLineNumber: 999);
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            string typeName;
-            var testData = new CompilationTestData();
-            context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-            Assert.Equal(locals.Count, 2);
-            VerifyLocal(testData, "<>x", locals[0], "<>m0", "this");
-            VerifyLocal(testData, "<>x", locals[1], "<>m1", "s");
-            locals.Free();
+            WithRuntimeInstancePortableBug(compilation, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__0.MoveNext()", atLineNumber: 999);
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var testData = new CompilationTestData();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.Equal(locals.Count, 2);
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "this");
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "s");
+                locals.Free();
+            });
         }
 
         [WorkItem(1139013, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1139013")]
@@ -2763,35 +2777,36 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                GetLocals(runtime, methodName, argumentsOnly: false, locals: locals, count: 3, typeName: out typeName, testData: out testData);
 
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            GetLocals(runtime, methodName, argumentsOnly: false, locals: locals, count: 3, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "z", expectedILOpt: zIL);
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "x", expectedILOpt: xIL);
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedILOpt: yIL);
+                locals.Free();
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "z", expectedILOpt: zIL);
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "x", expectedILOpt: xIL);
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedILOpt: yIL);
-            locals.Free();
+                var context = CreateMethodContext(runtime, methodName);
+                string error;
 
-            var context = CreateMethodContext(runtime, methodName);
-            string error;
+                testData = new CompilationTestData();
+                context.CompileExpression("z", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(zIL);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("z", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(zIL);
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(xIL);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(xIL);
-
-            testData = new CompilationTestData();
-            context.CompileExpression("y", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(yIL);
+                testData = new CompilationTestData();
+                context.CompileExpression("y", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(yIL);
+            });
         }
 
         [WorkItem(1139013, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1139013")]
@@ -2858,42 +2873,43 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                GetLocals(runtime, methodName, argumentsOnly: false, locals: locals, count: 4, typeName: out typeName, testData: out testData);
 
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            GetLocals(runtime, methodName, argumentsOnly: false, locals: locals, count: 4, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "c", expectedILOpt: cIL);
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "z", expectedILOpt: zIL);
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "x", expectedILOpt: xIL);
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "y", expectedILOpt: yIL);
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "c", expectedILOpt: cIL);
-            VerifyLocal(testData, typeName, locals[1], "<>m1", "z", expectedILOpt: zIL);
-            VerifyLocal(testData, typeName, locals[2], "<>m2", "x", expectedILOpt: xIL);
-            VerifyLocal(testData, typeName, locals[3], "<>m3", "y", expectedILOpt: yIL);
+                locals.Free();
 
-            locals.Free();
+                var context = CreateMethodContext(runtime, methodName);
+                string error;
 
-            var context = CreateMethodContext(runtime, methodName);
-            string error;
+                testData = new CompilationTestData();
+                context.CompileExpression("c", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(cIL);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("c", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(cIL);
+                testData = new CompilationTestData();
+                context.CompileExpression("z", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(zIL);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("z", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(zIL);
+                testData = new CompilationTestData();
+                context.CompileExpression("x", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(xIL);
 
-            testData = new CompilationTestData();
-            context.CompileExpression("x", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(xIL);
-
-            testData = new CompilationTestData();
-            context.CompileExpression("y", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(yIL);
+                testData = new CompilationTestData();
+                context.CompileExpression("y", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(yIL);
+            });
         }
 
         [WorkItem(3236, "https://github.com/dotnet/roslyn/pull/3236")]
@@ -2929,30 +2945,31 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                string typeName;
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                CompilationTestData testData;
+                GetLocals(runtime, methodName, argumentsOnly: false, locals: locals, count: 1, typeName: out typeName, testData: out testData);
 
-            string typeName;
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
-            CompilationTestData testData;
-            GetLocals(runtime, methodName, argumentsOnly: false, locals: locals, count: 1, typeName: out typeName, testData: out testData);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "t", expectedILOpt: tIL);
 
-            VerifyLocal(testData, typeName, locals[0], "<>m0", "t", expectedILOpt: tIL);
+                locals.Free();
 
-            locals.Free();
+                var context = CreateMethodContext(runtime, methodName);
+                string error;
 
-            var context = CreateMethodContext(runtime, methodName);
-            string error;
-
-            testData = new CompilationTestData();
-            context.CompileExpression("t", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(tIL);
+                testData = new CompilationTestData();
+                context.CompileExpression("t", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(tIL);
+            });
         }
 
         [WorkItem(955, "https://github.com/aspnet/Home/issues/955")]
         [Fact]
         public void ConstantWithErrorType()
-        { 
+        {
             const string source = @"
 class Program
 {
@@ -2962,21 +2979,23 @@ class Program
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
-            var runtime = CreateRuntimeInstance(comp);
-            var badConst = new MockSymUnmanagedConstant(
-                "a",
-                1,
-                (int bufferLength, out int count, byte[] name) =>
-                {
-                    count = 0;
-                    return DiaSymReader.SymUnmanagedReaderExtensions.E_NOTIMPL;
-                });
-            var debugInfo = new MethodDebugInfoBytes.Builder(constants: new[] {badConst}).Build();
-            var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var badConst = new MockSymUnmanagedConstant(
+                    "a",
+                    1,
+                    (int bufferLength, out int count, byte[] name) =>
+                    {
+                        count = 0;
+                        return DiaSymReader.SymUnmanagedReaderExtensions.E_NOTIMPL;
+                    });
+                var debugInfo = new MethodDebugInfoBytes.Builder(constants: new[] { badConst }).Build();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
 
-            GetLocals(runtime, "Program.Main", debugInfo, locals, count: 0);
+                GetLocals(runtime, "Program.Main", debugInfo, locals, count: 0);
 
-            locals.Free();
+                locals.Free();
+            });
         }
 
         private static void GetLocals(RuntimeInstance runtime, string methodName, bool argumentsOnly, ArrayBuilder<LocalAndMethod> locals, int count, out string typeName, out CompilationTestData testData)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ManagedAddressOfTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ManagedAddressOfTests.cs
@@ -22,18 +22,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileExpression("&s", out error, testData);
-            Assert.Null(error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileExpression("&s", out error, testData);
+                Assert.Null(error);
 
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            AssertIsIntPtrPointer(methodData.Method.ReturnType);
-            methodData.VerifyIL(@"
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                AssertIsIntPtrPointer(methodData.Method.ReturnType);
+                methodData.VerifyIL(@"
 {
   // Code size        4 (0x4)
   .maxstack  1
@@ -42,6 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0003:  ret
 }
 ");
+            });
         }
 
         [Fact]
@@ -56,18 +56,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileExpression("&s", out error, testData);
-            Assert.Null(error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileExpression("&s", out error, testData);
+                Assert.Null(error);
 
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            AssertIsIntPtrPointer(methodData.Method.ReturnType);
-            methodData.VerifyIL(@"
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                AssertIsIntPtrPointer(methodData.Method.ReturnType);
+                methodData.VerifyIL(@"
 {
   // Code size        4 (0x4)
   .maxstack  1
@@ -77,6 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0003:  ret
 }
 ");
+            });
         }
 
         [Fact]
@@ -92,18 +92,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileExpression("&s", out error, testData);
-            Assert.Null(error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileExpression("&s", out error, testData);
+                Assert.Null(error);
 
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            AssertIsIntPtrPointer(methodData.Method.ReturnType);
-            methodData.VerifyIL(@"
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                AssertIsIntPtrPointer(methodData.Method.ReturnType);
+                methodData.VerifyIL(@"
 {
   // Code size        8 (0x8)
   .maxstack  1
@@ -113,6 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0007:  ret
 }
 ");
+            });
         }
 
         /// <remarks>
@@ -147,31 +147,30 @@ struct Generic<T>
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-
-
-            var types = new[]
+            WithRuntimeInstance(comp, runtime =>
             {
-                "C", // class
-                "D", // delegate
-                "I", // interface
-                "T", // type parameter
-                "int[]",
-                "Generic<int>",
-                "dynamic",
-            };
+                var context = CreateMethodContext(runtime, "C.M");
 
-            foreach (var type in types)
-            {
-                string error;
-                CompilationTestData testData = new CompilationTestData();
-                context.CompileExpression(string.Format("sizeof({0})", type), out error, testData);
-                // CONSIDER: change error code to make text less confusing?
-                Assert.Equal(string.Format("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')", type), error);
-            }
+                var types = new[]
+                {
+                    "C", // class
+                    "D", // delegate
+                    "I", // interface
+                    "T", // type parameter
+                    "int[]",
+                    "Generic<int>",
+                    "dynamic",
+                };
+
+                foreach (var type in types)
+                {
+                    string error;
+                    CompilationTestData testData = new CompilationTestData();
+                    context.CompileExpression(string.Format("sizeof({0})", type), out error, testData);
+                    // CONSIDER: change error code to make text less confusing?
+                    Assert.Equal(string.Format("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')", type), error);
+                }
+            });
         }
 
         [Fact]
@@ -186,15 +185,15 @@ struct Generic<T>
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileAssignment("a", "() => { var s = stackalloc string[1]; }", out error, testData);
-            // CONSIDER: change error code to make text less confusing?
-            Assert.Equal("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')", error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileAssignment("a", "() => { var s = stackalloc string[1]; }", out error, testData);
+                // CONSIDER: change error code to make text less confusing?
+                Assert.Equal("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')", error);
+            });
         }
 
         [Fact]
@@ -208,15 +207,15 @@ struct Generic<T>
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileExpression("(string*)null", out error, testData);
-            // CONSIDER: change error code to make text less confusing?
-            Assert.Equal("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')", error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileExpression("(string*)null", out error, testData);
+                // CONSIDER: change error code to make text less confusing?
+                Assert.Equal("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')", error);
+            });
         }
 
         /// <remarks>
@@ -234,15 +233,15 @@ struct Generic<T>
     }
 }";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(
-                runtime,
-                methodName: "C.M");
-            var testData = new CompilationTestData();
-            string error;
-            context.CompileAssignment("a", "() => { fixed (void* p = args) { } }", out error, testData);
-            // CONSIDER: change error code to make text less confusing?
-            Assert.Equal("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')", error);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                string error;
+                context.CompileAssignment("a", "() => { fixed (void* p = args) { } }", out error, testData);
+                // CONSIDER: change error code to make text less confusing?
+                Assert.Equal("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')", error);
+            });
         }
 
         private static void AssertIsIntPtrPointer(ITypeSymbol returnType)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -83,28 +83,30 @@ public class C
             var libRef = CreateCompilationWithMscorlib(libSource, assemblyName: "Lib").EmitToImageReference();
             var comp = CreateCompilationWithMscorlib(source, new[] { libRef }, TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef });
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, new[] { MscorlibRef }, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var expectedError = "error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.";
-            var expectedMissingAssemblyIdentity = new AssemblyIdentity("Lib");
+                var expectedError = "error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.";
+                var expectedMissingAssemblyIdentity = new AssemblyIdentity("Lib");
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
 
-            context.CompileExpression(
-                "parameter",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(expectedError, actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "parameter",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(expectedError, actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         [Fact]
@@ -120,28 +122,30 @@ public class C
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
 
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef });
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, new[] { MscorlibRef }, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var expectedError = "error CS1935: Could not find an implementation of the query pattern for source type 'int[]'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?";
-            var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
+                var expectedError = "error CS1935: Could not find an implementation of the query pattern for source type 'int[]'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?";
+                var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
 
-            context.CompileExpression(
-                "from i in array select i",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(expectedError, actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "from i in array select i",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(expectedError, actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         [WorkItem(1151888, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1151888")]
@@ -159,41 +163,43 @@ public class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemCoreRef }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef });
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, new[] { MscorlibRef }, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var expectedErrorTemplate = "error CS1061: 'int[]' does not contain a definition for '{0}' and no extension method '{0}' accepting a first argument of type 'int[]' could be found (are you missing a using directive or an assembly reference?)";
-            var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
+                var expectedErrorTemplate = "error CS1061: 'int[]' does not contain a definition for '{0}' and no extension method '{0}' accepting a first argument of type 'int[]' could be found (are you missing a using directive or an assembly reference?)";
+                var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
 
-            context.CompileExpression(
-                "array.Count()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(string.Format(expectedErrorTemplate, "Count"), actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "array.Count()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(string.Format(expectedErrorTemplate, "Count"), actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
 
-            context.CompileExpression(
-                "array.NoSuchMethod()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(string.Format(expectedErrorTemplate, "NoSuchMethod"), actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "array.NoSuchMethod()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(string.Format(expectedErrorTemplate, "NoSuchMethod"), actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         /// <remarks>
@@ -223,41 +229,43 @@ namespace System.Linq
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef });
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, new[] { MscorlibRef }, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var expectedErrorTemplate = "error CS1061: 'int[]' does not contain a definition for '{0}' and no extension method '{0}' accepting a first argument of type 'int[]' could be found (are you missing a using directive or an assembly reference?)";
-            var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
+                var expectedErrorTemplate = "error CS1061: 'int[]' does not contain a definition for '{0}' and no extension method '{0}' accepting a first argument of type 'int[]' could be found (are you missing a using directive or an assembly reference?)";
+                var expectedMissingAssemblyIdentity = EvaluationContextBase.SystemCoreIdentity;
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
 
-            context.CompileExpression(
-                "array.Count()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(string.Format(expectedErrorTemplate, "Count"), actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "array.Count()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(string.Format(expectedErrorTemplate, "Count"), actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
 
-            context.CompileExpression(
-                "array.NoSuchMethod()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(string.Format(expectedErrorTemplate, "NoSuchMethod"), actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "array.NoSuchMethod()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(string.Format(expectedErrorTemplate, "NoSuchMethod"), actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         [Fact]
@@ -301,59 +309,61 @@ class C
 ";
             var ilRef = CompileIL(il, appendDefaultHeader: false);
             var comp = CreateCompilationWithMscorlib(csharp, new[] { ilRef });
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var expectedMissingAssemblyIdentity = new AssemblyIdentity("pe2");
+                var expectedMissingAssemblyIdentity = new AssemblyIdentity("pe2");
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
 
-            context.CompileExpression(
-                "new global::Forwarded()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(
-                "error CS1068: The type name 'Forwarded' could not be found in the global namespace. This type has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Consider adding a reference to that assembly.",
-                actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "new global::Forwarded()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(
+                    "error CS1068: The type name 'Forwarded' could not be found in the global namespace. This type has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Consider adding a reference to that assembly.",
+                    actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
 
-            context.CompileExpression(
-                "new Forwarded()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(
-                "error CS1070: The type name 'Forwarded' could not be found. This type has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Consider adding a reference to that assembly.",
-                actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "new Forwarded()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(
+                    "error CS1070: The type name 'Forwarded' could not be found. This type has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Consider adding a reference to that assembly.",
+                    actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
 
-            context.CompileExpression(
-                "new NS.Forwarded()",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(
-                "error CS1069: The type name 'Forwarded' could not be found in the namespace 'NS'. This type has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Consider adding a reference to that assembly.",
-                actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                context.CompileExpression(
+                    "new NS.Forwarded()",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(
+                    "error CS1069: The type name 'Forwarded' could not be found in the namespace 'NS'. This type has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Consider adding a reference to that assembly.",
+                    actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         [Fact]
@@ -482,27 +492,29 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp, new[] { CSharpRef });
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, new[] { CSharpRef }, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            const string expectedError = "error CS0012: The type 'Exception' is defined in an assembly that is not referenced. You must add a reference to assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.";
-            var expectedMissingAssemblyIdentity = comp.Assembly.CorLibrary.Identity;
+                const string expectedError = "error CS0012: The type 'Exception' is defined in an assembly that is not referenced. You must add a reference to assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.";
+                var expectedMissingAssemblyIdentity = comp.Assembly.CorLibrary.Identity;
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
-            context.CompileExpression(
-                "$stowedexception",
-                DkmEvaluationFlags.TreatAsExpression,
-                ImmutableArray.Create(ExceptionAlias("Microsoft.CSharp.RuntimeBinder.RuntimeBinderException, Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", stowed: true)),
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(expectedError, actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                context.CompileExpression(
+                    "$stowedexception",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    ImmutableArray.Create(ExceptionAlias("Microsoft.CSharp.RuntimeBinder.RuntimeBinderException, Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", stowed: true)),
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(expectedError, actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         [WorkItem(1114866, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1114866")]
@@ -520,27 +532,29 @@ class C
             var runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage");
             Assert.True(runtimeAssemblies.Any());
 
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef }.Concat(runtimeAssemblies));
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, new[] { MscorlibRef }.Concat(runtimeAssemblies), runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            const string expectedError = "error CS0234: The type or namespace name 'UI' does not exist in the namespace 'Windows' (are you missing an assembly reference?)";
-            var expectedMissingAssemblyIdentity = new AssemblyIdentity("Windows.UI", contentType: System.Reflection.AssemblyContentType.WindowsRuntime);
+                const string expectedError = "error CS0234: The type or namespace name 'UI' does not exist in the namespace 'Windows' (are you missing an assembly reference?)";
+                var expectedMissingAssemblyIdentity = new AssemblyIdentity("Windows.UI", contentType: System.Reflection.AssemblyContentType.WindowsRuntime);
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
-            context.CompileExpression(
-                "typeof(@Windows.UI.Colors)",
-                DkmEvaluationFlags.None,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(expectedError, actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                context.CompileExpression(
+                    "typeof(@Windows.UI.Colors)",
+                    DkmEvaluationFlags.None,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(expectedError, actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         /// <remarks>
@@ -561,27 +575,29 @@ class C
             var runtimeAssemblies = ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI");
             Assert.True(runtimeAssemblies.Any());
 
-            var runtime = CreateRuntimeInstance(comp, new[] { MscorlibRef }.Concat(runtimeAssemblies));
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, new[] { MscorlibRef }.Concat(runtimeAssemblies), runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            const string expectedError = "error CS0234: The type or namespace name 'Xaml' does not exist in the namespace 'Windows.UI' (are you missing an assembly reference?)";
-            var expectedMissingAssemblyIdentity = new AssemblyIdentity("Windows.UI.Xaml", contentType: System.Reflection.AssemblyContentType.WindowsRuntime);
+                const string expectedError = "error CS0234: The type or namespace name 'Xaml' does not exist in the namespace 'Windows.UI' (are you missing an assembly reference?)";
+                var expectedMissingAssemblyIdentity = new AssemblyIdentity("Windows.UI.Xaml", contentType: System.Reflection.AssemblyContentType.WindowsRuntime);
 
-            ResultProperties resultProperties;
-            string actualError;
-            ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
-            context.CompileExpression(
-                "typeof(Windows.@UI.Xaml.Application)",
-                DkmEvaluationFlags.None,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out actualError,
-                out actualMissingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData: null);
-            Assert.Equal(expectedError, actualError);
-            Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+                ResultProperties resultProperties;
+                string actualError;
+                ImmutableArray<AssemblyIdentity> actualMissingAssemblyIdentities;
+                context.CompileExpression(
+                    "typeof(Windows.@UI.Xaml.Application)",
+                    DkmEvaluationFlags.None,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out actualError,
+                    out actualMissingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData: null);
+                Assert.Equal(expectedError, actualError);
+                Assert.Equal(expectedMissingAssemblyIdentity, actualMissingAssemblyIdentities.Single());
+            });
         }
 
         [WorkItem(1154988, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1154988")]
@@ -596,33 +612,35 @@ class C
     } 
 }";
             var comp = CreateCompilationWithMscorlib(source);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var missingModule = runtime.Modules.First();
-            var missingIdentity = missingModule.GetMetadataReader().ReadAssemblyIdentityOrThrow();
+                var missingModule = runtime.Modules.First();
+                var missingIdentity = missingModule.GetMetadataReader().ReadAssemblyIdentityOrThrow();
 
-            var numRetries = 0;
-            string errorMessage;
-            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
-                runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
-                context,
-                (_, diagnostics) =>
-                {
-                    numRetries++;
-                    Assert.InRange(numRetries, 0, 2); // We don't want to loop forever... 
-                    diagnostics.Add(new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDef, "MissingType", missingIdentity), Location.None));
-                    return null;
-                },
-                (AssemblyIdentity assemblyIdentity, out uint uSize) =>
-                {
-                    uSize = (uint)missingModule.MetadataLength;
-                    return missingModule.MetadataAddress;
-                },
-                out errorMessage);
+                var numRetries = 0;
+                string errorMessage;
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
+                    runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
+                    context,
+                    (_, diagnostics) =>
+                    {
+                        numRetries++;
+                        Assert.InRange(numRetries, 0, 2); // We don't want to loop forever... 
+                        diagnostics.Add(new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDef, "MissingType", missingIdentity), Location.None));
+                        return null;
+                    },
+                    (AssemblyIdentity assemblyIdentity, out uint uSize) =>
+                    {
+                        uSize = (uint)missingModule.MetadataLength;
+                        return missingModule.MetadataAddress;
+                    },
+                    out errorMessage);
 
-            Assert.Equal(2, numRetries); // Ensure that we actually retried and that we bailed out on the second retry if the same identity was seen in the diagnostics.
-            Assert.Equal($"error CS0012: The type 'MissingType' is defined in an assembly that is not referenced. You must add a reference to assembly '{missingIdentity}'.", errorMessage);
+                Assert.Equal(2, numRetries); // Ensure that we actually retried and that we bailed out on the second retry if the same identity was seen in the diagnostics.
+                Assert.Equal($"error CS0012: The type 'MissingType' is defined in an assembly that is not referenced. You must add a reference to assembly '{missingIdentity}'.", errorMessage);
+            });
         }
 
         [WorkItem(1151888, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1151888")]
@@ -637,39 +655,41 @@ class C
     } 
 }";
             var comp = CreateCompilationWithMscorlib(source);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, "C.M");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var missingModule = runtime.Modules.First();
-            var missingIdentity = missingModule.GetMetadataReader().ReadAssemblyIdentityOrThrow();
+                var missingModule = runtime.Modules.First();
+                var missingIdentity = missingModule.GetMetadataReader().ReadAssemblyIdentityOrThrow();
 
-            var shouldSucceed = false;
-            string errorMessage;
-            var compileResult = ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
-                runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
-                context,
-                (_, diagnostics) =>
-                {
-                    if (shouldSucceed)
+                var shouldSucceed = false;
+                string errorMessage;
+                var compileResult = ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
+                    runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
+                    context,
+                    (_, diagnostics) =>
                     {
-                        return TestCompileResult.Instance;
-                    }
-                    else
+                        if (shouldSucceed)
+                        {
+                            return TestCompileResult.Instance;
+                        }
+                        else
+                        {
+                            shouldSucceed = true;
+                            diagnostics.Add(new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDef, "MissingType", missingIdentity), Location.None));
+                            return null;
+                        }
+                    },
+                    (AssemblyIdentity assemblyIdentity, out uint uSize) =>
                     {
-                        shouldSucceed = true;
-                        diagnostics.Add(new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDef, "MissingType", missingIdentity), Location.None));
-                        return null;
-                    }
-                },
-                (AssemblyIdentity assemblyIdentity, out uint uSize) =>
-                {
-                    uSize = (uint)missingModule.MetadataLength;
-                    return missingModule.MetadataAddress;
-                },
-                out errorMessage);
+                        uSize = (uint)missingModule.MetadataLength;
+                        return missingModule.MetadataAddress;
+                    },
+                    out errorMessage);
 
-            Assert.Same(TestCompileResult.Instance, compileResult);
-            Assert.Null(errorMessage);
+                Assert.Same(TestCompileResult.Instance, compileResult);
+                Assert.Null(errorMessage);
+            });
         }
 
         [WorkItem(2547, "https://github.com/dotnet/roslyn/issues/2547")]
@@ -690,46 +710,47 @@ class UseLinq
 }";
 
             var compilation = CreateCompilation(source, new[] { MscorlibRef, SystemCoreRef });
+            WithRuntimeInstance(compilation, new[] { MscorlibRef }, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var runtime = CreateRuntimeInstance(compilation, new[] { MscorlibRef });
-            var context = CreateMethodContext(runtime, "C.M");
+                var systemCore = SystemCoreRef.ToModuleInstance();
+                var fakeSystemLinq = CreateCompilationWithMscorlib45("", assemblyName: "System.Linq").
+                    EmitToImageReference().ToModuleInstance();
 
-            var systemCore = SystemCoreRef.ToModuleInstance();
-            var fakeSystemLinq = CreateCompilationWithMscorlib45("", assemblyName: "System.Linq").
-                EmitToImageReference().ToModuleInstance();
-
-            string errorMessage;
-            CompilationTestData testData;
-            int retryCount = 0;
-            var compileResult = ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
-                runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
-                "args.Where(a => a.Length > 0)",
-                ImmutableArray<Alias>.Empty,
-                (_1, _2) => context, // ignore new blocks and just keep using the same failed context...
-                (AssemblyIdentity assemblyIdentity, out uint uSize) =>
-                {
-                    retryCount++;
-                    MetadataBlock block;
-                    switch (retryCount)
+                string errorMessage;
+                CompilationTestData testData;
+                int retryCount = 0;
+                var compileResult = ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
+                    runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
+                    "args.Where(a => a.Length > 0)",
+                    ImmutableArray<Alias>.Empty,
+                    (_1, _2) => context, // ignore new blocks and just keep using the same failed context...
+                    (AssemblyIdentity assemblyIdentity, out uint uSize) =>
                     {
-                        case 1:
-                            Assert.Equal(EvaluationContextBase.SystemLinqIdentity, assemblyIdentity);
-                            block = fakeSystemLinq.MetadataBlock;
-                            break;
-                        case 2:
-                            Assert.Equal(EvaluationContextBase.SystemCoreIdentity, assemblyIdentity);
-                            block = systemCore.MetadataBlock;
-                            break;
-                        default:
-                            throw ExceptionUtilities.Unreachable;
-                    }
-                    uSize = (uint)block.Size;
-                    return block.Pointer;
-                },
-                errorMessage: out errorMessage,
-                testData: out testData);
+                        retryCount++;
+                        MetadataBlock block;
+                        switch (retryCount)
+                        {
+                            case 1:
+                                Assert.Equal(EvaluationContextBase.SystemLinqIdentity, assemblyIdentity);
+                                block = fakeSystemLinq.MetadataBlock;
+                                break;
+                            case 2:
+                                Assert.Equal(EvaluationContextBase.SystemCoreIdentity, assemblyIdentity);
+                                block = systemCore.MetadataBlock;
+                                break;
+                            default:
+                                throw ExceptionUtilities.Unreachable;
+                        }
+                        uSize = (uint)block.Size;
+                        return block.Pointer;
+                    },
+                    errorMessage: out errorMessage,
+                    testData: out testData);
 
-            Assert.Equal(2, retryCount);
+                Assert.Equal(2, retryCount);
+            });
         }
 
         private sealed class TestCompileResult : CompileResult

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
@@ -40,17 +40,15 @@ class C
         (new C()).M();
     }
 }";
-            var compilation0 = CSharpTestBase.CreateCompilationWithMscorlib(
-                source,
-                options: TestOptions.DebugExe,
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName());
-            var runtime = CreateRuntimeInstance(compilation0);
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("this", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("this", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -58,6 +56,7 @@ class C
   IL_0000:  ldarg.0
   IL_0001:  ret
 }");
+            });
         }
 
         [WorkItem(1035310, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1035310")]
@@ -86,14 +85,14 @@ public interface I
             var referencePIA = compilationPIA.EmitToImageReference(embedInteropTypes: true);
 
             var compilation0 = CreateCompilationWithMscorlib(source, new[] { referencePIA }, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0);
-
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression("o", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression("o", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        2 (0x2)
   .maxstack  1
@@ -101,6 +100,7 @@ public interface I
   IL_0000:  ldloc.0
   IL_0001:  ret
 }");
+            });
         }
 
         /// <summary>

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
@@ -33,16 +33,18 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
-
-            foreach (var expr in new[] { "this", "null", "1", "F", "p", "l" })
+            WithRuntimeInstance(comp, runtime =>
             {
-                Assert.Equal(DkmEvaluationResultCategory.Data, GetResultProperties(context, expr).Category);
-            }
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            Assert.Equal(DkmEvaluationResultCategory.Method, GetResultProperties(context, "M()").Category);
-            Assert.Equal(DkmEvaluationResultCategory.Property, GetResultProperties(context, "P").Category);
+                foreach (var expr in new[] { "this", "null", "1", "F", "p", "l" })
+                {
+                    Assert.Equal(DkmEvaluationResultCategory.Data, GetResultProperties(context, expr).Category);
+                }
+
+                Assert.Equal(DkmEvaluationResultCategory.Method, GetResultProperties(context, "M()").Category);
+                Assert.Equal(DkmEvaluationResultCategory.Property, GetResultProperties(context, "P").Category);
+            });
         }
 
         [Fact]
@@ -66,18 +68,20 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
-
-            foreach (var expr in new[] { "this", "null", "1", "P", "F", "M()", "p", "l" })
+            WithRuntimeInstance(comp, runtime =>
             {
-                Assert.Equal(DkmEvaluationResultStorageType.None, GetResultProperties(context, expr).StorageType);
-            }
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            foreach (var expr in new[] { "SP", "SF", "SM()" })
-            {
-                Assert.Equal(DkmEvaluationResultStorageType.Static, GetResultProperties(context, expr).StorageType);
-            }
+                foreach (var expr in new[] { "this", "null", "1", "P", "F", "M()", "p", "l" })
+                {
+                    Assert.Equal(DkmEvaluationResultStorageType.None, GetResultProperties(context, expr).StorageType);
+                }
+
+                foreach (var expr in new[] { "SP", "SF", "SM()" })
+                {
+                    Assert.Equal(DkmEvaluationResultStorageType.Static, GetResultProperties(context, expr).StorageType);
+                }
+            });
         }
 
         [Fact]
@@ -142,11 +146,13 @@ internal class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            // Used the declared accessibility, rather than the effective accessibility.
-            Assert.Equal(DkmEvaluationResultAccessType.Public, GetResultProperties(context, "F").AccessType);
+                // Used the declared accessibility, rather than the effective accessibility.
+                Assert.Equal(DkmEvaluationResultAccessType.Public, GetResultProperties(context, "F").AccessType);
+            });
         }
 
         [Fact]
@@ -171,18 +177,20 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "P").ModifierFlags);
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "VP").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "P").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "VP").ModifierFlags);
 
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "M()").ModifierFlags);
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "VM()").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "M()").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "VM()").ModifierFlags);
 
-            // Field-like events are borderline since they bind as event accesses, but get emitted as field accesses.
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "E").ModifierFlags);
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "VE").ModifierFlags);
+                // Field-like events are borderline since they bind as event accesses, but get emitted as field accesses.
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "E").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "VE").ModifierFlags);
+            });
         }
 
         [Fact]
@@ -207,11 +215,13 @@ abstract class Derived : Base
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "Derived.Test");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "Derived.Test");
 
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "Abstract").ModifierFlags);
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "Override").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "Abstract").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.Virtual, GetResultProperties(context, "Override").ModifierFlags);
+            });
         }
 
         [Fact]
@@ -234,18 +244,20 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
-
-            foreach (var expr in new[] { "null", "1", "1 + 1", "CF", "cl" })
+            WithRuntimeInstance(comp, runtime =>
             {
-                Assert.Equal(DkmEvaluationResultTypeModifierFlags.Constant, GetResultProperties(context, expr).ModifierFlags);
-            }
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            foreach (var expr in new[] { "this", "F", "SRF", "p", "l" })
-            {
-                Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, expr).ModifierFlags);
-            }
+                foreach (var expr in new[] { "null", "1", "1 + 1", "CF", "cl" })
+                {
+                    Assert.Equal(DkmEvaluationResultTypeModifierFlags.Constant, GetResultProperties(context, expr).ModifierFlags);
+                }
+
+                foreach (var expr in new[] { "this", "F", "SRF", "p", "l" })
+                {
+                    Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, expr).ModifierFlags);
+                }
+            });
         }
 
         [Fact]
@@ -266,11 +278,13 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "F").ModifierFlags);
-            Assert.Equal(DkmEvaluationResultTypeModifierFlags.Volatile, GetResultProperties(context, "VF").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.None, GetResultProperties(context, "F").ModifierFlags);
+                Assert.Equal(DkmEvaluationResultTypeModifierFlags.Volatile, GetResultProperties(context, "VF").ModifierFlags);
+            });
         }
 
         [Fact]
@@ -287,22 +301,24 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            ResultProperties resultProperties;
-            string error;
-            var testData = new CompilationTestData();
-            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            context.CompileAssignment("P", "1", NoAliases, DebuggerDiagnosticFormatter.Instance, out resultProperties, out error, out missingAssemblyIdentities, EnsureEnglishUICulture.PreferredOrNull, testData);
-            Assert.Null(error);
-            Assert.Empty(missingAssemblyIdentities);
+                ResultProperties resultProperties;
+                string error;
+                var testData = new CompilationTestData();
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                context.CompileAssignment("P", "1", NoAliases, DebuggerDiagnosticFormatter.Instance, out resultProperties, out error, out missingAssemblyIdentities, EnsureEnglishUICulture.PreferredOrNull, testData);
+                Assert.Null(error);
+                Assert.Empty(missingAssemblyIdentities);
 
-            Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect, resultProperties.Flags);
-            Assert.Equal(default(DkmEvaluationResultCategory), resultProperties.Category); // Not Data
-            Assert.Equal(default(DkmEvaluationResultAccessType), resultProperties.AccessType); // Not Public
-            Assert.Equal(default(DkmEvaluationResultStorageType), resultProperties.StorageType);
-            Assert.Equal(default(DkmEvaluationResultTypeModifierFlags), resultProperties.ModifierFlags); // Not Virtual
+                Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect, resultProperties.Flags);
+                Assert.Equal(default(DkmEvaluationResultCategory), resultProperties.Category); // Not Data
+                Assert.Equal(default(DkmEvaluationResultAccessType), resultProperties.AccessType); // Not Public
+                Assert.Equal(default(DkmEvaluationResultStorageType), resultProperties.StorageType);
+                Assert.Equal(default(DkmEvaluationResultTypeModifierFlags), resultProperties.ModifierFlags); // Not Virtual
+            });
         }
 
         [Fact]
@@ -319,31 +335,33 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            ResultProperties resultProperties;
-            string error;
-            var testData = new CompilationTestData();
-            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            context.CompileExpression(
-                "int z = 1;",
-                DkmEvaluationFlags.None,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData);
-            Assert.Null(error);
-            Assert.Empty(missingAssemblyIdentities);
+                ResultProperties resultProperties;
+                string error;
+                var testData = new CompilationTestData();
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                context.CompileExpression(
+                    "int z = 1;",
+                    DkmEvaluationFlags.None,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData);
+                Assert.Null(error);
+                Assert.Empty(missingAssemblyIdentities);
 
-            Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
-            Assert.Equal(default(DkmEvaluationResultCategory), resultProperties.Category); // Not Data
-            Assert.Equal(default(DkmEvaluationResultAccessType), resultProperties.AccessType);
-            Assert.Equal(default(DkmEvaluationResultStorageType), resultProperties.StorageType);
-            Assert.Equal(default(DkmEvaluationResultTypeModifierFlags), resultProperties.ModifierFlags);
+                Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
+                Assert.Equal(default(DkmEvaluationResultCategory), resultProperties.Category); // Not Data
+                Assert.Equal(default(DkmEvaluationResultAccessType), resultProperties.AccessType);
+                Assert.Equal(default(DkmEvaluationResultStorageType), resultProperties.StorageType);
+                Assert.Equal(default(DkmEvaluationResultTypeModifierFlags), resultProperties.ModifierFlags);
+            });
         }
 
         [Fact]
@@ -358,13 +376,15 @@ class C
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(comp);
-            var context = CreateMethodContext(runtime, methodName: "C.Test");
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, methodName: "C.Test");
 
-            VerifyErrorResultProperties(context, "x => x");
-            VerifyErrorResultProperties(context, "Test");
-            VerifyErrorResultProperties(context, "Missing");
-            VerifyErrorResultProperties(context, "C");
+                VerifyErrorResultProperties(context, "x => x");
+                VerifyErrorResultProperties(context, "Test");
+                VerifyErrorResultProperties(context, "Missing");
+                VerifyErrorResultProperties(context, "C");
+            });
         }
 
         private static ResultProperties GetResultProperties(EvaluationContext context, string expr)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -523,18 +523,20 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.UsingAliases.Count);
-            Assert.Equal(0, imports.ExternAliases.Length);
+                Assert.Equal(0, imports.UsingAliases.Count);
+                Assert.Equal(0, imports.ExternAliases.Length);
 
-            var actualNamespace = imports.Usings.Single().NamespaceOrType;
-            Assert.Equal(SymbolKind.Namespace, actualNamespace.Kind);
-            Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)actualNamespace).Extent.Kind);
-            Assert.Equal("System", actualNamespace.ToTestDisplayString());
+                var actualNamespace = imports.Usings.Single().NamespaceOrType;
+                Assert.Equal(SymbolKind.Namespace, actualNamespace.Kind);
+                Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)actualNamespace).Extent.Kind);
+                Assert.Equal("System", actualNamespace.ToTestDisplayString());
+            });
         }
 
         [Fact]
@@ -556,25 +558,27 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
-
-            var imports = importsList.Single();
-
-            Assert.Equal(0, imports.UsingAliases.Count);
-            Assert.Equal(0, imports.ExternAliases.Length);
-
-            var usings = imports.Usings.Select(u => u.NamespaceOrType).ToArray();
-            Assert.Equal(3, usings.Length);
-
-            var expectedNames = new[] { "System", "System.IO", "System.Text" };
-            for (int i = 0; i < usings.Length; i++)
+            WithRuntimeInstancePortableBug(comp, runtime =>
             {
-                var actualNamespace = usings[i];
-                Assert.Equal(SymbolKind.Namespace, actualNamespace.Kind);
-                Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)actualNamespace).Extent.Kind);
-                Assert.Equal(expectedNames[i], actualNamespace.ToTestDisplayString());
-            }
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+
+                var imports = importsList.Single();
+
+                Assert.Equal(0, imports.UsingAliases.Count);
+                Assert.Equal(0, imports.ExternAliases.Length);
+
+                var usings = imports.Usings.Select(u => u.NamespaceOrType).ToArray();
+                Assert.Equal(3, usings.Length);
+
+                var expectedNames = new[] { "System", "System.IO", "System.Text" };
+                for (int i = 0; i < usings.Length; i++)
+                {
+                    var actualNamespace = usings[i];
+                    Assert.Equal(SymbolKind.Namespace, actualNamespace.Kind);
+                    Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)actualNamespace).Extent.Kind);
+                    Assert.Equal(expectedNames[i], actualNamespace.ToTestDisplayString());
+                }
+            });
         }
 
         [Fact]
@@ -599,23 +603,25 @@ namespace A
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "A.C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single()).AsEnumerable().ToArray();
-            Assert.Equal(2, importsList.Length);
-
-            var expectedNames = new[] { "System.IO", "System" }; // Innermost-to-outermost
-            for (int i = 0; i < importsList.Length; i++)
+            WithRuntimeInstancePortableBug(comp, runtime =>
             {
-                var imports = importsList[i];
+                var importsList = GetImports(runtime, "A.C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single()).AsEnumerable().ToArray();
+                Assert.Equal(2, importsList.Length);
 
-                Assert.Equal(0, imports.UsingAliases.Count);
-                Assert.Equal(0, imports.ExternAliases.Length);
+                var expectedNames = new[] { "System.IO", "System" }; // Innermost-to-outermost
+                for (int i = 0; i < importsList.Length; i++)
+                {
+                    var imports = importsList[i];
 
-                var actualNamespace = imports.Usings.Single().NamespaceOrType;
-                Assert.Equal(SymbolKind.Namespace, actualNamespace.Kind);
-                Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)actualNamespace).Extent.Kind);
-                Assert.Equal(expectedNames[i], actualNamespace.ToTestDisplayString());
-            }
+                    Assert.Equal(0, imports.UsingAliases.Count);
+                    Assert.Equal(0, imports.ExternAliases.Length);
+
+                    var actualNamespace = imports.Usings.Single().NamespaceOrType;
+                    Assert.Equal(SymbolKind.Namespace, actualNamespace.Kind);
+                    Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)actualNamespace).Extent.Kind);
+                    Assert.Equal(expectedNames[i], actualNamespace.ToTestDisplayString());
+                }
+            });
         }
 
         [Fact]
@@ -635,26 +641,28 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.Usings.Length);
-            Assert.Equal(0, imports.ExternAliases.Length);
+                Assert.Equal(0, imports.Usings.Length);
+                Assert.Equal(0, imports.ExternAliases.Length);
 
-            var usingAliases = imports.UsingAliases;
+                var usingAliases = imports.UsingAliases;
 
-            Assert.Equal(1, usingAliases.Count);
-            Assert.Equal("S", usingAliases.Keys.Single());
+                Assert.Equal(1, usingAliases.Count);
+                Assert.Equal("S", usingAliases.Keys.Single());
 
-            var aliasSymbol = usingAliases.Values.Single().Alias;
-            Assert.Equal("S", aliasSymbol.Name);
+                var aliasSymbol = usingAliases.Values.Single().Alias;
+                Assert.Equal("S", aliasSymbol.Name);
 
-            var namespaceSymbol = aliasSymbol.Target;
-            Assert.Equal(SymbolKind.Namespace, namespaceSymbol.Kind);
-            Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)namespaceSymbol).Extent.Kind);
-            Assert.Equal("System", namespaceSymbol.ToTestDisplayString());
+                var namespaceSymbol = aliasSymbol.Target;
+                Assert.Equal(SymbolKind.Namespace, namespaceSymbol.Kind);
+                Assert.Equal(NamespaceKind.Module, ((NamespaceSymbol)namespaceSymbol).Extent.Kind);
+                Assert.Equal("System", namespaceSymbol.ToTestDisplayString());
+            });
         }
 
         [WorkItem(1084059, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1084059")]
@@ -675,17 +683,19 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.UsingAliases.Count);
-            Assert.Equal(0, imports.ExternAliases.Length);
+                Assert.Equal(0, imports.UsingAliases.Count);
+                Assert.Equal(0, imports.ExternAliases.Length);
 
-            var actualType = imports.Usings.Single().NamespaceOrType;
-            Assert.Equal(SymbolKind.NamedType, actualType.Kind);
-            Assert.Equal("System.Math", actualType.ToTestDisplayString());
+                var actualType = imports.Usings.Single().NamespaceOrType;
+                Assert.Equal(SymbolKind.NamedType, actualType.Kind);
+                Assert.Equal("System.Math", actualType.ToTestDisplayString());
+            });
         }
 
         [Fact]
@@ -705,25 +715,27 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.Usings.Length);
-            Assert.Equal(0, imports.ExternAliases.Length);
+                Assert.Equal(0, imports.Usings.Length);
+                Assert.Equal(0, imports.ExternAliases.Length);
 
-            var usingAliases = imports.UsingAliases;
+                var usingAliases = imports.UsingAliases;
 
-            Assert.Equal(1, usingAliases.Count);
-            Assert.Equal("I", usingAliases.Keys.Single());
+                Assert.Equal(1, usingAliases.Count);
+                Assert.Equal("I", usingAliases.Keys.Single());
 
-            var aliasSymbol = usingAliases.Values.Single().Alias;
-            Assert.Equal("I", aliasSymbol.Name);
+                var aliasSymbol = usingAliases.Values.Single().Alias;
+                Assert.Equal("I", aliasSymbol.Name);
 
-            var typeSymbol = aliasSymbol.Target;
-            Assert.Equal(SymbolKind.NamedType, typeSymbol.Kind);
-            Assert.Equal(SpecialType.System_Int32, ((NamedTypeSymbol)typeSymbol).SpecialType);
+                var typeSymbol = aliasSymbol.Target;
+                Assert.Equal(SymbolKind.NamedType, typeSymbol.Kind);
+                Assert.Equal(SpecialType.System_Int32, ((NamedTypeSymbol)typeSymbol).SpecialType);
+            });
         }
 
         [Fact]
@@ -759,36 +771,38 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.ExternAliases.Length);
+                Assert.Equal(0, imports.ExternAliases.Length);
 
-            var @using = imports.Usings.Single();
-            var importedNamespace = @using.NamespaceOrType;
-            Assert.Equal(SymbolKind.Namespace, importedNamespace.Kind);
-            Assert.Equal("namespace", importedNamespace.Name);
+                var @using = imports.Usings.Single();
+                var importedNamespace = @using.NamespaceOrType;
+                Assert.Equal(SymbolKind.Namespace, importedNamespace.Kind);
+                Assert.Equal("namespace", importedNamespace.Name);
 
-            var usingAliases = imports.UsingAliases;
+                var usingAliases = imports.UsingAliases;
 
-            const string keyword1 = "object";
-            const string keyword2 = "string";
-            AssertEx.SetEqual(usingAliases.Keys, keyword1, keyword2);
+                const string keyword1 = "object";
+                const string keyword2 = "string";
+                AssertEx.SetEqual(usingAliases.Keys, keyword1, keyword2);
 
-            var namespaceAlias = usingAliases[keyword1];
-            var typeAlias = usingAliases[keyword2];
+                var namespaceAlias = usingAliases[keyword1];
+                var typeAlias = usingAliases[keyword2];
 
-            Assert.Equal(keyword1, namespaceAlias.Alias.Name);
-            var aliasedNamespace = namespaceAlias.Alias.Target;
-            Assert.Equal(SymbolKind.Namespace, aliasedNamespace.Kind);
-            Assert.Equal("@namespace", aliasedNamespace.ToTestDisplayString());
+                Assert.Equal(keyword1, namespaceAlias.Alias.Name);
+                var aliasedNamespace = namespaceAlias.Alias.Target;
+                Assert.Equal(SymbolKind.Namespace, aliasedNamespace.Kind);
+                Assert.Equal("@namespace", aliasedNamespace.ToTestDisplayString());
 
-            Assert.Equal(keyword2, typeAlias.Alias.Name);
-            var aliasedType = typeAlias.Alias.Target;
-            Assert.Equal(SymbolKind.NamedType, aliasedType.Kind);
-            Assert.Equal("@namespace.@class<@namespace.@interface>.@struct", aliasedType.ToTestDisplayString());
+                Assert.Equal(keyword2, typeAlias.Alias.Name);
+                var aliasedType = typeAlias.Alias.Target;
+                Assert.Equal(SymbolKind.NamedType, aliasedType.Kind);
+                Assert.Equal("@namespace.@class<@namespace.@interface>.@struct", aliasedType.ToTestDisplayString());
+            });
         }
 
         [Fact]
@@ -808,25 +822,27 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.Usings.Length);
-            Assert.Equal(0, imports.ExternAliases.Length);
+                Assert.Equal(0, imports.Usings.Length);
+                Assert.Equal(0, imports.ExternAliases.Length);
 
-            var usingAliases = imports.UsingAliases;
+                var usingAliases = imports.UsingAliases;
 
-            Assert.Equal(1, usingAliases.Count);
-            Assert.Equal("I", usingAliases.Keys.Single());
+                Assert.Equal(1, usingAliases.Count);
+                Assert.Equal("I", usingAliases.Keys.Single());
 
-            var aliasSymbol = usingAliases.Values.Single().Alias;
-            Assert.Equal("I", aliasSymbol.Name);
+                var aliasSymbol = usingAliases.Values.Single().Alias;
+                Assert.Equal("I", aliasSymbol.Name);
 
-            var typeSymbol = aliasSymbol.Target;
-            Assert.Equal(SymbolKind.NamedType, typeSymbol.Kind);
-            Assert.Equal("System.Collections.Generic.IEnumerable<System.String>", typeSymbol.ToTestDisplayString());
+                var typeSymbol = aliasSymbol.Target;
+                Assert.Equal(SymbolKind.NamedType, typeSymbol.Kind);
+                Assert.Equal("System.Collections.Generic.IEnumerable<System.String>", typeSymbol.ToTestDisplayString());
+            });
         }
 
         [Fact]
@@ -847,25 +863,27 @@ class C
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("X")) });
             comp.VerifyDiagnostics();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.Usings.Length);
-            Assert.Equal(0, imports.UsingAliases.Count);
+                Assert.Equal(0, imports.Usings.Length);
+                Assert.Equal(0, imports.UsingAliases.Count);
 
-            var externAliases = imports.ExternAliases;
+                var externAliases = imports.ExternAliases;
 
-            Assert.Equal(1, externAliases.Length);
+                Assert.Equal(1, externAliases.Length);
 
-            var aliasSymbol = externAliases.Single().Alias;
-            Assert.Equal("X", aliasSymbol.Name);
+                var aliasSymbol = externAliases.Single().Alias;
+                Assert.Equal("X", aliasSymbol.Name);
 
-            var targetSymbol = aliasSymbol.Target;
-            Assert.Equal(SymbolKind.Namespace, targetSymbol.Kind);
-            Assert.True(((NamespaceSymbol)targetSymbol).IsGlobalNamespace);
-            Assert.Equal("System.Xml.Linq", targetSymbol.ContainingAssembly.Name);
+                var targetSymbol = aliasSymbol.Target;
+                Assert.Equal(SymbolKind.Namespace, targetSymbol.Kind);
+                Assert.True(((NamespaceSymbol)targetSymbol).IsGlobalNamespace);
+                Assert.Equal("System.Xml.Linq", targetSymbol.ContainingAssembly.Name);
+            });
         }
 
         [Fact]
@@ -889,29 +907,31 @@ class C
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("X")) });
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(1, imports.ExternAliases.Length);
+                Assert.Equal(1, imports.ExternAliases.Length);
 
-            var @using = imports.Usings.Single();
-            var importedNamespace = @using.NamespaceOrType;
-            Assert.Equal(SymbolKind.Namespace, importedNamespace.Kind);
-            Assert.Equal("System.Xml", importedNamespace.ToTestDisplayString());
+                var @using = imports.Usings.Single();
+                var importedNamespace = @using.NamespaceOrType;
+                Assert.Equal(SymbolKind.Namespace, importedNamespace.Kind);
+                Assert.Equal("System.Xml", importedNamespace.ToTestDisplayString());
 
-            var usingAliases = imports.UsingAliases;
-            Assert.Equal(2, usingAliases.Count);
-            AssertEx.SetEqual(usingAliases.Keys, "SXL", "LO");
+                var usingAliases = imports.UsingAliases;
+                Assert.Equal(2, usingAliases.Count);
+                AssertEx.SetEqual(usingAliases.Keys, "SXL", "LO");
 
-            var typeAlias = usingAliases["SXL"].Alias;
-            Assert.Equal("SXL", typeAlias.Name);
-            Assert.Equal("System.Xml.Linq", typeAlias.Target.ToTestDisplayString());
+                var typeAlias = usingAliases["SXL"].Alias;
+                Assert.Equal("SXL", typeAlias.Name);
+                Assert.Equal("System.Xml.Linq", typeAlias.Target.ToTestDisplayString());
 
-            var namespaceAlias = usingAliases["LO"].Alias;
-            Assert.Equal("LO", namespaceAlias.Name);
-            Assert.Equal("System.Xml.Linq.LoadOptions", namespaceAlias.Target.ToTestDisplayString());
+                var namespaceAlias = usingAliases["LO"].Alias;
+                Assert.Equal("LO", namespaceAlias.Name);
+                Assert.Equal("System.Xml.Linq.LoadOptions", namespaceAlias.Target.ToTestDisplayString());
+            });
         }
 
         [Fact]
@@ -935,32 +955,32 @@ class C
             var comp = CreateCompilationWithMscorlib(source, new[] { SystemXmlLinqRef.WithAliases(ImmutableArray.Create("global", "X")) });
             comp.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Verify();
 
-            var runtime = CreateRuntimeInstance(comp);
-            var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
+            WithRuntimeInstancePortableBug(comp, runtime =>
+            {
+                var importsList = GetImports(runtime, "C.M", comp.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<Syntax.LiteralExpressionSyntax>().Single());
 
-            var imports = importsList.Single();
+                var imports = importsList.Single();
 
-            Assert.Equal(0, imports.Usings.Length);
-            Assert.Equal(1, imports.ExternAliases.Length);
+                Assert.Equal(0, imports.Usings.Length);
+                Assert.Equal(1, imports.ExternAliases.Length);
 
-            var usingAliases = imports.UsingAliases;
-            Assert.Equal(2, usingAliases.Count);
-            AssertEx.SetEqual(usingAliases.Keys, "A", "B");
+                var usingAliases = imports.UsingAliases;
+                Assert.Equal(2, usingAliases.Count);
+                AssertEx.SetEqual(usingAliases.Keys, "A", "B");
 
-            var aliasA = usingAliases["A"].Alias;
-            Assert.Equal("A", aliasA.Name);
-            Assert.Equal("System.Xml.Linq", aliasA.Target.ToTestDisplayString());
+                var aliasA = usingAliases["A"].Alias;
+                Assert.Equal("A", aliasA.Name);
+                Assert.Equal("System.Xml.Linq", aliasA.Target.ToTestDisplayString());
 
-            var aliasB = usingAliases["B"].Alias;
-            Assert.Equal("B", aliasB.Name);
-            Assert.Equal(aliasA.Target, aliasB.Target);
+                var aliasB = usingAliases["B"].Alias;
+                Assert.Equal("B", aliasB.Name);
+                Assert.Equal(aliasA.Target, aliasB.Target);
+            });
         }
 
         private static ImportChain GetImports(RuntimeInstance runtime, string methodName, Syntax.ExpressionSyntax syntax)
         {
-            var evalContext = CreateMethodContext(
-                runtime,
-                methodName: methodName);
+            var evalContext = CreateMethodContext(runtime, methodName);
             var compContext = evalContext.CreateCompilationContext(syntax);
             return compContext.NamespaceBinder.ImportChain;
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
@@ -47,14 +47,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             Assert.True(runtimeAssemblies.Length >= 2);
            
             // no reference to Windows.winmd
-            var runtime = CreateRuntimeInstance(compilation0, new[] { MscorlibRef }.Concat(runtimeAssemblies));
-
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("(p == null) ? f : null", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            WithRuntimeInstance(compilation0, new[] { MscorlibRef }.Concat(runtimeAssemblies), runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("(p == null) ? f : null", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -65,6 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0005:  ldarg.0
   IL_0006:  ret
 }");
+            });
         }
 
         [ConditionalFact(typeof(OSVersionWin8))]
@@ -88,20 +89,21 @@ class C
             Assert.True(runtimeAssemblies.Length >= 1);
 
             // no reference to Windows.winmd
-            var runtime = CreateRuntimeInstance(compilation0, new[] { MscorlibRef }.Concat(runtimeAssemblies));
-
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("X::Windows.Storage.FileProperties.PhotoOrientation.Unspecified", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            WithRuntimeInstancePortableBug(compilation0, new[] { MscorlibRef }.Concat(runtimeAssemblies), runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("X::Windows.Storage.FileProperties.PhotoOrientation.Unspecified", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldc.i4.0
   IL_0001:  ret
 }");
+            });
         }
 
         [Fact]
@@ -172,13 +174,14 @@ class C
     }
 }";
             var compilation0 = CreateCompilationWithMscorlib(source, compileReferences, TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(compilation0, runtimeReferences);
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression("(object)a ?? (object)b ?? (object)t ?? f", out error, testData);
-            Assert.Null(error);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            WithRuntimeInstance(compilation0, runtimeReferences, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("(object)a ?? (object)b ?? (object)t ?? f", out error, testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       17 (0x11)
   .maxstack  2
@@ -197,40 +200,41 @@ class C
   IL_000f:  ldarg.3
   IL_0010:  ret
 }");
-            testData = new CompilationTestData();
-            var result = context.CompileExpression("default(Windows.Storage.StorageFolder)", out error, testData);
-            Assert.Null(error);
-            var methodData = testData.GetMethodData("<>x.<>m0");
-            methodData.VerifyIL(
+                testData = new CompilationTestData();
+                var result = context.CompileExpression("default(Windows.Storage.StorageFolder)", out error, testData);
+                Assert.Null(error);
+                var methodData = testData.GetMethodData("<>x.<>m0");
+                methodData.VerifyIL(
 @"{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldnull
   IL_0001:  ret
 }");
-            // Check return type is from runtime assembly.
-            var assemblyReference = AssemblyMetadata.CreateFromImage(result.Assembly).GetReference();
-            var compilation = CSharpCompilation.Create(
-                assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
-                references: runtimeReferences.Concat(ImmutableArray.Create<MetadataReference>(assemblyReference)));
-            var assembly = ImmutableArray.CreateRange(result.Assembly);
-            using (var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(assembly)))
-            {
-                var reader = metadata.MetadataReader;
-                var typeDef = reader.GetTypeDef("<>x");
-                var methodHandle = reader.GetMethodDefHandle(typeDef, "<>m0");
-                var module = (PEModuleSymbol)compilation.GetMember("<>x").ContainingModule;
-                var metadataDecoder = new MetadataDecoder(module);
-                SignatureHeader signatureHeader;
-                BadImageFormatException metadataException;
-                var parameters = metadataDecoder.GetSignatureForMethod(methodHandle, out signatureHeader, out metadataException);
-                Assert.Equal(parameters.Length, 5);
-                var actualReturnType = parameters[0].Type;
-                Assert.Equal(actualReturnType.TypeKind, TypeKind.Class); // not error
-                var expectedReturnType = compilation.GetMember("Windows.Storage.StorageFolder");
-                Assert.Equal(expectedReturnType, actualReturnType);
-                Assert.Equal(storageAssemblyName, actualReturnType.ContainingAssembly.Name);
-            }
+                // Check return type is from runtime assembly.
+                var assemblyReference = AssemblyMetadata.CreateFromImage(result.Assembly).GetReference();
+                var compilation = CSharpCompilation.Create(
+                    assemblyName: ExpressionCompilerUtilities.GenerateUniqueName(),
+                    references: runtimeReferences.Concat(ImmutableArray.Create<MetadataReference>(assemblyReference)));
+                var assembly = ImmutableArray.CreateRange(result.Assembly);
+                using (var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(assembly)))
+                {
+                    var reader = metadata.MetadataReader;
+                    var typeDef = reader.GetTypeDef("<>x");
+                    var methodHandle = reader.GetMethodDefHandle(typeDef, "<>m0");
+                    var module = (PEModuleSymbol)compilation.GetMember("<>x").ContainingModule;
+                    var metadataDecoder = new MetadataDecoder(module);
+                    SignatureHeader signatureHeader;
+                    BadImageFormatException metadataException;
+                    var parameters = metadataDecoder.GetSignatureForMethod(methodHandle, out signatureHeader, out metadataException);
+                    Assert.Equal(parameters.Length, 5);
+                    var actualReturnType = parameters[0].Type;
+                    Assert.Equal(actualReturnType.TypeKind, TypeKind.Class); // not error
+                    var expectedReturnType = compilation.GetMember("Windows.Storage.StorageFolder");
+                    Assert.Equal(expectedReturnType, actualReturnType);
+                    Assert.Equal(storageAssemblyName, actualReturnType.ContainingAssembly.Name);
+                }
+            });
         }
 
         /// <summary>
@@ -248,27 +252,25 @@ class C
     {
     }
 }";
-            var compilation = CreateCompilationWithMscorlib(source, ImmutableArray.CreateRange(WinRtRefs), TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(
-                compilation,
-                ImmutableArray.Create(MscorlibRef).Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage", "Windows.Foundation.Collections")));
+            var compilation = CreateCompilationWithMscorlib(source, WinRtRefs, TestOptions.DebugDll);
+            WithRuntimeInstance(compilation, new[] { MscorlibRef }.Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Storage", "Windows.Foundation.Collections")), runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
 
-            var context = CreateMethodContext(runtime, "C.M");
+                var aliases = ImmutableArray.Create(
+                    VariableAlias("s", "Windows.Storage.StorageFolder, Windows.Storage, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime"),
+                    VariableAlias("d", "Windows.Foundation.DateTime, Windows.Foundation, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime"));
 
-            var aliases = ImmutableArray.Create(
-                VariableAlias("s", "Windows.Storage.StorageFolder, Windows.Storage, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime"),
-                VariableAlias("d", "Windows.Foundation.DateTime, Windows.Foundation, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime"));
-
-            string error;
-            var testData = new CompilationTestData();
-            context.CompileExpression(
-                "(object)s.Attributes ?? d.UniversalTime",
-                DkmEvaluationFlags.TreatAsExpression,
-                aliases,
-                out error,
-                testData);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"{
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+                    "(object)s.Attributes ?? d.UniversalTime",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    aliases,
+                    out error,
+                    testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+    @"{
   // Code size       55 (0x37)
   .maxstack  2
   IL_0000:  ldstr      ""s""
@@ -286,6 +288,7 @@ class C
   IL_0031:  box        ""long""
   IL_0036:  ret
 }");
+            });
         }
 
         [WorkItem(1117084, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1117084")]
@@ -299,28 +302,27 @@ class C
     {
     }
 }";
-            var compilation = CreateCompilationWithMscorlib(source, ImmutableArray.CreateRange(WinRtRefs), TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(
-                compilation,
-                ImmutableArray.Create(MscorlibRef).Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Foundation", "Windows.UI", "Windows.UI.Xaml")));
-
-            var context = CreateMethodContext(runtime, "C.M");
-            string error;
-            ResultProperties resultProperties;
-            ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
-            var testData = new CompilationTestData();
-            var result = context.CompileExpression(
-                "f.RenderSize",
-                DkmEvaluationFlags.TreatAsExpression,
-                NoAliases,
-                DebuggerDiagnosticFormatter.Instance,
-                out resultProperties,
-                out error,
-                out missingAssemblyIdentities,
-                EnsureEnglishUICulture.PreferredOrNull,
-                testData);
-            var expectedAssemblyIdentity = WinRtRefs.Single(r => r.Display == "System.Runtime.WindowsRuntime.dll").GetAssemblyIdentity();
-            Assert.Equal(expectedAssemblyIdentity, missingAssemblyIdentities.Single());
+            var compilation = CreateCompilationWithMscorlib(source, WinRtRefs, TestOptions.DebugDll);
+            WithRuntimeInstance(compilation, new[] { MscorlibRef }.Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.Foundation", "Windows.UI", "Windows.UI.Xaml")), runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+                ResultProperties resultProperties;
+                ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                var testData = new CompilationTestData();
+                var result = context.CompileExpression(
+                    "f.RenderSize",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    NoAliases,
+                    DebuggerDiagnosticFormatter.Instance,
+                    out resultProperties,
+                    out error,
+                    out missingAssemblyIdentities,
+                    EnsureEnglishUICulture.PreferredOrNull,
+                    testData);
+                var expectedAssemblyIdentity = WinRtRefs.Single(r => r.Display == "System.Runtime.WindowsRuntime.dll").GetAssemblyIdentity();
+                Assert.Equal(expectedAssemblyIdentity, missingAssemblyIdentities.Single());
+            });
         }
 
         [WorkItem(1154988, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1154988")]
@@ -334,38 +336,37 @@ class C
     {
     }
 }";
-            var compilation = CreateCompilationWithMscorlib(source, ImmutableArray.CreateRange(WinRtRefs), TestOptions.DebugDll);
-            var runtime = CreateRuntimeInstance(
-                compilation,
-                ImmutableArray.Create(MscorlibRef).Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI", "Windows.UI.Xaml")));
-
-            string errorMessage;
-            var testData = new CompilationTestData();
-            ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
-                runtime.Modules.SelectAsArray(m => m.MetadataBlock),
-                "c.Dispatcher",
-                ImmutableArray<Alias>.Empty,
-                (metadataBlocks, _) =>
-                {
-                    return CreateMethodContext(runtime, "C.M");
-                },
-                (AssemblyIdentity assembly, out uint size) =>
-                {
-                    // Compilation should succeed without retry if we redirect assembly refs correctly.
-                    // Throwing so that we don't loop forever (as we did before fix)...
-                    throw ExceptionUtilities.Unreachable;
-                },
-                out errorMessage,
-                out testData);
-            Assert.Null(errorMessage);
-            testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"{
+            var compilation = CreateCompilationWithMscorlib(source, WinRtRefs, TestOptions.DebugDll);
+            WithRuntimeInstance(compilation, new[] { MscorlibRef }.Concat(ExpressionCompilerTestHelpers.GetRuntimeWinMds("Windows.UI", "Windows.UI.Xaml")), runtime =>
+            {
+                string errorMessage;
+                var testData = new CompilationTestData();
+                ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
+                    runtime.Modules.SelectAsArray(m => m.MetadataBlock),
+                    "c.Dispatcher",
+                    ImmutableArray<Alias>.Empty,
+                    (metadataBlocks, _) =>
+                    {
+                        return CreateMethodContext(runtime, "C.M");
+                    },
+                    (AssemblyIdentity assembly, out uint size) =>
+                    {
+                        // Compilation should succeed without retry if we redirect assembly refs correctly.
+                        // Throwing so that we don't loop forever (as we did before fix)...
+                        throw ExceptionUtilities.Unreachable;
+                    },
+                    out errorMessage,
+                    out testData);
+                Assert.Null(errorMessage);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+    @"{
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  callvirt   ""Windows.UI.Core.CoreDispatcher Windows.UI.Xaml.DependencyObject.Dispatcher.get""
   IL_0006:  ret
 }");
+            });
         }
 
         private static byte[] ToVersion1_3(byte[] bytes)


### PR DESCRIPTION
```WithRuntimeInstance``` helper executes the validation action twice - for both PDB formats.
Temporarily ```WithRuntimeInstancePortableBug``` is also available for cases where the EE doesn't handle Portable PDBs well yet.