### PR TITLE
Work around EventListener crash

### DIFF
--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -1183,6 +1183,14 @@ foo()
             Assert.Equal("", output);
         }
 
+        // TODO (https://github.com/dotnet/roslyn/issues/7976): delete this
+        [WorkItem(7976, "https://github.com/dotnet/roslyn/issues/7976")]
+        [Fact]
+        public void Workaround7976()
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+        }
+
         #endregion
 
         private static ImmutableArray<string> SplitLines(string text)

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -1088,6 +1088,14 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Assert.Equal("> xyz", GetTextFromCurrentSnapshot());
         }
 
+        // TODO (https://github.com/dotnet/roslyn/issues/7976): delete this
+        [WorkItem(7976, "https://github.com/dotnet/roslyn/issues/7976")]
+        [WpfFact]
+        public void Workaround7976()
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+        }
+
         private string GetTextFromCurrentSnapshot()
         {
             return Window.TextView.TextBuffer.CurrentSnapshot.GetText();


### PR DESCRIPTION
...by ensuring that these assemblies take at least 10 seconds to run.

TODO: revert this change.

NOTE: the usual workaround - disabling appdomain creation in xunit -
doesn't work in this case because of assembly loading issues.  See #7976
for details.