### PR TITLE
Format lock statement with single statement appropriately 

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1273,6 +1273,54 @@ class C : Attribute
             await AssertFormatAfterTypeCharAsync(code, expected);
         }
 
+        [WorkItem(7900, "https://github.com/dotnet/roslyn/issues/7900")]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatLockStatementWithEmbeddedStatementOnSemicolonDifferentLine()
+        {
+            var code = @"class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l)
+                       Console.WriteLine(""d"");$$
+    }
+}";
+            var expected = @"class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l)
+            Console.WriteLine(""d"");
+    }
+}";
+            await AssertFormatAfterTypeCharAsync(code, expected);
+        }
+
+        [WorkItem(7900, "https://github.com/dotnet/roslyn/issues/7900")]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatLockStatementWithEmbeddedStatementOnSemicolonSameLine()
+        {
+            var code = @"class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l)      Console.WriteLine(""d"");$$
+    }
+}";
+            var expected = @"class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l) Console.WriteLine(""d"");
+    }
+}";
+            await AssertFormatAfterTypeCharAsync(code, expected);
+        }
+
         private static async Task AssertFormatAfterTypeCharAsync(string code, string expected, Dictionary<OptionKey, object> changedOptionSet = null)
         {
             using (var workspace = await TestWorkspace.CreateCSharpAsync(code))

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -385,7 +385,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                    node is WhileStatementSyntax ||
                    node is ForStatementSyntax ||
                    node is ForEachStatementSyntax ||
-                   node is UsingStatementSyntax;
+                   node is UsingStatementSyntax ||
+                   node is LockStatementSyntax;
         }
 
         public static bool IsNestedQueryExpression(this SyntaxToken token)

--- a/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
@@ -358,7 +358,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 node.Kind() == SyntaxKind.TryStatement ||
                 node.Kind() == SyntaxKind.CatchClause ||
                 node.Kind() == SyntaxKind.FinallyClause ||
-                node.Kind() == SyntaxKind.LabeledStatement;
+                node.Kind() == SyntaxKind.LabeledStatement ||
+                node.Kind() == SyntaxKind.LockStatement;
         }
 
         private static SyntaxNode GetTopContainingNode(SyntaxNode node)

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7160,5 +7160,53 @@ class Program
     public int SomeProperty {    [SomeAttribute] get;    [SomeAttribute] private set; }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(7900, "https://github.com/dotnet/roslyn/issues/7900")]
+        public async Task FormatEmbeddedStatementInsideLockStatement()
+        {
+            await AssertFormatAsync(@"
+class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l) Console.WriteLine(""d"");
+    }
+}", @"
+class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l)     Console.WriteLine(""d"");
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(7900, "https://github.com/dotnet/roslyn/issues/7900")]
+        public async Task FormatEmbeddedStatementInsideLockStatementDifferentLine()
+        {
+            await AssertFormatAsync(@"
+class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l)
+            Console.WriteLine(""d"");
+    }
+}",@"
+class C
+{
+    private object _l = new object();
+    public void M()
+    {
+        lock (_l)
+    Console.WriteLine(""d"");
+    }
+}");
+        }
     }
 }


### PR DESCRIPTION
Fixes #7900

Format lock statement with embedded statement as a special node

Review: @dotnet/roslyn-ide