### PR TITLE
Remove unnecessary Suppress operation around Else Statement

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
@@ -78,12 +78,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 AddSuppressWrappingIfOnSingleLineOperation(list, tokens.Item1, tokens.Item2);
             }
-
-            var ifStatementNode = node as IfStatementSyntax;
-            if (ifStatementNode?.Else != null)
-            {
-                AddSuppressWrappingIfOnSingleLineOperation(list, ifStatementNode.Else.ElseKeyword, ifStatementNode.Else.Statement.GetFirstToken(includeZeroWidth: true));
-            }
         }
 
         private void AddStatementExceptBlockSuppressOperations(List<SuppressOperation> list, SyntaxNode node)

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7238,5 +7238,42 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(6628, "https://github.com/dotnet/roslyn/issues/6628")]
+        public async Task SuppressOperationAroundSingleLineElseStatement()
+        {
+            var code = @"
+class C
+{
+    public void M()
+    {
+        if (true)
+        {
+        }
+        else { }
+    }
+}";
+            await AssertFormatAsync(code, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(6628, "https://github.com/dotnet/roslyn/issues/6628")]
+        public async Task SuppressOperationAroundSingleLineElseBoby()
+        {
+            var code = @"
+class C
+{
+    public void M()
+    {
+        if (true)
+        {
+        }
+        else
+        { }
+    }
+}";
+            await AssertFormatAsync(code, code);
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7208,5 +7208,35 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(6628, "https://github.com/dotnet/roslyn/issues/6628")]
+        public async Task RemoveUnnecessarySuppressOperationAroundElseStatement()
+        {
+            await AssertFormatAsync(@"
+class C
+{
+    public void M()
+    {
+        if (true)
+        {
+        }
+        else
+        {
+        }
+    }
+}", @"
+class C
+{
+    public void M()
+    {
+        if (true)
+        {
+        }
+        else {
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7211,7 +7211,7 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(6628, "https://github.com/dotnet/roslyn/issues/6628")]
-        public async Task RemoveUnnecessarySuppressOperationAroundElseStatement()
+        public async Task FormatElseBlockBracesOnDifferentLineToNewLines()
         {
             await AssertFormatAsync(@"
 class C
@@ -7241,7 +7241,7 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(6628, "https://github.com/dotnet/roslyn/issues/6628")]
-        public async Task SuppressOperationAroundSingleLineElseStatement()
+        public async Task FormatOnElseBlockBracesOnSameLineRemainsInSameLine_1()
         {
             var code = @"
 class C
@@ -7259,7 +7259,7 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(6628, "https://github.com/dotnet/roslyn/issues/6628")]
-        public async Task SuppressOperationAroundSingleLineElseBoby()
+        public async Task FormatOnElseBlockBracesOnSameLineRemainsInSameLine_2()
         {
             var code = @"
 class C


### PR DESCRIPTION
Fixes #6628

During some code refactoring an unnecessary suppress operation got
included. This fix removes the unnecessary addition

Review: @dotnet/roslyn-ide 