### PR TITLE
Smart format Try block without catch/finally block

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
@@ -48,13 +48,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
             var smartTokenformattingRules = _formattingRules;
             var common = startToken.GetCommonRoot(endToken);
-            if (common.ContainsDiagnostics)
+
+            // if there are errors, do not touch lines
+            // Exception: In the case of try-catch-finally block, a try block without a catch/finally block is considered incomplete
+            //            but we would like to apply line operation in a completed try block even if there is no catch/finally block
+            if (common.ContainsDiagnostics && !CloseBraceOfTryBlock(endToken))
             {
-                // if there is errors, do not touch lines
                 smartTokenformattingRules = (new NoLineChangeFormattingRule()).Concat(_formattingRules);
             }
 
             return Formatter.GetFormattedTextChanges(_root, new TextSpan[] { TextSpan.FromBounds(startToken.SpanStart, endToken.Span.End) }, workspace, _optionSet, smartTokenformattingRules, cancellationToken);
+        }
+
+        private bool CloseBraceOfTryBlock(SyntaxToken endToken)
+        {
+            return endToken.IsKind(SyntaxKind.CloseBraceToken) &&
+                endToken.Parent.IsKind(SyntaxKind.Block) &&
+                endToken.Parent.IsParentKind(SyntaxKind.TryStatement);
         }
 
         public Task<IList<TextChange>> FormatTokenAsync(Workspace workspace, SyntaxToken token, CancellationToken cancellationToken)

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -1869,6 +1869,37 @@ class Class
         }
 
         [WpfFact]
+        [WorkItem(6645, "https://github.com/dotnet/roslyn/issues/6645")]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task TryStatement5()
+        {
+            var code = @"using System;
+
+class Class
+{
+    void Method()
+    {
+        try {
+        }$$
+    }
+}";
+
+            var expected = @"using System;
+
+class Class
+{
+    void Method()
+    {
+        try
+        {
+        }
+    }
+}";
+
+            await AutoFormatOnCloseBraceAsync(code, expected, SyntaxKind.OpenBraceToken);
+        }
+
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
         [WorkItem(537555, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537555")]
         public async Task SingleLine()


### PR DESCRIPTION
Fixes #6645

Format try block on typing the close brace of the try block even if
there is no catch/finally block to make the try-catch-finally block
syntactically complete without diagnostics.

Review: @dotnet/roslyn-ide 