### PR TITLE
Fix standalone determinism tests

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/EndToEndDeterminismTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/EndToEndDeterminismTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 var errorsFile = srcFile + ".errors";
 
                 // Compile
-                var result = ProcessUtilities.Run("cmd", $"/C {CompilerServerUnitTests.CSharpCompilerClientExecutable} { finalFlags } { srcFile } /out:{ outFile } > { errorsFile }");
+                var result = ProcessUtilities.Run("cmd", $@"/C ""{CompilerServerUnitTests.CSharpCompilerClientExecutable}"" { finalFlags } { srcFile } /out:{ outFile } > { errorsFile }");
                 if (result.ExitCode != 0)
                 {
                     var errors = File.ReadAllText(errorsFile);


### PR DESCRIPTION
Standalone tests occur when we delete csc.exe / vbc.exe from the Binaries\Debug directory and run unit tests.  The tests will fall back to the installed version of the binaries inside MSbuild instead.

The determinism tests were not properly quoting the path to csc.exe.  When run from standalone the path contains a space and hence the tests failed.  Properly quoting the tests now.

closes #8340