### PR TITLE
Ensure that VB XML doc comment completion returns correct tag names

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/CompletionProviders/XmlDocCommentCompletion/AbstractDocCommentCompletionProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/CompletionProviders/XmlDocCommentCompletion/AbstractDocCommentCompletionProvider.cs
@@ -14,33 +14,67 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.C
 {
     internal abstract class AbstractDocCommentCompletionProvider : CompletionListProvider, ICustomCommitCompletionProvider
     {
+        // Tag names
+        protected const string CDataPrefixTagName = "![CDATA[";
+        protected const string CTagName = "c";
+        protected const string CodeTagName = "code";
+        protected const string CommentPrefixTagName = "!--";
+        protected const string CompletionListTagName = "completionlist";
+        protected const string DescriptionTagName = "description";
+        protected const string ExampleTagName = "example";
+        protected const string ExceptionTagName = "exception";
+        protected const string IncludeTagName = "include";
+        protected const string ItemTagName = "item";
+        protected const string ListTagName = "list";
+        protected const string ListHeaderTagName = "listheader";
+        protected const string ParaTagName = "para";
+        protected const string ParamTagName = "param";
+        protected const string ParamRefTagName = "paramref";
+        protected const string PermissionTagName = "permission";
+        protected const string RemarksTagName = "remarks";
+        protected const string ReturnsTagName = "returns";
+        protected const string SeeTagName = "see";
+        protected const string SeeAlsoTagName = "seealso";
+        protected const string SummaryTagName = "summary";
+        protected const string TermTagName = "term";
+        protected const string TypeParamTagName = "typeparam";
+        protected const string TypeParamRefTagName = "typeparamref";
+        protected const string ValueTagName = "value";
+
+        // Attribute names
+        protected const string CrefAttributeName = "cref";
+        protected const string FileAttributeName = "file";
+        protected const string NameAttributeName = "name";
+        protected const string PathAttributeName = "path";
+        protected const string TypeAttributeName = "type";
+
         private readonly Dictionary<string, string[]> _tagMap =
             new Dictionary<string, string[]>
             {
-                { "exception", new[] { "<exception cref=\"", "\"" } },
-                { "!--", new[] { "<!--", "-->" } },
-                { "![CDATA[", new[] { "<![CDATA[", "]]>" } },
-                { "include", new[] { "<include file=\'", "\' path=\'[@name=\"\"]\'/>" } },
-                { "permission", new[] { "<permission cref=\"", "\"" } },
-                { "see", new[] { "<see cref=\"", "\"/>" } },
-                { "seealso", new[] { "<seealso cref=\"", "\"/>" } },
-                { "list", new[] { "<list type=\"", "\"" } },
-                { "paramref", new[] { "<paramref name=\"", "\"/>" } },
-                { "typeparamref", new[] { "<typeparamref name=\"", "\"/>" } },
-                { "completionlist", new[] { "<completionlist cref=\"", "\"/>" } },
+                { ExceptionTagName,      new[] { $"<{ExceptionTagName} {CrefAttributeName}=\"",      "\"" } },
+                { CommentPrefixTagName,  new[] { $"<{CommentPrefixTagName}",                         "-->" } },
+                { CDataPrefixTagName,    new[] { $"<{CDataPrefixTagName}",                           "]]>" } },
+                { IncludeTagName,        new[] { $"<{IncludeTagName} {FileAttributeName}=\'",        $"\' {PathAttributeName}=\'[@name=\"\"]\'/>" } },
+                { PermissionTagName,     new[] { $"<{PermissionTagName} {CrefAttributeName}=\"",     "\"" } },
+                { SeeTagName,            new[] { $"<{SeeTagName} {CrefAttributeName}=\"",            "\"/>" } },
+                { SeeAlsoTagName,        new[] { $"<{SeeAlsoTagName} {CrefAttributeName}=\"",        "\"/>" } },
+                { ListTagName,           new[] { $"<{ListTagName} {TypeAttributeName}=\"",           "\"" } },
+                { ParamRefTagName,       new[] { $"<{ParamRefTagName} {NameAttributeName}=\"",       "\"/>" } },
+                { TypeParamRefTagName,   new[] { $"<{TypeParamRefTagName} {NameAttributeName}=\"",   "\"/>" } },
+                { CompletionListTagName, new[] { $"<{CompletionListTagName} {CrefAttributeName}=\"", "\"/>" } },
             };
 
         private readonly string[][] _attributeMap =
             new[]
             {
-                new[] { "exception", "cref", "cref=\"", "\"" },
-                new[] { "permission",  "cref", "cref=\"", "\"" },
-                new[] { "see", "cref", "cref=\"", "\"" },
-                new[] { "seealso", "cref", "cref=\"", "\"" },
-                new[] { "list", "type", "type=\"", "\"" },
-                new[] { "param", "name", "name=\"", "\"" },
-                new[] { "include", "file", "file=\"", "\"" },
-                new[] { "include", "path", "path=\"", "\"" }
+                new[] { ExceptionTagName, CrefAttributeName, $"{CrefAttributeName}=\"", "\"" },
+                new[] { PermissionTagName, CrefAttributeName, $"{CrefAttributeName}=\"", "\"" },
+                new[] { SeeTagName, CrefAttributeName, $"{CrefAttributeName}=\"", "\"" },
+                new[] { SeeAlsoTagName, CrefAttributeName, $"{CrefAttributeName}=\"", "\"" },
+                new[] { ListTagName, TypeAttributeName, $"{TypeAttributeName}=\"", "\"" },
+                new[] { ParamTagName, NameAttributeName, $"{NameAttributeName}=\"", "\"" },
+                new[] { IncludeTagName, FileAttributeName, $"{FileAttributeName}=\"", "\"" },
+                new[] { IncludeTagName, PathAttributeName, $"{PathAttributeName}=\"", "\"" }
             };
 
         public override async Task ProduceCompletionListAsync(CompletionListContext context)
@@ -79,37 +113,37 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.C
 
         protected IEnumerable<CompletionItem> GetAlwaysVisibleItems(TextSpan filterSpan)
         {
-            return new[] { "see", "seealso", "![CDATA[", "!--" }
+            return new[] { SeeTagName, SeeAlsoTagName, CDataPrefixTagName, CommentPrefixTagName }
                 .Select(t => GetItem(t, filterSpan));
         }
 
         protected IEnumerable<CompletionItem> GetNestedTags(TextSpan filterSpan)
         {
-            return new[] { "c", "code", "para", "list", "paramref", "typeparamref" }
+            return new[] { CTagName, CodeTagName, ParaTagName, ListTagName, ParamRefTagName, TypeParamRefTagName }
                 .Select(t => GetItem(t, filterSpan));
         }
 
         protected IEnumerable<CompletionItem> GetTopLevelRepeatableItems(TextSpan filterSpan)
         {
-            return new[] { "exception", "include", "permission" }
+            return new[] { ExceptionTagName, IncludeTagName, PermissionTagName }
                 .Select(t => GetItem(t, filterSpan));
         }
 
         protected IEnumerable<CompletionItem> GetListItems(TextSpan span)
         {
-            return new[] { "listheader", "term", "item", "description" }
+            return new[] { ListHeaderTagName, TermTagName, ItemTagName, DescriptionTagName }
                 .Select(t => GetItem(t, span));
         }
 
         protected IEnumerable<CompletionItem> GetListHeaderItems(TextSpan span)
         {
-            return new[] { "term", "description" }
+            return new[] { TermTagName, DescriptionTagName }
                 .Select(t => GetItem(t, span));
         }
 
         protected string FormatParameter(string kind, string name)
         {
-            return string.Format("{0} name=\"{1}\"", kind, name);
+            return $"{kind} {NameAttributeName}=\"{name}\"";
         }
 
         public void Commit(CompletionItem completionItem, ITextView textView, ITextBuffer subjectBuffer, ITextSnapshot triggerSnapshot, char? commitChar)

--- a/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -322,7 +322,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
             items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("typeparam", p), GetCompletionItemRules())))
 
             If returns Then
-                items.Add(GetItem("return", span))
+                items.Add(GetItem("returns", span))
             End If
 
             Return items

--- a/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -334,7 +334,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
 
             If nameSyntax.LocalName.ValueText = name Then
                 Return startTag.Attributes.OfType(Of XmlNameAttributeSyntax)() _
-                    .Where(Function(a) a.Name.ToString() = NameOf(name)) _
+                    .Where(Function(a) a.Name.ToString() = "name") _
                     .Select(Function(a) a.Reference.Identifier.ValueText) _
                     .FirstOrDefault()
             End If

--- a/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -14,25 +14,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
     Partial Friend Class XmlDocCommentCompletionProvider
         Inherits AbstractDocCommentCompletionProvider
 
-        ' Tag names
-        Private Const CompletionListTagName = "completionlist"
-        Private Const ExampleTagName = "example"
-        Private Const ExceptionTagName = "exception"
-        Private Const IncludeTagName = "include"
-        Private Const ParamTagName = "param"
-        Private Const PermissionTagName = "permission"
-        Private Const RemarksTagName = "remarks"
-        Private Const ReturnsTagName = "returns"
-        Private Const SummaryTagName = "summary"
-        Private Const TypeParamTagName = "typeparam"
-        Private Const ValueTagName = "value"
-
-        ' Attribute names
-        Private Const CrefAttributeName = "cref"
-        Private Const ListTagName = "list"
-        Private Const ListHeaderTagName = "listheader"
-        Private Const NameAttributeName = "name"
-
         Public Overrides Function IsTriggerCharacter(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean
             Return text(characterPosition) = "<"c OrElse (text(characterPosition) = "/"c AndAlso characterPosition > 0 AndAlso text(characterPosition - 1) = "<"c)
         End Function
@@ -174,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
 
             Dim nameToken = name.LocalName
             If Not nameToken.IsMissing AndAlso nameToken.ValueText.Length > 0 Then
-                Return SpecializedCollections.SingletonEnumerable(Of CompletionItem)(New XmlDocCommentCompletionItem(Me, span, nameToken.ValueText, nameToken.ValueText + ">", String.Empty, GetCompletionItemRules()))
+                Return SpecializedCollections.SingletonEnumerable(Of CompletionItem)(New XmlDocCommentCompletionItem(Me, span, nameToken.ValueText, nameToken.ValueText & ">", String.Empty, GetCompletionItemRules()))
             End If
 
             Return Nothing

--- a/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/EditorFeatures/VisualBasic/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -14,6 +14,25 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
     Partial Friend Class XmlDocCommentCompletionProvider
         Inherits AbstractDocCommentCompletionProvider
 
+        ' Tag names
+        Private Const CompletionListTagName = "completionlist"
+        Private Const ExampleTagName = "example"
+        Private Const ExceptionTagName = "exception"
+        Private Const IncludeTagName = "include"
+        Private Const ParamTagName = "param"
+        Private Const PermissionTagName = "permission"
+        Private Const RemarksTagName = "remarks"
+        Private Const ReturnsTagName = "returns"
+        Private Const SummaryTagName = "summary"
+        Private Const TypeParamTagName = "typeparam"
+        Private Const ValueTagName = "value"
+
+        ' Attribute names
+        Private Const CrefAttributeName = "cref"
+        Private Const ListTagName = "list"
+        Private Const ListHeaderTagName = "listheader"
+        Private Const NameAttributeName = "name"
+
         Public Overrides Function IsTriggerCharacter(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean
             Return text(characterPosition) = "<"c OrElse (text(characterPosition) = "/"c AndAlso characterPosition > 0 AndAlso text(characterPosition - 1) = "<"c)
         End Function
@@ -48,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
             If token.Parent.IsKind(SyntaxKind.XmlString) AndAlso token.Parent.Parent.IsKind(SyntaxKind.XmlAttribute) Then
                 Dim attribute = DirectCast(token.Parent.Parent, XmlAttributeSyntax)
                 Dim name = TryCast(attribute.Name, XmlNameSyntax)
-                If name IsNot Nothing AndAlso name.LocalName.ValueText = "cref" Then
+                If name IsNot Nothing AndAlso name.LocalName.ValueText = CrefAttributeName Then
                     Return Nothing
                 End If
             End If
@@ -99,21 +118,21 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
             If grandParent.IsKind(SyntaxKind.XmlElement) Then
                 items.AddRange(GetNestedTags(span))
 
-                If GetStartTagName(grandParent) = "list" Then
+                If GetStartTagName(grandParent) = ListTagName Then
                     items.AddRange(GetListItems(span))
                 End If
 
-                If GetStartTagName(grandParent) = "listheader" Then
+                If GetStartTagName(grandParent) = ListHeaderTagName Then
                     items.AddRange(GetListHeaderItems(span))
                 End If
             ElseIf token.Parent.IsKind(SyntaxKind.XmlText) AndAlso token.Parent.Parent.IsKind(SyntaxKind.XmlElement) Then
                 items.AddRange(GetNestedTags(span))
 
-                If GetStartTagName(token.Parent.Parent) = "list" Then
+                If GetStartTagName(token.Parent.Parent) = ListTagName Then
                     items.AddRange(GetListItems(span))
                 End If
 
-                If GetStartTagName(token.Parent.Parent) = "listheader" Then
+                If GetStartTagName(token.Parent.Parent) = ListHeaderTagName Then
                     items.AddRange(GetListHeaderItems(span))
                 End If
             ElseIf grandParent.IsKind(SyntaxKind.DocumentationCommentTrivia) Then
@@ -123,11 +142,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
 
             If token.Parent.IsKind(SyntaxKind.XmlElementStartTag, SyntaxKind.XmlName) Then
                 If parentElement.IsParentKind(SyntaxKind.XmlElement) Then
-                    If GetStartTagName(parentElement.Parent) = "list" Then
+                    If GetStartTagName(parentElement.Parent) = ListTagName Then
                         items.AddRange(GetListItems(span))
                     End If
 
-                    If GetStartTagName(parentElement.Parent) = "listheader" Then
+                    If GetStartTagName(parentElement.Parent) = ListHeaderTagName Then
                         items.AddRange(GetListHeaderItems(span))
                     End If
                 End If
@@ -209,12 +228,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
                         attributeName = DirectCast(targetToken.GetAncestor(Of XmlAttributeSyntax)().Name, XmlNameSyntax).LocalName.ValueText
                     End If
 
-                    If attributeName = "name" Then
-                        If tagName = "param" Then
+                    If attributeName = NameAttributeName Then
+                        If tagName = ParamTagName Then
                             items.AddRange(symbol.GetParameters().Select(Function(s) New XmlDocCommentCompletionItem(Me, span, s.Name, GetCompletionItemRules())))
                         End If
 
-                        If tagName = "typeparam" Then
+                        If tagName = TypeParamTagName Then
                             items.AddRange(symbol.GetTypeArguments().Select(Function(s) New XmlDocCommentCompletionItem(Me, span, s.Name, GetCompletionItemRules())))
                         End If
                     End If
@@ -256,9 +275,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
             Dim items = New List(Of CompletionItem)
 
             Dim typeParameters = type.GetTypeArguments().Select(Function(t) t.Name).ToSet()
-            RemoveExistingTags(parent, typeParameters, Function(e) FindName("typeparam", e))
+            RemoveExistingTags(parent, typeParameters, Function(e) FindName(TypeParamTagName, e))
 
-            items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("typeparam", p), GetCompletionItemRules())))
+            items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter(TypeParamTagName, p), GetCompletionItemRules())))
 
             Return items
         End Function
@@ -276,7 +295,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
                 If element IsNot Nothing AndAlso Not element.StartTag.IsMissing AndAlso Not element.EndTag.IsMissing Then
                     Dim startTag = element.StartTag
 
-                    If startTag.ToString() = "value" Then
+                    If startTag.ToString() = ValueTagName Then
                         value = False
                     End If
                 End If
@@ -284,14 +303,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
 
             If [property].IsIndexer Then
                 Dim parameters = [property].Parameters.Select(Function(p) p.Name).ToSet()
-                RemoveExistingTags(parent, parameters, Function(e) FindName("param", e))
-                items.AddRange(parameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("param", p), GetCompletionItemRules())))
+                RemoveExistingTags(parent, parameters, Function(e) FindName(ParamTagName, e))
+                items.AddRange(parameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter(ParamTagName, p), GetCompletionItemRules())))
             End If
 
-            items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("typeparam", p), GetCompletionItemRules())))
+            items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter(TypeParamTagName, p), GetCompletionItemRules())))
 
             If value Then
-                items.Add(GetItem("value", span))
+                items.Add(GetItem(ValueTagName, span))
             End If
 
             Return items
@@ -304,25 +323,25 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
             Dim typeParameters = method.TypeParameters.Select(Function(t) t.Name).ToSet()
             Dim returns = True
 
-            RemoveExistingTags(parent, parameters, Function(e) FindName("param", e))
-            RemoveExistingTags(parent, typeParameters, Function(e) FindName("typeparam", e))
+            RemoveExistingTags(parent, parameters, Function(e) FindName(ParamTagName, e))
+            RemoveExistingTags(parent, typeParameters, Function(e) FindName(TypeParamTagName, e))
 
             For Each node In parent.ChildNodes
                 Dim element = TryCast(node, XmlElementSyntax)
                 If element IsNot Nothing AndAlso Not element.StartTag.IsMissing AndAlso Not element.EndTag.IsMissing Then
                     Dim startTag = element.StartTag
 
-                    If startTag.ToString() = "returns" Then
+                    If startTag.ToString() = ReturnsTagName Then
                         returns = False
                     End If
                 End If
             Next
 
-            items.AddRange(parameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("param", p), GetCompletionItemRules())))
-            items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter("typeparam", p), GetCompletionItemRules())))
+            items.AddRange(parameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter(ParamTagName, p), GetCompletionItemRules())))
+            items.AddRange(typeParameters.Select(Function(p) New XmlDocCommentCompletionItem(Me, span, FormatParameter(TypeParamTagName, p), GetCompletionItemRules())))
 
             If returns Then
-                items.Add(GetItem("returns", span))
+                items.Add(GetItem(ReturnsTagName, span))
             End If
 
             Return items
@@ -334,7 +353,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
 
             If nameSyntax.LocalName.ValueText = name Then
                 Return startTag.Attributes.OfType(Of XmlNameAttributeSyntax)() _
-                    .Where(Function(a) a.Name.ToString() = "name") _
+                    .Where(Function(a) a.Name.ToString() = NameAttributeName) _
                     .Select(Function(a) a.Reference.Identifier.ValueText) _
                     .FirstOrDefault()
             End If
@@ -343,7 +362,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProvide
         End Function
 
         Private Function GetSingleUseTopLevelItems(parentTrivia As DocumentationCommentTriviaSyntax, span As TextSpan) As IEnumerable(Of CompletionItem)
-            Dim names = New HashSet(Of String)({"summary", "remarks", "exception", "include", "permission", "example", "completionlist"})
+            Dim names = New HashSet(Of String)({SummaryTagName, RemarksTagName, ExceptionTagName, IncludeTagName, PermissionTagName, ExampleTagName, CompletionListTagName})
 
             RemoveExistingTags(parentTrivia, names, Function(x) DirectCast(x.StartTag.Name, XmlNameSyntax).LocalName.ValueText)
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -1,8 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.Completion.CompletionProviders
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
@@ -19,13 +17,13 @@ Namespace Tests
             Return New XmlDocCommentCompletionProvider()
         End Function
 
-        Private Async Function VerifyItemsExistAsync(markup As String, ParamArray items() As String) As Threading.Tasks.Task
+        Private Async Function VerifyItemsExistAsync(markup As String, ParamArray items() As String) As Task
             For Each item In items
                 Await VerifyItemExistsAsync(markup, item)
             Next
         End Function
 
-        Private Async Function VerifyItemsAbsentAsync(markup As String, ParamArray items() As String) As Threading.Tasks.Task
+        Private Async Function VerifyItemsAbsentAsync(markup As String, ParamArray items() As String) As Task
             For Each item In items
                 Await VerifyItemIsAbsentAsync(markup, item)
             Next
@@ -33,190 +31,190 @@ Namespace Tests
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAnyLevelTags1() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;$$
+    ''' <$$
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "see", "seealso", "![CDATA[", "!--")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAnyLevelTags2() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;summary&gt;
-    ''' &lt;$$
-    ''' &lt;/summary&gt;
+    ''' <summary>
+    ''' <$$
+    ''' </summary>
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "see", "seealso", "![CDATA[", "!--")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAnyLevelTags3() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;summary&gt;
-    ''' &lt; &lt;see&gt;&lt;/see&gt;
-    ''' &lt;$$
-    ''' &lt;/summary&gt;
+    ''' <summary>
+    ''' <see></see>;
+    ''' <$$
+    ''' </summary>;
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "see", "seealso", "![CDATA[", "!--")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestRepeatableNestedTags1() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;$$
+    ''' <$$
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsAbsentAsync(text, "code", "list", "para", "paramref", "typeparamref")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestRepeatableNestedTags2() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;summary&gt;
-    ''' &lt;$$
-    ''' &lt;summary&gt;
+    ''' <summary>
+    ''' <$$
+    ''' </summary>
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "code", "list", "para", "paramref", "typeparamref")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestRepeatableTopLevelOnlyTags1() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;summary&gt;
-    ''' &lt;$$
-    ''' &lt;summary&gt;
+    ''' <summary>
+    ''' <$$
+    ''' </summary>
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsAbsentAsync(text, "exception", "include", "permission")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestRepeatableTopLevelOnlyTags2() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;$$
+    ''' <$$
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "exception", "include", "permission")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestTopLevelOnlyTags1() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;summary&gt;
-    ''' &lt;$$
-    ''' &lt;summary&gt;
+    ''' <summary>
+    ''' <$$
+    ''' </summary>
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsAbsentAsync(text, "example", "remarks", "summary", "value")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestTopLevelOnlyTags2() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;$$
+    ''' <$$
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "example", "remarks", "summary")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestTopLevelOnlyTags3() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;summary&gt;&lt;summary&gt;
-    ''' &lt;$$
+    ''' <summary>
+    ''' <$$
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsAbsentAsync(text, "example", "remarks", "summary", "value")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestListOnlyTags() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;list&gt;&lt;$$&lt;/list&gt;
+    ''' <list><$$</list>
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "listheader", "item", "term", "description")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestListHeaderTags() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;list&gt;  &lt;listheader&gt; &lt;$$  &lt;/listheader&gt;  &lt;/list&gt;
+    ''' <list>  <listheader> <$$  </listheader>  </list>
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "term", "description")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestMethodParamTypeParam() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;$$
+    ''' <$$
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "param name=""bar""", "typeparam name=""T""")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestIndexerParamTypeParam() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;$$
+    ''' <$$
     Default Public Property Item(bar as T)
         Get
         End Get
@@ -224,86 +222,86 @@ Class C(Of T)
         End Set
     End Sub
 End Property
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "param name=""bar""")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestTypeTypeParam() As Task
-            Dim text = <File>
-    ''' &lt;$$
+            Dim text = "
+    ''' <$$
 Class C(Of T)
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "typeparam name=""T""")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNoRepeatParam() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;param name="bar"&gt;&lt;/param;&gt;
-    ''' &lt;$$
+    ''' <param name=""bar""></param>
+    ''' <$$
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemIsAbsentAsync(text, "param name=""bar""")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAttributeAfterName() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;exception $$
+    ''' <exception $$
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemExistsAsync(text, "cref")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAttributeAfterNamePartiallyTyped() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;exception c$$
+    ''' <exception c$$
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemExistsAsync(text, "cref")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAttributeAfterAttribute() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;exception name="" $$
+    ''' <exception name="""" $$
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemExistsAsync(text, "cref")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestParameterNameInsideAttribute() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;param name = "$$"
+    ''' <param name = ""$$""
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemExistsAsync(text, "bar")
         End Function
@@ -312,21 +310,21 @@ End Class
         <WorkItem(746919, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/746919")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestCommitParam() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;param$$
+    ''' <param$$
     Sub Foo(Of T)(bar As T)
     End Sub
 End Class
-</File>.NormalizedValue
+"
 
-            Dim expected = <File>
+            Dim expected = "
 Class C(Of T)
-    ''' &lt;param name="bar"$$
+    ''' <param name=""bar""$$
     Sub Foo(Of T)(bar As T)
     End Sub
 End Class
-</File>.NormalizedValue
+"
 
             Await VerifyCustomCommitProviderAsync(text, "param name=""bar""", expected)
         End Function
@@ -334,13 +332,13 @@ End Class
         <WorkItem(623158, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/623158")>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestCloseTag() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;foo&gt;&lt;/$$
+    ''' <foo></$$
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemExistsAsync(text, "foo", usePreviousCharAsTrigger:=True)
         End Function
@@ -348,37 +346,40 @@ End Class
         <WorkItem(638805, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638805")>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNoParentElement() As Task
-            Dim text = <File><![CDATA[
+            Dim text = "
 ''' <summary>
 ''' </summary>
 ''' $$
 Module Program
-End Module]]></File>.Value
+End Module
+"
 
             Await VerifyItemsExistAsync(text, "see", "seealso", "![CDATA[", "!--")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNestedTagsOnSameLineAsCompletedTag() As Task
-            Dim text = <File><![CDATA[
+            Dim text = "
 ''' <summary>
 ''' <foo></foo>$$
 ''' 
 ''' </summary>
 Module Program
-End Module]]></File>.Value
+End Module
+"
 
             Await VerifyItemsExistAsync(text, "code", "list", "para", "paramref", "typeparamref")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNotInCref() As Task
-            Dim text = <File><![CDATA[
+            Dim text = "
 ''' <summary>
-''' <see cref="$$
+''' <see cref=""$$
 ''' </summary>
 Module Program
-End Module]]></File>.Value
+End Module
+"
 
             Await VerifyNoItemsExistAsync(text)
         End Function
@@ -386,21 +387,21 @@ End Module]]></File>.Value
         <WorkItem(638653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638653")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAllowTypingDoubleQuote() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;param$$
+    ''' <param$$
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.NormalizedValue
+"
 
-            Dim expected = <File>$$
+            Dim expected = "$$
 Class C(Of T)
-    ''' &lt;param
+    ''' <param
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.NormalizedValue
+"
 
             Await VerifyCustomCommitProviderAsync(text, "param name=""bar""", expected, Microsoft.CodeAnalysis.SourceCodeKind.Regular, commitChar:=""""c)
         End Function
@@ -408,49 +409,51 @@ End Class
         <WorkItem(638653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638653")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAllowTypingSpace() As Task
-            Dim text = <File>
+            Dim text = "
 Class C(Of T)
-    ''' &lt;param$$
+    ''' <param$$
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.NormalizedValue
+"
 
-            Dim expected = <File>$$
+            Dim expected = "$$
 Class C(Of T)
-    ''' &lt;param
+    ''' <param
     Sub Foo(Of T)(bar as T)
     End Sub
 End Class
-</File>.NormalizedValue
+"
 
             Await VerifyCustomCommitProviderAsync(text, "param name=""bar""", expected, Microsoft.CodeAnalysis.SourceCodeKind.Regular, commitChar:=" "c)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestCompletionList() As Task
-            Dim text = <File>
+            Dim text = "
 Class C
-    ''' &lt;$$
+    ''' <$$
     Sub Foo()
     End Sub
 End Class
-</File>.Value
+"
 
             Await VerifyItemsExistAsync(text, "completionlist")
         End Function
 
         <WorkItem(8546, "https://github.com/dotnet/roslyn/issues/8546")>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestReturns() As Task
+        Public Async Function TestReturnsOnMethod() As Task
             Dim text = "
 Class C
     ''' <$$
-    Property P As Integer
+    Function M() As Integer
+    End Function
 End Class
 "
 
             Await VerifyItemsExistAsync(text, "returns")
         End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -439,5 +439,18 @@ End Class
 
             Await VerifyItemsExistAsync(text, "completionlist")
         End Function
+
+        <WorkItem(8546, "https://github.com/dotnet/roslyn/issues/8546")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestReturns() As Task
+            Dim text = "
+Class C
+    ''' <$$
+    Property P As Integer
+End Class
+"
+
+            Await VerifyItemsExistAsync(text, "returns")
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #8546 

Note: The bug was trivial, but I went ahead and created constants for all of the tag and attribute name string literals sprinkled throughout XML doc comment completion to avoid bugs like these in the future.

tagging @dotnet/roslyn-ide 