### PR TITLE
Conditionally update SolutionExplorerShim to VSNext

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
@@ -26,6 +26,21 @@
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.CodeAnalysis.Sdk.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <Choose>
+    <When Condition="$(TF_BUILD_BUILDNUMBER) != ''">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <Private>false</Private>
+          <HintPath>..\..\..\..\..\Closed\References\VisualStudio\VSNext\Microsoft.VisualStudio.Shell.15.0\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
+      </ItemGroup>      
+    </Otherwise>
+  </Choose>  
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
@@ -74,7 +89,6 @@
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
     <Reference Include="Microsoft.VisualStudio.ImageCatalog, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"><Private>false</Private></Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -386,8 +386,6 @@
     <Compile Include="ProjectSystemShim\MockRuleSetFile.vb" />
     <Compile Include="ProjectSystemShim\VisualBasicProjectTests.vb" />
     <Compile Include="Snippets\SnippetServiceWaiter.vb" />
-    <Compile Include="SolutionExplorer\FakeAnalyzersCommandHandler.vb" />
-    <Compile Include="SolutionExplorer\RuleSetDocumentExtensionsTests.vb" />
     <Compile Include="StubVsEditorAdaptersFactoryService.vb" />
     <Compile Include="Preview\PreviewChangesTests.vb" />
     <Compile Include="Progression\CallsGraphQueryTests.vb" />
@@ -431,12 +429,6 @@
     <Compile Include="Snippets\TestExpansionClient.vb" />
     <Compile Include="Snippets\VisualBasicSnippetCommandHandlerTests.vb" />
     <Compile Include="Snippets\VisualBasicSnippetExpansionClientTests.vb" />
-    <Compile Include="SolutionExplorer\AnalyzerItemsSourceTests.vb" />
-    <Compile Include="SolutionExplorer\AnalyzerItemTests.vb" />
-    <Compile Include="SolutionExplorer\AnalyzersFolderItemTests.vb" />
-    <Compile Include="SolutionExplorer\AnalyzersFolderProviderTests.vb" />
-    <Compile Include="SolutionExplorer\DiagnosticDescriptorComparerTests.vb" />
-    <Compile Include="SolutionExplorer\DiagnosticItemTests.vb" />
     <Compile Include="Venus\AbstractContainedLanguageCodeSupportTests.vb" />
     <Compile Include="Venus\ContainedDocumentTests_AdjustIndentation.vb" />
     <Compile Include="Venus\ContainedDocumentTests_UpdateText.vb" />
@@ -444,6 +436,20 @@
     <Compile Include="Venus\VisualBasicContainedLanguageSupportTests.vb" />
     <Compile Include="VisualStudioTestExportProvider.vb" />
   </ItemGroup>
+  <Choose>
+    <When Condition="$(TF_BUILD_BUILDNUMBER) == ''">
+      <ItemGroup>
+        <Compile Include="SolutionExplorer\FakeAnalyzersCommandHandler.vb" />
+        <Compile Include="SolutionExplorer\RuleSetDocumentExtensionsTests.vb" />
+        <Compile Include="SolutionExplorer\AnalyzerItemsSourceTests.vb" />
+        <Compile Include="SolutionExplorer\AnalyzerItemTests.vb" />
+        <Compile Include="SolutionExplorer\AnalyzersFolderItemTests.vb" />
+        <Compile Include="SolutionExplorer\AnalyzersFolderProviderTests.vb" />
+        <Compile Include="SolutionExplorer\DiagnosticDescriptorComparerTests.vb" />
+        <Compile Include="SolutionExplorer\DiagnosticItemTests.vb" />
+      </ItemGroup>
+    </When>
+  </Choose>  
   <ItemGroup>
     <EmbeddedResource Include="Debugging\Resources.resx">
       <CustomToolNamespace>Microsoft.VisualStudio.LanguageServices.VisualBasic.UnitTests.Debugging</CustomToolNamespace>


### PR DESCRIPTION
Move solution explorer to VSNext and make corresponding tests conditional. I've tested this with `set TF_BUILD_BUILDNUMBER=123`. I had to leave the reference to the SolutionExplorerShim in the tests because other components depend on it. The condition on the tests is such that all of them run on local builds and Jenkins.