### PR TITLE
Fix and enable failing C# xplat syntax tests

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/LocationsTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/LocationsTests.cs
@@ -203,7 +203,7 @@ class X {
             AssertMappedSpanEqual(syntaxTree, "int s", "seconddirective", 19, 4, 19, 9, hasMappedPath: true);
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestLineMappingNoDirectives()
         {
             string sampleProgram = @"using System;
@@ -214,7 +214,7 @@ int x;
 
             AssertMappedSpanEqual(syntaxTree, "ing Sy", "c:\\foo.cs", 0, 2, 0, 8, hasMappedPath: false);
             AssertMappedSpanEqual(syntaxTree, "class X", "c:\\foo.cs", 1, 0, 1, 7, hasMappedPath: false);
-            AssertMappedSpanEqual(syntaxTree, "System;\r\nclass X", "c:\\foo.cs", 0, 6, 1, 7, hasMappedPath: false);
+            AssertMappedSpanEqual(syntaxTree, $"System;{Environment.NewLine}class X", "c:\\foo.cs", 0, 6, 1, 7, hasMappedPath: false);
             AssertMappedSpanEqual(syntaxTree, "x;", "c:\\foo.cs", 2, 4, 2, 6, hasMappedPath: false);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -2015,7 +2015,7 @@ return (i);
         }
 
         [WorkItem(2958, "DevDiv_Projects/Roslyn")]
-        [ClrOnlyFact]
+        [Fact]
         [Trait("Feature", "Directives")]
         public void TestRegionWithSingleLineComment()
         {
@@ -2030,14 +2030,14 @@ return (i);
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal("#region A//B\r\n", regionDirective.ToFullString());
+            Assert.Equal($"#region A//B{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("A//B", regionText.ToFullString());
         }
 
         [WorkItem(2958, "DevDiv_Projects/Roslyn")]
-        [ClrOnlyFact]
+        [Fact]
         [Trait("Feature", "Directives")]
         public void TestRegionWithInvalidSingleLineComment()
         {
@@ -2052,7 +2052,7 @@ return (i);
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal("#region A/\\B\r\n", regionDirective.ToFullString());
+            Assert.Equal($"#region A/\\B{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("A/\\B", regionText.ToFullString());

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -95,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, leading[0].ToFullString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestEmptyElementNoAttributesPrecedingClass()
         {
             var text =
@@ -110,7 +111,7 @@ class C { }";
             Assert.Equal(1, leading.Count);
             var node = leading[0];
             Assert.Equal(SyntaxKind.SingleLineDocumentationCommentTrivia, node.Kind());
-            Assert.Equal("/// <foo />\r\n", node.ToFullString());
+            Assert.Equal($"/// <foo />{Environment.NewLine}", node.ToFullString());
             var doc = (DocumentationCommentTriviaSyntax)node.GetStructure();
             Assert.Equal(3, doc.Content.Count);
             Assert.Equal(SyntaxKind.XmlText, doc.Content[0].Kind());
@@ -265,7 +266,7 @@ class C { }";
             Assert.Equal("x\"y\"z", attr.TextTokens[0].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestEmptyElementNoAttributesMultipleLines()
         {
             var text =
@@ -285,10 +286,10 @@ class C { }";
             Assert.Equal(SyntaxKind.XmlText, doc.Content[0].Kind());
             Assert.True(doc.Content[0].HasLeadingTrivia);
             Assert.Equal(SyntaxKind.XmlEmptyElement, doc.Content[1].Kind());
-            Assert.Equal("<foo \r\n/// />", doc.Content[1].ToFullString());
+            Assert.Equal($"<foo {Environment.NewLine}/// />", doc.Content[1].ToFullString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestEmptyElementNoAttributesMultipleLinesPrecedingClass()
         {
             var text =
@@ -303,17 +304,17 @@ class C { }";
             Assert.Equal(1, leading.Count);
             var node = leading[0];
             Assert.Equal(SyntaxKind.SingleLineDocumentationCommentTrivia, node.Kind());
-            Assert.Equal("/// <foo \r\n/// />\r\n", node.ToFullString());
+            Assert.Equal($"/// <foo {Environment.NewLine}/// />{Environment.NewLine}", node.ToFullString());
             var doc = (DocumentationCommentTriviaSyntax)node.GetStructure();
             Assert.Equal(3, doc.Content.Count);
             Assert.Equal(SyntaxKind.XmlText, doc.Content[0].Kind());
             Assert.True(doc.Content[0].HasLeadingTrivia);
             Assert.Equal(SyntaxKind.XmlEmptyElement, doc.Content[1].Kind());
-            Assert.Equal("<foo \r\n/// />", doc.Content[1].ToFullString());
+            Assert.Equal($"<foo {Environment.NewLine}/// />", doc.Content[1].ToFullString());
             Assert.Equal(SyntaxKind.XmlText, doc.Content[2].Kind());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestEmptyElementNoAttributesMultipleLinesDelimited()
         {
             var text =
@@ -334,7 +335,7 @@ class C { }";
             Assert.Equal(SyntaxKind.XmlText, doc.Content[0].Kind());
             Assert.True(doc.Content[0].HasLeadingTrivia);
             Assert.Equal(SyntaxKind.XmlEmptyElement, doc.Content[1].Kind());
-            Assert.Equal("<foo \r\n  * />", doc.Content[1].ToFullString());
+            Assert.Equal($"<foo {Environment.NewLine}  * />", doc.Content[1].ToFullString());
             Assert.Equal(SyntaxKind.XmlText, doc.Content[2].Kind());
         }
 
@@ -354,13 +355,13 @@ class C { }";
             Assert.Equal(2, leading.Count);
             var node = leading[0];
             Assert.Equal(SyntaxKind.MultiLineDocumentationCommentTrivia, node.Kind());
-            Assert.Equal("/** <foo \r\n  * />\r\n  */", node.ToFullString());
+            Assert.Equal($"/** <foo {Environment.NewLine}  * />{Environment.NewLine}  */", node.ToFullString());
             var doc = (DocumentationCommentTriviaSyntax)node.GetStructure();
             Assert.Equal(3, doc.Content.Count);
             Assert.Equal(SyntaxKind.XmlText, doc.Content[0].Kind());
             Assert.True(doc.Content[0].HasLeadingTrivia);
             Assert.Equal(SyntaxKind.XmlEmptyElement, doc.Content[1].Kind());
-            Assert.Equal("<foo \r\n  * />", doc.Content[1].ToFullString());
+            Assert.Equal($"<foo {Environment.NewLine}  * />", doc.Content[1].ToFullString());
             Assert.Equal(SyntaxKind.XmlText, doc.Content[2].Kind());
         }
 
@@ -701,7 +702,7 @@ class C { }";
             Assert.NotEqual(0, doc.ErrorsAndWarnings().Length);
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestNonEmptyElementNoAttributes()
         {
             var text =
@@ -728,13 +729,13 @@ class C { }";
             Assert.Equal(1, element.Content.Count);
             var textsyntax = (XmlTextSyntax)element.Content[0];
             Assert.Equal(4, textsyntax.ChildNodesAndTokens().Count);
-            Assert.Equal("\r\n", textsyntax.ChildNodesAndTokens()[0].ToString());
+            Assert.Equal(Environment.NewLine, textsyntax.ChildNodesAndTokens()[0].ToString());
             Assert.Equal(" bar", textsyntax.ChildNodesAndTokens()[1].ToString());
-            Assert.Equal("\r\n", textsyntax.ChildNodesAndTokens()[2].ToString());
+            Assert.Equal(Environment.NewLine, textsyntax.ChildNodesAndTokens()[2].ToString());
             Assert.Equal(" ", textsyntax.ChildNodesAndTokens()[3].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestNonEmptyElementNoAttributesDelimited()
         {
             var text =
@@ -762,13 +763,13 @@ class C { }";
             Assert.Equal(1, element.Content.Count);
             var textsyntax = (XmlTextSyntax)element.Content[0];
             Assert.Equal(4, textsyntax.ChildNodesAndTokens().Count);
-            Assert.Equal("\r\n", textsyntax.ChildNodesAndTokens()[0].ToString());
+            Assert.Equal(Environment.NewLine, textsyntax.ChildNodesAndTokens()[0].ToString());
             Assert.Equal(" bar", textsyntax.ChildNodesAndTokens()[1].ToString());
-            Assert.Equal("\r\n", textsyntax.ChildNodesAndTokens()[2].ToString());
+            Assert.Equal(Environment.NewLine, textsyntax.ChildNodesAndTokens()[2].ToString());
             Assert.Equal(" ", textsyntax.ChildNodesAndTokens()[3].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestCDataSection()
         {
             var text =
@@ -792,13 +793,13 @@ class C { }";
             var cdata = (XmlCDataSectionSyntax)doc.Content[1];
             Assert.Equal(5, cdata.TextTokens.Count);
             Assert.Equal(" this is a test", cdata.TextTokens[0].ToString());
-            Assert.Equal("\r\n", cdata.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, cdata.TextTokens[1].ToString());
             Assert.Equal(" of &some; cdata /// */ /**", cdata.TextTokens[2].ToString());
-            Assert.Equal("\r\n", cdata.TextTokens[3].ToString());
+            Assert.Equal(Environment.NewLine, cdata.TextTokens[3].ToString());
             Assert.Equal(" \"']]<>/></text", cdata.TextTokens[4].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestCDataSectionDelimited()
         {
             var text =
@@ -823,9 +824,9 @@ class C { }";
             var cdata = (XmlCDataSectionSyntax)doc.Content[1];
             Assert.Equal(5, cdata.TextTokens.Count);
             Assert.Equal(" this is a test", cdata.TextTokens[0].ToString());
-            Assert.Equal("\r\n", cdata.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, cdata.TextTokens[1].ToString());
             Assert.Equal(" of &some; cdata", cdata.TextTokens[2].ToString());
-            Assert.Equal("\r\n", cdata.TextTokens[3].ToString());
+            Assert.Equal(Environment.NewLine, cdata.TextTokens[3].ToString());
             Assert.Equal(" \"']]<>/></text", cdata.TextTokens[4].ToString());
             Assert.Equal(SyntaxKind.XmlText, doc.Content[2].Kind());
         }
@@ -854,7 +855,7 @@ class C { }";
             Assert.Equal(" incomplete", cdata.TextTokens[0].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestIncompleteEOLCDataSection()
         {
             var text = @"/// <![CDATA[ incomplete
@@ -867,7 +868,7 @@ class C { }"; // end of line/comment
             Assert.Equal(1, leading.Count);
             var node = leading[0];
             Assert.Equal(SyntaxKind.SingleLineDocumentationCommentTrivia, node.Kind());
-            Assert.Equal("/// <![CDATA[ incomplete\r\n", node.ToFullString());
+            Assert.Equal($"/// <![CDATA[ incomplete{Environment.NewLine}", node.ToFullString());
             var doc = (DocumentationCommentTriviaSyntax)node.GetStructure();
             Assert.Equal(2, doc.Content.Count);
             Assert.Equal(SyntaxKind.XmlText, doc.Content[0].Kind());
@@ -877,7 +878,7 @@ class C { }"; // end of line/comment
             Assert.Equal(1, cdata.ErrorsAndWarnings().Length);
             Assert.Equal(2, cdata.TextTokens.Count);
             Assert.Equal(" incomplete", cdata.TextTokens[0].ToString());
-            Assert.Equal("\r\n", cdata.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, cdata.TextTokens[1].ToString());
         }
 
         [Fact]
@@ -930,7 +931,7 @@ class C { }"; // end of line/comment
             Assert.Equal(" incomplete", cdata.TextTokens[0].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestComment()
         {
             var text =
@@ -954,13 +955,13 @@ class C { }"; // end of line/comment
             var comment = (XmlCommentSyntax)doc.Content[1];
             Assert.Equal(5, comment.TextTokens.Count);
             Assert.Equal(" this is a test", comment.TextTokens[0].ToString());
-            Assert.Equal("\r\n", comment.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, comment.TextTokens[1].ToString());
             Assert.Equal(" of &some; comment", comment.TextTokens[2].ToString());
-            Assert.Equal("\r\n", comment.TextTokens[3].ToString());
+            Assert.Equal(Environment.NewLine, comment.TextTokens[3].ToString());
             Assert.Equal(" \"']]<>/></text", comment.TextTokens[4].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestCommentDelimited()
         {
             var text =
@@ -985,9 +986,9 @@ class C { }"; // end of line/comment
             var comment = (XmlCommentSyntax)doc.Content[1];
             Assert.Equal(5, comment.TextTokens.Count);
             Assert.Equal(" this is a test", comment.TextTokens[0].ToString());
-            Assert.Equal("\r\n", comment.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, comment.TextTokens[1].ToString());
             Assert.Equal(" of &some; comment", comment.TextTokens[2].ToString());
-            Assert.Equal("\r\n", comment.TextTokens[3].ToString());
+            Assert.Equal(Environment.NewLine, comment.TextTokens[3].ToString());
             Assert.Equal(" \"']]<>/></text", comment.TextTokens[4].ToString());
             Assert.Equal(SyntaxKind.XmlText, doc.Content[2].Kind());
         }
@@ -1016,7 +1017,7 @@ class C { }"; // end of line/comment
             Assert.Equal(" incomplete", comment.TextTokens[0].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestIncompleteEOLComment()
         {
             var text = @"/// <!-- incomplete
@@ -1029,7 +1030,7 @@ class C { }"; // end of line/comment
             Assert.Equal(1, leading.Count);
             var node = leading[0];
             Assert.Equal(SyntaxKind.SingleLineDocumentationCommentTrivia, node.Kind());
-            Assert.Equal("/// <!-- incomplete\r\n", node.ToFullString());
+            Assert.Equal($"/// <!-- incomplete{Environment.NewLine}", node.ToFullString());
             var doc = (DocumentationCommentTriviaSyntax)node.GetStructure();
             Assert.Equal(2, doc.Content.Count);
             Assert.Equal(SyntaxKind.XmlText, doc.Content[0].Kind());
@@ -1039,7 +1040,7 @@ class C { }"; // end of line/comment
             Assert.Equal(1, comment.ErrorsAndWarnings().Length);
             Assert.Equal(2, comment.TextTokens.Count);
             Assert.Equal(" incomplete", comment.TextTokens[0].ToString());
-            Assert.Equal("\r\n", comment.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, comment.TextTokens[1].ToString());
         }
 
         [Fact]
@@ -1066,7 +1067,7 @@ class C { }"; // end of line/comment
             Assert.Equal(" incomplete", comment.TextTokens[0].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestProcessingInstruction()
         {
             var text =
@@ -1092,13 +1093,13 @@ class C { }"; // end of line/comment
             Assert.Equal("ProcessingInstruction", ProcessingInstruction.Name.LocalName.Text);
             Assert.Equal(5, ProcessingInstruction.TextTokens.Count);
             Assert.Equal(" this is a test", ProcessingInstruction.TextTokens[0].ToString());
-            Assert.Equal("\r\n", ProcessingInstruction.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, ProcessingInstruction.TextTokens[1].ToString());
             Assert.Equal(" of &a; ProcessingInstruction /// */ /**", ProcessingInstruction.TextTokens[2].ToString());
-            Assert.Equal("\r\n", ProcessingInstruction.TextTokens[3].ToString());
+            Assert.Equal(Environment.NewLine, ProcessingInstruction.TextTokens[3].ToString());
             Assert.Equal(" \"']]>/>?</text", ProcessingInstruction.TextTokens[4].ToString());
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestProcessingInstructionDelimited()
         {
             var text =
@@ -1126,9 +1127,9 @@ class C { }"; // end of line/comment
             Assert.Equal("localname", ProcessingInstruction.Name.LocalName.Text);
             Assert.Equal(5, ProcessingInstruction.TextTokens.Count);
             Assert.Equal(" this is a test <!--", ProcessingInstruction.TextTokens[0].ToString());
-            Assert.Equal("\r\n", ProcessingInstruction.TextTokens[1].ToString());
+            Assert.Equal(Environment.NewLine, ProcessingInstruction.TextTokens[1].ToString());
             Assert.Equal(" of &a; ProcessingInstruction", ProcessingInstruction.TextTokens[2].ToString());
-            Assert.Equal("\r\n", ProcessingInstruction.TextTokens[3].ToString());
+            Assert.Equal(Environment.NewLine, ProcessingInstruction.TextTokens[3].ToString());
             Assert.Equal(" \"']]>/></text>]]>", ProcessingInstruction.TextTokens[4].ToString());
             Assert.Equal(SyntaxKind.XmlText, doc.Content[2].Kind());
         }
@@ -1589,7 +1590,7 @@ class C { }";
         }
 
         [WorkItem(899559, "DevDiv/Personal")]
-        [ClrOnlyFact]
+        [Fact]
         public void TestNoZeroWidthTrivia()
         {
             var text =
@@ -1612,13 +1613,13 @@ x
             Assert.Equal(3, xmltext.ChildNodesAndTokens().Count);
             Assert.Equal(SyntaxKind.XmlTextLiteralNewLineToken, xmltext.ChildNodesAndTokens()[0].Kind());
             Assert.True(xmltext.ChildNodesAndTokens()[0].HasLeadingTrivia);
-            Assert.Equal("\r\n", xmltext.ChildNodesAndTokens()[0].ToString());
+            Assert.Equal(Environment.NewLine, xmltext.ChildNodesAndTokens()[0].ToString());
             Assert.Equal(SyntaxKind.XmlTextLiteralToken, xmltext.ChildNodesAndTokens()[1].Kind());
             Assert.False(xmltext.ChildNodesAndTokens()[1].HasLeadingTrivia);
             Assert.Equal("x", xmltext.ChildNodesAndTokens()[1].ToString());
             Assert.Equal(SyntaxKind.XmlTextLiteralNewLineToken, xmltext.ChildNodesAndTokens()[2].Kind());
             Assert.False(xmltext.ChildNodesAndTokens()[2].HasLeadingTrivia);
-            Assert.Equal("\r\n", xmltext.ChildNodesAndTokens()[2].ToString());
+            Assert.Equal(Environment.NewLine, xmltext.ChildNodesAndTokens()[2].ToString());
         }
 
         [WorkItem(906364, "DevDiv/Personal")]
@@ -2329,7 +2330,7 @@ class C{}";
         }
 
         [WorkItem(906704, "DevDiv/Personal")]
-        [ClrOnlyFact]
+        [Fact]
         public void TestSingleLineXmlCommentWithMissingStartTag()
         {
             var text = @"///</Foo>
@@ -2355,7 +2356,7 @@ class C{}";
             // we should get just 2 nodes
             Assert.Equal(2, xmlText.TextTokens.Count);
 
-            Assert.Equal("///</Foo>\r\n", xmlText.TextTokens.ToFullString());
+            Assert.Equal($"///</Foo>{Environment.NewLine}", xmlText.TextTokens.ToFullString());
         }
 
         [WorkItem(906719, "DevDiv/Personal")]
@@ -2865,24 +2866,23 @@ public class Program
         [Trait("Feature", "Xml Documentation Comments")]
         public void TestDocumentationComment()
         {
-            var expected = 
-                "/// <summary>\r\n" +
-                "/// This class provides extension methods for the <see cref=\"TypeName\"/> class.\r\n" +
-                "/// </summary>\r\n" +
-                "/// <threadsafety static=\"true\" instance=\"false\"/>\r\n" +
-                "/// <preliminary/>";
+            var expected = @"/// <summary>
+/// This class provides extension methods for the <see cref=""TypeName""/> class.
+/// </summary>
+/// <threadsafety static=""true"" instance=""false""/>
+/// <preliminary/>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
                     SyntaxFactory.XmlText("This class provides extension methods for the "),
                     SyntaxFactory.XmlSeeElement(
                         SyntaxFactory.TypeCref(SyntaxFactory.ParseTypeName("TypeName"))),
                     SyntaxFactory.XmlText(" class."),
-                    SyntaxFactory.XmlNewLine("\r\n")),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlThreadSafetyElement(),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlPreliminaryElement());
 
             var actual = documentationComment.ToFullString();
@@ -2895,15 +2895,15 @@ public class Program
         public void TestXmlSummaryElement()
         {
             var expected = 
-                "/// <summary>\r\n" +
-                "/// This class provides extension methods.\r\n" +
-                "/// </summary>";
+@"/// <summary>
+/// This class provides extension methods.
+/// </summary>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
                     SyntaxFactory.XmlText("This class provides extension methods."),
-                    SyntaxFactory.XmlNewLine("\r\n")));
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)));
 
             var actual = documentationComment.ToFullString();
 
@@ -2915,13 +2915,13 @@ public class Program
         public void TestXmlSeeElementAndXmlSeeAlsoElement()
         {
             var expected = 
-                "/// <summary>\r\n" + 
-                "/// This class provides extension methods for the <see cref=\"TypeName\"/> class and the <seealso cref=\"TypeName2\"/> class.\r\n" +
-                "/// </summary>";
+@"/// <summary>
+/// This class provides extension methods for the <see cref=""TypeName""/> class and the <seealso cref=""TypeName2""/> class.
+/// </summary>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
                     SyntaxFactory.XmlText("This class provides extension methods for the "),
                     SyntaxFactory.XmlSeeElement(
                         SyntaxFactory.TypeCref(SyntaxFactory.ParseTypeName("TypeName"))),
@@ -2929,7 +2929,7 @@ public class Program
                     SyntaxFactory.XmlSeeAlsoElement(
                         SyntaxFactory.TypeCref(SyntaxFactory.ParseTypeName("TypeName2"))),
                     SyntaxFactory.XmlText(" class."),
-                    SyntaxFactory.XmlNewLine("\r\n")));
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)));
 
             var actual = documentationComment.ToFullString();
 
@@ -2941,26 +2941,26 @@ public class Program
         public void TestXmlNewLineElement()
         {
             var expected = 
-                "/// <summary>\r\n" +
-                "/// This is a summary.\r\n" +
-                "/// </summary>\r\n" +
-                "/// \r\n" +
-                "/// \r\n" +
-                "/// <remarks>\r\n" +
-                "/// \r\n" +
-                "/// </remarks>";
+@"/// <summary>
+/// This is a summary.
+/// </summary>
+/// 
+/// 
+/// <remarks>
+/// 
+/// </remarks>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
                     SyntaxFactory.XmlText("This is a summary."),
-                    SyntaxFactory.XmlNewLine("\r\n")),
-                SyntaxFactory.XmlNewLine("\r\n"),
-                SyntaxFactory.XmlNewLine("\r\n"),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlRemarksElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
-                    SyntaxFactory.XmlNewLine("\r\n")));
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)));
 
             var actual = documentationComment.ToFullString();
 
@@ -2972,20 +2972,20 @@ public class Program
         public void TestXmlParamAndParamRefElement()
         {
             var expected = 
-                "/// <summary>\r\n" +
-                "/// <paramref name=\"b\"/>\r\n" +
-                "/// </summary>\r\n" +
-                "/// <param name=\"a\"></param>\r\n" +
-                "/// <param name=\"b\"></param>";
+@"/// <summary>
+/// <paramref name=""b""/>
+/// </summary>
+/// <param name=""a""></param>
+/// <param name=""b""></param>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
                     SyntaxFactory.XmlParamRefElement("b"),
-                    SyntaxFactory.XmlNewLine("\r\n")),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlParamElement("a"),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlParamElement("b"));
 
             var actual = documentationComment.ToFullString();
@@ -2998,22 +2998,22 @@ public class Program
         public void TestXmlReturnsElement()
         {
             var expected = 
-                "/// <summary>\r\n" +
-                "/// \r\n" +
-                "/// </summary>\r\n" +
-                "/// <returns>\r\n" +
-                "/// Returns a value.\r\n" +
-                "/// </returns>";
+@"/// <summary>
+/// 
+/// </summary>
+/// <returns>
+/// Returns a value.
+/// </returns>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
-                    SyntaxFactory.XmlNewLine("\r\n")),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlReturnsElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
                     SyntaxFactory.XmlText("Returns a value."),
-                    SyntaxFactory.XmlNewLine("\r\n")));
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)));
 
             var actual = documentationComment.ToFullString();
 
@@ -3025,24 +3025,24 @@ public class Program
         public void TestXmlRemarksElement()
         {
             var expected = 
-                "/// <summary>\r\n" +
-                "/// \r\n" +
-                "/// </summary>\r\n" +
-                "/// <remarks>\r\n" +
-                "/// Same as in class <see cref=\"TypeName\"/>.\r\n" +
-                "/// </remarks>";
+@"/// <summary>
+/// 
+/// </summary>
+/// <remarks>
+/// Same as in class <see cref=""TypeName""/>.
+/// </remarks>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
-                    SyntaxFactory.XmlNewLine("\r\n")),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlRemarksElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
                     SyntaxFactory.XmlText("Same as in class "),
                     SyntaxFactory.XmlSeeElement(SyntaxFactory.TypeCref(SyntaxFactory.ParseTypeName("TypeName"))),
                     SyntaxFactory.XmlText("."),
-                    SyntaxFactory.XmlNewLine("\r\n")));
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)));
 
             var actual = documentationComment.ToFullString();
 
@@ -3054,16 +3054,16 @@ public class Program
         public void TestXmlExceptionElement()
         {
             var expected = 
-                "/// <summary>\r\n" +
-                "/// \r\n" +
-                "/// </summary>\r\n" +
-                "/// <exception cref=\"InvalidOperationException\">This exception will be thrown if the object is in an invalid state when calling this method.</exception>";
+@"/// <summary>
+/// 
+/// </summary>
+/// <exception cref=""InvalidOperationException"">This exception will be thrown if the object is in an invalid state when calling this method.</exception>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"), 
-                    SyntaxFactory.XmlNewLine("\r\n")),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine), 
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlExceptionElement(
                     SyntaxFactory.TypeCref(
                         SyntaxFactory.ParseTypeName("InvalidOperationException")),
@@ -3079,16 +3079,16 @@ public class Program
         public void TestXmlPermissionElement()
         {
             var expected = 
-                "/// <summary>\r\n" +
-                "/// \r\n" +
-                "/// </summary>\r\n" +
-                "/// <permission cref=\"MyPermission\">Needs MyPermission to execute.</permission>";
+@"/// <summary>
+/// 
+/// </summary>
+/// <permission cref=""MyPermission"">Needs MyPermission to execute.</permission>";
 
             DocumentationCommentTriviaSyntax documentationComment = SyntaxFactory.DocumentationComment(
                 SyntaxFactory.XmlSummaryElement(
-                    SyntaxFactory.XmlNewLine("\r\n"),
-                    SyntaxFactory.XmlNewLine("\r\n")),
-                SyntaxFactory.XmlNewLine("\r\n"),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine),
+                    SyntaxFactory.XmlNewLine(Environment.NewLine)),
+                SyntaxFactory.XmlNewLine(Environment.NewLine),
                 SyntaxFactory.XmlPermissionElement(
                     SyntaxFactory.TypeCref(
                         SyntaxFactory.ParseTypeName("MyPermission")),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -6337,7 +6337,7 @@ public class Test
         }
 
         [WorkItem(542236, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542236")]
-        [ClrOnlyFact]
+        [Fact]
         public void InsertOpenBraceBeforeCodes()
         {
             var text = @"{
@@ -6348,7 +6348,7 @@ public class Test
             SyntaxTree syntaxTree = SyntaxFactory.ParseSyntaxTree(text);
             Assert.Equal(text, syntaxTree.GetCompilationUnitRoot().ToFullString());
 
-            Assert.Equal("{\r\n", syntaxTree.GetCompilationUnitRoot().GetLeadingTrivia().Node.ToFullString());
+            Assert.Equal($"{{{Environment.NewLine}", syntaxTree.GetCompilationUnitRoot().GetLeadingTrivia().Node.ToFullString());
 
             // The issue (9391) was exhibited while enumerating the diagnostics
             Assert.True(syntaxTree.GetDiagnostics().Select(d => ((IFormattable)d).ToString(null, EnsureEnglishUICulture.PreferredOrNull)).SequenceEqual(new[]
@@ -6843,7 +6843,7 @@ static
 
 
         [WorkItem(947819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/947819")]
-        [ClrOnlyFact]
+        [Fact]
         public void MissingOpenBraceForClass()
         {
             var source = @"namespace n
@@ -6854,13 +6854,18 @@ static
             var root = SyntaxFactory.ParseSyntaxTree(source).GetRoot();
 
             Assert.Equal(source, root.ToFullString());
+            // Verify incomplete class decls don't eat tokens of surrounding nodes
             var classDecl = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
-            Assert.Equal(new Text.TextSpan(20, 9), classDecl.Span);
-            Assert.Equal(new Text.TextSpan(16, 13), classDecl.FullSpan);
+            Assert.False(classDecl.Identifier.IsMissing);
+            Assert.True(classDecl.OpenBraceToken.IsMissing);
+            Assert.True(classDecl.CloseBraceToken.IsMissing);
+            var ns = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().Single();
+            Assert.False(ns.OpenBraceToken.IsMissing);
+            Assert.False(ns.CloseBraceToken.IsMissing);
         }
 
         [WorkItem(947819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/947819")]
-        [ClrOnlyFact]
+        [Fact]
         public void MissingOpenBraceForStruct()
         {
             var source = @"namespace n
@@ -6871,13 +6876,17 @@ static
             var root = SyntaxFactory.ParseSyntaxTree(source).GetRoot();
 
             Assert.Equal(source, root.ToFullString());
+            // Verify incomplete struct decls don't eat tokens of surrounding nodes
             var structDecl = root.DescendantNodes().OfType<StructDeclarationSyntax>().Single();
-            Assert.Equal(new Text.TextSpan(20, 14), structDecl.Span);
-            Assert.Equal(new Text.TextSpan(16, 18), structDecl.FullSpan);
+            Assert.True(structDecl.OpenBraceToken.IsMissing);
+            Assert.True(structDecl.CloseBraceToken.IsMissing);
+            var ns = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().Single();
+            Assert.False(ns.OpenBraceToken.IsMissing);
+            Assert.False(ns.CloseBraceToken.IsMissing);
         }
 
         [WorkItem(947819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/947819")]
-        [ClrOnlyFact]
+        [Fact]
         public void MissingNameForStruct()
         {
             var source = @"namespace n
@@ -6890,13 +6899,18 @@ static
             var root = SyntaxFactory.ParseSyntaxTree(source).GetRoot();
 
             Assert.Equal(source, root.ToFullString());
+            // Verify incomplete struct decls don't eat tokens of surrounding nodes
             var structDecl = root.DescendantNodes().OfType<StructDeclarationSyntax>().Single();
-            Assert.Equal(new Text.TextSpan(20, 24), structDecl.Span);
-            Assert.Equal(new Text.TextSpan(16, 30), structDecl.FullSpan);
+            Assert.True(structDecl.Identifier.IsMissing);
+            Assert.False(structDecl.OpenBraceToken.IsMissing);
+            Assert.False(structDecl.CloseBraceToken.IsMissing);
+            var ns = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().Single();
+            Assert.False(ns.OpenBraceToken.IsMissing);
+            Assert.False(ns.CloseBraceToken.IsMissing);
         }
 
         [WorkItem(947819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/947819")]
-        [ClrOnlyFact]
+        [Fact]
         public void MissingNameForClass()
         {
             var source = @"namespace n
@@ -6909,9 +6923,14 @@ static
             var root = SyntaxFactory.ParseSyntaxTree(source).GetRoot();
 
             Assert.Equal(source, root.ToFullString());
+            // Verify incomplete class decls don't eat tokens of surrounding nodes
             var classDecl = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
-            Assert.Equal(new Text.TextSpan(20, 19), classDecl.Span);
-            Assert.Equal(new Text.TextSpan(16, 25), classDecl.FullSpan);
+            Assert.True(classDecl.Identifier.IsMissing);
+            Assert.False(classDecl.OpenBraceToken.IsMissing);
+            Assert.False(classDecl.CloseBraceToken.IsMissing);
+            var ns = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().Single();
+            Assert.False(ns.OpenBraceToken.IsMissing);
+            Assert.False(ns.CloseBraceToken.IsMissing);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
@@ -1477,7 +1477,7 @@ class A { }
         }
 
         [WorkItem(536995, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536995")]
-        [ClrOnlyFact]
+        [Fact]
         public void TestTextAndSpanWithTrivia1()
         {
             var tree = SyntaxFactory.ParseSyntaxTree(
@@ -1486,8 +1486,6 @@ class A { }
 }/*END*/");
             var rootNode = tree.GetCompilationUnitRoot();
 
-            Assert.Equal(53, rootNode.FullSpan.Length);
-            Assert.Equal(44, rootNode.Span.Length);
             Assert.Equal(rootNode.FullSpan.Length, rootNode.ToFullString().Length);
             Assert.Equal(rootNode.Span.Length, rootNode.ToString().Length);
             Assert.Equal(true, rootNode.ToString().Contains("/*END*/"));
@@ -1495,7 +1493,7 @@ class A { }
         }
 
         [WorkItem(536996, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536996")]
-        [ClrOnlyFact]
+        [Fact]
         public void TestTextAndSpanWithTrivia2()
         {
             var tree = SyntaxFactory.ParseSyntaxTree(
@@ -1506,8 +1504,6 @@ namespace Microsoft.CSharp.Test
 /*END*/");
             var rootNode = tree.GetCompilationUnitRoot();
 
-            Assert.Equal(57, rootNode.FullSpan.Length);
-            Assert.Equal(46, rootNode.Span.Length);
             Assert.Equal(rootNode.FullSpan.Length, rootNode.ToFullString().Length);
             Assert.Equal(rootNode.Span.Length, rootNode.ToString().Length);
             Assert.Equal(true, rootNode.ToString().Contains("/*END*/"));
@@ -2326,7 +2322,7 @@ class C
             Assert.Equal(expectedText, text);
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestRemove_KeepUnbalancedDirectives()
         {
             var cu = SyntaxFactory.ParseCompilationUnit(@"
@@ -2339,7 +2335,7 @@ void M()
 {
 } // after
 #endregion
-}");
+}".NormalizeLineEndings());
 
             var expectedText = @"
 class C
@@ -2347,7 +2343,7 @@ class C
 
 #region Fred
 #endregion
-}";
+}".NormalizeLineEndings();
 
             var m = cu.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault();
             Assert.NotNull(m);
@@ -2359,7 +2355,7 @@ class C
             Assert.Equal(expectedText, text);
         }
 
-        [ClrOnlyFact]
+        [Fact]
         public void TestRemove_KeepDirectives()
         {
             var cu = SyntaxFactory.ParseCompilationUnit(@"
@@ -2374,7 +2370,7 @@ void M()
 #endif
 } // after
 #endregion
-}");
+}".NormalizeLineEndings());
 
             var expectedText = @"
 class C
@@ -2384,7 +2380,7 @@ class C
 #if true
 #endif
 #endregion
-}";
+}".NormalizeLineEndings();
 
             var m = cu.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault();
             Assert.NotNull(m);


### PR DESCRIPTION
In the initial move to running tests xplat, a number of tests were
disabled due to failures in xplat CI. Some of these failures are
inherent platform limitations, like tests which depend on the Windows
.NET Desktop framework, but some were simply improperly written tests.

This change re-enables and fixes the tests that were improperly or
non-portably written.