### PR TITLE
[WIP] Parse out incomplete members as fields.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2452,7 +2452,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         ErrorCode.ERR_BadModifierLocation,
                         misplacedModifier.Text);
 
-                    return _syntaxFactory.IncompleteMember(attributes, modifiers.ToTokenList(), type);
+                    // We have a complete type, but it's followed by a modifier.  This is likely 
+                    // something like:
+                    //
+                    //      WebClient
+                    //      public SomethingElse...
+                    //
+                    // In a case like this, just parse out a field with a missing variable declarator.
+                    // By doing this, all the rest of our features will light up properly (analyzers/etc.)
+                    return this.ParseNormalFieldDeclaration(attributes, modifiers, type, parentKind);
                 }
 
                 parse_member_name:;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2500,22 +2500,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         return null;
                     }
 
-                    var incompleteMember = _syntaxFactory.IncompleteMember(attributes, modifiers.ToTokenList(), type.IsMissing ? null : type);
-                    if (incompleteMember.ContainsDiagnostics)
+                    var incompleteField = CreateIncompleteField(attributes, modifiers, type);
+                    if (incompleteField.ContainsDiagnostics)
                     {
-                        return incompleteMember;
+                        return incompleteField;
                     }
                     else if (parentKind == SyntaxKind.NamespaceDeclaration ||
                              parentKind == SyntaxKind.CompilationUnit && !IsScript)
                     {
-                        return this.AddErrorToLastToken(incompleteMember, ErrorCode.ERR_NamespaceUnexpected);
+                        return this.AddErrorToLastToken(incompleteField, ErrorCode.ERR_NamespaceUnexpected);
                     }
                     else
                     {
                         //the error position should indicate CurrentToken
                         return this.AddError(
-                            incompleteMember,
-                            incompleteMember.FullWidth + this.CurrentToken.GetLeadingTriviaWidth(),
+                            incompleteField,
+                            incompleteField.FullWidth + this.CurrentToken.GetLeadingTriviaWidth(),
                             this.CurrentToken.Width,
                             ErrorCode.ERR_InvalidMemberDecl,
                             this.CurrentToken.Text);
@@ -2564,6 +2564,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 _pool.Free(attributes);
                 _termState = saveTermState;
             }
+        }
+
+        private FieldDeclarationSyntax CreateIncompleteField(
+            SyntaxListBuilder<AttributeListSyntax> attributes, SyntaxListBuilder modifiers, TypeSyntax type)
+        {
+            // Make a field declaration with all the provided values along with a missing name.
+            var variableDeclarator = _syntaxFactory.VariableDeclarator(CreateMissingIdentifierToken(), argumentList: null, initializer: null);
+            var variableDeclarators = SeparatedSyntaxListBuilder<VariableDeclaratorSyntax>.Create().Add(variableDeclarator).ToList();
+            var variableDeclaration = _syntaxFactory.VariableDeclaration(type, variableDeclarators);
+            return _syntaxFactory.FieldDeclaration(
+                attributes, modifiers.ToTokenList(), variableDeclaration, EatToken(SyntaxKind.SemicolonToken));
         }
 
         // if the modifiers do not contain async and the type is the identifier "async", then

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -29,6 +29,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
             }
         }
 
+        protected override bool AnalyzeIncompleteMembers => false;
+
         protected override DiagnosticDescriptor DiagnosticDescriptor => GetDiagnosticDescriptor(NameNotInContext, _nameNotInContextMessageFormat);
 
         protected override DiagnosticDescriptor DiagnosticDescriptor2 => GetDiagnosticDescriptor(ConstructorOverloadResolutionFailure, _constructorOverloadResolutionFailureMessageFormat);

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.AddImport
         where TIncompleteMemberSyntax : SyntaxNode
         where TLambdaExpressionSyntax : SyntaxNode
     {
+        protected abstract bool AnalyzeIncompleteMembers { get; }
         protected abstract DiagnosticDescriptor DiagnosticDescriptor { get; }
         protected abstract DiagnosticDescriptor DiagnosticDescriptor2 { get; }
         protected abstract ImmutableArray<TLanguageKindEnum> SyntaxKindsOfInterest { get; }
@@ -45,7 +46,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.AddImport
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            if (IsBrokenLambda(context) || context.Node is TIncompleteMemberSyntax)
+            if (IsBrokenLambda(context))
+            {
+                ReportUnboundIdentifierNames(context, context.Node);
+            }
+            else if (context.Node is TIncompleteMemberSyntax && this.AnalyzeIncompleteMembers)
             {
                 ReportUnboundIdentifierNames(context, context.Node);
             }

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
@@ -31,6 +31,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics
             End Get
         End Property
 
+        Protected Overrides ReadOnly Property AnalyzeIncompleteMembers As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
         Protected Overrides ReadOnly Property DiagnosticDescriptor As DiagnosticDescriptor
             Get
                 Return GetDiagnosticDescriptor(s_undefinedType1, _messageFormat)


### PR DESCRIPTION
Incomplete members are effectively black holes for IDE features.  Because they are not processed by the compiler nothing works on them (quick info, goto def, analyzers, etc.).  This change makes it so that the compiler does not create IncompleteMembers anymore when there is a clear type written by the user.  Instead, in the case where it used to do this we make a field instead. 

Now, all these scenarios light up properly and the user experience is much better.  

Fixes https://github.com/dotnet/roslyn/issues/7980

--

Note: PR not ready for review yet.  I'm sending this out to get jenkins coverage to see what needs to be fixed in tests.