### PR TITLE
Detect and report mismatch in nullability of reference types within constructed types during flow analysis.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2121,10 +2121,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, ErrorCode.ERR_ArrayElementCantBeRefAny, node, bestType);
             }
 
-            // Default inferred reference types to a nullable state.
-            var arrayType = ArrayTypeSymbol.CreateCSharpArray(Compilation.Assembly, 
-                                                              TypeSymbolWithAnnotations.Create(bestType, isNullableIfReferenceType: node.IsFeatureStaticNullCheckingEnabled()), 
-                                                              rank);
+            TypeSymbolWithAnnotations elementType;
+
+            if (node.IsFeatureStaticNullCheckingEnabled())
+            {
+                // For now erase all notion about nullability of reference types as the algorithm is not taking it into account yet.
+                // Default inferred reference type itself to a nullable state.
+                elementType = TypeSymbolWithAnnotations.Create(bestType.SetUnknownNullabilityForRefernceTypes(), isNullableIfReferenceType: true);
+            }
+            else
+            {
+                elementType = TypeSymbolWithAnnotations.Create(bestType);
+            }
+
+            var arrayType = ArrayTypeSymbol.CreateCSharpArray(Compilation.Assembly, elementType, rank);
             return BindArrayCreationWithInitializer(diagnostics, node, initializer, arrayType,
                 sizes: ImmutableArray<BoundExpression>.Empty, boundInitExprOpt: boundInitializerExpressions);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1354,5 +1354,9 @@
     <Field Name="Alignment" Type="BoundExpression" Null="allow"/>
     <Field Name="Format" Type="BoundExpression" Null="allow"/>
   </Node>
-  
+
+  <!-- Special node, used only during Data Flow Pass -->
+  <Node Name="BoundValuePlaceholder" Base="BoundExpression">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+  </Node>
 </Tree>

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -12444,6 +12444,60 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in argument of type &apos;{0}&apos; doesn&apos;t match target type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos;..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInArgument {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in argument doesn&apos;t match target type..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInArgument_Title {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInArgument_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in value of type &apos;{0}&apos; doesn&apos;t match target type &apos;{1}&apos;..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInAssignment {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInAssignment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in value doesn&apos;t match target type..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInAssignment_Title {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInAssignment_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in type of parameter &apos;{0}&apos; of &apos;{1}&apos; doesn&apos;t match the target delegate &apos;{2}&apos;..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInParameterTypeOfTargetDelegate {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInParameterTypeOfTargetDelegate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in type of parameter doesn&apos;t match the target delegate..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInParameterTypeOfTargetDelegate_Title {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInParameterTypeOfTargetDelegate_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Nullability of reference types in type of parameter &apos;{0}&apos; doesn&apos;t match implemented member &apos;{1}&apos;..
         /// </summary>
         internal static string WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation {
@@ -12512,6 +12566,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string WRN_NullabilityMismatchInParameterTypeOnPartial_Title {
             get {
                 return ResourceManager.GetString("WRN_NullabilityMismatchInParameterTypeOnPartial_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in return type of &apos;{0}&apos; doesn&apos;t match the target delegate &apos;{1}&apos;..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInReturnTypeOfTargetDelegate {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInReturnTypeOfTargetDelegate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nullability of reference types in return type doesn&apos;t match the target delegate..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInReturnTypeOfTargetDelegate_Title {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInReturnTypeOfTargetDelegate_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4801,4 +4801,28 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_NullableAttributeMissing" xml:space="preserve">
     <value>Compiler required type '{0}' cannot be found. Are you missing a reference?</value>
   </data>
+  <data name="WRN_NullabilityMismatchInAssignment" xml:space="preserve">
+    <value>Nullability of reference types in value of type '{0}' doesn't match target type '{1}'.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInAssignment_Title" xml:space="preserve">
+    <value>Nullability of reference types in value doesn't match target type.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInArgument" xml:space="preserve">
+    <value>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInArgument_Title" xml:space="preserve">
+    <value>Nullability of reference types in argument doesn't match target type.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInReturnTypeOfTargetDelegate" xml:space="preserve">
+    <value>Nullability of reference types in return type of '{0}' doesn't match the target delegate '{1}'.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInReturnTypeOfTargetDelegate_Title" xml:space="preserve">
+    <value>Nullability of reference types in return type doesn't match the target delegate.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInParameterTypeOfTargetDelegate" xml:space="preserve">
+    <value>Nullability of reference types in type of parameter '{0}' of '{1}' doesn't match the target delegate '{2}'.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInParameterTypeOfTargetDelegate_Title" xml:space="preserve">
+    <value>Nullability of reference types in type of parameter doesn't match the target delegate.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1342,5 +1342,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation = 8216,
         WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation = 8217,
         ERR_NullableAttributeMissing = 8218,
+        WRN_NullabilityMismatchInAssignment = 8219,
+        WRN_NullabilityMismatchInArgument = 8220,
+        WRN_NullabilityMismatchInReturnTypeOfTargetDelegate = 8221,
+        WRN_NullabilityMismatchInParameterTypeOfTargetDelegate = 8222,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -329,6 +329,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation:
+                case ErrorCode.WRN_NullabilityMismatchInAssignment:
+                case ErrorCode.WRN_NullabilityMismatchInArgument:
+                case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
+                case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, bool? isNullableIfReferenceType)
         {
-            if (isNullableIfReferenceType == false || !typeSymbol.IsReferenceType)
+            if (isNullableIfReferenceType == false || !typeSymbol.IsReferenceType || typeSymbol.IsNullableType())
             {
                 return Create(typeSymbol);
             }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -228,6 +228,10 @@ class X
                         case ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation:
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation:
+                        case ErrorCode.WRN_NullabilityMismatchInAssignment:
+                        case ErrorCode.WRN_NullabilityMismatchInArgument:
+                        case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
+                        case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         default:


### PR DESCRIPTION
@dotnet/roslyn-compiler Please review.