### PR TITLE
Move Mac testing to commit only

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -137,13 +137,19 @@ static void addPushTrigger(def myJob) {
   }
 }
 
-static void addPullRequestTrigger(def myJob, String contextName, String opsysName, String triggerKeyword = 'this', Boolean triggerOnly = false) {
+// Generates the standard trigger phrases.  This is the regex which ends up matching lines like:
+//  test win32 please
+static String generateTriggerPhrase(String jobName, string opsysName, Stringc triggerKeyword = 'this') {
+    return "(?i).*test\\W+(${jobName.replace('_', '/').substring(7)}|${opsysName}|${triggerKeyword}|${opsysName}\\W+${triggerKeyword}|${triggerKeyword}\\W+${opsysName})\\W+please.*";
+}
+
+static void addPullRequestTrigger(def myJob, String jobName, String triggerPhrase, Boolean triggerOnly = false) {
   myJob.with {
     triggers {
       pullRequest {
         admin('Microsoft')
         useGitHubHooks(true)
-        triggerPhrase("(?i).*test\\W+(${contextName.replace('_', '/').substring(7)}|${opsysName}|${triggerKeyword}|${opsysName}\\W+${triggerKeyword}|${triggerKeyword}\\W+${opsysName})\\W+please.*")
+        triggerPhrase(triggerPhrase)
         onlyTriggerPhrase(triggerOnly)
         autoCloseFailedPullRequests(false)
         orgWhitelist('Microsoft')
@@ -151,7 +157,7 @@ static void addPullRequestTrigger(def myJob, String contextName, String opsysNam
         permitAll(true)
         extensions {
           commitStatus {
-            context(contextName.replace('_', '/').substring(7))
+            context(jobName.replace('_', '/').substring(7))
           }
         }
       }
@@ -159,7 +165,7 @@ static void addPullRequestTrigger(def myJob, String contextName, String opsysNam
   }
 }
 
-static void addStandardJob(def myJob, String jobName, String branchName, String buildTarget, String opsys) {
+static void addStandardJob(def myJob, String jobName, String branchName, String triggerPhrase) {
   addLogRotator(myJob)
   addWrappers(myJob)
 
@@ -168,14 +174,7 @@ static void addStandardJob(def myJob, String jobName, String branchName, String 
   addArtifactArchiving(myJob, includePattern, excludePattern)
 
   if (branchName == 'prtest') {
-    switch (buildTarget) {
-      case 'unit32':
-        addPullRequestTrigger(myJob, jobName, opsys, "(unit|unit32|unit\\W+32)")
-        break;
-      case 'unit64':
-        addPullRequestTrigger(myJob, jobName, opsys, '(unit|unit64|unit\\W+64)')
-        break;
-    }
+    addPullRequestTrigger(myJob, jobName, triggerPhrase);
     addScm(myJob, '${sha1}', '+refs/pull/*:refs/remotes/origin/pr/*')
   } else {
     addPushTrigger(myJob)
@@ -202,6 +201,18 @@ def branchNames = []
             def myJob = job(jobName) {
               description('')
             }
+
+            // Generate the PR trigger phrase for this job.
+            String triggerKeyword = '';
+            switch (buildTarget) {
+              case 'unit32':
+                triggerKeyword =  '(unit|unit32|unit\\W+32)';
+                break;
+              case 'unit64':
+                triggerKeyword = '(unit|unit64|unit\\W+64)';
+                break;
+            }
+            String triggerPhrase = generateTriggerPhrase(jobName, opsys, triggerKeyword);
 
             switch (opsys) {
               case 'win':
@@ -238,7 +249,7 @@ set TMP=%TEMP%
             }
 
             addUnitPublisher(myJob)
-            addStandardJob(myJob, jobName, branchName, buildTarget, opsys)
+            addStandardJob(myJob, jobName, branchName, triggerPhrase);
           }
         }
       }
@@ -262,7 +273,7 @@ set TMP=%TEMP%
     }
 
     addConcurrentBuild(determinismJob, null)
-    addStandardJob(determinismJob, determinismJobName, branchName, "unit32", "win")
+    addStandardJob(determinismJob, determinismJobName, branchName, '');
   }
 }
 


### PR DESCRIPTION
After some investigation into machine count and overlap we've decided to move the Mac testing to occur on commits only.  This means it will no longer appear on the PR queue.  The justification is as follows:

- Mac machines are a limited resource because it must be physical hardware.  Can't just spin up more Mac VMS in Azure as we please.  Hence we must be a bit more judicious with our usage.
- 83% of all Mac jobs in Roslyn were PR jobs.  About 1/3 of these were actually dead builds.  Essentially builds queued / running where PR had a more recent push.  Hence these Mac builds never contributed to PR validation and were just eating resources.
- There is incredible overlap between our Linux and Mac jobs.  In the 9 months we've been running both jobs there have been 2 failures which only one of the jobs would have caught.  At least one of them would have been marked for explicit testing on both OS.

In short we're paying a lot for this right now and getting very litte in return.

Mac will **still** be validated though.  Every commit to master or future will trigger a Mac job and the results will be actively monitored by the infrastructure team.