### PR TITLE
Fix VB Inline Temporary Variable to work properly when identifiers differ by case

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -4181,5 +4181,32 @@ End Class
             Await TestAsync(code, expected, compareTokens:=False)
         End Function
 
+        <WorkItem(8119, "https://github.com/dotnet/roslyn/issues/8119")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
+        Public Async Function ShouldWorkEvenWhenReferencesVaryByCase() As Task
+            Dim code = "
+Imports System.Collections.Generic
+Class C
+    Sub M()
+        Dim [||]List As New List(Of String)
+        List.Add(""Apple"")
+        list.Add(""Banana"")
+    End Sub
+End Class
+"
+
+            Dim expected = "
+Imports System.Collections.Generic
+Class C
+    Sub M()
+        Call New List(Of String)().Add(""Apple"")
+        Call New List(Of String)().Add(""Banana"")
+    End Sub
+End Class
+"
+
+            Await TestAsync(code, expected, compareTokens:=False)
+        End Function
+
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.ReferenceRewriter.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.ReferenceRewriter.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
             End Sub
 
             Private Function IsReference(node As SimpleNameSyntax) As Boolean
-                If node.Identifier.ValueText <> _definition.Identifier.ValueText Then
+                If Not CaseInsensitiveComparison.Equals(node.Identifier.ValueText, _definition.Identifier.ValueText) Then
                     Return False
                 End If
 


### PR DESCRIPTION
Fixes #8119

Tagging @dpoeschl and @dotnet/roslyn-ide 