### PR TITLE
Normalize paths when generating pipe names

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             if (string.IsNullOrEmpty(pipeName))
             {
                 var clientDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                pipeName = DesktopBuildClient.GetPipeNameFromFileInfo(clientDirectory);
+                pipeName = DesktopBuildClient.GetPipeNameForPath(clientDirectory);
             }
 
             var mutexName = BuildProtocolConstants.GetServerMutexName(pipeName);

--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -284,5 +284,18 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.Null(_sessionKey);
             }
         }
+
+        public class MiscTest
+        {
+            [Fact]
+            public void GetBasePipeNameSlashes()
+            {
+                var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
+                var name = DesktopBuildClient.GetBasePipeName(path);
+                Assert.Equal(name, DesktopBuildClient.GetBasePipeName(path));
+                Assert.Equal(name, DesktopBuildClient.GetBasePipeName(path + Path.DirectorySeparatorChar));
+                Assert.Equal(name, DesktopBuildClient.GetBasePipeName(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
+            }
+        }
     }
 }


### PR DESCRIPTION
It turns out APIs are very inconsistent in whether they leave a trailing directory separator on path names.  This caused the client and server code to generate different pipe names for the same file location.  Hence VbcsCompiler -shutdown was failing because it used the wrong pipe name.  Fix this by normalizing path names.