### PR TITLE
Ignore synthesized delegates in AnonymousTypeManager.GetAnonymousTypeMap

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
@@ -754,8 +754,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             int parameterCount = delegateSignature.Length - (returnsVoid ? 0 : 1);
-
-            return _factory.Compilation.AnonymousTypeManager.SynthesizeDelegate(parameterCount, byRefs, returnsVoid).Construct(delegateSignature);
+            int generation = _factory.CompilationState.ModuleBuilderOpt.CurrentGenerationOrdinal;
+            var synthesizedType = _factory.Compilation.AnonymousTypeManager.SynthesizeDelegate(parameterCount, byRefs, returnsVoid, generation);
+            return synthesizedType.Construct(delegateSignature);
         }
 
         internal BoundExpression GetArgumentInfo(

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -8,13 +8,16 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
+    /// <summary>
+    /// Dynamic call-site delegate, for call-sites that do not
+    /// match System.Action or System.Func signatures.
+    /// </summary>
     internal sealed class SynthesizedDelegateSymbol : SynthesizedContainer
     {
         private readonly NamespaceOrTypeSymbol _containingSymbol;
         private readonly MethodSymbol _constructor;
         private readonly MethodSymbol _invoke;
 
-        // constructor for dynamic call-site delegate:
         public SynthesizedDelegateSymbol(
             NamespaceOrTypeSymbol containingSymbol,
             string name,

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -2850,5 +2850,185 @@ class C
 
             diff2.VerifyIL("C.F", expectedIL.Replace("<<VALUE>>", "2"));
         }
+
+        [WorkItem(179990, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/179990")]
+        [Fact]
+        public void SynthesizedDelegates()
+        {
+            var template =
+@"class C
+{
+    static void F(dynamic d, out object x, object y)
+    <N:0>{
+        <<CALL>>;
+    }</N:0>
+}";
+            var source0 = MarkedSource(template.Replace("<<CALL>>", "d.F(out x, new { })"));
+            var source1 = MarkedSource(template.Replace("<<CALL>>", "d.F(out x, new { y })"));
+            var source2 = MarkedSource(template.Replace("<<CALL>>", "d.F(new { y }, out x)"));
+
+            var compilation0 = CreateCompilationWithMscorlib(source0.Tree, options: ComSafeDebugDll, references: new[] { SystemCoreRef, CSharpRef });
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var v0 = CompileAndVerify(compilation0);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+            v0.VerifyIL("C.F",
+@"{
+  // Code size      112 (0x70)
+  .maxstack  9
+  IL_0000:  nop
+  IL_0001:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>> C.<>o__0.<>p__0""
+  IL_0006:  brfalse.s  IL_000a
+  IL_0008:  br.s       IL_0053
+  IL_000a:  ldc.i4     0x100
+  IL_000f:  ldstr      ""F""
+  IL_0014:  ldnull
+  IL_0015:  ldtoken    ""C""
+  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001f:  ldc.i4.3
+  IL_0020:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_0025:  dup
+  IL_0026:  ldc.i4.0
+  IL_0027:  ldc.i4.0
+  IL_0028:  ldnull
+  IL_0029:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_002e:  stelem.ref
+  IL_002f:  dup
+  IL_0030:  ldc.i4.1
+  IL_0031:  ldc.i4.s   17
+  IL_0033:  ldnull
+  IL_0034:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.2
+  IL_003c:  ldc.i4.1
+  IL_003d:  ldnull
+  IL_003e:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0043:  stelem.ref
+  IL_0044:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_0049:  call       ""System.Runtime.CompilerServices.CallSite<<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>> System.Runtime.CompilerServices.CallSite<<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_004e:  stsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>> C.<>o__0.<>p__0""
+  IL_0053:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>> C.<>o__0.<>p__0""
+  IL_0058:  ldfld      ""<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>> System.Runtime.CompilerServices.CallSite<<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>>.Target""
+  IL_005d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>> C.<>o__0.<>p__0""
+  IL_0062:  ldarg.0
+  IL_0063:  ldarg.1
+  IL_0064:  newobj     ""<>f__AnonymousType0..ctor()""
+  IL_0069:  callvirt   ""void <>A{00000004}<System.Runtime.CompilerServices.CallSite, dynamic, object, <empty anonymous type>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, ref object, <empty anonymous type>)""
+  IL_006e:  nop
+  IL_006f:  ret
+}");
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+            diff1.VerifyIL("C.F",
+@"{
+  // Code size      113 (0x71)
+  .maxstack  9
+  IL_0000:  nop
+  IL_0001:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>> C.<>o__0#1.<>p__0""
+  IL_0006:  brfalse.s  IL_000a
+  IL_0008:  br.s       IL_0053
+  IL_000a:  ldc.i4     0x100
+  IL_000f:  ldstr      ""F""
+  IL_0014:  ldnull
+  IL_0015:  ldtoken    ""C""
+  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001f:  ldc.i4.3
+  IL_0020:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_0025:  dup
+  IL_0026:  ldc.i4.0
+  IL_0027:  ldc.i4.0
+  IL_0028:  ldnull
+  IL_0029:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_002e:  stelem.ref
+  IL_002f:  dup
+  IL_0030:  ldc.i4.1
+  IL_0031:  ldc.i4.s   17
+  IL_0033:  ldnull
+  IL_0034:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.2
+  IL_003c:  ldc.i4.1
+  IL_003d:  ldnull
+  IL_003e:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0043:  stelem.ref
+  IL_0044:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_0049:  call       ""System.Runtime.CompilerServices.CallSite<<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>> System.Runtime.CompilerServices.CallSite<<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_004e:  stsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>> C.<>o__0#1.<>p__0""
+  IL_0053:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>> C.<>o__0#1.<>p__0""
+  IL_0058:  ldfld      ""<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>> System.Runtime.CompilerServices.CallSite<<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>>.Target""
+  IL_005d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>> C.<>o__0#1.<>p__0""
+  IL_0062:  ldarg.0
+  IL_0063:  ldarg.1
+  IL_0064:  ldarg.2
+  IL_0065:  newobj     ""<>f__AnonymousType1<object>..ctor(object)""
+  IL_006a:  callvirt   ""void <>A{00000004}#1<System.Runtime.CompilerServices.CallSite, dynamic, object, <anonymous type: object y>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, ref object, <anonymous type: object y>)""
+  IL_006f:  nop
+  IL_0070:  ret
+}");
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+            diff2.VerifyIL("C.F",
+@"{
+  // Code size      113 (0x71)
+  .maxstack  9
+  IL_0000:  nop
+  IL_0001:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>> C.<>o__0#2.<>p__0""
+  IL_0006:  brfalse.s  IL_000a
+  IL_0008:  br.s       IL_0053
+  IL_000a:  ldc.i4     0x100
+  IL_000f:  ldstr      ""F""
+  IL_0014:  ldnull
+  IL_0015:  ldtoken    ""C""
+  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001f:  ldc.i4.3
+  IL_0020:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_0025:  dup
+  IL_0026:  ldc.i4.0
+  IL_0027:  ldc.i4.0
+  IL_0028:  ldnull
+  IL_0029:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_002e:  stelem.ref
+  IL_002f:  dup
+  IL_0030:  ldc.i4.1
+  IL_0031:  ldc.i4.1
+  IL_0032:  ldnull
+  IL_0033:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0038:  stelem.ref
+  IL_0039:  dup
+  IL_003a:  ldc.i4.2
+  IL_003b:  ldc.i4.s   17
+  IL_003d:  ldnull
+  IL_003e:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0043:  stelem.ref
+  IL_0044:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_0049:  call       ""System.Runtime.CompilerServices.CallSite<<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>> System.Runtime.CompilerServices.CallSite<<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_004e:  stsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>> C.<>o__0#2.<>p__0""
+  IL_0053:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>> C.<>o__0#2.<>p__0""
+  IL_0058:  ldfld      ""<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object> System.Runtime.CompilerServices.CallSite<<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>>.Target""
+  IL_005d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<<>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>> C.<>o__0#2.<>p__0""
+  IL_0062:  ldarg.0
+  IL_0063:  ldarg.2
+  IL_0064:  newobj     ""<>f__AnonymousType1<object>..ctor(object)""
+  IL_0069:  ldarg.1
+  IL_006a:  callvirt   ""void <>A{00000008}#2<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, object>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: object y>, ref object)""
+  IL_006f:  nop
+  IL_0070:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.vb
@@ -15,8 +15,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Structure AnonymousTypeDescriptor
         Implements IEquatable(Of AnonymousTypeDescriptor)
 
-        Public Shared ReadOnly SubReturnParameterName As String = "Sub"
-        Public Shared ReadOnly FunctionReturnParameterName As String = "Function"
+        Public Const SubReturnParameterName As String = "Sub"
+        Public Const FunctionReturnParameterName As String = "Function"
 
         Friend Shared Function GetReturnParameterName(isFunction As Boolean) As String
             Return If(isFunction, FunctionReturnParameterName, SubReturnParameterName)

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -9067,6 +9067,30 @@ BC30567: Array initializer is missing 1 elements.
         End Sub
 
         <Fact()>
+        Public Sub BC30567ERR_InitializerTooFewElements1_2()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+    <compilation>
+        <file name="a.vb">
+Class C
+    Private A() As Object = New Object(0) {}
+    Private B As Object() = New Object(2) {}
+    Private C As Object(,) = New Object(1, 0) {}
+    Private D As Object(,) = New Object(1, 0) {{}, {2}}
+    Private E As Object(,) = New Object(0, 2) {}
+    Private F()() As Object = New Object(0)() {}
+    Private G()() As Object = New Object(0)() {New Object(0) {}}
+End Class
+    </file>
+    </compilation>)
+            compilation.AssertTheseDiagnostics(
+    <expected>
+BC30567: Array initializer is missing 1 elements.
+    Private D As Object(,) = New Object(1, 0) {{}, {2}}
+                                               ~~
+</expected>)
+        End Sub
+
+        <Fact()>
         Public Sub BC30568ERR_InitializerTooManyElements1()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
     <compilation name="InitializerTooManyElements1">


### PR DESCRIPTION
Ignore synthesized delegates in AnonymousTypeManager.GetAnonymousTypeMap
and add generation qualifier to synthesized delegate names to avoid name clashes across EnC generations.