### PR TITLE
Improve add-using perf in interactive window.

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -84,7 +84,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                         if (allSymbolReferences.Count == 0)
                         {
                             // No exact matches found.  Fall back to fuzzy searching.
-                            await FindResults(projectToAssembly, referenceToCompilation, project, allSymbolReferences, finder, exact: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                            // Only bother doing this for host workspaces.  We don't want this for 
+                            // things like the Interactive workspace as this will cause us to 
+                            // create expensive bktrees which we won't even be able to save for 
+                            // future use.
+                            if (document.Project.Solution.Workspace.Kind == WorkspaceKind.Host)
+                            {
+                                await FindResults(projectToAssembly, referenceToCompilation, project, allSymbolReferences, finder, exact: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                            }
                         }
 
                         // Nothing found at all. No need to proceed.

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// The spell checker we use for fuzzy match queries.
         /// </summary>
-        private readonly SpellChecker _spellChecker;
+        private readonly Lazy<SpellChecker> _lazySpellChecker;
 
         private static readonly StringComparer s_caseInsensitiveComparer = CaseInsensitiveComparison.Comparer;
 
@@ -45,11 +45,25 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 : StringComparer.Ordinal.Compare(s1, s2);
         };
 
+        private SymbolTreeInfo(VersionStamp version, IReadOnlyList<Node> orderedNodes)
+            : this(version, orderedNodes, new Lazy<SpellChecker>(() => new SpellChecker(orderedNodes.Select(n => n.Name))))
+        {
+        }
+
         private SymbolTreeInfo(VersionStamp version, IReadOnlyList<Node> orderedNodes, SpellChecker spellChecker)
+            : this(version, orderedNodes, new Lazy<SpellChecker>(() => spellChecker))
+        {
+            // Make the lazy 'Created'.  This is a no-op since we already have the underlying spell
+            // checker.  This way if we end up wanting to serialize this tree info, we'll also
+            // serialize the spell checker.
+            var unused = _lazySpellChecker.Value;
+        }
+
+        private SymbolTreeInfo(VersionStamp version, IReadOnlyList<Node> orderedNodes, Lazy<SpellChecker> lazySpellChecker)
         {
             _version = version;
             _nodes = orderedNodes;
-            _spellChecker = spellChecker;
+            _lazySpellChecker = lazySpellChecker;
         }
 
         public int Count => _nodes.Count;
@@ -84,7 +98,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         public async Task<IEnumerable<ISymbol>> FuzzyFindAsync(AsyncLazy<IAssemblySymbol> lazyAssembly, string name, CancellationToken cancellationToken)
         {
-            var similarNames = _spellChecker.FindSimilarWords(name);
+            var similarNames = _lazySpellChecker.Value.FindSimilarWords(name);
             var result = new List<ISymbol>();
 
             foreach (var similarName in similarNames)
@@ -291,8 +305,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var list = new List<Node>();
             GenerateNodes(assembly.GlobalNamespace, list);
 
-            var spellChecker = new SpellChecker(list.Select(n => n.Name));
-            return new SymbolTreeInfo(version, SortNodes(list), spellChecker);
+            return new SymbolTreeInfo(version, SortNodes(list));
         }
 
         private static Node[] SortNodes(List<Node> nodes)


### PR DESCRIPTION
1. When creating symbol tree infos, lazily produce BKtrees.  That way we don't
   take the perf hit for features that want to search but don't need fuzzy matching

2. Don't perform fuzzy matching interactive.  The problem here is that interactive
   Doesn't have a 'serialization service'.  As such, when VS loads and we run
   interactive, we end up having to produce all the same BKtrees for metadata again.
   In normal scenarios we can store these in the .vs file, so we only pay the price
   the very first time.  In Interactive we always pay the price the first time
   after VS loads.

This lowers the first run of add-using in interactive from about 5 seconds for me to about 1 second.