### PR TITLE
Fix Code Model race for real this time

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interop/CleanableWeakComHandleTable.cs
@@ -212,6 +212,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
             return null;
         }
 
+        public bool ContainsKey(TKey key)
+        {
+            this.AssertIsForeground();
+
+            return _table.ContainsKey(key);
+        }
+
         public bool TryGetValue(TKey key, out TValue value)
         {
             this.AssertIsForeground();

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -199,8 +199,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             // If we're creating an element with the same node key as an element that's already in the table, just remove
             // the old element. The old element will continue to function but the new element will replace it in the cache.
 
-            EnvDTE.CodeElement oldElement;
-            if (_codeElementTable.TryGetValue(nodeKey, out oldElement))
+            if (_codeElementTable.ContainsKey(nodeKey))
             {
                 _codeElementTable.Remove(nodeKey);
             }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -3845,22 +3845,7 @@ class C$$
             Await TestElement(code,
                 Sub(state, codeClass)
                     For i = 1 To 100
-                        Dim initialDocument = state.FileCodeModelObject.GetDocument()
-                        Dim variable As EnvDTE.CodeVariable
-
-                        Try
-                            variable = codeClass.AddVariable("x", "System.Int32")
-                        Catch ex As InvalidOperationException
-                            Assert.False(True,
-$"Failed to add variable in loop iteration {i}!
-
-Exception: {ex.Message}
-
-Document text:
-{initialDocument.GetTextAsync(CancellationToken.None).Result}")
-
-                            Throw ex
-                        End Try
+                        Dim variable = codeClass.AddVariable("x", "System.Int32")
 
                         ' Now, delete the variable that we just added.
                         Dim startPoint = variable.StartPoint

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeClassTests.vb
@@ -3154,22 +3154,7 @@ End Class
             Await TestElement(code,
                 Sub(state, codeClass)
                     For i = 1 To 100
-                        Dim initialDocument = state.FileCodeModelObject.GetDocument()
-                        Dim variable As EnvDTE.CodeVariable
-
-                        Try
-                            variable = codeClass.AddVariable("x", "System.Int32")
-                        Catch ex As InvalidOperationException
-                            Assert.False(True,
-$"Failed to add variable in loop iteration {i}!
-
-Exception: {ex.Message}
-
-Document text:
-{initialDocument.GetTextAsync(CancellationToken.None).Result}")
-
-                            Throw ex
-                        End Try
+                        Dim variable = codeClass.AddVariable("x", "System.Int32")
 
                         ' Now, delete the variable that we just added.
                         Dim startPoint = variable.StartPoint


### PR DESCRIPTION
Fixes #8576

I thought I'd fixed this race with PR #8607. After all, the check-in tests were passing on the PR and the tests all passed locally on my machine. However, it still failed consistently on the build server. Clearly the problem was more subtle that I'd originally thought.

Finally, I noticed that the only test passes that were failing were on x86 *Release* (insert sound of forehead being smacked). After compiling Release, I could reproduce the problem locally.

It turns out that this was a race with GC. In a previous fix, when adding an element to FileCodeModel's element cache, we would first check to see if the element was already in the cache. If it was in the cache, we'd remove it before adding it. However, the test to see if the element was in the cache called `CleanableWeakComHandleTable.TryGetValue(TKey key, out TValue value)`, which would only return true if `key` was in the cache and `value` was not set to null. In essence, it's defined like so:

```C#
public bool TryGetValue(TKey key, out TValue value)
{
    this.AssertIsForeground();

    WeakComHandle<TValue, TValue> handle;
    if (_table.TryGetValue(key, out handle))
    {
        value = handle.ComAggregateObject;
        return value != null;
    }

    value = null;
    return false;
}
```

Notice how it only returns true when value is not null? Since the `CleanableWeakComHandleTable` weakly holds onto elements, calling this to determine whether a key is in the table is clearly not correct because the element can get GC'd. In Release, the GC can be a bit more aggressive (often due to additional hints in the optimized JIT code), causing more situations where a key would be in the table with a null value. For those items, `TryGetValue` returns false, so we wouldn't remove the key from the table before adding it again, resulting in a collision.

The fix is to create a simpler `CleanableWeakComHandleTable.ContainsKey(TKey key)` that doesn't rely on the value in the table and use that instead.

```C#
public bool ContainsKey(TKey key)
{
    this.AssertIsForeground();

    return _table.ContainsKey(key);
}
```

tagging @dotnet/roslyn-ide 