### PR TITLE
Removed quiet verbosity from Restore.cmd

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -2,7 +2,7 @@
 @setlocal
 
 set NuGetExe="%~dp0NuGet.exe"
-set NuGetAdditionalCommandLineArgs=-verbosity quiet -configfile "%~dp0nuget.config" -Project2ProjectTimeOut 1200
+set NuGetAdditionalCommandLineArgs=-configfile "%~dp0nuget.config" -Project2ProjectTimeOut 1200
 
 REM If someone passed in a different Roslyn solution, use that.
 REM We make use of this when Roslyn is an sub-module for some 


### PR DESCRIPTION
Because restore can be very slow I think it would be more valuable to show the actual nuget restore output.

There is more value in seeing this:

```
Restoring packages for Z:\Documents\dev\roslyn\src\Compilers\VisualBasic\Test\Performance\project.json...
All packages are compatible with .NETFramework,Version=v4.6.
All packages are compatible with .NETFramework,Version=v4.6 (win7).
All packages are compatible with .NETFramework,Version=v4.6 (win7-anycpu).
Restoring packages for Z:\Documents\dev\roslyn\src\Interactive\CsiCore\project.json...
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 1161ms
Installing runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR 1.0.1-beta-23504.
Installing runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR 1.0.1-beta-23504.
Installing runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR 1.0.1-beta-23504.
Restoring packages for Z:\Documents\dev\roslyn\src\Interactive\VbiCore\project.json...
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.ubuntu.14.04-x64.microsoft.netcore.runtime.coreclr/index.json 283ms
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 393ms
Restoring packages for Z:\Documents\dev\roslyn\src\Compilers\Server\PortableServer\project.json...
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 368ms
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.ubuntu.14.04-x64.microsoft.netcore.runtime.coreclr/index.json 314ms
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.osx.10.10-x64.microsoft.netcore.runtime.coreclr/index.json 522ms
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.osx.10.10-x64.microsoft.netcore.runtime.coreclr/index.json 1056ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 475ms
  NotFound https://dotnet.myget.org/F/dotnet-buildtools/api/v3/flatcontainer/runtime.ubuntu.14.04-x64.microsoft.netcore.runtime.coreclr/index.json 1559ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.osx.10.10-x64.microsoft.netcore.runtime.coreclr/index.json 1565ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 1613ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 1579ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 1609ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.ubuntu.14.04-x64.microsoft.netcore.runtime.coreclr/index.json 1711ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.osx.10.10-x64.microsoft.netcore.runtime.coreclr/index.json 1649ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.ubuntu.14.04-x64.microsoft.netcore.runtime.coreclr/index.json 1733ms
  NotFound https://dotnet.myget.org/F/dotnet-coreclr/api/v3/flatcontainer/runtime.osx.10.10-x64.microsoft.netcore.runtime.coreclr/index.json 1736ms
  NotFound https://dotnet.myget.org/F/dotnet-buildtools/api/v3/flatcontainer/runtime.win7-x64.microsoft.netcore.runtime.coreclr/index.json 1760ms
  NotFound https://dotnet.myget.org/F/dotnet-buildtools/api/v3/flatcontainer/runtime.osx.10.10-x64.microsoft.netcore.runtime.coreclr/index.json 1976ms
  NotFound https://dotnet.myget.org/F/dotnet-buildtools/api/v3/flatcontainer/runtime.ubuntu.14.04-x64.microsoft.netcore.runtime.coreclr/index.json 2008ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/runtime.ubuntu.14.04-x64.microsoft.netcore.runtime.coreclr/index.json 2006ms
  NotFound https://dotnet.myget.org/F/dotnet-buildtools/api/v3/flatcontainer/runtime.osx.10.10-x64.microsoft.netcore.runtime.coreclr/index.json 2026ms
  NotFound https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/flatcontainer/microsoft.build.framework/index.json 2227ms
All packages are compatible with .NETPlatform,Version=v5.4.
All packages are compatible with .NETFramework,Version=v4.6.
All packages are compatible with DNXCore,Version=v5.0.
All packages are compatible with .NETFramework,Version=v4.6 (win-x86).
All packages are compatible with .NETFramework,Version=v4.6 (win-x64).
All packages are compatible with DNXCore,Version=v5.0 (win7-x86).
All packages are compatible with DNXCore,Version=v5.0 (win7-x64).
```

Than this (potentially for a couple of minutes) where you start to wonder if something has crashed:
```
λ Restore.cmd
Restoring packages: Toolsets
Restoring packages: Samples
Restoring packages: Roslyn (this may take some time)
```