### PR TITLE
Turn off extension deploy everywhere

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -17,6 +17,7 @@
     <OutputDirectory>Binaries\$(Configuration)</OutputDirectory>
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages</NuGetPackageRoot>
     <XunitVersion>2.1.0</XunitVersion>
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
 
   <Target Name="Build">

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -71,7 +71,7 @@ if defined Perf (
   set Target=BuildAndTest
 )
 
-msbuild %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath=%bindir%\Bootstrap BuildAndTest.proj /t:%Target% /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /p:DeployExtension=false /fileloggerparameters:LogFile=%bindir%\Build.log;verbosity=diagnostic || goto :BuildFailed
+msbuild %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath=%bindir%\Bootstrap BuildAndTest.proj /t:%Target% /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /fileloggerparameters:LogFile=%bindir%\Build.log;verbosity=diagnostic || goto :BuildFailed
 
 call :TerminateBuildProcesses
 


### PR DESCRIPTION
Right now cibuild turns off extension deployment but BuildAndTest keeps
it on. This turns it off by default for both.

/cc @jmarolf @dotnet/roslyn-infrastructure @jaredpar 