### PR TITLE
Fix bug in IVsSimpleLibrary2.CreateNavInfo(...) implementation where we were clearing string builders before they were used

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -395,11 +395,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 }
             }
 
-            SharedPools.Default<StringBuilder>().ClearAndFree(namespaceName);
-            SharedPools.Default<StringBuilder>().ClearAndFree(className);
-
             // TODO: Make sure we pass the right value for Visual Basic.
             ppNavInfo = this.LibraryService.NavInfoFactory.Create(libraryName, referenceOwnerName, namespaceName.ToString(), className.ToString(), memberName);
+
+            SharedPools.Default<StringBuilder>().ClearAndFree(namespaceName);
+            SharedPools.Default<StringBuilder>().ClearAndFree(className);
 
             return VSConstants.S_OK;
         }


### PR DESCRIPTION
This bug results in Go to Definition not working from XAML if it navigates to the Object Browser.

Tagging @dotnet/roslyn-ide 