### PR TITLE
Formatting: Space after lock keyword

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentKind == SyntaxKind.OpenParenToken &&
                 (previousKind == SyntaxKind.IfKeyword || previousKind == SyntaxKind.WhileKeyword || previousKind == SyntaxKind.SwitchKeyword ||
                 previousKind == SyntaxKind.ForKeyword || previousKind == SyntaxKind.ForEachKeyword || previousKind == SyntaxKind.CatchKeyword ||
-                previousKind == SyntaxKind.UsingKeyword || previousKind == SyntaxKind.WhenKeyword))
+                previousKind == SyntaxKind.UsingKeyword || previousKind == SyntaxKind.WhenKeyword || previousKind == SyntaxKind.LockKeyword))
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpaceAfterControlFlowStatementKeyword);
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4878,6 +4878,7 @@ class Program
             await AssertFormatAsync(expected, code, changedOptionSet: optionSet);
         }
 
+        [WorkItem(176345, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/176345")]
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task TestSpacingOptionAfterControlFlowKeyword()
         {
@@ -4913,6 +4914,9 @@ class Program
 
         using (somevar)
         { }
+
+        lock (somevar)
+        { }
     }
 }";
             var expected = @"
@@ -4946,6 +4950,9 @@ class Program
         { }
 
         using(somevar)
+        { }
+
+        lock(somevar)
         { }
     }
 }";


### PR DESCRIPTION
Space Formatting Rule was missing lock keyword in checks for space after
control flow keywords.

Fixes internal bug 176345