### PR TITLE
C# Formatting in autoprops missing close brace

### DIFF
--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
@@ -354,5 +354,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         {
             return token.IsKind(SyntaxKind.OpenBraceToken) && token.Parent.IsKind(SyntaxKind.AccessorList);
         }
+
+        public static bool IsOpenBraceOfPropertyAccessorList(this SyntaxToken token)
+        {
+            return token.IsOpenBraceOfAccessorList() && (token.Parent?.IsParentKind(SyntaxKind.PropertyDeclaration) ?? false);
+        }
+
+        public static bool IsOpenBraceOfAutoPropertyAccessorList(this SyntaxToken token)
+        {
+            return token.IsOpenBraceOfPropertyAccessorList()
+                ? ((AccessorListSyntax)token.Parent).Accessors.FirstOrDefault()?.Body == null
+                : false;
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -86,18 +86,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     // case: type PropertyName { get;
                     //  in auto properties that are single line and incomplete, 
                     //  do not move accessors onto new lines.
-                    if (previousToken.IsOpenBraceOfAccessorList() &&
-                        previousToken.Parent?.Parent is PropertyDeclarationSyntax)
+                    if (previousToken.IsOpenBraceOfAutoPropertyAccessorList())
                     {
                         var propertyDeclaration = (PropertyDeclarationSyntax)previousToken.Parent.Parent;
                         var isSingleLine = FormattingRangeHelper.AreTwoTokensOnSameLine(
-                                                propertyDeclaration.GetFirstToken(), 
+                                                propertyDeclaration.GetFirstToken(),
                                                 propertyDeclaration.GetLastToken());
                         var closeBraceToken = propertyDeclaration.AccessorList.CloseBraceToken;
 
                         if (isSingleLine && closeBraceToken.IsMissing)
                         {
-                                return null;
+                            return null;
                         }
                     }
 

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7249,6 +7249,28 @@ class Program
         [WorkItem(7768, "https://github.com/dotnet/roslyn/issues/7768")]
         [WorkItem(8228, "https://github.com/dotnet/roslyn/issues/8228")]
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task MoveAccessorOfIncompleteFullPropToNextLine()
+        {
+            var code = @"class Program
+{
+    public int P {get {return P;
+    private int f;
+}";
+            var expected = @"class Program
+{
+    public int P
+    {
+        get
+        {
+            return P;
+    private int f;
+}";
+            await AssertFormatAsync(expected, code);
+        }
+
+        [WorkItem(7768, "https://github.com/dotnet/roslyn/issues/7768")]
+        [WorkItem(8228, "https://github.com/dotnet/roslyn/issues/8228")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task MoveAccessorOfIncompleteIndexerToNextLine()
         {
             // This is a test to ensure that the fix for 7668 does not

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7220,6 +7220,35 @@ class Program
         [WorkItem(7768, "https://github.com/dotnet/roslyn/issues/7768")]
         [WorkItem(8228, "https://github.com/dotnet/roslyn/issues/8228")]
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task MoveAccessorOfIncompleteMultiLineAutoPropToNextLine()
+        {
+            var code = @"class Program
+{
+    public int P 
+    { get;
+
+    static void Main(string[] args)
+    {
+
+    }
+}";
+            var expected = @"class Program
+{
+    public int P
+    {
+        get;
+
+    static void Main(string[] args)
+    {
+
+    }
+}";
+            await AssertFormatAsync(expected, code);
+        }
+
+        [WorkItem(7768, "https://github.com/dotnet/roslyn/issues/7768")]
+        [WorkItem(8228, "https://github.com/dotnet/roslyn/issues/8228")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task MoveAccessorOfIncompleteIndexerToNextLine()
         {
             // This is a test to ensure that the fix for 7668 does not


### PR DESCRIPTION
**TL;DR:**
With auto brace completion turned off, ensure that we keep the accessors
of a property whose close curly is missing, on the same line.

Fixes #7768, #8228.

**Long Summary:**

With Auto brace completion turned off, type `get;` at `$$` :
```C#
string Property {$$
```

it results in
```C#
string Property {
    get;
```
##### Observe:

- completion list was up
- semicolon committed the completion list and triggered the formatting.

##### Implementation Notes:

1. the semicolon first commits completion, and then invokes the formatter with the span that contains text **`{get;`**
The span to format is determined by an helper `CommonFormattingHelpers.GetFormattingSpan` which simply covers from _previous token to next token of a given span_. Formatting this span puts `get` on the next line.
 
2. the semicolon then triggers formatting, with the span that encompasses the text **`get;`** Notice that the formatter now arrives at a different span to format than the above. this is because it uses `FormattingRangeHelper.FindAppropriateRange` which has smarts about different scenarios and notably has adjustments for including or excluding the leading open brace from formatting. So essentially, this would not move the accessor to the new line, but for this case though, the newline has already been put in by step 1.

_So, we have a few ways to fix this :_

1. Do not invoke formatting from completion list
2. Fix the helper (`GetFormattingSpan`) to determine spans to include knowledge about when to include/exclude the leading open brace. 
3. Fix the general case for auto properties, that when their close brace is missing and the syntax node has an error, do not force the accessor onto a new line. This should work even when invoked from format document or format selection.

_This PR implements approach 3, and creates 2 future work items to :_

1. #8337: Investigate and understand why we need to invoke the formatter from completion list, especially in this case when semicolon is a trigger character for formatting as well.
2. #8338: Possibly consolidate the helper methods in `FormattingRangeHelper` and `CommonFormattingHelpers` classes that are used to determine the span/range to format
