### PR TITLE
Fix a missing reference to Microsoft.VisualStudio.Shell.15.0

### DIFF
--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -26,6 +26,22 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
+  <Choose>
+    <When Condition="$(TF_BUILD_BUILDNUMBER) != ''">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <Private>false</Private>
+          <HintPath>..\..\..\..\..\Closed\References\VisualStudio\VSNext\Microsoft.VisualStudio.Shell.15.0\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+		<Private>false</Private></Reference>
+      </ItemGroup>      
+    </Otherwise>
+  </Choose> 
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
@@ -154,9 +170,6 @@
     <Reference Include="Microsoft.VisualStudio.Progression.CodeSchema, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Progression.Common, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Progression.Interfaces, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>false</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>false</Private>
     </Reference>


### PR DESCRIPTION
Encountered following build errors, which is probably caused by #8554.

```
...src\Open\src\VisualStudio\Core\Test\SolutionExplorer\FakeAnalyzersCommandHandler.vb (9, 0)
'AnalyzerContextMenuController' cannot implement 'AnalyzerContextMenuController' because there is no matching property on interface 'IAnalyzersCommandHandler'.
...src\Open\src\VisualStudio\Core\Test\SolutionExplorer\FakeAnalyzersCommandHandler.vb (15, 0)
'AnalyzerFolderContextMenuController' cannot implement 'AnalyzerFolderContextMenuController' because there is no matching property on interface 'IAnalyzersCommandHandler'.
...src\Open\src\VisualStudio\Core\Test\SolutionExplorer\FakeAnalyzersCommandHandler.vb (21, 0)
'DiagnosticContextMenuController' cannot implement 'DiagnosticContextMenuController' because there is no matching property on interface 'IAnalyzersCommandHandler'.
...src\Open\src\VisualStudio\Core\Test\SolutionExplorer\FakeAnalyzersCommandHandler.vb (7, 0)
Reference required to assembly 'Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' containing the type 'IContextMenuController'. Add one to your project.
```

@dotnet/roslyn-infrastructure @natidea 