### PR TITLE
Simplify IAssemblyReference

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/AssemblyReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/AssemblyReference.cs
@@ -21,63 +21,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             _targetAssembly = assemblySymbol;
         }
 
-        public AssemblyIdentity MetadataIdentity => _targetAssembly.Identity;
+        public AssemblyIdentity Identity => _targetAssembly.Identity;
 
         public override string ToString()
         {
             return _targetAssembly.ToString();
         }
 
-        #region Cci.IAssemblyReference
-
         void Cci.IReference.Dispatch(Cci.MetadataVisitor visitor)
         {
             visitor.Visit(this);
         }
 
-        string Cci.IAssemblyReference.Culture
-        {
-            get
-            {
-                return MetadataIdentity.CultureName;
-            }
-        }
-
-        bool Cci.IAssemblyReference.IsRetargetable
-        {
-            get
-            {
-                return MetadataIdentity.IsRetargetable;
-            }
-        }
-
-        AssemblyContentType Cci.IAssemblyReference.ContentType
-        {
-            get
-            {
-                return MetadataIdentity.ContentType;
-            }
-        }
-
-        ImmutableArray<byte> Cci.IAssemblyReference.PublicKeyToken
-        {
-            get { return MetadataIdentity.PublicKeyToken; }
-        }
-
-        Version Cci.IAssemblyReference.Version
-        {
-            get { return MetadataIdentity.Version; }
-        }
-
-        string Cci.IAssemblyReference.GetDisplayName()
-        {
-            return MetadataIdentity.GetDisplayName();
-        }
-
-        string Cci.INamedEntity.Name
-        {
-            get { return MetadataIdentity.Name; }
-        }
+        string Cci.INamedEntity.Name => Identity.Name;
 
         Cci.IAssemblyReference Cci.IModuleReference.GetContainingAssembly(CodeAnalysis.Emit.EmitContext context)
         {
@@ -93,7 +49,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             return null;
         }
-
-        #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -161,44 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
         }
 
-        string Cci.IAssemblyReference.Culture
-        {
-            get
-            {
-                return _sourceAssembly.Identity.CultureName;
-            }
-        }
-
-        bool Cci.IAssemblyReference.IsRetargetable
-        {
-            get
-            {
-                return _sourceAssembly.Identity.IsRetargetable;
-            }
-        }
-
-        AssemblyContentType Cci.IAssemblyReference.ContentType
-        {
-            get
-            {
-                return _sourceAssembly.Identity.ContentType;
-            }
-        }
-
-        ImmutableArray<byte> Cci.IAssemblyReference.PublicKeyToken
-        {
-            get { return _sourceAssembly.Identity.PublicKeyToken; }
-        }
-
-        Version Cci.IAssemblyReference.Version
-        {
-            get { return _sourceAssembly.Identity.Version; }
-        }
-
-        string Cci.IAssemblyReference.GetDisplayName()
-        {
-            return _sourceAssembly.Identity.GetDisplayName();
-        }
+        AssemblyIdentity Cci.IAssemblyReference.Identity => _sourceAssembly.Identity;
 
         internal override string Name
         {

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.PortableExecutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGen;
@@ -136,10 +137,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private void ValidateReferencedAssembly(AssemblySymbol assembly, AssemblyReference asmRef, DiagnosticBag diagnostics)
         {
             AssemblyIdentity asmIdentity = SourceModule.ContainingAssembly.Identity;
-            AssemblyIdentity refIdentity = asmRef.MetadataIdentity;
+            AssemblyIdentity refIdentity = asmRef.Identity;
 
             if (asmIdentity.IsStrongName && !refIdentity.IsStrongName &&
-                ((Cci.IAssemblyReference)asmRef).ContentType != System.Reflection.AssemblyContentType.WindowsRuntime)
+                asmRef.Identity.ContentType != AssemblyContentType.WindowsRuntime)
             {
                 // Dev12 reported error, we have changed it to a warning to allow referencing libraries 
                 // built for platforms that don't support strong names.

--- a/src/Compilers/Core/Portable/Emit/ErrorType.cs
+++ b/src/Compilers/Core/Portable/Emit/ErrorType.cs
@@ -174,53 +174,23 @@ namespace Microsoft.CodeAnalysis.Emit
         /// <summary>
         /// A fake containing assembly for an ErrorType object.
         /// </summary>
-        private class ErrorAssembly : Cci.IAssemblyReference
+        private sealed class ErrorAssembly : Cci.IAssemblyReference
         {
             public static readonly ErrorAssembly Singleton = new ErrorAssembly();
+            
             /// <summary>
             /// For the name we will use a word "Error" followed by a guid, generated on the spot.
             /// </summary>
-            private static readonly string s_name = "Error" + Guid.NewGuid().ToString("B");
+            private static readonly AssemblyIdentity s_identity = new AssemblyIdentity(
+                name: "Error" + Guid.NewGuid().ToString("B"),
+                version: AssemblyIdentity.NullVersion,
+                cultureName: "",
+                publicKeyOrToken: ImmutableArray<byte>.Empty,
+                hasPublicKey: false,
+                isRetargetable: false,
+                contentType: AssemblyContentType.Default);
 
-            string Cci.IAssemblyReference.Culture
-            {
-                get
-                {
-                    return "";
-                }
-            }
-
-            bool Cci.IAssemblyReference.IsRetargetable
-            {
-                get
-                {
-                    return false;
-                }
-            }
-
-            AssemblyContentType Cci.IAssemblyReference.ContentType
-            {
-                get
-                {
-                    return AssemblyContentType.Default;
-                }
-            }
-
-            ImmutableArray<byte> Cci.IAssemblyReference.PublicKeyToken
-            {
-                get
-                {
-                    return ImmutableArray<byte>.Empty;
-                }
-            }
-
-            Version Cci.IAssemblyReference.Version
-            {
-                get
-                {
-                    return AssemblyIdentity.NullVersion;
-                }
-            }
+            AssemblyIdentity Cci.IAssemblyReference.Identity => s_identity;
 
             Cci.IAssemblyReference Cci.IModuleReference.GetContainingAssembly(EmitContext context)
             {
@@ -242,18 +212,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 return null;
             }
 
-            public string GetDisplayName()
-            {
-                return s_name;
-            }
-
-            string Cci.INamedEntity.Name
-            {
-                get
-                {
-                    return s_name;
-                }
-            }
+            string Cci.INamedEntity.Name => s_identity.Name;
         }
     }
 }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Cci
         {
             foreach (AssemblyReferenceAlias alias in Module.GetAssemblyReferenceAliases(Context))
             {
-                UsingNamespace("Z" + alias.Name + " " + alias.Assembly.GetDisplayName(), Module);
+                UsingNamespace("Z" + alias.Name + " " + alias.Assembly.Identity.GetDisplayName(), Module);
             }
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2568,16 +2568,18 @@ namespace Microsoft.Cci
             foreach (var assemblyRef in assemblyRefs)
             {
                 AssemblyRefTableRow r = new AssemblyRefTableRow();
-                r.Version = assemblyRef.Version;
-                r.PublicKeyToken = heaps.GetBlobIndex(assemblyRef.PublicKeyToken);
+                var identity = assemblyRef.Identity;
+
+                r.Version = identity.Version;
+                r.PublicKeyToken = heaps.GetBlobIndex(identity.PublicKeyToken);
 
                 Debug.Assert(!string.IsNullOrEmpty(assemblyRef.Name));
                 r.Name = this.GetStringIndexForPathAndCheckLength(assemblyRef.Name, assemblyRef);
 
-                r.Culture = heaps.GetStringIndex(assemblyRef.Culture);
+                r.Culture = heaps.GetStringIndex(identity.CultureName);
 
-                r.IsRetargetable = assemblyRef.IsRetargetable;
-                r.ContentType = assemblyRef.ContentType;
+                r.IsRetargetable = identity.IsRetargetable;
+                r.ContentType = identity.ContentType;
                 _assemblyRefTable.Add(r);
             }
         }
@@ -2594,24 +2596,12 @@ namespace Microsoft.Cci
 
             public bool Equals(IAssemblyReference x, IAssemblyReference y)
             {
-                if (ReferenceEquals(x, y))
-                {
-                    return true;
-                }
-
-                return
-                    x.Version.Equals(y.Version) &&
-                    ByteSequenceComparer.Equals(x.PublicKeyToken, y.PublicKeyToken) &&
-                    x.Name == y.Name &&
-                    x.Culture == y.Culture;
+                return x.Identity == y.Identity;
             }
 
             public int GetHashCode(IAssemblyReference reference)
             {
-                return Hash.Combine(reference.Version,
-                       Hash.Combine(ByteSequenceComparer.GetHashCode(reference.PublicKeyToken),
-                       Hash.Combine(reference.Name.GetHashCode(),
-                       Hash.Combine(reference.Culture, 0))));
+                return reference.Identity.GetHashCode();
             }
         }
 
@@ -2627,7 +2617,7 @@ namespace Microsoft.Cci
             IAssembly assembly = this.module.AsAssembly;
             _assemblyKey = heaps.GetBlobIndex(assembly.PublicKey);
             _assemblyName = this.GetStringIndexForPathAndCheckLength(assembly.Name, assembly);
-            _assemblyCulture = heaps.GetStringIndex(assembly.Culture);
+            _assemblyCulture = heaps.GetStringIndex(assembly.Identity.CultureName);
         }
 
         private BlobIdx _assemblyKey;
@@ -4118,11 +4108,13 @@ namespace Microsoft.Cci
             }
 
             IAssembly assembly = this.module.AsAssembly;
+            var identity = assembly.Identity;
+
             writer.WriteUInt32((uint)assembly.HashAlgorithm);
-            writer.WriteUInt16((ushort)assembly.Version.Major);
-            writer.WriteUInt16((ushort)assembly.Version.Minor);
-            writer.WriteUInt16((ushort)assembly.Version.Build);
-            writer.WriteUInt16((ushort)assembly.Version.Revision);
+            writer.WriteUInt16((ushort)identity.Version.Major);
+            writer.WriteUInt16((ushort)identity.Version.Minor);
+            writer.WriteUInt16((ushort)identity.Version.Build);
+            writer.WriteUInt16((ushort)identity.Version.Revision);
             writer.WriteUInt32(assembly.Flags);
             writer.WriteReference((uint)heaps.ResolveBlobIndex(_assemblyKey), metadataSizes.BlobIndexSize);
 
@@ -4948,13 +4940,15 @@ namespace Microsoft.Cci
         /// </summary>
         internal static string StrongName(IAssemblyReference assemblyReference)
         {
+            var identity = assemblyReference.Identity;
+
             var pooled = PooledStringBuilder.GetInstance();
             StringBuilder sb = pooled.Builder;
-            sb.Append(assemblyReference.Name);
-            sb.AppendFormat(CultureInfo.InvariantCulture, ", Version={0}.{1}.{2}.{3}", assemblyReference.Version.Major, assemblyReference.Version.Minor, assemblyReference.Version.Build, assemblyReference.Version.Revision);
-            if (!string.IsNullOrEmpty(assemblyReference.Culture))
+            sb.Append(identity.Name);
+            sb.AppendFormat(CultureInfo.InvariantCulture, ", Version={0}.{1}.{2}.{3}", identity.Version.Major, identity.Version.Minor, identity.Version.Build, identity.Version.Revision);
+            if (!string.IsNullOrEmpty(identity.CultureName))
             {
-                sb.AppendFormat(CultureInfo.InvariantCulture, ", Culture={0}", assemblyReference.Culture);
+                sb.AppendFormat(CultureInfo.InvariantCulture, ", Culture={0}", identity.CultureName);
             }
             else
             {
@@ -4962,9 +4956,9 @@ namespace Microsoft.Cci
             }
 
             sb.Append(", PublicKeyToken=");
-            if (assemblyReference.PublicKeyToken.Length > 0)
+            if (identity.PublicKeyToken.Length > 0)
             {
-                foreach (byte b in assemblyReference.PublicKeyToken)
+                foreach (byte b in identity.PublicKeyToken)
                 {
                     sb.Append(b.ToString("x2"));
                 }
@@ -4974,18 +4968,18 @@ namespace Microsoft.Cci
                 sb.Append("null");
             }
 
-            if (assemblyReference.IsRetargetable)
+            if (identity.IsRetargetable)
             {
                 sb.Append(", Retargetable=Yes");
             }
 
-            if (assemblyReference.ContentType == AssemblyContentType.WindowsRuntime)
+            if (identity.ContentType == AssemblyContentType.WindowsRuntime)
             {
                 sb.Append(", ContentType=WindowsRuntime");
             }
             else
             {
-                Debug.Assert(assemblyReference.ContentType == AssemblyContentType.Default);
+                Debug.Assert(identity.ContentType == AssemblyContentType.Default);
             }
 
             return pooled.ToStringAndFree();

--- a/src/Compilers/Core/Portable/PEWriter/Units.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Units.cs
@@ -51,34 +51,7 @@ namespace Microsoft.Cci
     /// </summary>
     internal interface IAssemblyReference : IModuleReference
     {
-        /// <summary>
-        /// Identifies the culture associated with the assembly reference. Typically specified for satellite assemblies with localized resources.
-        /// Empty if not specified.
-        /// </summary>
-        string Culture { get; }
-
-        /// <summary>
-        /// True if the implementation of the referenced assembly used at runtime is not expected to match the version seen at compile time.
-        /// </summary>
-        bool IsRetargetable { get; }
-
-        /// <summary>
-        /// Type of code contained in an assembly. Determines assembly binding model.
-        /// </summary>
-        AssemblyContentType ContentType { get; }
-
-        /// <summary>
-        /// The hashed 8 bytes of the public key of the referenced assembly. 
-        /// Empty if the referenced assembly does not have a public key.
-        /// </summary>
-        ImmutableArray<byte> PublicKeyToken { get; }
-
-        /// <summary>
-        /// The version of the assembly reference.
-        /// </summary>
-        Version Version { get; }
-
-        string GetDisplayName();
+        AssemblyIdentity Identity { get; }
     }
 
     /// <summary>

--- a/src/Compilers/VisualBasic/Portable/Emit/AssemblyReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/AssemblyReference.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             _targetAssembly = assemblySymbol
         End Sub
 
-        Public ReadOnly Property MetadataIdentity As AssemblyIdentity
+        Public ReadOnly Property Identity As AssemblyIdentity Implements Cci.IAssemblyReference.Identity
             Get
                 Return _targetAssembly.Identity
             End Get
@@ -27,43 +27,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             visitor.Visit(DirectCast(Me, Cci.IAssemblyReference))
         End Sub
 
-        Private ReadOnly Property IAssemblyReferenceCulture As String Implements Cci.IAssemblyReference.Culture
-            Get
-                Return MetadataIdentity.CultureName
-            End Get
-        End Property
-
-        Private ReadOnly Property IAssemblyReferenceIsRetargetable As Boolean Implements Cci.IAssemblyReference.IsRetargetable
-            Get
-                Return MetadataIdentity.IsRetargetable
-            End Get
-        End Property
-
-        Private ReadOnly Property IAssemblyReferenceContentType As AssemblyContentType Implements Cci.IAssemblyReference.ContentType
-            Get
-                Return MetadataIdentity.ContentType
-            End Get
-        End Property
-
-        Private ReadOnly Property IAssemblyReferencePublicKeyToken As ImmutableArray(Of Byte) Implements Cci.IAssemblyReference.PublicKeyToken
-            Get
-                Return MetadataIdentity.PublicKeyToken
-            End Get
-        End Property
-
-        Private ReadOnly Property IAssemblyReferenceVersion As Version Implements Cci.IAssemblyReference.Version
-            Get
-                Return MetadataIdentity.Version
-            End Get
-        End Property
-
-        Private Function IAssemblyReferenceGetDisplayName() As String Implements Cci.IAssemblyReference.GetDisplayName
-            Return MetadataIdentity.GetDisplayName()
-        End Function
-
         Private ReadOnly Property INamedEntityName As String Implements Cci.INamedEntity.Name
             Get
-                Return MetadataIdentity.Name
+                Return Identity.Name
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/PEAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEAssemblyBuilder.vb
@@ -135,39 +135,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Next
         End Sub
 
-        Private ReadOnly Property IAssemblyReferenceCulture As String Implements Cci.IAssemblyReference.Culture
+        Private ReadOnly Property Identity As AssemblyIdentity Implements Cci.IAssembly.Identity
             Get
-                Return m_SourceAssembly.Identity.CultureName
+                Return m_SourceAssembly.Identity
             End Get
         End Property
-
-        Private ReadOnly Property IAssemblyReferenceIsRetargetable As Boolean Implements Cci.IAssemblyReference.IsRetargetable
-            Get
-                Return m_SourceAssembly.Identity.IsRetargetable
-            End Get
-        End Property
-
-        Private ReadOnly Property IAssemblyReferenceContentType As AssemblyContentType Implements Cci.IAssemblyReference.ContentType
-            Get
-                Return m_SourceAssembly.Identity.ContentType
-            End Get
-        End Property
-
-        Private ReadOnly Property IAssemblyReferencePublicKeyToken As ImmutableArray(Of Byte) Implements Cci.IAssemblyReference.PublicKeyToken
-            Get
-                Return m_SourceAssembly.Identity.PublicKeyToken
-            End Get
-        End Property
-
-        Private ReadOnly Property IAssemblyReferenceVersion As Version Implements Cci.IAssemblyReference.Version
-            Get
-                Return m_SourceAssembly.Identity.Version
-            End Get
-        End Property
-
-        Private Function IAssemblyReferenceGetDisplayName() As String Implements Cci.IAssemblyReference.GetDisplayName
-            Return m_SourceAssembly.Identity.GetDisplayName()
-        End Function
 
         Friend Overrides ReadOnly Property Name As String
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -139,10 +139,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
         Private Sub ValidateReferencedAssembly(assembly As AssemblySymbol, asmRef As AssemblyReference, diagnostics As DiagnosticBag)
             Dim asmIdentity As AssemblyIdentity = SourceModule.ContainingAssembly.Identity
-            Dim refIdentity As AssemblyIdentity = asmRef.MetadataIdentity
+            Dim refIdentity As AssemblyIdentity = asmRef.Identity
 
             If asmIdentity.IsStrongName AndAlso Not refIdentity.IsStrongName AndAlso
-               DirectCast(asmRef, Cci.IAssemblyReference).ContentType <> Reflection.AssemblyContentType.WindowsRuntime Then
+               asmRef.Identity.ContentType <> Reflection.AssemblyContentType.WindowsRuntime Then
                 ' Dev12 reported error, we have changed it to a warning to allow referencing libraries 
                 ' built for platforms that don't support strong names.
                 diagnostics.Add(ErrorFactory.ErrorInfo(ERRID.WRN_ReferencedAssemblyDoesNotHaveStrongName, assembly), NoLocation.Singleton)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/AssemblyReference.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/AssemblyReference.cs
@@ -19,40 +19,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             _identity = identity;
         }
 
-        AssemblyContentType IAssemblyReference.ContentType
-        {
-            get { return _identity.ContentType; }
-        }
-
-        string IAssemblyReference.Culture
-        {
-            get { return _identity.CultureName; }
-        }
-
-        bool IAssemblyReference.IsRetargetable
-        {
-            get { return _identity.IsRetargetable; }
-        }
-
-        string INamedEntity.Name
-        {
-            get { return _identity.Name; }
-        }
-
-        ImmutableArray<byte> IAssemblyReference.PublicKeyToken
-        {
-            get { return _identity.PublicKeyToken; }
-        }
-
-        Version IAssemblyReference.Version
-        {
-            get { return _identity.Version; }
-        }
-
-        string IAssemblyReference.GetDisplayName()
-        {
-            return _identity.GetDisplayName();
-        }
+        AssemblyIdentity IAssemblyReference.Identity => _identity;
+        string INamedEntity.Name => _identity.Name;
 
         IAssemblyReference IModuleReference.GetContainingAssembly(EmitContext context)
         {


### PR DESCRIPTION
The only property that's needed is Identity returning AssemblyIdentity.