### PR TITLE
Fix the NuGet package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash
 OS_NAME = $(shell uname -s)
-NUGET_PACKAGE_NAME = nuget.48
+NUGET_PACKAGE_NAME = nuget.50
 BUILD_CONFIGURATION = Debug
 BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
 BUILD_LOG_PATH =

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -3,7 +3,7 @@
 REM Parse Arguments.
 
 set NugetZipUrlRoot=https://dotnetci.blob.core.windows.net/roslyn
-set NugetZipUrl=%NuGetZipUrlRoot%/nuget.48.zip
+set NugetZipUrl=%NuGetZipUrlRoot%/nuget.50.zip
 set RoslynRoot=%~dp0
 set BuildConfiguration=Debug
 set BuildRestore=false

--- a/src/Tools/UploadNugetZip/CreateAndUpload.ps1
+++ b/src/Tools/UploadNugetZip/CreateAndUpload.ps1
@@ -23,7 +23,7 @@ echo "=           Clearing nuget caches"
 echo "==============================================="
 echo ""
 
- & $ScriptDir\..\..\..\nuget.exe locals all -clear
+& $ScriptDir\..\..\..\nuget.exe locals all -clear
 
 echo ""
 echo "==============================================="
@@ -31,7 +31,7 @@ echo "=       Restoring nuget to fill cache"
 echo "==============================================="
 echo ""
 
- & $ScriptDir\..\..\..\Restore.cmd
+& $ScriptDir\..\..\..\Restore.cmd
 
 echo ""
 echo "==============================================="
@@ -39,8 +39,8 @@ echo "=       Zipping $HOME/.nuget into $ScriptDir/$NugetZipName "
 echo "==============================================="
 echo ""
 
- Add-Type -Assembly "System.IO.Compression.FileSystem";
- [System.IO.Compression.ZipFile]::CreateFromDirectory("$HOME/.nuget", "$ScriptDir/$NugetZipName");
+Add-Type -Assembly "System.IO.Compression.FileSystem";
+[System.IO.Compression.ZipFile]::CreateFromDirectory("$HOME/.nuget", "$ScriptDir/$NugetZipName", "Fastest", $true);
 
 echo "Done"
 


### PR DESCRIPTION
The script for creating / uploading the NuGet file was failing to include the .nuget directory in the ZIP file.  That caused everything to be unpacked to ~\packages instead of ~\.nuget\packages.

The previous PR worked because the new packages weren't being actively used in the master branch (consumed in a child branch that's a WIP).  This PR corrects the issue in the upload scripts and re-generated the ZIP.