### PR TITLE
Fix null reference exception when typing a dot after a complete VB Handles clause

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/HandlesClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/HandlesClauseCompletionProviderTests.vb
@@ -228,5 +228,26 @@ End Class</text>.Value
 
             Await VerifyNoItemsExistAsync(text)
         End Function
+
+        <WorkItem(8307, "https://github.com/dotnet/roslyn/issues/8307")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DontCrashOnDotAfterCompleteHandlesClause() As Task
+            Dim text = "
+Imports System
+
+Class C
+    Public Event E As EventHandler
+End Class
+
+Class D
+    WithEvents c As New C
+
+    Sub OnE(sender As Object, e As EventArgs) Handles c.E.$$
+
+    End Sub
+End Class"
+
+            Await VerifyNoItemsExistAsync(text)
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/HandlesClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/HandlesClauseCompletionProvider.vb
@@ -91,18 +91,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Dim previousToken = token.GetPreviousToken()
             Select Case previousToken.Kind
                 Case SyntaxKind.MeKeyword, SyntaxKind.MyClassKeyword
-                    result = context.SemanticModel.LookupSymbols(context.Position, TryCast(containingType, INamespaceOrTypeSymbol)) _
-                        .OfType(Of IEventSymbol)()
+                    result = context.SemanticModel.LookupSymbols(context.Position, containingType).OfType(Of IEventSymbol)()
                 Case SyntaxKind.MyBaseKeyword
-                    result = context.SemanticModel.LookupSymbols(context.Position, TryCast(containingType.BaseType, INamespaceOrTypeSymbol)) _
-                        .OfType(Of IEventSymbol)()
+                    result = context.SemanticModel.LookupSymbols(context.Position, containingType.BaseType).OfType(Of IEventSymbol)()
                 Case SyntaxKind.IdentifierToken
                     ' We must be looking at a WithEvents property.
                     Dim symbolInfo = context.SemanticModel.GetSymbolInfo(previousToken, cancellationToken)
                     If symbolInfo.Symbol IsNot Nothing Then
-                        Dim type = TryCast(symbolInfo.Symbol, IPropertySymbol).Type
+                        Dim type = TryCast(symbolInfo.Symbol, IPropertySymbol)?.Type
                         If type IsNot Nothing Then
-                            result = context.SemanticModel.LookupSymbols(token.SpanStart, TryCast(type, INamespaceOrTypeSymbol)).OfType(Of IEventSymbol)()
+                            result = context.SemanticModel.LookupSymbols(token.SpanStart, type).OfType(Of IEventSymbol)()
                         End If
                     End If
             End Select
@@ -116,7 +114,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                                               context As VisualBasicSyntaxContext) As CompletionItem
 
             Dim displayAndInsertionText = CompletionUtilities.GetDisplayAndInsertionText(
-                symbol, isAttributeNameContext:=False, isAfterDot:=context.IsRightOfNameSeparator, isWithinAsyncMethod:=DirectCast(context, VisualBasicSyntaxContext).WithinAsyncMethod, syntaxFacts:=context.GetLanguageService(Of ISyntaxFactsService)())
+                symbol, isAttributeNameContext:=False, isAfterDot:=context.IsRightOfNameSeparator, isWithinAsyncMethod:=context.WithinAsyncMethod, syntaxFacts:=context.GetLanguageService(Of ISyntaxFactsService)())
 
             Return New SymbolCompletionItem(Me,
                                             displayAndInsertionText.Item1,


### PR DESCRIPTION
Fixes #8307

Tagging @rchande and @dotnet/roslyn-ide 