### PR TITLE
Fix speculation analyzer to correctly use converted type when testing conversions with Option Strict On

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -8434,6 +8434,7 @@ End Class
             Await TestAsync(input, expected)
         End Function
 
+        <WorkItem(2560, "https://github.com/dotnet/roslyn/issues/2560")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Async Function TestVisualBasic_Remove_IntegerToByte_OptionStrictOff() As Task
             Dim input =
@@ -8465,6 +8466,7 @@ End Class
             Await TestAsync(input, expected)
         End Function
 
+        <WorkItem(2560, "https://github.com/dotnet/roslyn/issues/2560")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn1() As Task
             Dim input =
@@ -8496,6 +8498,7 @@ End Class
             Await TestAsync(input, expected)
         End Function
 
+        <WorkItem(2560, "https://github.com/dotnet/roslyn/issues/2560")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn2() As Task
             Dim input =
@@ -8529,6 +8532,7 @@ End Class
             Await TestAsync(input, expected)
         End Function
 
+        <WorkItem(2560, "https://github.com/dotnet/roslyn/issues/2560")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn3() As Task
             Dim input =
@@ -8562,6 +8566,7 @@ End Class
             Await TestAsync(input, expected)
         End Function
 
+        <WorkItem(2560, "https://github.com/dotnet/roslyn/issues/2560")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn4() As Task
             Dim input =
@@ -8592,6 +8597,7 @@ End Class
 
             Await TestAsync(input, expected)
         End Function
+
 #End Region
 
     End Class

--- a/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
@@ -4456,11 +4456,173 @@ End Class
 
             Await TestAsync(input, expected, DontPreferIntrinsicPredefinedTypeKeywordInDeclaration)
         End Function
+
+        <WorkItem(8381, "https://github.com/dotnet/roslyn/issues/8381")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function SimplifyMeRegardlessOfTypeAndOptionStrict1() As Task
+            Dim input =
+        <Workspace>
+            <Project Language="Visual Basic" CommonReferences="true">
+                <Document>
+Option Strict On
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        {|SimplifyParent:Me.field1|} = 0
+        Me.field2 = 0
+    End Sub
+End Class
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+Option Strict On
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        field1 = 0
+        Me.field2 = 0
+    End Sub
+End Class
+</text>
+
+            Await TestAsync(input, expected, DontQualifyMemberAccessWithThisOrMe)
+        End Function
+
+        <WorkItem(8381, "https://github.com/dotnet/roslyn/issues/8381")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function SimplifyMeRegardlessOfTypeAndOptionStrict2() As Task
+            Dim input =
+        <Workspace>
+            <Project Language="Visual Basic" CommonReferences="true">
+                <Document>
+Option Strict On
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        Me.field1 = 0
+        {|SimplifyParent:Me.field2|} = 0
+    End Sub
+End Class
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+Option Strict On
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        Me.field1 = 0
+        field2 = 0
+    End Sub
+End Class
+</text>
+
+            Await TestAsync(input, expected, DontQualifyMemberAccessWithThisOrMe)
+        End Function
+
+        <WorkItem(8381, "https://github.com/dotnet/roslyn/issues/8381")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function SimplifyMeRegardlessOfTypeAndOptionStrict3() As Task
+            Dim input =
+        <Workspace>
+            <Project Language="Visual Basic" CommonReferences="true">
+                <Document>
+Option Strict Off
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        {|SimplifyParent:Me.field1|} = 0
+        Me.field2 = 0
+    End Sub
+End Class
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+Option Strict Off
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        field1 = 0
+        Me.field2 = 0
+    End Sub
+End Class
+</text>
+
+            Await TestAsync(input, expected, DontQualifyMemberAccessWithThisOrMe)
+        End Function
+
+        <WorkItem(8381, "https://github.com/dotnet/roslyn/issues/8381")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function SimplifyMeRegardlessOfTypeAndOptionStrict4() As Task
+            Dim input =
+        <Workspace>
+            <Project Language="Visual Basic" CommonReferences="true">
+                <Document>
+Option Strict Off
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        Me.field1 = 0
+        {|SimplifyParent:Me.field2|} = 0
+    End Sub
+End Class
+                </Document>
+            </Project>
+        </Workspace>
+
+            Dim expected =
+              <text>
+Option Strict Off
+
+Class Class1
+    Private field1 As Short
+    Private field2 As Integer
+
+    Public Sub New()
+        Me.field1 = 0
+        field2 = 0
+    End Sub
+End Class
+</text>
+
+            Await TestAsync(input, expected, DontQualifyMemberAccessWithThisOrMe)
+        End Function
+
 #End Region
 
 #Region "Helpers"
 
         Shared DontPreferIntrinsicPredefinedTypeKeywordInDeclaration As Dictionary(Of OptionKey, Object) = New Dictionary(Of OptionKey, Object) From {{New OptionKey(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, LanguageNames.VisualBasic), False}}
+        Shared DontQualifyMemberAccessWithThisOrMe As Dictionary(Of OptionKey, Object) = New Dictionary(Of OptionKey, Object) From {{New OptionKey(SimplificationOptions.QualifyMemberAccessWithThisOrMe, LanguageNames.VisualBasic), False}}
 
 #End Region
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -16,16 +16,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal sealed class CSharpSimplifyTypeNamesDiagnosticAnalyzer : SimplifyTypeNamesDiagnosticAnalyzerBase<SyntaxKind>
     {
-        private static readonly ImmutableArray<SyntaxKind> s_kindsOfInterest = ImmutableArray.Create(SyntaxKind.QualifiedName,
+        private static readonly SyntaxKind[] s_kindsOfInterest = new[]
+        {
+            SyntaxKind.QualifiedName,
             SyntaxKind.AliasQualifiedName,
             SyntaxKind.GenericName,
             SyntaxKind.IdentifierName,
             SyntaxKind.SimpleMemberAccessExpression,
-            SyntaxKind.QualifiedCref);
+            SyntaxKind.QualifiedCref
+        };
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.RegisterSyntaxNodeAction(AnalyzeNode, s_kindsOfInterest.ToArray());
+            analysisContext.RegisterSyntaxNodeAction(AnalyzeNode, s_kindsOfInterest);
         }
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
@@ -14,13 +13,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
     Friend NotInheritable Class VisualBasicSimplifyTypeNamesDiagnosticAnalyzer
         Inherits SimplifyTypeNamesDiagnosticAnalyzerBase(Of SyntaxKind)
 
-        Private Shared ReadOnly s_kindsOfInterest As ImmutableArray(Of SyntaxKind) = ImmutableArray.Create(SyntaxKind.QualifiedName,
-                                                                                                          SyntaxKind.SimpleMemberAccessExpression,
-                                                                                                          SyntaxKind.IdentifierName,
-                                                                                                          SyntaxKind.GenericName)
+        Private Shared ReadOnly s_kindsOfInterest As SyntaxKind() =
+            {SyntaxKind.QualifiedName, SyntaxKind.SimpleMemberAccessExpression, SyntaxKind.IdentifierName, SyntaxKind.GenericName}
 
         Public Overrides Sub Initialize(context As AnalysisContext)
-            context.RegisterSyntaxNodeAction(AddressOf AnalyzeNode, s_kindsOfInterest.ToArray())
+            context.RegisterSyntaxNodeAction(AddressOf AnalyzeNode, s_kindsOfInterest)
         End Sub
 
         Protected Overrides Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
@@ -48,8 +45,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         End Sub
 
         Private Shared Function IsNodeKindInteresting(node As SyntaxNode) As Boolean
-            ' PERF: Use dedicated EqualityComparer to avoid boxing of enums.
-            Return s_kindsOfInterest.IndexOf(node.Kind, startIndex:=0, equalityComparer:=SyntaxFacts.EqualityComparer) >= 0
+            ' PERF: We use Array.IndexOf(Of T) below to avoid boxing of enums.
+            Return Array.IndexOf(s_kindsOfInterest, node.Kind) >= 0
         End Function
 
         Friend Shared Function IsCandidate(node As SyntaxNode) As Boolean

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -14,14 +14,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         Inherits SimplifyTypeNamesDiagnosticAnalyzerBase(Of SyntaxKind)
 
         Private Shared ReadOnly s_kindsOfInterest As SyntaxKind() =
-            {SyntaxKind.QualifiedName, SyntaxKind.SimpleMemberAccessExpression, SyntaxKind.IdentifierName, SyntaxKind.GenericName}
+        {
+            SyntaxKind.QualifiedName,
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxKind.IdentifierName,
+            SyntaxKind.GenericName
+        }
 
         Public Overrides Sub Initialize(context As AnalysisContext)
             context.RegisterSyntaxNodeAction(AddressOf AnalyzeNode, s_kindsOfInterest)
         End Sub
 
         Protected Overrides Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
-            If context.Node.Ancestors(ascendOutOfTrivia:=False).Any(Function(n) IsNodeKindInteresting(n)) Then
+            If context.Node.Ancestors(ascendOutOfTrivia:=False).Any(AddressOf IsNodeKindInteresting) Then
                 ' Already simplified an ancestor of this node.
                 Return
             End If
@@ -45,8 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         End Sub
 
         Private Shared Function IsNodeKindInteresting(node As SyntaxNode) As Boolean
-            ' PERF: We use Array.IndexOf(Of T) below to avoid boxing of enums.
-            Return Array.IndexOf(s_kindsOfInterest, node.Kind) >= 0
+            Return s_kindsOfInterest.Contains(node.Kind)
         End Function
 
         Friend Shared Function IsCandidate(node As SyntaxNode) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -538,7 +538,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
 
             If Me.OriginalSemanticModel.OptionStrict() <> OptionStrict.Off AndAlso
                Me.SpeculativeSemanticModel.GetConstantValue(newExpression).HasValue Then
-                Dim newExpressionType = Me.SpeculativeSemanticModel.GetTypeInfo(newExpression).Type
+                Dim newExpressionType = Me.SpeculativeSemanticModel.GetTypeInfo(newExpression).ConvertedType
                 newConversion = Me.OriginalSemanticModel.Compilation.ClassifyConversion(newExpressionType, newTargetType)
             End If
 


### PR DESCRIPTION
Fixes #8381

Previously, I'd made a fix to the speculation analyzer to not remove necessary casts in the presence of Option Strict On. For example:

```VB
Option Strict On
Class C
	Sub M()
		Dim b As Byte
		b += CByte(1)
	End Sub
End Class
```

This was fixed to address #2560. However, the fix was less than ideal because it had to work around the fact that there isn't a compiler API
available to retrieve the built-in operator of an AssignmentStatement in VB (#6366). Essentially, here's how the workaround works:

When Option Strict is not Off and an assignment statement is being replaced with another assignment statement, the workaround checks the type
of the new expression on the right and verifies that it's convertible to the type of the expression on the right. For the example above, it checks
to see if '1' (System.Int32) is implicitly convertible to 'b' (System.Byte), which it isn't. So, the cast is left behind for Option Strict On.

***...Fast forward to now...***

```VB
Option Strict On
Class C
	Privat i As Short
	Sub M()
		Me.i = 0
	End Sub
End Class
```

It turns out that this was caused by the workaround described above. With that workaround, we check to see if the '0' (System.Int32) is convertible
to 'Me.i' (System.Int16). It isn't, so things go askew. The fix is to use the *converted type* of the expression on the right (System.Int16) and check
to see if it is convertible to the type on the left.

tagging @dotnet/roslyn-ide 