### PR TITLE
Ambiguous assemblies Option B: Handle an additional "duplicate reference" error code in the EE

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -415,6 +415,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             switch ((ErrorCode)diagnostic.Code)
             {
                 case ErrorCode.ERR_DuplicateImport:
+                case ErrorCode.ERR_DuplicateImportSimple:
                 case ErrorCode.ERR_SameFullNameAggAgg:
                 case ErrorCode.ERR_AmbigCall:
                     return true;


### PR DESCRIPTION
**Problem**: the EE can't evaluate expressions when there are multiple assemblies with the same (weak) name loaded.

**Solution**: enable the existing retry logic in this particular scenario (by adding another error code to the list).

**Pro**: Conservative - only kicks in if regular evaluation fails.  Can't break anything but the C# EE.

**Con**: Only helps on retry.  As soon as there are ambiguous assemblies, every single expression will have to be evaluated twice.
