### PR TITLE
Correctly localize the "Failure" and "Warning" strings

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnostic.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceDiagnostic.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public class WorkspaceDiagnostic
     {
         public WorkspaceDiagnosticKind Kind { get; }
@@ -18,13 +18,16 @@ namespace Microsoft.CodeAnalysis
 
         public override string ToString()
         {
-            return GetDebuggerDisplay();
-        }
+            string kindText;
 
-        /// <remarks>Internal for testing purposes</remarks>
-        internal string GetDebuggerDisplay()
-        {
-            return string.Format("[{0}] {1}", this.Kind.ToString(), this.Message);
+            switch (Kind)
+            {
+                case WorkspaceDiagnosticKind.Failure: kindText = WorkspacesResources.Failure; break;
+                case WorkspaceDiagnosticKind.Warning: kindText = WorkspacesResources.Warning; break;
+                default: throw ExceptionUtilities.UnexpectedValue(Kind);
+            }
+
+            return $"[{kindText}] {Message}";
         }
     }
 }

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -431,6 +431,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failure.
+        /// </summary>
+        internal static string Failure {
+            get {
+                return ResourceManager.GetString("Failure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File was externally modified: {0}..
         /// </summary>
         internal static string FileWasExternallyModified {
@@ -1066,6 +1075,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string ValueTooLargeToBeRepresented {
             get {
                 return ResourceManager.GetString("ValueTooLargeToBeRepresented", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning.
+        /// </summary>
+        internal static string Warning {
+            get {
+                return ResourceManager.GetString("Warning", resourceCulture);
             }
         }
         

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -459,4 +459,10 @@
   <data name="FixableDiagnosticIdsIncorrectlyInitialized" xml:space="preserve">
     <value>'{0}' returned an uninitialized ImmutableArray</value>
   </data>
+  <data name="Failure" xml:space="preserve">
+    <value>Failure</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
 </root>

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -1299,7 +1299,7 @@ End Class";
             Assert.NotNull(diagnostic);
             var dd = diagnostic as DocumentDiagnostic;
             Assert.NotNull(dd);
-            Assert.Equal(dd.GetDebuggerDisplay(), string.Format("[{0}] {1}", dd.Kind.ToString(), dd.Message));
+            Assert.Equal(dd.ToString(), string.Format("[{0}] {1}", WorkspacesResources.Failure, dd.Message));
         }
 
         private bool WaitFor(Func<bool> condition, TimeSpan timeout)


### PR DESCRIPTION
*Review:* @dotnet/roslyn-ide 

Fixes part of internal bug 163139.