### PR TITLE
Fix race in Code Model cache

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -196,30 +196,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         internal void OnCodeElementCreated(SyntaxNodeKey nodeKey, EnvDTE.CodeElement element)
         {
-            _codeElementTable.Add(nodeKey, element);
-        }
+            // If we're creating an element with the same node key as an element that's already in the table, just remove
+            // the old element. The old element will continue to function but the new element will replace it in the cache.
 
-        internal void OnBeforeCodeElementCreated(SyntaxNode node)
-        {
-            // It's conceivable that a consumer is creating a code element with the same node key as a "dead" element
-            // that hasn't been removed from the cache yet. For example, the element could have been "deleted" by
-            // simply replacing its text in the underlying buffer. To handle this situation, we test to see if the
-            // element is "dead" by checking whether it's underlying node is invalid (that is, it can't be found by
-            // its node key). If the element is "dead", we'll go ahead and remove it from the cache here to avoid a
-            // collision with the new element.
-
-            var nodeKey = CodeModelService.TryGetNodeKey(node);
-            EnvDTE.CodeElement codeElement;
-            if (!nodeKey.IsEmpty && _codeElementTable.TryGetValue(nodeKey, out codeElement))
+            EnvDTE.CodeElement oldElement;
+            if (_codeElementTable.TryGetValue(nodeKey, out oldElement))
             {
-                var managedElement = ComAggregate.GetManagedObject<AbstractKeyedCodeElement>(codeElement);
-                Debug.Assert(managedElement != null, $"Could not get the underlying {nameof(AbstractKeyedCodeElement)} from {nameof(codeElement)} with {nameof(nodeKey)}: {nodeKey}");
-
-                if (managedElement?.IsValidNode() != true)
-                {
-                    _codeElementTable.Remove(nodeKey);
-                }
+                _codeElementTable.Remove(nodeKey);
             }
+
+            _codeElementTable.Add(nodeKey, element);
         }
 
         internal void OnCodeElementDeleted(SyntaxNodeKey nodeKey)

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel_CodeGen.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel_CodeGen.cs
@@ -62,8 +62,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 var resultNode = CodeModelService.InsertMember(
                     document, IsBatchOpen, insertionIndex, containerNode, memberNode, CancellationToken.None, out newDocument);
 
-                OnBeforeCodeElementCreated(resultNode);
-
                 return Tuple.Create(resultNode, newDocument);
             });
         }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -3854,6 +3854,8 @@ class C$$
                             Assert.False(True,
 $"Failed to add variable in loop iteration {i}!
 
+Exception: {ex.Message}
+
 Document text:
 {initialDocument.GetTextAsync(CancellationToken.None).Result}")
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -3163,6 +3163,8 @@ End Class
                             Assert.False(True,
 $"Failed to add variable in loop iteration {i}!
 
+Exception: {ex.Message}
+
 Document text:
 {initialDocument.GetTextAsync(CancellationToken.None).Result}")
 


### PR DESCRIPTION
Fixes #8576

This addresses a race condition introduced in our per-FileCodeModel cache of code elements by PR #8424. In that change, we attempted to handle the situation where a code model element is about to be inserted in the cache with the same "node key" is an element that is already in the cache. This can happen in normal operation if a Code Model consumer were to programmatically add a variable, delete the variable's underlying text and immediately add the same variable again. The original fix would conditionally remove the old element from the cache if its "node key" could not be resolved in the FileCodeModel's current syntax tree. Then it would add the new element with the same "node key" to the cache. However, this appears to not be deterministic and would sometimes result in a collision.

This PR changes the policy to *unconditionally* remove the old element from the cache if one exists before adding the new element. Because the purpose of the cache is to return existing elements when accessing various collections (e.g. "Members"), it makes sense that the latest element would be returned. In addition, because the "node key" referenced by the old element has become valid again, accessing properties on the old element will continue to work.

Tagging @dotnet/roslyn-ide 