### PR TITLE
Work around compilation events appearing in the queue too late.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _syntaxAndDeclarations = syntaxAndDeclarations;
 
             Debug.Assert((object)_lazyAssemblySymbol == null);
-            if (EventQueue != null) EventQueue.Enqueue(new CompilationStartedEvent(this));
+            if (EventQueue != null) EventQueue.TryEnqueue(new CompilationStartedEvent(this));
         }
 
         internal override void ValidateDebugEntryPoint(IMethodSymbol debugEntryPoint, DiagnosticBag diagnostics)
@@ -1715,13 +1715,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (completedCompilationUnit)
             {
-                EventQueue.Enqueue(new CompilationUnitCompletedEvent(this, tree));
+                EventQueue.TryEnqueue(new CompilationUnitCompletedEvent(this, tree));
             }
 
             if (completedCompilation)
             {
-                EventQueue.Enqueue(new CompilationCompletedEvent(this));
-                EventQueue.Complete(); // signal the end of compilation events
+                EventQueue.TryEnqueue(new CompilationCompletedEvent(this));
+                if (!EventQueue.IsCompleted) EventQueue.Complete(); // signal the end of compilation events
             }
         }
 
@@ -2885,10 +2885,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal void SymbolDeclaredEvent(Symbol symbol)
         {
-            if (EventQueue?.IsCompleted == false)
-            {
-                EventQueue.Enqueue(new SymbolDeclaredCompilationEvent(this, symbol));
-            }
+            EventQueue?.TryEnqueue(new SymbolDeclaredCompilationEvent(this, symbol));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2885,7 +2885,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal void SymbolDeclaredEvent(Symbol symbol)
         {
-            if (EventQueue != null) EventQueue.Enqueue(new SymbolDeclaredCompilationEvent(this, symbol));
+            if (EventQueue?.IsCompleted == false)
+            {
+                EventQueue.Enqueue(new SymbolDeclaredCompilationEvent(this, symbol));
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -948,7 +948,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return semanticModel;
                     });
 
-                    _compilation.EventQueue.Enqueue(new SymbolDeclaredCompilationEvent(_compilation, methodSymbol, lazySemanticModel));
+                    _compilation.EventQueue.TryEnqueue(new SymbolDeclaredCompilationEvent(_compilation, methodSymbol, lazySemanticModel));
                 }
 
                 // Don't lower if we're not emitting or if there were errors. 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -904,7 +904,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             foreach (var compilationEvent in _analysisState.GetPendingEvents(analyzers, tree))
             {
-                eventQueue.Enqueue(compilationEvent);
+                eventQueue.TryEnqueue(compilationEvent);
             }
 
             return eventQueue;
@@ -920,7 +920,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             foreach (var compilationEvent in _analysisState.GetPendingEvents(analyzers, includeSourceEvents, includeNonSourceEvents))
             {
-                eventQueue.Enqueue(compilationEvent);
+                eventQueue.TryEnqueue(compilationEvent);
             }
 
             return eventQueue;

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -1193,7 +1193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 End If
                                 Return semanticModel
                             End Function)
-                        compilation.EventQueue.Enqueue(New SymbolDeclaredCompilationEvent(compilation, method, lazySemanticModel))
+                        compilation.EventQueue.TryEnqueue(New SymbolDeclaredCompilationEvent(compilation, method, lazySemanticModel))
                     End If
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -446,7 +446,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(_lazyAssemblySymbol Is Nothing)
             If Me.EventQueue IsNot Nothing Then
-                Me.EventQueue.Enqueue(New CompilationStartedEvent(Me))
+                Me.EventQueue.TryEnqueue(New CompilationStartedEvent(Me))
             End If
         End Sub
 
@@ -1647,12 +1647,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End SyncLock
 
             If completedCompilationUnit Then
-                EventQueue.Enqueue(New CompilationUnitCompletedEvent(Me, tree))
+                EventQueue.TryEnqueue(New CompilationUnitCompletedEvent(Me, tree))
             End If
 
             If completedCompilation Then
-                EventQueue.Enqueue(New CompilationCompletedEvent(Me))
-                EventQueue.Complete() ' signal the End Of compilation events
+                EventQueue.TryEnqueue(New CompilationCompletedEvent(Me))
+                If Not EventQueue.IsCompleted Then EventQueue.Complete() ' signal the End Of compilation events
             End If
         End Sub
 
@@ -1673,7 +1673,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Sub SymbolDeclaredEvent(symbol As Symbol)
             If ShouldAddEvent(symbol) Then
-                EventQueue.Enqueue(New SymbolDeclaredCompilationEvent(Me, symbol))
+                EventQueue.TryEnqueue(New SymbolDeclaredCompilationEvent(Me, symbol))
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1657,7 +1657,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Friend Function ShouldAddEvent(symbol As Symbol) As Boolean
-            If EventQueue Is Nothing Then
+            If EventQueue Is Nothing OrElse EventQueue.IsCompleted Then
                 Return False
             End If
 


### PR DESCRIPTION
I suspect this occurs due to syntax error recovery because the semantic model does not
find appropriate symbols in the symbol table, and creates them as needed, but I was unable to reproduce the issue to verify that. We prevent the crash by suppressing events that arise too late.
Fixes #8178 

@dotnet/roslyn-compiler Please review.
