### PR TITLE
Re-enable Add Using in the Interactive Window

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -420,8 +421,24 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         private bool IsInteractiveCodeFixProvider(CodeFixProvider provider)
         {
             // TODO (https://github.com/dotnet/roslyn/issues/4932): Don't restrict CodeFixes in Interactive
-            return provider?.GetType()?.Name == "AbstractAddImportCodeFixProvider`1" ||
-                provider is FullyQualify.AbstractFullyQualifyCodeFixProvider;
+            if (provider is FullyQualify.AbstractFullyQualifyCodeFixProvider)
+            {
+                return true;
+            }
+
+            var providerType = provider?.GetType();
+            while (providerType != null)
+            {
+                if (providerType.IsConstructedGenericType && 
+                    providerType.GetGenericTypeDefinition() == typeof(AddImport.AbstractAddImportCodeFixProvider<>))
+                {
+                    return true;
+                }
+
+                providerType = providerType.GetTypeInfo().BaseType;
+            }
+
+            return false;
         }
 
         private static readonly Func<DiagnosticId, List<CodeFixProvider>> s_createList = _ => new List<CodeFixProvider>();


### PR DESCRIPTION
0366402f9fc6f8d03cbaa3290bd1e0aba2a1492f switched from a reflection test
to a string test and overlooked the fact that the test was for a subtype.

This wasn't caught by an integration test since the integration test was
disabled (https://github.com/dotnet/roslyn/issues/6587).