### PR TITLE
Strengthen emit against overflow of user string heap.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8126,6 +8126,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string literals..
+        /// </summary>
+        internal static string ERR_TooManyUserStrings {
+            get {
+                return ResourceManager.GetString("ERR_TooManyUserStrings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A format specifier may not contain trailing whitespace..
         /// </summary>
         internal static string ERR_TrailingWhitespaceInFormatSpecifier {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4672,4 +4672,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="SyntaxTreeIsNotASubmission" xml:space="preserve">
     <value>Syntax tree should be created from a submission.</value>
   </data>
+  <data name="ERR_TooManyUserStrings" xml:space="preserve">
+    <value>Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string literals.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1319,5 +1319,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadAwaitInStaticVariableInitializer = 8100,
         ERR_InvalidPathMap = 8101,
         ERR_PublicSignButNoKey = 8102,
+        ERR_TooManyUserStrings = 8103,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -201,6 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // PE Writer:
         public override int ERR_MetadataNameTooLong { get { return (int)ErrorCode.ERR_MetadataNameTooLong; } }
         public override int ERR_EncReferenceToAddedMember { get { return (int)ErrorCode.ERR_EncReferenceToAddedMember; } }
+        public override int ERR_TooManyUserStrings { get { return (int)ErrorCode.ERR_TooManyUserStrings; } }
 
         public override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -202,6 +202,7 @@ namespace Microsoft.CodeAnalysis
         // PE writing:
         public abstract int ERR_MetadataNameTooLong { get; }
         public abstract int ERR_EncReferenceToAddedMember { get; }
+        public abstract int ERR_TooManyUserStrings { get; }
 
         public abstract void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute);
         public abstract void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataHeapsBuilder.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataHeapsBuilder.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Cci
             return (index.HeapPosition == 0) ? 0 : _blobHeapStartOffset + index.HeapPosition;
         }
 
-        public int GetUserStringToken(string str)
+        public bool TryGetUserStringToken(string str, out int token)
         {
             int index;
             if (!_userStrings.TryGetValue(str, out index))
@@ -269,6 +269,14 @@ namespace Microsoft.Cci
                 Debug.Assert(!_streamsAreComplete);
 
                 index = _userStringWriter.Position + _userStringHeapStartOffset;
+
+                // User strings are referenced by metadata tokens (8 bits of which are used for the token type) leaving only 24 bits for the offset. 
+                if ((index & 0xFF000000) != 0)
+                {
+                    token = 0;
+                    return false;
+                }
+
                 _userStrings.Add(str, index);
                 _userStringWriter.WriteCompressedInteger((uint)str.Length * 2 + 1);
 
@@ -327,7 +335,8 @@ namespace Microsoft.Cci
                 _userStringWriter.WriteByte(stringKind);
             }
 
-            return 0x70000000 | index;
+            token = 0x70000000 | index;
+            return true;
         }
 
         public void Complete()

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1681,6 +1681,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_DebugEntryPointNotSourceMethodDefinition = 37252
         ERR_InvalidPathMap = 37253
         ERR_PublicSignNoKey = 37254
+        ERR_TooManyUserStrings = 37255
 
         ERR_LastPlusOne
 

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -491,6 +491,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return ERRID.ERR_EncReferenceToAddedMember
             End Get
         End Property
+
+        Public Overrides ReadOnly Property ERR_TooManyUserStrings As Integer
+            Get
+                Return ERRID.ERR_TooManyUserStrings
+            End Get
+        End Property
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -10254,6 +10254,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string or XML literals..
+        '''</summary>
+        Friend ReadOnly Property ERR_TooManyUserStrings() As String
+            Get
+                Return ResourceManager.GetString("ERR_TooManyUserStrings", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Method cannot contain both a &apos;Try&apos; statement and an &apos;On Error&apos; or &apos;Resume&apos; statement..
         '''</summary>
         Friend ReadOnly Property ERR_TryAndOnErrorDoNotMix() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5344,4 +5344,7 @@
   <data name="SyntaxTreeIsNotASubmission" xml:space="preserve">
     <value>Syntax tree should be created from a submission.</value>
   </data>
+  <data name="ERR_TooManyUserStrings" xml:space="preserve">
+    <value>Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string or XML literals.</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EmitErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EmitErrorTests.vb
@@ -574,6 +574,35 @@ BC35000: Requested operation is not available because the runtime library functi
 ]]></expected>)
         End Sub
 
+        <Fact, WorkItem(8287, "https://github.com/dotnet/roslyn/issues/8287")>
+        Public Sub ToManyUserStrings()
+
+            Dim source As New System.Text.StringBuilder()
+            source.Append("
+Module C
+    Sub Main()
+")
+
+            For i As Integer = 1 To 11
+                source.Append(
+"       System.Console.WriteLine(""")
+                source.Append(ChrW(AscW("A"c) + i), 1000000)
+                source.Append(""")
+")
+            Next
+
+            source.Append("
+    End Sub
+End Module")
+
+            Dim compilation = CreateCompilationWithReferences(VisualBasicSyntaxTree.ParseText(source.ToString()), {MscorlibRef, SystemRef, MsvbRef})
+
+            AssertTheseEmitDiagnostics(compilation,
+<expected>
+BC37255: Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string or XML literals.
+</expected>)
+        End Sub
+
 #End Region
 
     End Class

--- a/src/Test/Utilities/Shared/Mocks/TestMessageProvider.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestMessageProvider.cs
@@ -354,5 +354,13 @@ namespace Roslyn.Test.Utilities
                 throw new NotImplementedException();
             }
         }
+
+        public override int ERR_TooManyUserStrings
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #8287.

@dotnet/roslyn-compiler Please review.