### PR TITLE
Use partial semantics for Navigate To

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
         {
             public string DisplayString => _lazyDisplayString.Value;
             public Document Document { get; }
-            public Glyph Glyph => _lazySymbol.Value?.GetGlyph() ?? Glyph.Error;
+            public Glyph Glyph => Symbol?.GetGlyph() ?? Glyph.Error;
             public TextSpan SourceSpan => _declaredSymbolInfo.Span;
             public ISymbol Symbol => _lazySymbol.Value;
             public ImmutableArray<INavigableItem> ChildItems => ImmutableArray<INavigableItem>.Empty;

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
@@ -33,9 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                 Document = document;
                 _declaredSymbolInfo = declaredSymbolInfo;
 
-                // Cancellation isn't supported when computing the various properties that depend on the symbol, hence
-                // CancellationToken.None.
-                _lazySymbol = new Lazy<ISymbol>(() => declaredSymbolInfo.GetSymbolAsync(document, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult());
+                _lazySymbol = new Lazy<ISymbol>(FindSymbol);
                 _lazyDisplayString = new Lazy<string>(() =>
                 {
                     try
@@ -52,6 +50,22 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                         throw ExceptionUtilities.Unreachable;
                     }
                 });
+            }
+
+            private ISymbol FindSymbol()
+            {
+                // Here, we will use partial semantics. We are going to use this symbol to get a glyph, display string,
+                // and potentially documentation comments. The first two should work fine even if we don't have full
+                // references, and the latter will probably be fine. (It wouldn't be if you have a partial type
+                // and we didn't get all the trees parsed yet to know that. In other words, an edge case we don't care about.)
+
+                // Cancellation isn't supported when computing the various properties that depend on the symbol, hence
+                // CancellationToken.None.
+                var semanticModel = Document.GetPartialSemanticModelAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+                var root = semanticModel.SyntaxTree.GetRoot(CancellationToken.None);
+                var node = root.FindNode(_declaredSymbolInfo.Span);
+                return semanticModel.GetDeclaredSymbol(node, CancellationToken.None);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/AbstractNavigateToSearchService.SearchResult.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/AbstractNavigateToSearchService.SearchResult.cs
@@ -23,10 +23,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             public string SecondarySort { get; }
             public bool IsCaseSensitive { get; }
 
-            private Document _document;
-            private DeclaredSymbolInfo _declaredSymbolInfo;
-            private Lazy<string> _lazyAdditionalInfo;
-            private Lazy<string> _lazySummary;
+            private readonly Document _document;
+            private readonly DeclaredSymbolInfo _declaredSymbolInfo;
+            private readonly Lazy<string> _lazyAdditionalInfo;
+            private readonly Lazy<string> _lazySummary;
 
             public SearchResult(Document document, DeclaredSymbolInfo declaredSymbolInfo, string kind, MatchKind matchKind, bool isCaseSensitive, INavigableItem navigableItem)
             {

--- a/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
@@ -33,8 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
                 // literal they're hovering over.
                 // Partial semantics should always be sufficient because the (unconverted) type
                 // of a literal can always easily be determined.
-                var partialDocument = await document.WithFrozenPartialSemanticsAsync(cancellationToken).ConfigureAwait(false);
-                var semanticModel = await partialDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var semanticModel = await document.GetPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 var type = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
                 return type == null
                     ? default(DebugDataTipInfo)

--- a/src/Workspaces/Core/Portable/FindSymbols/DeclaredSymbolInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/DeclaredSymbolInfo.cs
@@ -47,15 +47,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             TypeParameterCount = typeParameterCount;
         }
 
-        public async Task<ISymbol> GetSymbolAsync(Document document, CancellationToken cancellationToken)
-        {
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var node = root.FindNode(Span);
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var symbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
-            return symbol;
-        }
-
         internal void WriteTo(ObjectWriter writer)
         {
             writer.WriteString(Name);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -163,5 +163,26 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var declarationInfo = await SyntaxTreeInfo.GetDeclarationInfoAsync(document, cancellationToken).ConfigureAwait(false);
             return declarationInfo.DeclaredSymbolInfos;
         }
+
+        /// <summary>
+        /// Returns the semantic model for this document that may be produced from partial semantics. The semantic model
+        /// is only guaranteed to contain the syntax tree for <paramref name="document"/> and nothing else.
+        /// </summary>
+        public static async Task<SemanticModel> GetPartialSemanticModelAsync(this Document document, CancellationToken cancellationToken)
+        {
+            Compilation compilation;
+
+            if (document.Project.TryGetCompilation(out compilation))
+            {
+                // We already have a compilation, so at this point it's fastest to just get a SemanticModel
+                return await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var frozenDocument = await document.WithFrozenPartialSemanticsAsync(cancellationToken).ConfigureAwait(false);
+                return await frozenDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+        }
     }
 }


### PR DESCRIPTION
In theory this should make things block less than we already are, as a partial mitigation for #8260.

*Review:* @dotnet/roslyn-ide