### PR TITLE
Prevent NaN from slipping into .Measure calls.

### DIFF
--- a/src/EditorFeatures/Core/Host/IPreviewPaneService.cs
+++ b/src/EditorFeatures/Core/Host/IPreviewPaneService.cs
@@ -8,6 +8,6 @@ namespace Microsoft.CodeAnalysis.Editor.Host
 {
     internal interface IPreviewPaneService : IWorkspaceService
     {
-        object GetPreviewPane(DiagnosticData diagnostic, string language, string projectType, IList<object> previewContent);
+        object GetPreviewPane(DiagnosticData diagnostic, string language, string projectType, IReadOnlyList<object> previewContent);
     }
 }

--- a/src/EditorFeatures/Core/Implementation/SolutionPreviewResult.cs
+++ b/src/EditorFeatures/Core/Implementation/SolutionPreviewResult.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor
 
         public bool IsEmpty => _previews.Count == 0;
 
-        public async Task<IList<object>> GetPreviewsAsync(DocumentId preferredDocumentId = null, ProjectId preferredProjectId = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IReadOnlyList<object>> GetPreviewsAsync(DocumentId preferredDocumentId = null, ProjectId preferredProjectId = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             AssertIsForeground();
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
@@ -16,6 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 {
     internal partial class PreviewPane : UserControl, IDisposable
     {
+        private const double DefaultWidth = 400;
+
         private static readonly string s_dummyThreeLineTitle = "A" + Environment.NewLine + "A" + Environment.NewLine + "A";
         private static readonly Size s_infiniteSize = new Size(double.PositiveInfinity, double.PositiveInfinity);
 
@@ -26,8 +28,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
         private double _heightForThreeLineTitle;
         private IWpfDifferenceViewer _previewDiffViewer;
 
-        public PreviewPane(Image severityIcon, string id, string title, string description, Uri helpLink, string helpLinkToolTipText,
-            IList<object> previewContent, bool logIdVerbatimInTelemetry)
+        public PreviewPane(
+            Image severityIcon,
+            string id,
+            string title,
+            string description,
+            Uri helpLink,
+            string helpLinkToolTipText,
+            IReadOnlyList<object> previewContent,
+            bool logIdVerbatimInTelemetry)
         {
             InitializeComponent();
 
@@ -62,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             InitializePreviewElement(previewContent);
         }
 
-        private void InitializePreviewElement(IList<object> previewItems)
+        private void InitializePreviewElement(IReadOnlyList<object> previewItems)
         {
             var previewElement = CreatePreviewElement(previewItems);
 
@@ -84,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             AdjustWidthAndHeight(previewElement);
         }
 
-        private FrameworkElement CreatePreviewElement(IList<object> previewItems)
+        private FrameworkElement CreatePreviewElement(IReadOnlyList<object> previewItems)
         {
             if (previewItems == null || previewItems.Count == 0)
             {
@@ -175,7 +184,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             {
                 preview = new Border()
                 {
-                    Width = 400,
+                    Width = DefaultWidth,
                     MinHeight = 75,
                     Child = textBlock
                 };
@@ -202,7 +211,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             }
             else
             {
-                PreviewDockPanel.Measure(availableSize: new Size(previewElement.Width, double.PositiveInfinity));
+                PreviewDockPanel.Measure(availableSize: new Size(
+                    double.IsNaN(previewElement.Width) ? DefaultWidth : previewElement.Width,
+                    double.PositiveInfinity));
                 headerStackPanelWidth = PreviewDockPanel.DesiredSize.Width;
                 if (IsNormal(headerStackPanelWidth))
                 {

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             return helpLink;
         }
 
-        object IPreviewPaneService.GetPreviewPane(DiagnosticData diagnostic, string language, string projectType, IList<object> previewContent)
+        object IPreviewPaneService.GetPreviewPane(DiagnosticData diagnostic, string language, string projectType, IReadOnlyList<object> previewContent)
         {
             var title = diagnostic?.Message;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/8514