### PR TITLE
Adjust the Portable PDB validation code to account for missing VB fake locals

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -370,7 +370,7 @@ End Module
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494"), WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
+        <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
         Public Sub LocalCapturedInBetweenSuspensionPoints_Debug()
             Dim source =
 <compilation>
@@ -444,7 +444,7 @@ End Class
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494")>
+        <Fact>
         Public Sub LocalCapturedInBetweenSuspensionPoints_Release()
             Dim source =
 <compilation>
@@ -506,7 +506,7 @@ End Class
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494"), WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
+        <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
         Public Sub LocalNotCapturedInBetweenSuspensionPoints_Debug()
             Dim source =
 <compilation>
@@ -578,7 +578,7 @@ End Class
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494")>
+        <Fact>
         Public Sub LocalNotCapturedInBetweenSuspensionPoints_Release()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
@@ -126,7 +126,7 @@ End Module
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494"), WorkItem(651996, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/651996"), WorkItem(789705, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/789705")>
+        <Fact, WorkItem(651996, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/651996"), WorkItem(789705, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/789705")>
         Public Sub IteratorWithLiftedMultipleSameNameLocals()
             Dim source =
 <compilation>
@@ -219,7 +219,7 @@ End Module
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494"), WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
+        <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
         Public Sub LocalCapturedAndHoisted()
             Dim source =
 <compilation>
@@ -273,7 +273,7 @@ End Class
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494"), WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
+        <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
         Public Sub LocalCapturedAndNotHoisted()
             Dim source =
 <compilation>
@@ -322,7 +322,7 @@ End Class
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494"), WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
+        <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
         Public Sub LocalHoistedAndNotCapture()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -4349,7 +4349,7 @@ End Class
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494")>
+        <Fact>
         Public Sub ImportsInAsync()
             Dim source =
 "Imports System.Linq
@@ -4394,7 +4394,7 @@ End Class"
 </symbols>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8494")>
+        <Fact>
         Public Sub ImportsInAsyncLambda()
             Dim source =
 "Imports System.Linq

--- a/src/Test/Utilities/Shared/Pdb/PdbValidation.cs
+++ b/src/Test/Utilities/Shared/Pdb/PdbValidation.cs
@@ -143,14 +143,20 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private static void RemoveEmptyScopes(XElement pdb)
         {
-            var emptyScopes = from e in pdb.DescendantsAndSelf()
-                              where e.Name == "scope" && !e.HasElements
-                              select e;
+            XElement[] emptyScopes;
 
-            foreach (var e in emptyScopes.ToArray())
+            do
             {
-                e.Remove();
+                emptyScopes = (from e in pdb.DescendantsAndSelf()
+                               where e.Name == "scope" && !e.HasElements
+                               select e).ToArray();
+
+                foreach (var e in emptyScopes)
+                {
+                    e.Remove();
+                }
             }
+            while (emptyScopes.Any());
         }
 
         private static void RemoveEmptySequencePoints(XElement pdb)
@@ -190,7 +196,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                             e.Name == "type" ||
                                             e.Name == "defunct" ||
                                             e.Name == "extern" ||
-                                            e.Name == "externinfo"
+                                            e.Name == "externinfo" ||
+                                            e.Name == "local" && e.Attributes().Any(a => a.Name.LocalName == "name" && a.Value.StartsWith("$VB$ResumableLocal_"))
                                       select e;
 
             foreach (var e in nonPortableElements.ToArray())


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/8494.