### PR TITLE
Ensure DeclarationTreeBuilder.GetModifiers doesn't throw on unexpected tokens that have errors.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTreeBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTreeBuilder.vb
@@ -791,7 +791,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Case SyntaxKind.IteratorKeyword : bit = DeclarationModifiers.Iterator
 
                     Case Else
-                        Throw ExceptionUtilities.UnexpectedValue(modifier.Kind)
+                        ' It is possible to run into other tokens here, but only in error conditions.
+                        ' We are going to ignore them here.
+                        If Not modifier.GetDiagnostics().Any(Function(d) d.Severity = DiagnosticSeverity.Error) Then
+                            Throw ExceptionUtilities.UnexpectedValue(modifier.Kind)
+                        End If
                 End Select
 
                 result = result Or bit

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -3347,6 +3347,56 @@ expectedOutput:="FalseTrue112")
 
         End Sub
 
+        <Fact, WorkItem(8400, "https://github.com/dotnet/roslyn/issues/8400")>
+        Public Sub WrongModifier()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="C">
+    <file name="a.vb"><![CDATA[
+    public class AAA : IBBB
+    {
+        public static AAA MMM(Stream xamlStream)
+        {
+            // Note: create custom module catalog 
+    ]]></file>
+</compilation>)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30481: 'Class' statement must end with a matching 'End Class'.
+public class AAA : IBBB
+~~~~~~~~~~~~~~~~
+BC30188: Declaration expected.
+public class AAA : IBBB
+                   ~~~~
+BC30035: Syntax error.
+    {
+    ~
+BC30235: 'static' is not valid on a member variable declaration.
+        public static AAA MMM(Stream xamlStream)
+               ~~~~~~
+BC30205: End of statement expected.
+        public static AAA MMM(Stream xamlStream)
+                          ~~~
+BC30035: Syntax error.
+        {
+        ~
+BC30035: Syntax error.
+            // Note: create custom module catalog
+            ~
+BC30188: Declaration expected.
+            // Note: create custom module catalog
+                     ~~~~~~
+BC31140: 'Custom' modifier can only be used immediately before an 'Event' declaration.
+            // Note: create custom module catalog
+                            ~~~~~~
+BC30617: 'Module' statements can occur only at file or namespace level.
+            // Note: create custom module catalog
+                            ~~~~~~~~~~~~~~~~~~~~~
+BC30625: 'Module' statement must end with a matching 'End Module'.
+            // Note: create custom module catalog
+                            ~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+        End Sub
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #8400.