### PR TITLE
Change how we format on certain commit..

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -259,5 +259,62 @@ $$
             await VerifyItemInLinkedFilesAsync(markup, "public", null);
             await VerifyItemInLinkedFilesAsync(markup, "for", null);
         }
+
+        [WorkItem(7768, "https://github.com/dotnet/roslyn/issues/7768")]
+        [WorkItem(8228, "https://github.com/dotnet/roslyn/issues/8228")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task FormattingAfterCompletionCommit_AfterGetAccessorInSingleLineIncompleteProperty()
+        {
+            var markupBeforeCommit = @"class Program
+{
+    int P {g$$
+    void Main() { }
+}";
+
+            var expectedCodeAfterCommit = @"class Program
+{
+    int P {get;
+    void Main() { }
+}";
+            await VerifyProviderCommitAsync(markupBeforeCommit, "get", expectedCodeAfterCommit, commitChar: ';', textTypedSoFar: "g");
+        }
+
+        [WorkItem(7768, "https://github.com/dotnet/roslyn/issues/7768")]
+        [WorkItem(8228, "https://github.com/dotnet/roslyn/issues/8228")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task FormattingAfterCompletionCommit_AfterBothAccessorsInSingleLineIncompleteProperty()
+        {
+            var markupBeforeCommit = @"class Program
+{
+    int P {get;set$$
+    void Main() { }
+}";
+
+            var expectedCodeAfterCommit = @"class Program
+{
+    int P {get;set;
+    void Main() { }
+}";
+            await VerifyProviderCommitAsync(markupBeforeCommit, "set", expectedCodeAfterCommit, commitChar: ';', textTypedSoFar: "set");
+        }
+
+        [WorkItem(7768, "https://github.com/dotnet/roslyn/issues/7768")]
+        [WorkItem(8228, "https://github.com/dotnet/roslyn/issues/8228")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task FormattingAfterCompletionCommit_InSingleLineMethod()
+        {
+            var markupBeforeCommit = @"class Program
+{
+    public static void Test() { return$$
+    void Main() { }
+}";
+
+            var expectedCodeAfterCommit = @"class Program
+{
+    public static void Test() { return;
+    void Main() { }
+}";
+            await VerifyProviderCommitAsync(markupBeforeCommit, "return", expectedCodeAfterCommit, commitChar: ';', textTypedSoFar: "return");
+        }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -122,14 +123,32 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             var formattingService = document.GetLanguageService<IEditorFormattingService>();
-            if (formattingService != null &&
-                (item.ShouldFormatOnCommit || (commitChar != null && formattingService.SupportsFormattingOnTypedCharacter(document, commitChar.GetValueOrDefault()))))
+
+            var commitCharTriggersFormatting = commitChar != null && 
+                    (formattingService?.SupportsFormattingOnTypedCharacter(document, commitChar.GetValueOrDefault()) 
+                     ?? false);
+
+            if (formattingService != null && (item.ShouldFormatOnCommit || commitCharTriggersFormatting))
             {
                 // Formatting the completion item affected span is done as a separate transaction because this gives the user
                 // the flexibility to undo the formatting but retain the changes associated with the completion item
                 using (var formattingTransaction = _undoHistoryRegistry.GetHistory(this.TextView.TextBuffer).CreateTransaction(EditorFeaturesResources.IntelliSenseCommitFormatting))
                 {
-                    var changes = formattingService.GetFormattingChangesAsync(document, textChange.Span, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+                    var caretPoint = this.TextView.GetCaretPoint(this.SubjectBuffer);
+                    IList<TextChange> changes;
+                    if (commitCharTriggersFormatting && caretPoint.HasValue)
+                    {
+                        // if the commit character is supported by formatting service, then let the formatting service
+                        // find the appropriate range to format.
+                        changes = formattingService.GetFormattingChangesAsync(document, commitChar.Value, caretPoint.Value.Position, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+                    }
+                    else
+                    {
+                        // if this is not a supported trigger character for formatting service (space or tab etc.)
+                        // then format the span of the textchange.
+                        changes = formattingService.GetFormattingChangesAsync(document, textChange.Span, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+                    }
+
                     document.Project.Solution.Workspace.ApplyTextChanges(document.Id, changes, CancellationToken.None);
                     formattingTransaction.Complete();
                 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -149,7 +149,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                         changes = formattingService.GetFormattingChangesAsync(document, textChange.Span, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
                     }
 
-                    document.Project.Solution.Workspace.ApplyTextChanges(document.Id, changes, CancellationToken.None);
+                    if (changes != null && !changes.IsEmpty())
+                    {
+                        document.Project.Solution.Workspace.ApplyTextChanges(document.Id, changes, CancellationToken.None);
+                    }
+
                     formattingTransaction.Complete();
                 }
             }


### PR DESCRIPTION
..chars from completion. We used to call the formatting service from the
completion list with the span equal to that of the text that we
inserted, in all cases. This may not be the right approach in all cases
and that is manifested when we are formatting for a typed char that
happens to be the trigger character for the formatter as well. In such
cases we must find the right span to give to the formatter, or in other
words, the span the formatter would have come up with if it were
triggered first for the typed char. We do this by simply invoking the
appropriate formatting service API and giving it the typed char and its
position, which lets the formatting service to compute the right
span.
We do this only when were invoking the completion's commit char is also
a trigger for formatting. In other cases, we continue taking the
existing code path of formatting by giving it a known span.

Fixes #7768, #8228