### PR TITLE
Stop deploying extension in BuildAndTest.proj

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -17,42 +17,46 @@
     <OutputDirectory>Binaries\$(Configuration)</OutputDirectory>
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages</NuGetPackageRoot>
     <XunitVersion>2.1.0</XunitVersion>
-    <DeployExtension>false</DeployExtension>
+    <MSBuildCommonProperties>
+      RestorePackages=false;
+      TreatWarningsAsErrors=true;
+      DeployExtension=false;
+    </MSBuildCommonProperties>
   </PropertyGroup>
 
   <Target Name="Build">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="$(MSBuildCommonProperties)"
              Targets="Build"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"
              Projects="$(SamplesSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="$(MSBuildCommonProperties)"
              Targets="Build"/>
   </Target>
 
   <Target Name="Clean">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false"
+             Properties="$(MSBuildCommonProperties)"
              Targets="Clean"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"
              Projects="$(SamplesSolution)"
-             Properties="RestorePackages=false"
+             Properties="$(MSBuildCommonProperties)"
              Targets="Clean"/>
   </Target>
 
   <Target Name="Rebuild">
     <MSBuild BuildInParallel="true"
              Projects="$(RoslynSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="$(MSBuildCommonProperties)"
              Targets="Rebuild"/>
     <MSBuild BuildInParallel="true"
              Condition="'$(ManualTest)' == ''"
              Projects="$(SamplesSolution)"
-             Properties="RestorePackages=false;TreatWarningsAsErrors=true"
+             Properties="$(MSBuildCommonProperties)"
              Targets="Rebuild"/>
   </Target>
 


### PR DESCRIPTION
Fixes #8498

2ed2262 caused CIBuild's to start deploying extensions
because properties are not inherited by nested MSBuild
instances. Actually pass down DeployExtension=false.