### PR TITLE
VB: Don't show "Each" keyword in completion list in nearly complete For loop

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Return keywords.Select(Function(k) k.Keyword)
         End Function
 
-        Friend Async Function VerifyRecommendationsAreExactlyAsync(testSource As XElement, ParamArray recommendations As String()) As Tasks.Task
+        Friend Async Function VerifyRecommendationsAreExactlyAsync(testSource As XElement, ParamArray recommendations As String()) As Task
             Dim source = ConvertTestSourceTag(testSource)
             Dim recommendedKeywords = (Await GetRecommendedKeywordStringsAsync(source.Replace("|", ""), source.IndexOf("|"c))) _
                                       .OrderBy(Function(recommendation) recommendation) _
@@ -43,14 +43,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Assert.Equal(recommendations.OrderBy(Function(recommendation) recommendation).ToArray(), recommendedKeywords)
         End Function
 
-        Friend Async Function VerifyRecommendationDescriptionTextIsAsync(testSource As XElement, keyword As String, text As String) As Tasks.Task
+        Friend Async Function VerifyRecommendationDescriptionTextIsAsync(testSource As XElement, keyword As String, text As String) As Task
             Dim source = ConvertTestSourceTag(testSource)
             Dim recommendedKeyword = (Await GetRecommendedKeywordsAsync(source.Replace("|", ""), source.IndexOf("|"c))).Single(Function(r) r.Keyword = keyword)
             Dim expectedText = text.Trim()
             Assert.Equal(expectedText, recommendedKeyword.DescriptionFactory(CancellationToken.None).GetFullText())
         End Function
 
-        Friend Async Function VerifyRecommendationsContainAsync(testSource As XElement, ParamArray recommendations As String()) As Tasks.Task
+        Friend Async Function VerifyRecommendationsContainAsync(testSource As XElement, ParamArray recommendations As String()) As Task
             Assert.NotEmpty(recommendations)
 
             Dim source = ConvertTestSourceTag(testSource)
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Await VerifyRecommendationsContainPartiallyTypedAsync(source, recommendations)
         End Function
 
-        Private Async Function VerifyRecommendationsContainNothingTypedAsync(source As String, ParamArray recommendations As String()) As Tasks.Task
+        Private Async Function VerifyRecommendationsContainNothingTypedAsync(source As String, ParamArray recommendations As String()) As Task
             ' Test with the | removed
             Dim recommendedKeywords = Await GetRecommendedKeywordsAsync(source.Replace("|", ""), source.IndexOf("|"c))
 
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Next
         End Sub
 
-        Private Async Function VerifyRecommendationsContainPartiallyTypedAsync(source As String, ParamArray recommendations As String()) As Tasks.Task
+        Private Async Function VerifyRecommendationsContainPartiallyTypedAsync(source As String, ParamArray recommendations As String()) As Task
             ' Test with the | replaced with the first character of the keywords we expect
             For Each partiallyTypedRecommendation In recommendations.Select(Function(recommendation) recommendation(0)).Distinct()
                 Dim recommendedKeywords = (Await GetRecommendedKeywordStringsAsync(source.Replace("|"c, partiallyTypedRecommendation), source.IndexOf("|"c) + 1)).ToArray()
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Next
         End Function
 
-        Friend Async Function VerifyRecommendationsMissingAsync(testSource As XElement, ParamArray recommendations As String()) As Tasks.Task
+        Friend Async Function VerifyRecommendationsMissingAsync(testSource As XElement, ParamArray recommendations As String()) As Task
             Assert.NotEmpty(recommendations)
 
             Dim source = ConvertTestSourceTag(testSource)
@@ -100,6 +100,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             For Each recommendation In recommendations
                 Assert.DoesNotContain(recommendation, recommendedKeywords)
             Next
+        End Function
+
+        Friend Async Function VerifyNoRecommendationsAsync(testSource As XElement) As Task
+            Dim source = ConvertTestSourceTag(testSource)
+
+            Dim recommendedKeywords = (Await GetRecommendedKeywordStringsAsync(source.Replace("|", ""), source.IndexOf("|"c))) _
+                                      .OrderBy(Function(recommendation) recommendation) _
+                                      .ToArray()
+
+            Assert.Equal(0, recommendedKeywords.Length)
         End Function
     End Module
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/EachKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/EachKeywordRecommenderTests.vb
@@ -41,5 +41,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.St
 <MethodBody>For _
 |</MethodBody>, "Each")
         End Function
+
+        <WorkItem(4946, "http://github.com/dotnet/roslyn/issues/4946")>
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function NotInForLoop() As Task
+            Await VerifyRecommendationsAreExactlyAsync(
+<MethodBody>For | = 1 To 100
+Next</MethodBody>, {})
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/EachKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Statements/EachKeywordRecommenderTests.vb
@@ -45,9 +45,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.St
         <WorkItem(4946, "http://github.com/dotnet/roslyn/issues/4946")>
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Async Function NotInForLoop() As Task
-            Await VerifyRecommendationsAreExactlyAsync(
+            Await VerifyNoRecommendationsAsync(
 <MethodBody>For | = 1 To 100
-Next</MethodBody>, {})
+Next</MethodBody>)
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Statements/EachKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Statements/EachKeywordRecommender.vb
@@ -3,6 +3,7 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Statements
     ''' <summary>
@@ -19,10 +20,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Stat
             Dim targetToken = context.TargetToken
 
             If targetToken.IsKind(SyntaxKind.ForKeyword) AndAlso targetToken.Parent.IsKind(SyntaxKind.ForStatement) Then
-                Return SpecializedCollections.SingletonEnumerable(New RecommendedKeyword("Each", VBFeaturesResources.ForEachKeywordToolTip))
-            Else
-                Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()
+                Dim forStatement = DirectCast(targetToken.Parent, ForStatementSyntax)
+                If forStatement.EqualsToken = Nothing OrElse forStatement.EqualsToken.IsMissing Then
+                    Return SpecializedCollections.SingletonEnumerable(New RecommendedKeyword("Each", VBFeaturesResources.ForEachKeywordToolTip))
+                End If
             End If
+
+            Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #4946

This is a tweak to ensure that the completion list does not display the "Each" keyword in a For loop that is already recognizable as a For loop (e.g. has an '=' token). For example, this case:

```VB
For | = 1 to 10
Next
```

The reason for this tweak is to avoid a conflict with the VB "For" snippet. If "Each" is recommended in this position, it causes the completion list to be displayed, which steals the TAB key from snippet navigation. VS 2013 did not show "Each" here either for exactly the same reason.

Tagging @dotnet/roslyn-ide 