### PR TITLE
Fix EnC for compilations with dependencies using time-based versioning

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -102,10 +102,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             // We need to transfer the references from the current source compilation but don't need its syntax trees.
             var metadataCompilation = compilation.RemoveAllSyntaxTrees();
 
-            var metadataAssembly = metadataCompilation.GetBoundReferenceManager().CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata.Create(originalMetadata), MetadataImportOptions.All);
+            ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> assemblyReferenceIdentityMap;
+            var metadataAssembly = metadataCompilation.GetBoundReferenceManager().CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata.Create(originalMetadata), MetadataImportOptions.All, out assemblyReferenceIdentityMap);
             var metadataDecoder = new MetadataDecoder(metadataAssembly.PrimaryModule);
             var metadataAnonymousTypes = GetAnonymousTypeMapFromMetadata(originalMetadata.MetadataReader, metadataDecoder);
-            var metadataSymbols = new EmitBaseline.MetadataSymbols(metadataAnonymousTypes, metadataDecoder);
+            var metadataSymbols = new EmitBaseline.MetadataSymbols(metadataAnonymousTypes, metadataDecoder, assemblyReferenceIdentityMap);
 
             return InterlockedOperations.Initialize(ref initialBaseline.LazyMetadataSymbols, metadataSymbols);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -219,27 +219,49 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// Used by EnC to create symbols for emit baseline. The PE symbols are used by <see cref="CSharpSymbolMatcher"/>.
             /// 
             /// The assembly references listed in the metadata AssemblyRef table are matched to the resolved references 
-            /// stored on this <see cref="ReferenceManager"/>. Each AssemblyRef is matched against the assembly identities
-            /// using an exact equality comparison. No unification or further resolution is performed.
+            /// stored on this <see cref="ReferenceManager"/>. We assume that the dependencies of the baseline metadata are 
+            /// the same as the dependencies of the current compilation. This is not exactly true when the dependencies use 
+            /// time-based versioning pattern, e.g. AssemblyVersion("1.0.*"). In that case we assume only the version
+            /// changed and nothing else.
+            /// 
+            /// Each AssemblyRef is matched against the assembly identities using an exact equality comparison modulo version. 
+            /// AssemblyRef with lower version in metadata is matched to a PE assembly symbol with the higher version 
+            /// (provided that the assembly name, culture, PKT and flags are the same) if there is no symbol with the exactly matching version. 
+            /// If there are multiple symbols with higher versions selects the one with the minimal version among them.
+            /// 
+            /// Matching to a higher version is necessary to support EnC for projects whose P2P dependencies use time-based versioning pattern. 
+            /// The versions of the dependent projects seen from the IDE will be higher than 
+            /// the one written in the metadata at the time their respective baselines are built.
+            /// 
+            /// No other unification or further resolution is performed.
             /// </remarks>
-            public PEAssemblySymbol CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata metadata, MetadataImportOptions importOptions)
+            public PEAssemblySymbol CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata metadata, MetadataImportOptions importOptions, out ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> assemblyReferenceIdentityMap)
             {
                 AssertBound();
 
                 // If the compilation has a reference from metadata to source assembly we can't share the referenced PE symbols.
                 Debug.Assert(!HasCircularReference);
 
-                var referencedAssembliesByIdentity = new Dictionary<AssemblyIdentity, AssemblySymbol>();
+                // The identity map first tries to match exactly, then it uses given comparer to chose among identities of the same name.
+                var referencedAssembliesByIdentity = new AssemblyIdentityMap<AssemblySymbol>();
                 foreach (var symbol in this.ReferencedAssemblies)
                 {
                     referencedAssembliesByIdentity.Add(symbol.Identity, symbol);
                 }
 
                 var assembly = metadata.GetAssembly();
+
                 var peReferences = assembly.AssemblyReferences.SelectAsArray(MapAssemblyIdentityToResolvedSymbol, referencedAssembliesByIdentity);
+
+                // Build a map of the PE assembly symbol identities to the identities of the original metadata AssemblyRefs.
+                // This map will be used in emit when serializing AssemblyRef table of the delta. For the delta to be compatible with
+                // the original metadata we need to map the identities of the PE assembly symbols back to the original AssemblyRefs (if different).
+                // In other words, we pretend that the versions of the dependencies haven't changed.
+                assemblyReferenceIdentityMap = GetAssemblyReferenceIdentityMap(assembly.AssemblyReferences, peReferences);
+
                 var assemblySymbol = new PEAssemblySymbol(assembly, DocumentationProvider.Default, isLinked: false, importOptions: importOptions);
 
-                var unifiedAssemblies = this.UnifiedAssemblies.WhereAsArray(unified => referencedAssembliesByIdentity.ContainsKey(unified.OriginalReference));
+                var unifiedAssemblies = this.UnifiedAssemblies.WhereAsArray(unified => referencedAssembliesByIdentity.Contains(unified.OriginalReference, allowHigherVersion: false));
                 InitializeAssemblyReuseData(assemblySymbol, peReferences, unifiedAssemblies);
 
                 if (assembly.ContainsNoPiaLocalTypes())
@@ -250,13 +272,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return assemblySymbol;
             }
 
-            private static AssemblySymbol MapAssemblyIdentityToResolvedSymbol(AssemblyIdentity identity, Dictionary<AssemblyIdentity, AssemblySymbol> map)
+            private static AssemblySymbol MapAssemblyIdentityToResolvedSymbol(AssemblyIdentity identity, AssemblyIdentityMap<AssemblySymbol> map)
             {
                 AssemblySymbol symbol;
-                if (map.TryGetValue(identity, out symbol))
+                if (map.TryGetValue(identity, out symbol, allowHigherVersion: true))
                 {
                     return symbol;
                 }
+
                 return new MissingAssemblySymbol(identity);
             }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -156,6 +161,76 @@ class C
   IL_0007:  ret
 }";
             AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL);
+        }
+
+        [Fact]
+        public void DependencyVersionWildcards()
+        {
+            string srcLib = @"
+[assembly: System.Reflection.AssemblyVersion(""1.0.*"")]
+
+public class D { }
+";
+
+            string src1 = @"
+using System;
+class C 
+{ 
+    public static int F(D a) { return 1; }
+}
+";
+            string src2 = @"
+using System;
+class C 
+{ 
+    public static int F(D a) { return 2; }
+}
+";
+            var lib1 = CreateCompilationWithMscorlib(srcLib, assemblyName: "Lib", options: TestOptions.DebugDll);
+            lib1.VerifyDiagnostics();
+
+            Compilation lib2;
+
+            do
+            {
+                Thread.Sleep(1000);
+                lib2 = CreateCompilationWithMscorlib(srcLib, assemblyName: "Lib", options: TestOptions.DebugDll);
+            }
+            while (lib1.Assembly.Identity.Version == lib2.Assembly.Identity.Version);
+            lib2.VerifyDiagnostics();
+
+            var compilation0 = CreateCompilation(src1, new[] { MscorlibRef, lib1.ToMetadataReference() }, assemblyName: "C", options: TestOptions.DebugDll);
+            var compilation1 = compilation0.WithSource(src2).WithReferences(new[] { MscorlibRef, lib2.ToMetadataReference() });
+
+            var v0 = CompileAndVerify(compilation0);
+            var v1 = CompileAndVerify(compilation1);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, EmptyLocalsProvider);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, f0, f1)));
+
+            var md1 = diff1.GetMetadata();
+
+            var aggReader = new AggregatedMetadataReader(md0.MetadataReader, md1.Reader);
+
+            VerifyAssemblyReferences(aggReader, new[] 
+            {
+                "mscorlib, 4.0.0.0",
+                "Lib, " + lib1.Assembly.Identity.Version,
+                "mscorlib, 4.0.0.0",
+                "Lib, " + lib1.Assembly.Identity.Version,
+            });
+        }
+
+        public void VerifyAssemblyReferences(AggregatedMetadataReader reader, string[] expected)
+        {
+            AssertEx.Equal(expected, reader.GetAssemblyReferences().Select(aref => $"{reader.GetString(aref.Name)}, {aref.Version}"));
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -41,6 +41,7 @@
     <Compile Include="InternalUtilities\StreamExtensionsTests.cs" />
     <Compile Include="InternalUtilities\StringExtensionsTests.cs" />
     <Compile Include="MetadataReferences\AssemblyIdentityExtensions.cs" />
+    <Compile Include="MetadataReferences\AssemblyIdentityMapTests.cs" />
     <Compile Include="PEWriter\BlobUtilitiesTests.cs" />
     <Compile Include="PEWriter\BlobTests.cs" />
     <Compile Include="PEWriter\UsedNamespaceOrTypeTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityMapTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityMapTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class AssemblyIdentityMapTests
+    {
+        [Fact]
+        public void Map()
+        {
+            var map = new AssemblyIdentityMap<int>();
+            map.Add(new AssemblyIdentity("a", new Version(1, 0, 0, 0)), 10);
+            map.Add(new AssemblyIdentity("a", new Version(1, 8, 0, 0)), 18);
+            map.Add(new AssemblyIdentity("a", new Version(1, 5, 0, 0)), 15);
+
+            map.Add(new AssemblyIdentity("b", new Version(1, 0, 0, 0)), 10);
+            map.Add(new AssemblyIdentity("b", new Version(1, 0, 0, 0)), 20);
+
+            int value;
+            Assert.True(map.Contains(new AssemblyIdentity("a", new Version(1, 0, 0, 0))));
+            Assert.True(map.TryGetValue(new AssemblyIdentity("a", new Version(1, 0, 0, 0)), out value));
+            Assert.Equal(10, value);
+
+            Assert.True(map.Contains(new AssemblyIdentity("a", new Version(1, 1, 0, 0))));
+            Assert.True(map.TryGetValue(new AssemblyIdentity("a", new Version(1, 1, 0, 0)), out value));
+            Assert.Equal(15, value);
+
+            Assert.True(map.Contains(new AssemblyIdentity("a", new Version(1, 0, 0, 0)), allowHigherVersion: false));
+            Assert.True(map.TryGetValue(new AssemblyIdentity("a", new Version(1, 0, 0, 0)), out value, allowHigherVersion: false));
+            Assert.Equal(10, value);
+
+            Assert.False(map.Contains(new AssemblyIdentity("a", new Version(1, 1, 0, 0)), allowHigherVersion: false));
+            Assert.False(map.TryGetValue(new AssemblyIdentity("a", new Version(1, 1, 0, 0)), out value, allowHigherVersion: false));
+            Assert.Equal(0, value);
+
+            Assert.False(map.Contains(new AssemblyIdentity("b", new Version(1, 1, 0, 0)), allowHigherVersion: true));
+            Assert.False(map.Contains(new AssemblyIdentity("b", new Version(1, 1, 0, 0)), allowHigherVersion: false));
+
+            // returns the first value added to the map if there are multiple matching identities:
+            Assert.True(map.TryGetValue(new AssemblyIdentity("b", new Version(1, 0, 0, 0)), out value));
+            Assert.Equal(10, value);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Binding\AbstractLookupSymbolsInfo.cs" />
     <Compile Include="CaseInsensitiveComparison.cs" />
     <Compile Include="CodeGen\ILEmitStyle.cs" />
+    <Compile Include="MetadataReference\AssemblyIdentityMap.cs" />
     <Compile Include="Compilation\OperationVisitor.cs" />
     <Compile Include="Compilation\OperationWalker.cs" />
     <Compile Include="Compilation\ScriptCompilationInfo.cs" />

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -348,6 +348,12 @@ namespace Microsoft.CodeAnalysis.Emit
             return _assemblyRefIndex.Rows;
         }
 
+        protected override AssemblyIdentity MapAssemblyReferenceIdentity(AssemblyIdentity identity)
+        {
+            AssemblyIdentity mapped;
+            return _previousGeneration.InitialBaseline.LazyMetadataSymbols.AssemblyReferenceIdentityMap.TryGetValue(identity, out mapped) ? mapped : identity;
+        }
+
         protected override int GetOrAddModuleRefIndex(string reference)
         {
             return _moduleRefIndex.GetOrAdd(reference);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -59,15 +59,18 @@ namespace Microsoft.CodeAnalysis.Emit
         internal sealed class MetadataSymbols
         {
             public readonly IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypes;
+            public readonly ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> AssemblyReferenceIdentityMap;
             public readonly object MetadataDecoder;
 
-            public MetadataSymbols(IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypes, object metadataDecoder)
+            public MetadataSymbols(IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypes, object metadataDecoder, ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> assemblyReferenceIdentityMap)
             {
                 Debug.Assert(anonymousTypes != null);
                 Debug.Assert(metadataDecoder != null);
+                Debug.Assert(assemblyReferenceIdentityMap != null);
 
                 this.AnonymousTypes = anonymousTypes;
                 this.MetadataDecoder = metadataDecoder;
+                this.AssemblyReferenceIdentityMap = assemblyReferenceIdentityMap;
             }
         }
 

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -62,6 +62,11 @@ namespace Roslyn.Utilities
                 return _many.IsDefault ? 1 : _many.Length;
             }
         }
+
+        public OneOrMany<T> Add(T item)
+        {
+            return new OneOrMany<T>(_many.IsDefault ? ImmutableArray.Create(_one, item) : _many.Add(item));
+        }
     }
 
     internal static class OneOrMany

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Implements a map from an assembly identity to a value. The map allows to look up the value by an identity
+    /// that either exactly matches the original identity key or whose version is lower (that is the resulting value 
+    /// corresponds to an identity with a higher version).
+    /// </summary>
+    internal sealed class AssemblyIdentityMap<TValue>
+    {
+        private readonly Dictionary<string, OneOrMany<KeyValuePair<AssemblyIdentity, TValue>>> _map;
+
+        public AssemblyIdentityMap(Func<AssemblyIdentity, AssemblyIdentity, bool> secondaryComparer = null)
+        {
+            _map = new Dictionary<string, OneOrMany<KeyValuePair<AssemblyIdentity, TValue>>>(AssemblyIdentityComparer.SimpleNameComparer);
+        }
+
+        public bool Contains(AssemblyIdentity identity, bool allowHigherVersion = true)
+        {
+            TValue value;
+            return TryGetValue(identity, out value, allowHigherVersion);
+        }
+
+        public bool TryGetValue(AssemblyIdentity identity, out TValue value, bool allowHigherVersion = true)
+        {
+            OneOrMany<KeyValuePair<AssemblyIdentity, TValue>> sameName;
+            if (_map.TryGetValue(identity.Name, out sameName))
+            {
+                int minHigherVersionCandidate = -1;
+
+                for (int i = 0; i < sameName.Count; i++)
+                {
+                    AssemblyIdentity currentIdentity = sameName[i].Key;
+
+                    if (EqualModuloNameAndVersion(currentIdentity, identity))
+                    {
+                        if (currentIdentity.Version == identity.Version)
+                        {
+                            value = sameName[i].Value;
+                            return true;
+                        }
+
+                        // only higher version candidates are considered for match:
+                        if (!allowHigherVersion || currentIdentity.Version < identity.Version)
+                        {
+                            continue;
+                        }
+
+                        if (minHigherVersionCandidate == -1 || currentIdentity.Version < sameName[minHigherVersionCandidate].Key.Version)
+                        {
+                            minHigherVersionCandidate = i;
+                        }
+                    }
+                }
+
+                if (minHigherVersionCandidate >= 0)
+                {
+                    value = sameName[minHigherVersionCandidate].Value;
+                    return true;
+                }
+            }
+
+            value = default(TValue);
+            return false;
+        }
+
+        private static bool EqualModuloNameAndVersion(AssemblyIdentity x, AssemblyIdentity y)
+        {
+            return
+                x.IsRetargetable == y.IsRetargetable &&
+                x.ContentType == y.ContentType &&
+                AssemblyIdentityComparer.CultureComparer.Equals(x.CultureName, y.CultureName) &&
+                AssemblyIdentity.KeysEqual(x, y);
+        }
+
+        public void Add(AssemblyIdentity identity, TValue value)
+        {
+            var pair = KeyValuePair.Create(identity, value);
+
+            OneOrMany<KeyValuePair<AssemblyIdentity, TValue>> sameName;
+            _map[identity.Name] = _map.TryGetValue(identity.Name, out sameName) ? sameName.Add(pair) : OneOrMany.Create(pair);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
@@ -222,6 +222,11 @@ namespace Microsoft.Cci
             return _assemblyRefIndex.Rows;
         }
 
+        protected override AssemblyIdentity MapAssemblyReferenceIdentity(AssemblyIdentity identity)
+        {
+            return identity;
+        }
+
         protected override int GetOrAddModuleRefIndex(string reference)
         {
             return _moduleRefIndex.GetOrAdd(reference);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2560,6 +2560,8 @@ namespace Microsoft.Cci
             public bool IsRetargetable;
         }
 
+        protected abstract AssemblyIdentity MapAssemblyReferenceIdentity(AssemblyIdentity identity);
+
         private void PopulateAssemblyRefTableRows()
         {
             var assemblyRefs = this.GetAssemblyRefs();
@@ -2568,7 +2570,7 @@ namespace Microsoft.Cci
             foreach (var assemblyRef in assemblyRefs)
             {
                 AssemblyRefTableRow r = new AssemblyRefTableRow();
-                var identity = assemblyRef.Identity;
+                var identity = MapAssemblyReferenceIdentity(assemblyRef.Identity);
 
                 r.Version = identity.Version;
                 r.PublicKeyToken = heaps.GetBlobIndex(identity.PublicKeyToken);

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -485,6 +485,27 @@ namespace Microsoft.CodeAnalysis
             aliasesOfReferencedAssemblies = aliasesOfReferencedAssembliesBuilder.ToImmutableAndFree();
         }
 
+        internal ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> GetAssemblyReferenceIdentityMap(ImmutableArray<AssemblyIdentity> originalIdentities, ImmutableArray<TAssemblySymbol> symbols)
+        {
+            Debug.Assert(originalIdentities.Length == symbols.Length);
+
+            ImmutableDictionary<AssemblyIdentity, AssemblyIdentity>.Builder lazyBuilder = null;
+            for (int i = 0; i < originalIdentities.Length; i++)
+            {
+                if (originalIdentities[i].Version != symbols[i].Identity.Version)
+                {
+                    lazyBuilder = lazyBuilder ?? ImmutableDictionary.CreateBuilder<AssemblyIdentity, AssemblyIdentity>();
+                    lazyBuilder.Add(symbols[i].Identity, originalIdentities[i]);
+                }
+                else
+                {
+                    Debug.Assert(originalIdentities[i] == symbols[i].Identity);
+                }
+            }
+
+            return lazyBuilder?.ToImmutable() ?? ImmutableDictionary<AssemblyIdentity, AssemblyIdentity>.Empty;
+        }
+
         // #r references are recursive, their aliases should be merged into all their dependencies.
         //
         // For example, if a compilation has a reference to LibA with alias A and the user #r's LibB with alias B,

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -102,10 +102,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             ' We need to transfer the references from the current source compilation but don't need its syntax trees.
             Dim metadataCompilation = compilation.RemoveAllSyntaxTrees()
 
-            Dim metadataAssembly = metadataCompilation.GetBoundReferenceManager().CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata.Create(originalMetadata), MetadataImportOptions.All)
+            Dim assemblyReferenceIdentityMap As ImmutableDictionary(Of AssemblyIdentity, AssemblyIdentity) = Nothing
+            Dim metadataAssembly = metadataCompilation.GetBoundReferenceManager().CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata.Create(originalMetadata), MetadataImportOptions.All, assemblyReferenceIdentityMap)
             Dim metadataDecoder = New MetadataDecoder(metadataAssembly.PrimaryModule)
             Dim metadataAnonymousTypes = GetAnonymousTypeMapFromMetadata(originalMetadata.MetadataReader, metadataDecoder)
-            Dim metadataSymbols = New EmitBaseline.MetadataSymbols(metadataAnonymousTypes, metadataDecoder)
+            Dim metadataSymbols = New EmitBaseline.MetadataSymbols(metadataAnonymousTypes, metadataDecoder, assemblyReferenceIdentityMap)
 
             Return InterlockedOperations.Initialize(initialBaseline.LazyMetadataSymbols, metadataSymbols)
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
@@ -173,32 +174,52 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(compilation._lazyAssemblySymbol IsNot Nothing)
             End Sub
 
-            ''' <summary>
-            ''' Creates a <see cref="PEAssemblySymbol"/> from specified metadata. 
-            ''' </summary>
-            ''' <remarks>
-            ''' Used by EnC to create symbols for emit baseline. The PE symbols are used by <see cref="VisualBasicSymbolMatcher"/>.
-            ''' 
-            ''' The assembly references listed in the metadata AssemblyRef table are matched to the resolved references 
-            ''' stored on this <see cref="ReferenceManager"/>. Each AssemblyRef is matched against the assembly identities
-            ''' using an exact equality comparison. No unification Or further resolution is performed.
-            ''' </remarks>
-            Friend Function CreatePEAssemblyForAssemblyMetadata(metadata As AssemblyMetadata, importOptions As MetadataImportOptions) As PEAssemblySymbol
+            '''  <summary>
+            '''  Creates a <see cref="PEAssemblySymbol"/> from specified metadata. 
+            '''  </summary>
+            '''  <remarks>
+            '''  Used by EnC to create symbols for emit baseline. The PE symbols are used by <see cref="VisualBasicSymbolMatcher"/>.
+            '''  
+            '''  The assembly references listed in the metadata AssemblyRef table are matched to the resolved references 
+            '''  stored on this <see cref="ReferenceManager"/>. We assume that the dependencies of the baseline metadata are 
+            '''  the same as the dependencies of the current compilation. This Is Not exactly true when the dependencies use 
+            '''  time-based versioning pattern, e.g. AssemblyVersion("1.0.*"). In that case we assume only the version
+            '''  changed And nothing else.
+            '''  
+            '''  Each AssemblyRef Is matched against the assembly identities using an exact equality comparison modulo version. 
+            '''  AssemblyRef with lower version in metadata Is matched to a PE assembly symbol with the higher version 
+            '''  (provided that the assembly name, culture, PKT And flags are the same) if there Is no symbol with the exactly matching version. 
+            '''  If there are multiple symbols with higher versions selects the one with the minimal version among them.
+            '''  
+            '''  Matching to a higher version Is necessary to support EnC for projects whose P2P dependencies use time-based versioning pattern. 
+            '''  The versions of the dependent projects seen from the IDE will be higher than 
+            '''  the one written in the metadata at the time their respective baselines are built.
+            '''  
+            '''  No other unification Or further resolution Is performed.
+            '''  </remarks>
+            Friend Function CreatePEAssemblyForAssemblyMetadata(metadata As AssemblyMetadata, importOptions As MetadataImportOptions, <Out> ByRef assemblyReferenceIdentityMap As ImmutableDictionary(Of AssemblyIdentity, AssemblyIdentity)) As PEAssemblySymbol
                 AssertBound()
 
                 ' If the compilation has a reference from metadata to source assembly we can't share the referenced PE symbols.
                 Debug.Assert(Not HasCircularReference)
 
-                Dim referencedAssembliesByIdentity = New Dictionary(Of AssemblyIdentity, AssemblySymbol)()
+                Dim referencedAssembliesByIdentity = New AssemblyIdentityMap(Of AssemblySymbol)()
                 For Each symbol In Me.ReferencedAssemblies
                     referencedAssembliesByIdentity.Add(symbol.Identity, symbol)
                 Next
 
                 Dim assembly = metadata.GetAssembly
                 Dim peReferences = assembly.AssemblyReferences.SelectAsArray(AddressOf MapAssemblyIdentityToResolvedSymbol, referencedAssembliesByIdentity)
+
+                ' Build a map of the PE assembly symbol identities to the identities of the original metadata AssemblyRefs.
+                ' This map will be used in emit when serializing AssemblyRef table of the delta. For the delta to be compatible with
+                ' the original metadata we need to map the identities of the PE assembly symbols back to the original AssemblyRefs (if different).
+                ' In other words, we pretend that the versions of the dependencies haven't changed.
+                assemblyReferenceIdentityMap = GetAssemblyReferenceIdentityMap(assembly.AssemblyReferences, peReferences)
+
                 Dim assemblySymbol = New PEAssemblySymbol(assembly, DocumentationProvider.Default, isLinked:=False, importOptions:=importOptions)
 
-                Dim unifiedAssemblies = Me.UnifiedAssemblies.WhereAsArray(Function(unified) referencedAssembliesByIdentity.ContainsKey(unified.OriginalReference))
+                Dim unifiedAssemblies = Me.UnifiedAssemblies.WhereAsArray(Function(unified) referencedAssembliesByIdentity.Contains(unified.OriginalReference))
                 InitializeAssemblyReuseData(assemblySymbol, peReferences, unifiedAssemblies)
 
                 If assembly.ContainsNoPiaLocalTypes() Then
@@ -208,7 +229,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return assemblySymbol
             End Function
 
-            Private Shared Function MapAssemblyIdentityToResolvedSymbol(identity As AssemblyIdentity, map As Dictionary(Of AssemblyIdentity, AssemblySymbol)) As AssemblySymbol
+            Private Shared Function MapAssemblyIdentityToResolvedSymbol(identity As AssemblyIdentity, map As AssemblyIdentityMap(Of AssemblySymbol)) As AssemblySymbol
                 Dim symbol As AssemblySymbol = Nothing
                 If map.TryGetValue(identity, symbol) Then
                     Return symbol
@@ -395,7 +416,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     referencedModulesMap,
                                     boundReferenceDirectiveMap,
                                     boundReferenceDirectives,
-                                    ExplicitReferences,
+                                    explicitReferences,
                                     implicitlyResolvedReferences,
                                     hasCircularReference,
                                     resolutionDiagnostics.ToReadOnly(),

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -175,6 +175,7 @@
     <Content Include="CodeGen\ConversionsILGenTestSource.vb" />
     <Content Include="CodeGen\ConversionsILGenTestSource1.vb" />
     <Content Include="CodeGen\ConversionsILGenTestSource2.vb" />
+    <Compile Include="Emit\EditAndContinue\AssemblyReferencesTests.vb" />
     <Content Include="ExpressionTrees\Results\CheckedAndOrXor.txt" />
     <Content Include="ExpressionTrees\Results\CheckedAndUncheckedIsIsNot.txt" />
     <Content Include="ExpressionTrees\Results\CheckedAndUncheckedIsIsNotNothing.txt" />

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
@@ -1,0 +1,87 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Emit
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Imports Roslyn.Test.MetadataUtilities
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+
+    Public Class AssemblyReferencesTests
+        Inherits EditAndContinueTestBase
+
+        <Fact>
+        Public Sub DependencyVersionWildcards()
+            Dim srcLib = "
+<Assembly: System.Reflection.AssemblyVersion(""1.0.*"")>
+
+Public Class D
+End Class
+"
+
+            Dim src1 = "
+Imports System
+Class C 
+    Public Shared Function F(a As D) As Integer
+        Return 1
+    End Function
+End Class
+"
+            Dim src2 = "
+Imports System
+Class C 
+    Public Shared Function F(a As D) As Integer
+        Return 2
+    End Function
+End Class
+"
+            Dim lib1 = CreateCompilationWithMscorlib({srcLib}, assemblyName:="Lib", options:=TestOptions.DebugDll)
+            lib1.VerifyDiagnostics()
+
+            Dim lib2 As Compilation
+
+            Do
+                Thread.Sleep(1000)
+                lib2 = CreateCompilationWithMscorlib({srcLib}, assemblyName:="Lib", options:=TestOptions.DebugDll)
+            Loop While lib1.Assembly.Identity.Version = lib2.Assembly.Identity.Version
+
+            lib2.VerifyDiagnostics()
+
+            Dim compilation0 = CreateCompilationWithMscorlib({src1}, {lib1.ToMetadataReference()}, assemblyName:="C", options:=TestOptions.DebugDll)
+            Dim compilation1 = compilation0.WithSource(src2).WithReferences({MscorlibRef, lib2.ToMetadataReference()})
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim v1 = CompileAndVerify(compilation1)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, EmptyLocalsProvider)
+
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1)))
+
+            Dim md1 = diff1.GetMetadata()
+
+            Dim aggReader = New AggregatedMetadataReader(md0.MetadataReader, md1.Reader)
+
+            VerifyAssemblyReferences(aggReader,
+            {
+                "mscorlib, 4.0.0.0",
+                "Lib, " & lib1.Assembly.Identity.Version.ToString(),
+                "mscorlib, 4.0.0.0",
+                "Lib, " & lib1.Assembly.Identity.Version.ToString()
+            })
+        End Sub
+
+        Public Sub VerifyAssemblyReferences(reader As AggregatedMetadataReader, expected As String())
+            AssertEx.Equal(expected, reader.GetAssemblyReferences().Select(Function(aref) $"{reader.GetString(aref.Name)}, {aref.Version}"))
+        End Sub
+    End Class
+End Namespace

--- a/src/Test/PdbUtilities/Metadata/AggregatedMetadataReader.cs
+++ b/src/Test/PdbUtilities/Metadata/AggregatedMetadataReader.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace Roslyn.Test.MetadataUtilities
+{
+    public sealed class AggregatedMetadataReader
+    {
+        private readonly MetadataAggregator _aggregator;
+        public readonly MetadataReader Last;
+        public ImmutableArray<MetadataReader> Readers { get; }
+
+        public AggregatedMetadataReader(params MetadataReader[] readers)
+            : this((IEnumerable<MetadataReader>)readers)
+        {
+        }
+
+        public AggregatedMetadataReader(IEnumerable<MetadataReader> readers)
+        {
+            Readers = ImmutableArray.CreateRange(readers);
+            Last = Readers.Last();
+            _aggregator = new MetadataAggregator(readers.First(), readers.Skip(1).ToArray());
+        }
+
+        private TEntity GetValue<TEntity>(Handle handle, Func<MetadataReader, Handle, TEntity> getter)
+        {
+            int generation;
+            var genHandle = _aggregator.GetGenerationHandle(handle, out generation);
+            return getter(Readers[generation], genHandle);
+        }
+
+        public IEnumerable<AssemblyReference> GetAssemblyReferences() => 
+            Readers.SelectMany(r => r.AssemblyReferences.Select(h => r.GetAssemblyReference(h)));
+
+        public string GetString(StringHandle handle) => GetValue(handle, (r, h) => r.GetString((StringHandle)h));
+    }
+}

--- a/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
+++ b/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
@@ -626,6 +626,11 @@ namespace Roslyn.Test.MetadataUtilities
             return sb.ToString();
         }
 
+        private string Version(Version version)
+        {
+            return version.Major + "." + version.Minor + "." + version.Build + "." + version.Revision;
+        }
+
         private string SequencePoint(SequencePoint sequencePoint)
         {
             string range = sequencePoint.IsHidden ?
@@ -1110,7 +1115,7 @@ namespace Roslyn.Test.MetadataUtilities
 
             AddRow(
                 Literal(entry.Name),
-                entry.Version.Major + "." + entry.Version.Minor + "." + entry.Version.Revision + "." + entry.Version.Build,
+                Version(entry.Version),
                 Literal(entry.Culture),
                 Literal(entry.PublicKey, BlobKind.Key),
                 EnumValue<int>(entry.Flags),
@@ -1136,7 +1141,7 @@ namespace Roslyn.Test.MetadataUtilities
 
                 AddRow(
                     Literal(entry.Name),
-                    entry.Version.Major + "." + entry.Version.Minor + "." + entry.Version.Revision + "." + entry.Version.Build,
+                    Version(entry.Version),
                     Literal(entry.Culture),
                     Literal(entry.PublicKeyOrToken, BlobKind.Key),
                     EnumValue<int>(entry.Flags)

--- a/src/Test/PdbUtilities/PdbUtilities.csproj
+++ b/src/Test/PdbUtilities/PdbUtilities.csproj
@@ -110,6 +110,7 @@
     <Compile Include="..\..\Debugging\Roslyn.Reflection.Metadata.Decoding\SignatureTypeHandleCode.cs">
       <Link>Roslyn.Reflection.Metadata.Decoding\SignatureTypeHandleCode.cs</Link>
     </Compile>
+    <Compile Include="Metadata\AggregatedMetadataReader.cs" />
     <Compile Include="Metadata\ILVisualizer.cs" />
     <Compile Include="Metadata\ILVisualizerAsTokens.cs" />
     <Compile Include="Metadata\MetadataVisualizer.cs" />


### PR DESCRIPTION
A project whose assembly version attribute contains wildcard gets a new version number every time a compilation is created for it. 

Consider a project P whose dependency D uses time-based versioning. When P is built the AssemblyRef in the metadata of P will encode version V1 of D. When D is opened in the IDE (and anytime the IDE decides to create a compilation for it) the version of the corresponding assembly symbol changes to Vn, V1 <= V2 <= V3 <= ... . 

EnC assumes that AssemblyRefs of the baseline metadata match exactly to the AssemblyRefs of the compilation, which is not the case here. The initial matching thus needs to be able to match to a closest higher version if there is no exactly matching version. Note that it is possible to construct a project P that references two projects D1 and D2 of the same name D and different versions, either/both of these versions may be time-based -- e.g. ```1.0.*``` and ```2.0.*```. Ideally we would know that time-based versioning has been used for the assembly, but this fact is not preserved in metadata. We do therefore match higher version for any dependency.

Updating the matching isn't enough however. The delta metadata is emitted using symbols of the current compilation and thus AssemblyRefs in the delta metadata are to the higher version (V2). We need to map them back to the original versions, so that the CLR can apply the delta and unify the AssemblyRefs with others in the merged runtime metadata.

Fixes https://github.com/dotnet/roslyn/issues/4575