### PR TITLE
Harden determinism job

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -56,6 +56,7 @@ call :TerminateBuildProcesses
 
 if defined TestDeterminism (
     powershell -noprofile -executionPolicy RemoteSigned -file "%RoslynRoot%\build\scripts\test-determinism.ps1" "%bindir%\Bootstrap" || goto :BuildFailed
+    call :TerminateBuildProcesses
     exit /b 0
 )
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -153,7 +153,7 @@ static void addStandardJob(def myJob, String jobName, String branchName, String 
   addLogRotator(myJob)
   addWrappers(myJob)
 
-  def includePattern = "Binaries/**/*.pdb,Binaries/**/*.xml,Binaries/**/*.baseline*,Binaries/**/*.original*,,Binaries/**/*.key,Binaries/**/*.log,Binaries/**/*.dmp"
+  def includePattern = "Binaries/**/*.pdb,Binaries/**/*.xml,Binaries/**/*.log,Binaries/**/*.dmp,Binaries/**/*.zip"
   def excludePattern = "Binaries/Obj/**,Binaries/Bootstrap/**"
   addArtifactArchiving(myJob, includePattern, excludePattern)
 
@@ -250,5 +250,4 @@ set TMP=%TEMP%
     addStandardJob(determinismJob, determinismJobName, branchName, "unit32", "win")
   }
 }
-
 


### PR DESCRIPTION
This hardens the determinism job:
- Properly terminates build processes on exit
- Creates a zip file of all information needed for investigation on
failure