### PR TITLE
Fix #help output in InteractiveWindow

### DIFF
--- a/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
+++ b/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
@@ -167,7 +167,9 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         internal IEnumerable<string> Help()
         {
-            string format = "{0,-" + _maxCommandNameLength + "}  {1}";
+            // The magic number `19` here is calculated based on how the description is dispayed for other help entries to keep the texts aligned
+            // (As of now other help entries include REPL commands and script derectives, both have manually formatted help description strings.
+            string format = "{0,-" + Math.Max(19, _maxCommandNameLength) + "}  {1}";
             return _commands.GroupBy(entry => entry.Value).
                 Select(group => string.Format(format, string.Join(_commandSeparator, group.Key.Names.Select(s => CommandPrefix + s)), group.Key.Description)).
                 OrderBy(line => line);
@@ -358,6 +360,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             DisplayCommandUsage(command, _window.OutputWriter, displayDetails: true);
         }
 
-        private bool UseSmartUpDown =>_window.TextView.Options.GetOptionValue(InteractiveWindowOptions.SmartUpDown);
+        private bool UseSmartUpDown => _window.TextView.Options.GetOptionValue(InteractiveWindowOptions.SmartUpDown);
     }
 }

--- a/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
+++ b/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
@@ -39,6 +39,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             CommandPrefix = prefix;
             _window = window;
 
+            _shortcutDescriptions = GenerateShortcutDescriptions();
             Dictionary<string, IInteractiveWindowCommand> commandsDict = new Dictionary<string, IInteractiveWindowCommand>();
             foreach (var command in commands)
             {
@@ -237,25 +238,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         private const string HelpIndent = "  ";
 
-        private static readonly string[] s_shortcutDescriptions = new[]
-        {
-"Enter                " + InteractiveWindowResources.EnterHelp,
-"Ctrl-Enter           " + InteractiveWindowResources.CtrlEnterHelp1,
-"                     " + InteractiveWindowResources.CtrlEnterHelp1,
-"Shift-Enter          " + InteractiveWindowResources.ShiftEnterHelp,
-"Escape               " + InteractiveWindowResources.EscapeHelp,
-"Alt-UpArrow          " + InteractiveWindowResources.AltUpArrowHelp,
-"Alt-DownArrow        " + InteractiveWindowResources.AltDownArrowHelp,
-"Ctrl-Alt-UpArrow     " + InteractiveWindowResources.CtrlAltUpArrowHelp,
-"Ctrl-Alt-DownArrow   " + InteractiveWindowResources.CtrlAltDownArrowHelp,
-"UpArrow              " + InteractiveWindowResources.UpArrowHelp1,
-"                     " + InteractiveWindowResources.UpArrowHelp2,
-"DownArrow            " + InteractiveWindowResources.DownArrowHelp1,
-"                     " + InteractiveWindowResources.DownArrowHelp2,
-"Ctrl-K, Ctrl-Enter   " + InteractiveWindowResources.CtrlKCtrlEnterHelp,
-"Ctrl-E, Ctrl-Enter   " + InteractiveWindowResources.CtrlECtrlEnterHelp,
-"Ctrl-A               " + InteractiveWindowResources.CtrlAHelp,
-        };
+        private readonly List<string> _shortcutDescriptions;
 
         private static readonly string[] s_CSVBScriptDirectives = new[]
         {
@@ -263,10 +246,35 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 "#load                " + InteractiveWindowResources.LoadHelp
         };
 
+        internal List<string> GenerateShortcutDescriptions()
+        {
+            var list = new List<string>();
+            list.Add("Enter                " + InteractiveWindowResources.EnterHelp);
+            list.Add("Ctrl-Enter           " + InteractiveWindowResources.CtrlEnterHelp1);
+            list.Add("                     " + InteractiveWindowResources.CtrlEnterHelp2);
+            list.Add("Shift-Enter          " + InteractiveWindowResources.ShiftEnterHelp);
+            list.Add("Escape               " + InteractiveWindowResources.EscapeHelp);
+            list.Add("Alt-UpArrow          " + InteractiveWindowResources.AltUpArrowHelp);
+            list.Add("Alt-DownArrow        " + InteractiveWindowResources.AltDownArrowHelp);
+            list.Add("Ctrl-Alt-UpArrow     " + InteractiveWindowResources.CtrlAltUpArrowHelp);
+            list.Add("Ctrl-Alt-DownArrow   " + InteractiveWindowResources.CtrlAltDownArrowHelp);
+            if (UseSmartUpDown)
+            {
+                list.Add("UpArrow              " + InteractiveWindowResources.UpArrowHelp1);
+                list.Add("                     " + InteractiveWindowResources.UpArrowHelp2);
+                list.Add("DownArrow            " + InteractiveWindowResources.DownArrowHelp1);
+                list.Add("                     " + InteractiveWindowResources.DownArrowHelp2);
+            }
+            list.Add("Ctrl-K, Ctrl-Enter   " + InteractiveWindowResources.CtrlKCtrlEnterHelp);
+            list.Add("Ctrl-E, Ctrl-Enter   " + InteractiveWindowResources.CtrlECtrlEnterHelp);
+            list.Add("Ctrl-A               " + InteractiveWindowResources.CtrlAHelp);
+            return list;
+        }
+
         public void DisplayHelp()
         {
             _window.WriteLine(InteractiveWindowResources.KeyboardShortcuts);
-            foreach (var line in s_shortcutDescriptions)
+            foreach (var line in _shortcutDescriptions)
             {
                 _window.Write(HelpIndent);
                 _window.WriteLine(line);
@@ -349,5 +357,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
         {
             DisplayCommandUsage(command, _window.OutputWriter, displayDetails: true);
         }
+
+        private bool UseSmartUpDown =>_window.TextView.Options.GetOptionValue(InteractiveWindowOptions.SmartUpDown);
     }
 }

--- a/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
+++ b/src/InteractiveWindow/Editor/Commands/InteractiveWindowCommands.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
@@ -39,7 +40,6 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
             CommandPrefix = prefix;
             _window = window;
 
-            _shortcutDescriptions = GenerateShortcutDescriptions();
             Dictionary<string, IInteractiveWindowCommand> commandsDict = new Dictionary<string, IInteractiveWindowCommand>();
             foreach (var command in commands)
             {
@@ -240,47 +240,61 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Commands
 
         private const string HelpIndent = "  ";
 
-        private readonly List<string> _shortcutDescriptions;
-
         private static readonly string[] s_CSVBScriptDirectives = new[]
         {
-"#r                   " + InteractiveWindowResources.RefHelp,
-"#load                " + InteractiveWindowResources.LoadHelp
+            "#r                   " + InteractiveWindowResources.RefHelp,
+            "#load                " + InteractiveWindowResources.LoadHelp
         };
 
-        internal List<string> GenerateShortcutDescriptions()
+        private static readonly string[] s_shortcutDescriptions = new[]
         {
-            var list = new List<string>();
-            list.Add("Enter                " + InteractiveWindowResources.EnterHelp);
-            list.Add("Ctrl-Enter           " + InteractiveWindowResources.CtrlEnterHelp1);
-            list.Add("                     " + InteractiveWindowResources.CtrlEnterHelp2);
-            list.Add("Shift-Enter          " + InteractiveWindowResources.ShiftEnterHelp);
-            list.Add("Escape               " + InteractiveWindowResources.EscapeHelp);
-            list.Add("Alt-UpArrow          " + InteractiveWindowResources.AltUpArrowHelp);
-            list.Add("Alt-DownArrow        " + InteractiveWindowResources.AltDownArrowHelp);
-            list.Add("Ctrl-Alt-UpArrow     " + InteractiveWindowResources.CtrlAltUpArrowHelp);
-            list.Add("Ctrl-Alt-DownArrow   " + InteractiveWindowResources.CtrlAltDownArrowHelp);
-            if (UseSmartUpDown)
+            "Enter                " + InteractiveWindowResources.EnterHelp,
+            "Ctrl-Enter           " + InteractiveWindowResources.CtrlEnterHelp1,
+            "                     " + InteractiveWindowResources.CtrlEnterHelp2,
+            "Shift-Enter          " + InteractiveWindowResources.ShiftEnterHelp,
+            "Escape               " + InteractiveWindowResources.EscapeHelp,
+            "Alt-UpArrow          " + InteractiveWindowResources.AltUpArrowHelp,
+            "Alt-DownArrow        " + InteractiveWindowResources.AltDownArrowHelp,
+            "Ctrl-Alt-UpArrow     " + InteractiveWindowResources.CtrlAltUpArrowHelp,
+            "Ctrl-Alt-DownArrow   " + InteractiveWindowResources.CtrlAltDownArrowHelp,
+            "Ctrl-K, Ctrl-Enter   " + InteractiveWindowResources.CtrlKCtrlEnterHelp,
+            "Ctrl-E, Ctrl-Enter   " + InteractiveWindowResources.CtrlECtrlEnterHelp,
+            "Ctrl-A               " + InteractiveWindowResources.CtrlAHelp
+        };
+
+        private static readonly string[] s_shortcutDescriptionsSmartUpDown = new[]
+        {
+            "UpArrow              " + InteractiveWindowResources.UpArrowHelp1,
+            "                     " + InteractiveWindowResources.UpArrowHelp2,
+            "DownArrow            " + InteractiveWindowResources.DownArrowHelp1,
+            "                     " + InteractiveWindowResources.DownArrowHelp2
+        };
+
+
+        internal string ShortcutDescriptions
+        {
+            get
             {
-                list.Add("UpArrow              " + InteractiveWindowResources.UpArrowHelp1);
-                list.Add("                     " + InteractiveWindowResources.UpArrowHelp2);
-                list.Add("DownArrow            " + InteractiveWindowResources.DownArrowHelp1);
-                list.Add("                     " + InteractiveWindowResources.DownArrowHelp2);
+                var sb = new StringBuilder();
+                foreach (var line in s_shortcutDescriptions)
+                {
+                    sb.Append(HelpIndent + line + "\r\n");
+                }
+                if (UseSmartUpDown)
+                {
+                    foreach (var line in s_shortcutDescriptionsSmartUpDown)
+                    {
+                        sb.Append(HelpIndent + line + "\r\n");
+                    }
+                }
+                return sb.ToString();
             }
-            list.Add("Ctrl-K, Ctrl-Enter   " + InteractiveWindowResources.CtrlKCtrlEnterHelp);
-            list.Add("Ctrl-E, Ctrl-Enter   " + InteractiveWindowResources.CtrlECtrlEnterHelp);
-            list.Add("Ctrl-A               " + InteractiveWindowResources.CtrlAHelp);
-            return list;
         }
 
         public void DisplayHelp()
         {
             _window.WriteLine(InteractiveWindowResources.KeyboardShortcuts);
-            foreach (var line in _shortcutDescriptions)
-            {
-                _window.Write(HelpIndent);
-                _window.WriteLine(line);
-            }
+            _window.Write(ShortcutDescriptions);
 
             _window.WriteLine(InteractiveWindowResources.ReplCommands);
             foreach (var line in Help())

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -182,6 +182,61 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             Assert.NotNull(commands.Where(n => n.Names.First() == "reset").SingleOrDefault());
         }
 
+        [WorkItem(8121, "https://github.com/dotnet/roslyn/issues/8121")]
+        [WpfFact]
+        public void InteractiveWindow_GetHelpShortcutDescriptionss()
+        {
+            var interactiveCommands = new InteractiveCommandsFactory(null, null).CreateInteractiveCommands(
+                Window,
+                string.Empty,
+                Enumerable.Empty<IInteractiveWindowCommand>());
+
+            var noSmartUpDownExpected =
+@"Enter                If the current submission appears to be complete, evaluate it.  Otherwise, insert a new line.
+Ctrl-Enter           Within the current submission, evaluate the current submission.
+                     Within a previous submission, append the previous submission to the current submission.
+Shift-Enter          Insert a new line.
+Escape               Clear the current submission.
+Alt-UpArrow          Replace the current submission with a previous submission.
+Alt-DownArrow        Replace the current submission with a subsequent submission (after having previously navigated backwards).
+Ctrl-Alt-UpArrow     Replace the current submission with a previous submission beginning with the same text.
+Ctrl-Alt-DownArrow   Replace the current submission with a subsequent submission beginning with the same text (after having previously navigated backwards).
+Ctrl-K, Ctrl-Enter   Paste the selection at the end of interactive buffer, leave caret at the end of input.
+Ctrl-E, Ctrl-Enter   Paste and execute the selection before any pending input in the interactive buffer.
+Ctrl-A               First press, select the submission containing the cursor.  Second press, select all text in the window.";
+
+            // By default, SmartUpDown option is not set
+            var descriptions = ((Commands.Commands)interactiveCommands).GenerateShortcutDescriptions();
+            var combined = descriptions.Aggregate((a, b) => a + "\r\n" + b);
+            Assert.Equal(noSmartUpDownExpected, combined);
+
+
+            var withSmartUpDownExpected =
+@"Enter                If the current submission appears to be complete, evaluate it.  Otherwise, insert a new line.
+Ctrl-Enter           Within the current submission, evaluate the current submission.
+                     Within a previous submission, append the previous submission to the current submission.
+Shift-Enter          Insert a new line.
+Escape               Clear the current submission.
+Alt-UpArrow          Replace the current submission with a previous submission.
+Alt-DownArrow        Replace the current submission with a subsequent submission (after having previously navigated backwards).
+Ctrl-Alt-UpArrow     Replace the current submission with a previous submission beginning with the same text.
+Ctrl-Alt-DownArrow   Replace the current submission with a subsequent submission beginning with the same text (after having previously navigated backwards).
+UpArrow              At the end of the current submission, replace the current submission with a previous submission.
+                     Elsewhere, move the cursor up one line.
+DownArrow            At the end of the current submission, replace the current submission with a subsequent submission (after having previously navigated backwards).
+                     Elsewhere, move the cursor down one line.
+Ctrl-K, Ctrl-Enter   Paste the selection at the end of interactive buffer, leave caret at the end of input.
+Ctrl-E, Ctrl-Enter   Paste and execute the selection before any pending input in the interactive buffer.
+Ctrl-A               First press, select the submission containing the cursor.  Second press, select all text in the window.";
+
+            // Set SmartUpDown option to true
+            Window.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, true);
+
+            descriptions = ((Commands.Commands)interactiveCommands).GenerateShortcutDescriptions();
+            combined = descriptions.Aggregate((a, b) => a + "\r\n" + b);
+            Assert.Equal(withSmartUpDownExpected, combined);
+        }
+
         [WorkItem(6625, "https://github.com/dotnet/roslyn/issues/6625")]
         [WpfFact]
         public void InteractiveWindow_DisplayCommandsHelp()

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -192,49 +192,49 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
                 Enumerable.Empty<IInteractiveWindowCommand>());
 
             var noSmartUpDownExpected =
-@"Enter                If the current submission appears to be complete, evaluate it.  Otherwise, insert a new line.
-Ctrl-Enter           Within the current submission, evaluate the current submission.
-                     Within a previous submission, append the previous submission to the current submission.
-Shift-Enter          Insert a new line.
-Escape               Clear the current submission.
-Alt-UpArrow          Replace the current submission with a previous submission.
-Alt-DownArrow        Replace the current submission with a subsequent submission (after having previously navigated backwards).
-Ctrl-Alt-UpArrow     Replace the current submission with a previous submission beginning with the same text.
-Ctrl-Alt-DownArrow   Replace the current submission with a subsequent submission beginning with the same text (after having previously navigated backwards).
-Ctrl-K, Ctrl-Enter   Paste the selection at the end of interactive buffer, leave caret at the end of input.
-Ctrl-E, Ctrl-Enter   Paste and execute the selection before any pending input in the interactive buffer.
-Ctrl-A               First press, select the submission containing the cursor.  Second press, select all text in the window.";
+@"  Enter                If the current submission appears to be complete, evaluate it.  Otherwise, insert a new line.
+  Ctrl-Enter           Within the current submission, evaluate the current submission.
+                       Within a previous submission, append the previous submission to the current submission.
+  Shift-Enter          Insert a new line.
+  Escape               Clear the current submission.
+  Alt-UpArrow          Replace the current submission with a previous submission.
+  Alt-DownArrow        Replace the current submission with a subsequent submission (after having previously navigated backwards).
+  Ctrl-Alt-UpArrow     Replace the current submission with a previous submission beginning with the same text.
+  Ctrl-Alt-DownArrow   Replace the current submission with a subsequent submission beginning with the same text (after having previously navigated backwards).
+  Ctrl-K, Ctrl-Enter   Paste the selection at the end of interactive buffer, leave caret at the end of input.
+  Ctrl-E, Ctrl-Enter   Paste and execute the selection before any pending input in the interactive buffer.
+  Ctrl-A               First press, select the submission containing the cursor.  Second press, select all text in the window.
+";
 
             // By default, SmartUpDown option is not set
-            var descriptions = ((Commands.Commands)interactiveCommands).GenerateShortcutDescriptions();
-            var combined = descriptions.Aggregate((a, b) => a + "\r\n" + b);
-            Assert.Equal(noSmartUpDownExpected, combined);
+            var descriptions = ((Commands.Commands)interactiveCommands).ShortcutDescriptions;
+            Assert.Equal(noSmartUpDownExpected, descriptions);
 
 
             var withSmartUpDownExpected =
-@"Enter                If the current submission appears to be complete, evaluate it.  Otherwise, insert a new line.
-Ctrl-Enter           Within the current submission, evaluate the current submission.
-                     Within a previous submission, append the previous submission to the current submission.
-Shift-Enter          Insert a new line.
-Escape               Clear the current submission.
-Alt-UpArrow          Replace the current submission with a previous submission.
-Alt-DownArrow        Replace the current submission with a subsequent submission (after having previously navigated backwards).
-Ctrl-Alt-UpArrow     Replace the current submission with a previous submission beginning with the same text.
-Ctrl-Alt-DownArrow   Replace the current submission with a subsequent submission beginning with the same text (after having previously navigated backwards).
-UpArrow              At the end of the current submission, replace the current submission with a previous submission.
-                     Elsewhere, move the cursor up one line.
-DownArrow            At the end of the current submission, replace the current submission with a subsequent submission (after having previously navigated backwards).
-                     Elsewhere, move the cursor down one line.
-Ctrl-K, Ctrl-Enter   Paste the selection at the end of interactive buffer, leave caret at the end of input.
-Ctrl-E, Ctrl-Enter   Paste and execute the selection before any pending input in the interactive buffer.
-Ctrl-A               First press, select the submission containing the cursor.  Second press, select all text in the window.";
+@"  Enter                If the current submission appears to be complete, evaluate it.  Otherwise, insert a new line.
+  Ctrl-Enter           Within the current submission, evaluate the current submission.
+                       Within a previous submission, append the previous submission to the current submission.
+  Shift-Enter          Insert a new line.
+  Escape               Clear the current submission.
+  Alt-UpArrow          Replace the current submission with a previous submission.
+  Alt-DownArrow        Replace the current submission with a subsequent submission (after having previously navigated backwards).
+  Ctrl-Alt-UpArrow     Replace the current submission with a previous submission beginning with the same text.
+  Ctrl-Alt-DownArrow   Replace the current submission with a subsequent submission beginning with the same text (after having previously navigated backwards).
+  Ctrl-K, Ctrl-Enter   Paste the selection at the end of interactive buffer, leave caret at the end of input.
+  Ctrl-E, Ctrl-Enter   Paste and execute the selection before any pending input in the interactive buffer.
+  Ctrl-A               First press, select the submission containing the cursor.  Second press, select all text in the window.
+  UpArrow              At the end of the current submission, replace the current submission with a previous submission.
+                       Elsewhere, move the cursor up one line.
+  DownArrow            At the end of the current submission, replace the current submission with a subsequent submission (after having previously navigated backwards).
+                       Elsewhere, move the cursor down one line.
+";
 
             // Set SmartUpDown option to true
             Window.TextView.Options.SetOptionValue(InteractiveWindowOptions.SmartUpDown, true);
 
-            descriptions = ((Commands.Commands)interactiveCommands).GenerateShortcutDescriptions();
-            combined = descriptions.Aggregate((a, b) => a + "\r\n" + b);
-            Assert.Equal(withSmartUpDownExpected, combined);
+            descriptions = ((Commands.Commands)interactiveCommands).ShortcutDescriptions;
+            Assert.Equal(withSmartUpDownExpected, descriptions);
         }
 
         [WorkItem(6625, "https://github.com/dotnet/roslyn/issues/6625")]
@@ -244,7 +244,7 @@ Ctrl-A               First press, select the submission containing the cursor.  
             var commandList = MockCommands("foo").ToArray();
             var commands = new Commands.Commands(null, "&", commandList);
 
-            Assert.Equal(new string[] { "&foo  Description of foo command."}, commands.Help().ToArray());
+            Assert.Equal(new string[] { "&foo                 Description of foo command." }, commands.Help().ToArray());
         }
 
         [WorkItem(3970, "https://github.com/dotnet/roslyn/issues/3970")]


### PR DESCRIPTION
So the help text generated is based on the value of SmartUpDown option. This fixes #8121.

@dotnet/roslyn-interactive 
