### PR TITLE
Dont move constructor body to new line if in same line as Constructor Initializer

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (constructorInitializerNode != null)
             {
                 var constructorDeclarationNode = constructorInitializerNode.Parent as ConstructorDeclarationSyntax;
-                if (constructorDeclarationNode != null && constructorDeclarationNode.Body != null)
+                if (constructorDeclarationNode?.Body != null)
                 {
                     AddSuppressWrappingIfOnSingleLineOperation(list, constructorInitializerNode.ColonToken, constructorDeclarationNode.Body.CloseBraceToken);
                 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -42,6 +42,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
+            var constructorInitializerNode = node as ConstructorInitializerSyntax;
+            if (constructorInitializerNode != null)
+            {
+                var constructorDeclarationNode = constructorInitializerNode.Parent as ConstructorDeclarationSyntax;
+                if (constructorDeclarationNode != null && constructorDeclarationNode.Body != null)
+                {
+                    AddSuppressWrappingIfOnSingleLineOperation(list, constructorInitializerNode.ColonToken, constructorDeclarationNode.Body.CloseBraceToken);
+                }
+
+                return;
+            }
+
             var whileStatementNode = node as DoStatementSyntax;
             if (whileStatementNode != null)
             {
@@ -59,6 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 {
                     AddSuppressWrappingIfOnSingleLineOperation(list, tokens.Item1, propertyDeclNode.AccessorList.GetLastToken());
                 }
+
                 return;
             }
 

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7147,6 +7147,61 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(6905, "https://github.com/dotnet/roslyn/issues/6905")]
+        public async Task KeepConstructorBodyInSameLineAsBaseConstructorInitializer()
+        {
+            var code = @"
+class C
+{
+    public C(int s)
+        : base() { }
+    public C()
+    {
+    }
+}";
+            await AssertFormatAsync(code, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(6905, "https://github.com/dotnet/roslyn/issues/6905")]
+        public async Task KeepConstructorBodyInSameLineAsThisConstructorInitializer()
+        {
+            var code = @"
+class C
+{
+    public C(int s)
+        : this() { }
+    public C()
+    {
+    }
+}";
+            await AssertFormatAsync(code, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(6905, "https://github.com/dotnet/roslyn/issues/6905")]
+        public async Task KeepConstructorBodyInSameLineAsThisConstructorInitializerAdjustSpace()
+        {
+            await AssertFormatAsync(@"
+class C
+{
+    public C(int s)
+        : this() { }
+    public C()
+    {
+    }
+}", @"
+class C
+{
+    public C(int s)
+        : this()      { }
+    public C()
+    {
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(4720, "https://github.com/dotnet/roslyn/issues/4720")]
         public async Task OneSpaceBetweenAccessorsAndAttributes()
         {


### PR DESCRIPTION
Fixes #6905

If the constructor body is in the same line as the base/this constructor
initializer then dont move the body to next line instead keep in the
same line.

Review : @dotnet/roslyn-ide 