### PR TITLE
Suppress $ReturnValue in the Locals window

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -297,6 +297,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                             var typeNameDecoder = new EETypeNameDecoder(Compilation, (PEModuleSymbol)_currentFrame.ContainingModule);
                             foreach (var alias in aliases)
                             {
+                                if (alias.IsReturnValue0())
+                                {
+                                    Debug.Assert(aliases.Where(a => a.Kind == DkmClrAliasKind.ReturnValue).Count() > 1);
+                                    continue;
+                                }
+
                                 var local = PlaceholderLocalSymbol.Create(
                                     typeNameDecoder,
                                     _currentFrame,

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -297,9 +297,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                             var typeNameDecoder = new EETypeNameDecoder(Compilation, (PEModuleSymbol)_currentFrame.ContainingModule);
                             foreach (var alias in aliases)
                             {
-                                if (alias.IsReturnValue0())
+                                if (alias.IsReturnValueWithoutIndex())
                                 {
-                                    Debug.Assert(aliases.Where(a => a.Kind == DkmClrAliasKind.ReturnValue).Count() > 1);
+                                    Debug.Assert(aliases.Count(a => a.Kind == DkmClrAliasKind.ReturnValue) > 1);
                                     continue;
                                 }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -253,6 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0005:  castclass  ""System.IO.IOException""
   IL_000a:  ret
 }");
+                // $ReturnValue is suppressed since it always matches the last $ReturnValueN
                 VerifyLocal(testData, typeName, locals[1], "<>m1", "$ReturnValue2", "Method M2 returned", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size       12 (0xc)
@@ -262,15 +263,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0006:  castclass  ""string""
   IL_000b:  ret
 }");
-                // $ReturnValue is suppressed since it always matches the last $ReturnValueN
-//                VerifyLocal(testData, typeName, locals[2], "<>m2", "$ReturnValue", "Method M returned", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
-//@"{
-//  // Code size        7 (0x7)
-//  .maxstack  1
-//  IL_0000:  ldc.i4.0
-//  IL_0001:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(int)""
-//  IL_0006:  ret
-//}");
                 VerifyLocal(testData, typeName, locals[2], "<>m2", "$2", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
 @"{
   // Code size       16 (0x10)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PseudoVariableUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PseudoVariableUtilities.cs
@@ -54,5 +54,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     return DkmClrCompilationResultFlags.None;
             }
         }
+
+        internal static bool IsReturnValue0(this Alias alias)
+        {
+            int index;
+            return
+                alias.Kind == DkmClrAliasKind.ReturnValue &&
+                TryParseReturnValueIndex(alias.FullName, out index) &&
+                index == 0;
+        }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PseudoVariableUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PseudoVariableUtilities.cs
@@ -55,13 +55,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
         }
 
-        internal static bool IsReturnValue0(this Alias alias)
+        internal static bool IsReturnValueWithoutIndex(this Alias alias)
         {
-            int index;
+            Debug.Assert(alias.Kind != DkmClrAliasKind.ReturnValue || 
+                alias.FullName.StartsWith("$ReturnValue", StringComparison.OrdinalIgnoreCase));
             return
                 alias.Kind == DkmClrAliasKind.ReturnValue &&
-                TryParseReturnValueIndex(alias.FullName, out index) &&
-                index == 0;
+                alias.FullName.Length == 12; // "$ReturnValue"
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PseudoVariableUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PseudoVariableUtilities.cs
@@ -32,14 +32,15 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
     internal static class PseudoVariableUtilities
     {
+        private const int ReturnValuePrefixLength = 12; // "$ReturnValue"
+
         internal static bool TryParseReturnValueIndex(string name, out int index)
         {
             Debug.Assert(name.StartsWith("$ReturnValue", StringComparison.OrdinalIgnoreCase));
-            const int prefixLength = 12; // "$ReturnValue"
             int n = name.Length;
             index = 0;
-            return (n == prefixLength) ||
-                ((n > prefixLength) && int.TryParse(name.Substring(prefixLength), NumberStyles.None, CultureInfo.InvariantCulture, out index));
+            return (n == ReturnValuePrefixLength) ||
+                ((n > ReturnValuePrefixLength) && int.TryParse(name.Substring(ReturnValuePrefixLength), NumberStyles.None, CultureInfo.InvariantCulture, out index));
         }
 
         internal static DkmClrCompilationResultFlags GetLocalResultFlags(this Alias alias)
@@ -61,7 +62,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 alias.FullName.StartsWith("$ReturnValue", StringComparison.OrdinalIgnoreCase));
             return
                 alias.Kind == DkmClrAliasKind.ReturnValue &&
-                alias.FullName.Length == 12; // "$ReturnValue"
+                alias.FullName.Length == ReturnValuePrefixLength;
         }
     }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -232,8 +232,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                             ' Pseudo-variables: $exception, $ReturnValue, etc.
                             Dim typeNameDecoder = New EETypeNameDecoder(Me.Compilation, DirectCast(_currentFrame.ContainingModule, PEModuleSymbol))
                             For Each [alias] As [Alias] In aliases
-                                If [alias].IsReturnValue0() Then
-                                    Debug.Assert(aliases.Where(Function(a) a.Kind = DkmClrAliasKind.ReturnValue).Count() > 1)
+                                If [alias].IsReturnValueWithoutIndex() Then
+                                    Debug.Assert(aliases.Count(Function(a) a.Kind = DkmClrAliasKind.ReturnValue) > 1)
                                     Continue For
                                 End If
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.VisualStudio.Debugger.Clr
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Utilities
 
@@ -231,6 +232,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                             ' Pseudo-variables: $exception, $ReturnValue, etc.
                             Dim typeNameDecoder = New EETypeNameDecoder(Me.Compilation, DirectCast(_currentFrame.ContainingModule, PEModuleSymbol))
                             For Each [alias] As [Alias] In aliases
+                                If [alias].IsReturnValue0() Then
+                                    Debug.Assert(aliases.Where(Function(a) a.Kind = DkmClrAliasKind.ReturnValue).Count() > 1)
+                                    Continue For
+                                End If
+
                                 Dim methodName = GetNextMethodName(methodBuilder)
                                 Dim syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken))
                                 Dim local = PlaceholderLocalSymbol.Create(typeNameDecoder, _currentFrame, [alias])

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -7,8 +7,8 @@ Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
-Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Xunit
 
@@ -160,7 +160,7 @@ End Class"
                         diagnostics:=diagnostics,
                         typeName:=typeName,
                         testData:=testData)
-                    Assert.Equal(7, locals.Count)
+            Assert.Equal(6, locals.Count)
                     VerifyLocal(testData, typeName, locals(0), "<>m0", "$exception", "Error", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
 "{
   // Code size       11 (0xb)
@@ -178,15 +178,16 @@ End Class"
   IL_0006:  castclass  ""String""
   IL_000b:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(2), "<>m2", "$ReturnValue", "Method M returned", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
-"{
-  // Code size        7 (0x7)
-  .maxstack  1
-  IL_0000:  ldc.i4.0
-  IL_0001:  call       ""Function Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(Integer) As Object""
-  IL_0006:  ret
-}")
-                    VerifyLocal(testData, typeName, locals(3), "<>m3", "$2", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
+                    ' $ReturnValue is suppressed since it always matches the last $ReturnValueN
+                    '            VerifyLocal(testData, typeName, locals(2), "<>m2", "$ReturnValue", "Method M returned", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
+                    '"{
+                    '  // Code size        7 (0x7)
+                    '  .maxstack  1
+                    '  IL_0000:  ldc.i4.0
+                    '  IL_0001:  call       ""Function Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(Integer) As Object""
+                    '  IL_0006:  ret
+                    '}")
+                    VerifyLocal(testData, typeName, locals(2), "<>m2", "$2", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
 "{
   // Code size       16 (0x10)
   .maxstack  1
@@ -195,7 +196,7 @@ End Class"
   IL_000a:  unbox.any  ""Boolean""
   IL_000f:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(4), "<>m4", "o", expectedILOpt:=
+                    VerifyLocal(testData, typeName, locals(3), "<>m3", "o", expectedILOpt:=
 "{
   // Code size       16 (0x10)
   .maxstack  1
@@ -204,14 +205,14 @@ End Class"
   IL_000a:  castclass  ""C""
   IL_000f:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(5), "<>m5", "Me", expectedILOpt:=
+                    VerifyLocal(testData, typeName, locals(4), "<>m4", "Me", expectedILOpt:=
 "{
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(6), "<>m6", "o", expectedILOpt:=
+                    VerifyLocal(testData, typeName, locals(5), "<>m5", "o", expectedILOpt:=
 "{
   // Code size        2 (0x2)
   .maxstack  1
@@ -219,6 +220,11 @@ End Class"
   IL_0001:  ret
 }")
                     locals.Free()
+                    
+                    ' Confirm that the Watch window is unaffected by the filtering in the Locals window.
+                    Dim errorString As String = Nothing
+                    context.CompileExpression("$ReturnValue", DkmEvaluationFlags.TreatAsExpression, aliases, errorString)
+                    Assert.Null(errorString)
                 End Sub)
         End Sub
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -169,6 +169,7 @@ End Class"
   IL_0005:  castclass  ""System.IO.IOException""
   IL_000a:  ret
 }")
+                    ' $ReturnValue is suppressed since it always matches the last $ReturnValueN
                     VerifyLocal(testData, typeName, locals(1), "<>m1", "$ReturnValue2", "Method M2 returned", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
 "{
   // Code size       12 (0xc)
@@ -178,15 +179,6 @@ End Class"
   IL_0006:  castclass  ""String""
   IL_000b:  ret
 }")
-                    ' $ReturnValue is suppressed since it always matches the last $ReturnValueN
-                    '            VerifyLocal(testData, typeName, locals(2), "<>m2", "$ReturnValue", "Method M returned", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
-                    '"{
-                    '  // Code size        7 (0x7)
-                    '  .maxstack  1
-                    '  IL_0000:  ldc.i4.0
-                    '  IL_0001:  call       ""Function Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetReturnValue(Integer) As Object""
-                    '  IL_0006:  ret
-                    '}")
                     VerifyLocal(testData, typeName, locals(2), "<>m2", "$2", expectedFlags:=DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:=
 "{
   // Code size       16 (0x10)


### PR DESCRIPTION
...since it will always be redundant with the last $ReturnValueN.

Fixes #6755.