### PR TITLE
Rename ContinueAsync to RunFromAsync and make it public

### DIFF
--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -810,7 +810,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         {
                             var task = (stateOpt == null) ?
                                 script.RunAsync(_globals, CancellationToken.None) :
-                                script.ContinueAsync(stateOpt, CancellationToken.None);
+                                script.RunFromAsync(stateOpt, CancellationToken.None);
                             return await task.ConfigureAwait(false);
                         }
                         catch (FileLoadException e) when (e.InnerException is InteractiveAssemblyLoaderException)

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -185,7 +185,7 @@ d.Do()"
         {
             var state = await CSharpScript.RunAsync("X + Y", globals: new Globals());
 
-            await Assert.ThrowsAsync<ArgumentNullException>("previousState", () => state.Script.ContinueAsync(null));
+            await Assert.ThrowsAsync<ArgumentNullException>("previousState", () => state.Script.RunFromAsync(null));
         }
 
         [Fact]
@@ -194,7 +194,7 @@ d.Do()"
             var state1 = await CSharpScript.RunAsync("X + Y + 1", globals: new Globals());
             var state2 = await CSharpScript.RunAsync("X + Y + 2", globals: new Globals());
 
-            await Assert.ThrowsAsync<ArgumentException>("previousState", () => state1.Script.ContinueAsync(state2));
+            await Assert.ThrowsAsync<ArgumentException>("previousState", () => state1.Script.RunFromAsync(state2));
         }
 
         [Fact]

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             {
                 var task = (state == null) ?
                     newScript.RunAsync(globals, cancellationToken) :
-                    newScript.ContinueAsync(state, cancellationToken);
+                    newScript.RunFromAsync(state, cancellationToken);
 
                 state = task.GetAwaiter().GetResult();
             }

--- a/src/Scripting/Core/PublicAPI.Unshipped.txt
+++ b/src/Scripting/Core/PublicAPI.Unshipped.txt
@@ -15,6 +15,8 @@ Microsoft.CodeAnalysis.Scripting.Hosting.PrintOptions.MemberDisplayFormat.get ->
 Microsoft.CodeAnalysis.Scripting.Hosting.PrintOptions.MemberDisplayFormat.set -> void
 Microsoft.CodeAnalysis.Scripting.Hosting.PrintOptions.NumberRadix.get -> int
 Microsoft.CodeAnalysis.Scripting.Hosting.PrintOptions.NumberRadix.set -> void
+Microsoft.CodeAnalysis.Scripting.Script.RunFromAsync(Microsoft.CodeAnalysis.Scripting.ScriptState previousState, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Scripting.ScriptState>
+Microsoft.CodeAnalysis.Scripting.Script<T>.RunFromAsync(Microsoft.CodeAnalysis.Scripting.ScriptState previousState, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Scripting.ScriptState<T>>
 abstract Microsoft.CodeAnalysis.Scripting.Hosting.ObjectFormatter.FormatObject(object obj, Microsoft.CodeAnalysis.Scripting.Hosting.PrintOptions options) -> string
 abstract Microsoft.CodeAnalysis.Scripting.Hosting.ObjectFormatter.FormatException(System.Exception e) -> string
 virtual Microsoft.CodeAnalysis.Scripting.Hosting.PrintOptions.IsValidRadix(int radix) -> bool

--- a/src/Scripting/Core/Script.cs
+++ b/src/Scripting/Core/Script.cs
@@ -142,17 +142,17 @@ namespace Microsoft.CodeAnalysis.Scripting
         internal abstract Task<ScriptState> CommonRunAsync(object globals, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Continue script execution from the specified state.
+        /// Run the script from the specified state.
         /// </summary>
         /// <param name="previousState">
         /// Previous state of the script execution.
         /// </param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="ScriptState"/> that represents the state after running the script, including all declared variables and return value.</returns>
-        internal Task<ScriptState> ContinueAsync(ScriptState previousState, CancellationToken cancellationToken = default(CancellationToken)) =>
-            CommonContinueAsync(previousState, cancellationToken);
+        public Task<ScriptState> RunFromAsync(ScriptState previousState, CancellationToken cancellationToken = default(CancellationToken)) =>
+            CommonRunFromAsync(previousState, cancellationToken);
 
-        internal abstract Task<ScriptState> CommonContinueAsync(ScriptState previousState, CancellationToken cancellationToken);
+        internal abstract Task<ScriptState> CommonRunFromAsync(ScriptState previousState, CancellationToken cancellationToken);
 
         /// <summary>
         /// Forces the script through the compilation step.
@@ -285,8 +285,8 @@ namespace Microsoft.CodeAnalysis.Scripting
         internal override Task<ScriptState> CommonRunAsync(object globals, CancellationToken cancellationToken) =>
             RunAsync(globals, cancellationToken).CastAsync<ScriptState<T>, ScriptState>();
 
-        internal override Task<ScriptState> CommonContinueAsync(ScriptState previousState, CancellationToken cancellationToken) =>
-            ContinueAsync(previousState, cancellationToken).CastAsync<ScriptState<T>, ScriptState>();
+        internal override Task<ScriptState> CommonRunFromAsync(ScriptState previousState, CancellationToken cancellationToken) =>
+            RunFromAsync(previousState, cancellationToken).CastAsync<ScriptState<T>, ScriptState>();
 
         /// <exception cref="CompilationErrorException">Compilation has errors.</exception>
         private Func<object[], Task<T>> GetExecutor(CancellationToken cancellationToken)
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         }
 
         /// <summary>
-        /// Continue script execution from the specified state.
+        /// Run the script from the specified state.
         /// </summary>
         /// <param name="previousState">
         /// Previous state of the script execution.
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// <returns>A <see cref="ScriptState"/> that represents the state after running the script, including all declared variables and return value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="previousState"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="previousState"/> is not a previous execution state of this script.</exception>
-        internal new Task<ScriptState<T>> ContinueAsync(ScriptState previousState, CancellationToken cancellationToken = default(CancellationToken))
+        public new Task<ScriptState<T>> RunFromAsync(ScriptState previousState, CancellationToken cancellationToken = default(CancellationToken))
         {
             // The following validation and executor construction may throw;
             // do so synchronously so that the exception is not wrapped in the task.

--- a/src/Scripting/Core/ScriptState.cs
+++ b/src/Scripting/Core/ScriptState.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Scripting
 
         public Task<ScriptState<TResult>> ContinueWithAsync<TResult>(string code, ScriptOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Script.ContinueWith<TResult>(code, options).ContinueAsync(this, cancellationToken);
+            return Script.ContinueWith<TResult>(code, options).RunFromAsync(this, cancellationToken);
         }
 
         // How do we resolve overloads? We should use the language semantics.


### PR DESCRIPTION
This API is necessary to implement a REPL and is also used by our REPL host. 
Making it public as per customer request.