### PR TITLE
Fix F5 for CSharpWinRTTest

### DIFF
--- a/src/Compilers/CSharp/Test/WinRT/CSharpWinRTTest.csproj
+++ b/src/Compilers/CSharp/Test/WinRT/CSharpWinRTTest.csproj
@@ -62,5 +62,6 @@
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\..\build\Targets\VSL.Imports.targets" />
+    <Import Project="..\..\..\..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />
   </ImportGroup>
 </Project>


### PR DESCRIPTION
This project file wasn't including our xunit targets file and hence didn't have an F5 experience.

closes #8078