### PR TITLE
Verify that bound node has ConstantValue even when underlying symbol has one.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -916,13 +916,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             userDefinedConversionsMightStillBeApplicable = False
             Dim conv As ConversionKind
 
-            ' Using <symbol>.IsConstant() for field accesses can result in an infinite loop.
-            ' To detect such a loop pass the already visited constants from the binder.
+            ' Using source.IsConstant for field accesses can result in an infinite loop.
+            ' To resolve the cycle, first call GetConstantValue with the already visited constants from the binder.                  
+            ' The check for source.IsConstant is still necessary because the node might still 
+            ' be considered as a non-constant in some error conditions (a reference before declaration,
+            ' for example).
             Dim sourceIsConstant As Boolean = False
             If source.Kind = BoundKind.FieldAccess Then
-                sourceIsConstant = DirectCast(source, BoundFieldAccess).FieldSymbol.GetConstantValue(binder.ConstantFieldsInProgress) IsNot Nothing
+                sourceIsConstant = DirectCast(source, BoundFieldAccess).FieldSymbol.GetConstantValue(binder.ConstantFieldsInProgress) IsNot Nothing AndAlso source.IsConstant
             ElseIf source.Kind = BoundKind.Local Then
-                sourceIsConstant = DirectCast(source, BoundLocal).LocalSymbol.GetConstantValue(binder) IsNot Nothing
+                sourceIsConstant = DirectCast(source, BoundLocal).LocalSymbol.GetConstantValue(binder) IsNot Nothing AndAlso source.IsConstant
             Else
                 sourceIsConstant = source.IsConstant
             End If

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -4727,5 +4727,28 @@ Expected - 2
             CompileAndVerify(compilation, expectedOutput:=expectedOutput).VerifyDiagnostics()
         End Sub
 
+        <WorkItem(8475, "https://github.com/dotnet/roslyn/issues/8475")>
+        <Fact()>
+        Public Sub ConvertConstantBeforeItsDeclaration()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Class Program
+    Shared Sub Main()
+        Dim x as Integer = STR
+        Const STR As String = ""
+    End Sub
+End Class
+    ]]></file>
+    </compilation>, options:=TestOptions.ReleaseExe)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC32000: Local variable 'STR' cannot be referred to before it is declared.
+        Dim x as Integer = STR
+                           ~~~
+</expected>)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixed #8475.

@dotnet/roslyn-compiler Please review.