### PR TITLE
Handle default parameter values for event accessors in CreateBinderForNodeAndUsage.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
@@ -382,7 +382,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Case SyntaxKind.FunctionLambdaHeader,
                                  SyntaxKind.SubLambdaHeader,
                                  SyntaxKind.SetAccessorStatement,
-                                 SyntaxKind.GetAccessorStatement
+                                 SyntaxKind.GetAccessorStatement,
+                                 SyntaxKind.AddHandlerAccessorStatement,
+                                 SyntaxKind.RemoveHandlerAccessorStatement,
+                                 SyntaxKind.RaiseEventAccessorStatement
                                 ' Default values are not valid (and not bound) for lambda parameters or property accessors
                                 Return Nothing
 


### PR DESCRIPTION
Fixes #8401.