### PR TITLE
Fix outlining for parenthesized lambdas

### DIFF
--- a/src/EditorFeatures/CSharp/Outlining/CSharpOutliningService.cs
+++ b/src/EditorFeatures/CSharp/Outlining/CSharpOutliningService.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Outlining
             builder.Add<MethodDeclarationSyntax, MethodDeclarationOutliner, MetadataAsSource.MethodDeclarationOutliner>();
             builder.Add<NamespaceDeclarationSyntax, NamespaceDeclarationOutliner>();
             builder.Add<OperatorDeclarationSyntax, OperatorDeclarationOutliner, MetadataAsSource.OperatorDeclarationOutliner>();
+            builder.Add<ParenthesizedLambdaExpressionSyntax, ParenthesizedLambdaExpressionOutliner>();
             builder.Add<PropertyDeclarationSyntax, PropertyDeclarationOutliner, MetadataAsSource.PropertyDeclarationOutliner>();
             builder.Add<RegionDirectiveTriviaSyntax, RegionDirectiveOutliner, MetadataAsSource.RegionDirectiveOutliner>();
             builder.Add<SimpleLambdaExpressionSyntax, SimpleLambdaExpressionOutliner>();

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -256,6 +256,7 @@
     <Compile Include="Outlining\AbstractSyntaxNodeOutlinerTests.cs" />
     <Compile Include="Outlining\AbstractSyntaxOutlinerTests.cs" />
     <Compile Include="Outlining\AbstractSyntaxTriviaOutlinerTests.cs" />
+    <Compile Include="Outlining\OutliningServiceTests.cs" />
     <Compile Include="Preview\TestOnly_CompilerDiagnosticAnalyzerProviderService.cs" />
     <Compile Include="DocCommentFormatting\DocCommentFormattingTests.cs" />
     <Compile Include="DocumentationComments\AbstractDocumentationCommentTests.cs" />

--- a/src/EditorFeatures/Test/Outlining/OutliningServiceTests.cs
+++ b/src/EditorFeatures/Test/Outlining/OutliningServiceTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Implementation.Outlining;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Outlining
+{
+    public class OutliningServiceTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestSimpleLambda()
+        {
+            var code =
+@"using System.Linq;
+class C
+{
+    static void Foo()
+    {
+        var q = Enumerable.Range(1, 100).Where(x =>
+        {
+            return x % 2 == 0;
+        });
+    }
+}
+";
+
+            using (var workspace = await TestWorkspace.CreateCSharpAsync(code))
+            {
+                var spans = await GetSpansFromWorkspaceAsync(workspace);
+
+                // ensure all 4 outlining region tags were found (usings, class, method, lambda)
+                Assert.Equal(4, spans.Count);
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestParenthesizedLambda()
+        {
+            var code =
+@"using System.Linq;
+class C
+{
+    static void Foo()
+    {
+        var q = Enumerable.Range(1, 100).Where((x) =>
+        {
+            return x % 2 == 0;
+        });
+    }
+}
+";
+
+            using (var workspace = await TestWorkspace.CreateCSharpAsync(code))
+            {
+                var spans = await GetSpansFromWorkspaceAsync(workspace);
+
+                // ensure all 4 outlining region tags were found (usings, class, method, lambda)
+                Assert.Equal(4, spans.Count);
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestAnonymousDelegate()
+        {
+            var code =
+@"using System.Linq;
+class C
+{
+    static void Foo()
+    {
+        var q = Enumerable.Range(1, 100).Where(delegate (int x)
+        {
+            return x % 2 == 0;
+        });
+    }
+}
+";
+
+            using (var workspace = await TestWorkspace.CreateCSharpAsync(code))
+            {
+                var spans = await GetSpansFromWorkspaceAsync(workspace);
+
+                // ensure all 4 outlining region tags were found (usings, class, method, anonymous delegate)
+                Assert.Equal(4, spans.Count);
+            }
+        }
+
+        private static async Task<IList<OutliningSpan>> GetSpansFromWorkspaceAsync(TestWorkspace workspace)
+        {
+            var hostDocument = workspace.Documents.First();
+            var document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
+            var outliningService = document.Project.LanguageServices.GetService<IOutliningService>();
+
+            return await outliningService.GetOutliningSpansAsync(document, CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8259

We shipped with outlining working for simple lambdas and anonymous delegates, but parenthesized lambdas apparently got missed at some point.

tagging @dotnet/roslyn-ide 