### PR TITLE
Test projects automatically inherit app.config

### DIFF
--- a/build/Defaults/app.config
+++ b/build/Defaults/app.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- The default app.config for test projects that do not specify one -->
+<configuration>
+  <appSettings>
+    <add key="xunit.appDomain" value="denied"/>
+    <add key="xunit.diagnosticMessages" value="false"/>
+    <add key="xunit.parallelizeTestCollections" value="false"/>
+  </appSettings>
+  <system.diagnostics>
+    <trace>
+      <listeners>
+        <remove name="Default" />
+        <add name="ThrowingTraceListener" type="Microsoft.CodeAnalysis.ThrowingTraceListener, Roslyn.Test.Utilities.Desktop" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
+</configuration>

--- a/build/Targets/Roslyn.Toolsets.Xunit.targets
+++ b/build/Targets/Roslyn.Toolsets.Xunit.targets
@@ -18,4 +18,22 @@
     <StartArguments Condition="'$(StartArguments)' == ''">$(XUnitArguments)</StartArguments>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PrepareForBuildDependsOn>$(PrepareForBuildDependsOn);AddDefaultTestAppConfig</PrepareForBuildDependsOn>
+  </PropertyGroup>
+
+  <!-- Add a default test app.config, if the project doesn't already have one-->
+  <Target Name="AddDefaultTestAppConfig">
+    <PropertyGroup>
+      <_AlreadyHasAppConfig Condition="'%(None.Filename)%(None.Extension)' == 'app.config'">true</_AlreadyHasAppConfig>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(_AlreadyHasAppConfig)' != 'true'">
+      <None Include="$(MSBuildThisFileDirectory)..\Defaults\app.config">
+        <Link>app.config</Link>
+      </None>
+    </ItemGroup>
+
+  </Target>
+
 </Project>


### PR DESCRIPTION
Changed it so that all projects inherit a "default"
app.config if one isn't explictly referenced.