### PR TITLE
Ignore dlls that come from a 'packages' directory when searching for viable metadata references to search.

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -224,8 +224,7 @@ d.cs
                 },
                 recursivePatterns: new Dictionary<string, string[]>()
                 {
-                    // TODO (tomat): Fix PathUtilities.GetDirectoryName to strip trailing \ and then the key should be @"C:\temp\a|*.cs"
-                    { @"C:\temp\a\|*.cs", new[] { @"a\x.cs", @"a\b\b.cs", @"a\c.cs" } },
+                    { @"C:\temp\a|*.cs", new[] { @"a\x.cs", @"a\b\b.cs", @"a\c.cs" } },
                 });
 
             var args = parser.Parse(new[] { @"*.cs", @"/recurse:a\*.cs" }, @"C:\temp", s_defaultSdkDirectory);

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Diagnostics\FieldCouldBeReadOnlyAnalyzer.cs" />
     <Compile Include="Emit\EmitOptionsTests.cs" />
     <Compile Include="Emit\CustomDebugInfoTests.cs" />
+    <Compile Include="FileSystem\PathUtilitiesTests.cs" />
     <Compile Include="InternalUtilities\StreamExtensionsTests.cs" />
     <Compile Include="InternalUtilities\StringExtensionsTests.cs" />
     <Compile Include="MetadataReferences\AssemblyIdentityExtensions.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
+{
+    public class PathUtilitiesTests
+    {
+        [Fact]
+        public void TestGetDirectoryName_WindowsPaths_Absolute()
+        {
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\foo", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\",
+                PathUtilities.GetDirectoryName(@"C:\temp", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"C:\", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"C:", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(null, isUnixLike: false));
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_WindowsPaths_Relative()
+        {
+            Assert.Equal(
+                @"foo\temp",
+                PathUtilities.GetDirectoryName(@"foo\temp\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"foo\temp",
+                PathUtilities.GetDirectoryName(@"foo\temp\foo", isUnixLike: false));
+
+            Assert.Equal(
+                @"foo\temp",
+                PathUtilities.GetDirectoryName(@"foo\temp\", isUnixLike: false));
+
+            Assert.Equal(
+                @"foo",
+                PathUtilities.GetDirectoryName(@"foo\temp", isUnixLike: false));
+
+            Assert.Equal(
+                @"foo",
+                PathUtilities.GetDirectoryName(@"foo\", isUnixLike: false));
+
+            Assert.Equal(
+                "",
+                PathUtilities.GetDirectoryName(@"foo", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(null, isUnixLike: false));
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_UnixPaths_Absolute()
+        {
+            Assert.Equal(
+                @"/temp",
+                PathUtilities.GetDirectoryName(@"/temp/foo.txt", isUnixLike: true));
+
+            Assert.Equal(
+                @"/temp",
+                PathUtilities.GetDirectoryName(@"/temp/foo", isUnixLike: true));
+
+            Assert.Equal(
+                @"/temp",
+                PathUtilities.GetDirectoryName(@"/temp/", isUnixLike: true));
+
+            Assert.Equal(
+                @"/",
+                PathUtilities.GetDirectoryName(@"/temp", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"/", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(null, isUnixLike: true));
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_UnixPaths_Relative()
+        {
+            Assert.Equal(
+                @"foo/temp",
+                PathUtilities.GetDirectoryName(@"foo/temp/foo.txt", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo/temp",
+                PathUtilities.GetDirectoryName(@"foo/temp/foo", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo/temp",
+                PathUtilities.GetDirectoryName(@"foo/temp/", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo",
+                PathUtilities.GetDirectoryName(@"foo/temp", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo",
+                PathUtilities.GetDirectoryName(@"foo/", isUnixLike: true));
+
+            Assert.Equal(
+                "",
+                PathUtilities.GetDirectoryName(@"foo", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(null, isUnixLike: true));
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_WindowsSharePaths()
+        {
+            Assert.Equal(
+                @"\\server\temp",
+                PathUtilities.GetDirectoryName(@"\\server\temp\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"\\server\temp",
+                PathUtilities.GetDirectoryName(@"\\server\temp\foo", isUnixLike: false));
+
+            Assert.Equal(
+                @"\\server\temp",
+                PathUtilities.GetDirectoryName(@"\\server\temp\", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"\\server\temp", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"\\server\", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"\\server", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"\\", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"\", isUnixLike: false));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(null, isUnixLike: false));
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_EsotericCases()
+        {
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\\\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp\..",
+                PathUtilities.GetDirectoryName(@"C:\temp\..\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\..", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp\.",
+                PathUtilities.GetDirectoryName(@"C:\temp\.\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\.", isUnixLike: false));
+        }
+
+        [Fact]
+        public void TestContainsPathComponent()
+        {
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "packages"));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "packages"));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "packages"));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "packages"));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "packages"));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "packages"));
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,76 +11,42 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
 {
     public class PathUtilitiesTests
     {
+        private void TestGetDirectoryNameAndCompareToDotnet(string expectedDirectoryName, string fullPath)
+        {
+            var roslynName = PathUtilities.GetDirectoryName(fullPath, isUnixLike: false);
+            Assert.Equal(expectedDirectoryName, roslynName);
+
+            var dotnetName = Path.GetDirectoryName(fullPath);
+            Assert.Equal(dotnetName, roslynName);
+        }
+
         [Fact]
         public void TestGetDirectoryName_WindowsPaths_Absolute()
         {
-            Assert.Equal(
-                @"C:\temp",
-                PathUtilities.GetDirectoryName(@"C:\temp\foo.txt", isUnixLike: false));
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\foo");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\", @"C:\temp");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"C:\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"C:");
 
-            Assert.Equal(
-                @"C:\temp",
-                PathUtilities.GetDirectoryName(@"C:\temp\foo", isUnixLike: false));
-
-            Assert.Equal(
-                @"C:\temp",
-                PathUtilities.GetDirectoryName(@"C:\temp\", isUnixLike: false));
-
-            Assert.Equal(
-                @"C:\",
-                PathUtilities.GetDirectoryName(@"C:\temp", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"C:\", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"C:", isUnixLike: false));
-
+            // dotnet throws on empty argument.  But not on null... go figure.
             Assert.Equal(
                 null,
                 PathUtilities.GetDirectoryName(@"", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(null, isUnixLike: false));
+            
+            TestGetDirectoryNameAndCompareToDotnet(null, null);
         }
 
         [Fact]
         public void TestGetDirectoryName_WindowsPaths_Relative()
         {
-            Assert.Equal(
-                @"foo\temp",
-                PathUtilities.GetDirectoryName(@"foo\temp\foo.txt", isUnixLike: false));
-
-            Assert.Equal(
-                @"foo\temp",
-                PathUtilities.GetDirectoryName(@"foo\temp\foo", isUnixLike: false));
-
-            Assert.Equal(
-                @"foo\temp",
-                PathUtilities.GetDirectoryName(@"foo\temp\", isUnixLike: false));
-
-            Assert.Equal(
-                @"foo",
-                PathUtilities.GetDirectoryName(@"foo\temp", isUnixLike: false));
-
-            Assert.Equal(
-                @"foo",
-                PathUtilities.GetDirectoryName(@"foo\", isUnixLike: false));
-
-            Assert.Equal(
-                "",
-                PathUtilities.GetDirectoryName(@"foo", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(null, isUnixLike: false));
+            TestGetDirectoryNameAndCompareToDotnet(@"foo\temp", @"foo\temp\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo\temp", @"foo\temp\foo");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo\temp", @"foo\temp\");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo", @"foo\temp");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo", @"foo\");
+            TestGetDirectoryNameAndCompareToDotnet("", @"foo");
         }
 
         [Fact]
@@ -153,54 +120,23 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
         [Fact]
         public void TestGetDirectoryName_WindowsSharePaths()
         {
-            Assert.Equal(
-                @"\\server\temp",
-                PathUtilities.GetDirectoryName(@"\\server\temp\foo.txt", isUnixLike: false));
-
-            Assert.Equal(
-                @"\\server\temp",
-                PathUtilities.GetDirectoryName(@"\\server\temp\foo", isUnixLike: false));
-
-            Assert.Equal(
-                @"\\server\temp",
-                PathUtilities.GetDirectoryName(@"\\server\temp\", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"\\server\temp", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"\\server\", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"\\server", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"\\", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(@"\", isUnixLike: false));
-
-            Assert.Equal(
-                null,
-                PathUtilities.GetDirectoryName(null, isUnixLike: false));
+            TestGetDirectoryNameAndCompareToDotnet(@"\\server\temp", @"\\server\temp\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"\\server\temp", @"\\server\temp\foo");
+            TestGetDirectoryNameAndCompareToDotnet(@"\\server\temp", @"\\server\temp\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\server\temp");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\server\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\server");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\");
         }
 
         [Fact]
         public void TestGetDirectoryName_EsotericCases()
         {
-            Assert.Equal(
-                @"C:\temp",
-                PathUtilities.GetDirectoryName(@"C:\temp\\foo.txt", isUnixLike: false));
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\\\foo.txt");
 
-            Assert.Equal(
-                @"C:\temp",
-                PathUtilities.GetDirectoryName(@"C:\temp\\\foo.txt", isUnixLike: false));
-
+            // Dotnet does normalization of dots, so we can't compare against it here.
             Assert.Equal(
                 @"C:\temp\..",
                 PathUtilities.GetDirectoryName(@"C:\temp\..\foo.txt", isUnixLike: false));
@@ -216,6 +152,29 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
             Assert.Equal(
                 @"C:\temp",
                 PathUtilities.GetDirectoryName(@"C:\temp\.", isUnixLike: false));
+
+            TestGetDirectoryNameAndCompareToDotnet(@"C:temp", @"C:temp\\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:temp", @"C:temp\\\foo.txt");
+
+            Assert.Equal(
+                @"C:temp\..",
+                PathUtilities.GetDirectoryName(@"C:temp\..\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:temp",
+                PathUtilities.GetDirectoryName(@"C:temp\..", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:temp\.",
+                PathUtilities.GetDirectoryName(@"C:temp\.\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:temp",
+                PathUtilities.GetDirectoryName(@"C:temp\.", isUnixLike: false));
+
+            TestGetDirectoryNameAndCompareToDotnet(@"C:temp", @"C:temp\");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:", @"C:temp");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"C:");
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -181,17 +181,82 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
         public void TestContainsPathComponent()
         {
             Assert.True(
-                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "packages"));
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "packages", ignoreCase: true));
             Assert.True(
-                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "packages"));
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "packages", ignoreCase: true));
             Assert.False(
-                PathUtilities.ContainsPathComponent(@"\\packages\temp", "packages"));
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "packages", ignoreCase: true));
             Assert.True(
-                PathUtilities.ContainsPathComponent(@"c:\packages", "packages"));
+                PathUtilities.ContainsPathComponent(@"c:\packages", "packages", ignoreCase: true));
             Assert.False(
-                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "packages"));
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "packages", ignoreCase: true));
             Assert.False(
-                PathUtilities.ContainsPathComponent(@"c:\package\temp", "packages"));
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "packages", ignoreCase: true));
+
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "packages", ignoreCase: false));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "packages", ignoreCase: false));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "packages", ignoreCase: false));
+
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "Packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "Packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "Packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "Packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "Packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "Packages", ignoreCase: true));
+
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "Packages", ignoreCase: false));
+
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\Packages\temp", "packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\Packages\temp", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\Packages\temp", "packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\Packages", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages1\temp", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Package\temp", "packages", ignoreCase: true));
+
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\server\Packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\Packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages1\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Package\temp", "packages", ignoreCase: false));
         }
     }
 }

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -399,11 +399,6 @@ namespace Roslyn.Utilities
                 var currentPath = path;
                 while (currentPath != null)
                 {
-                    if (count > 64)
-                    {
-                        throw new InvalidOperationException("Iterated too many times on: " + path);
-                    }
-
                     var currentName = GetFileName(currentPath);
                     if (StringComparer.OrdinalIgnoreCase.Equals(currentName, component))
                     {

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -506,9 +506,15 @@ namespace Roslyn.Utilities
         {
             if (path?.IndexOf(component, StringComparison.OrdinalIgnoreCase) >= 0)
             {
+                int count = 0;
                 var currentPath = path;
                 while (currentPath != null)
                 {
+                    if (count > 64)
+                    {
+                        throw new InvalidOperationException("Iterated too many times on: " + path);
+                    }
+
                     var currentName = GetFileName(currentPath);
                     if (StringComparer.OrdinalIgnoreCase.Equals(currentName, component))
                     {
@@ -516,6 +522,7 @@ namespace Roslyn.Utilities
                     }
 
                     currentPath = GetDirectoryName(currentPath);
+                    count++;
                 }
             }
 

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -391,16 +391,19 @@ namespace Roslyn.Utilities
         /// not have "foo" as a component. That's because here "foo" is the server name portion
         /// of the UNC path, and not an actual directory or file name.
         /// </summary>
-        internal static bool ContainsPathComponent(string path, string component)
+        internal static bool ContainsPathComponent(string path, string component, bool ignoreCase)
         {
-            if (path?.IndexOf(component, StringComparison.OrdinalIgnoreCase) >= 0)
+            var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            if (path?.IndexOf(component, comparison) >= 0)
             {
+                var comparer = ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
                 int count = 0;
                 var currentPath = path;
                 while (currentPath != null)
                 {
                     var currentName = GetFileName(currentPath);
-                    if (StringComparer.OrdinalIgnoreCase.Equals(currentName, component))
+                    if (comparer.Equals(currentName, component))
                     {
                         return true;
                     }

--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -139,6 +139,16 @@ namespace Roslyn.Utilities
                 .GetTypeInfo()
                 .GetDeclaredMethod(nameof(GetTempFileName), paramTypes: new Type[] { })
                 .CreateDelegate(typeof(Func<string>));
+
+            internal static readonly Func<string, string> GetFileName = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(GetFileName), paramTypes: new[] { typeof(string) })
+                .CreateDelegate<Func<string, string>>();
+
+            internal static readonly Func<string, string> GetDirectoryName = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(GetDirectoryName), paramTypes: new[] { typeof(string) })
+                .CreateDelegate<Func<string, string>>();
         }
 
         internal static class File

--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -139,16 +139,6 @@ namespace Roslyn.Utilities
                 .GetTypeInfo()
                 .GetDeclaredMethod(nameof(GetTempFileName), paramTypes: new Type[] { })
                 .CreateDelegate(typeof(Func<string>));
-
-            internal static readonly Func<string, string> GetFileName = Type
-                .GetTypeInfo()
-                .GetDeclaredMethod(nameof(GetFileName), paramTypes: new[] { typeof(string) })
-                .CreateDelegate<Func<string, string>>();
-
-            internal static readonly Func<string, string> GetDirectoryName = Type
-                .GetTypeInfo()
-                .GetDeclaredMethod(nameof(GetDirectoryName), paramTypes: new[] { typeof(string) })
-                .CreateDelegate<Func<string, string>>();
         }
 
         internal static class File

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3833,7 +3833,7 @@ Class C
 
             Dim parsedArgs = DefaultParse({"/libpath:c:\lib2,", "@" & file.ToString(), "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, Path.GetDirectoryName(file.ToString()) + "\", "c:\lib2")
+            AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, Path.GetDirectoryName(file.ToString()), "c:\lib2")
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -293,21 +293,19 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
         {
             const string Packages = nameof(Packages);
 
-            if (!string.IsNullOrWhiteSpace(reference.FilePath))
+            var filePath = reference.FilePath;
+            if (filePath?.IndexOf(Packages, StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                if (reference.FilePath.IndexOf(Packages, StringComparison.OrdinalIgnoreCase) >= 0)
+                var currentPath = filePath;
+                while (currentPath != null)
                 {
-                    var currentPath = reference.FilePath;
-                    while (currentPath != null)
+                    var name = PathUtilities.GetFileName(currentPath);
+                    if (StringComparer.OrdinalIgnoreCase.Equals(name, Packages))
                     {
-                        var name = PathUtilities.GetFileName(currentPath);
-                        if (StringComparer.OrdinalIgnoreCase.Equals(name, Packages))
-                        {
-                            return true;
-                        }
-
-                        currentPath = PathUtilities.GetDirectoryName(currentPath);
+                        return true;
                     }
+
+                    currentPath = PathUtilities.GetDirectoryName(currentPath);
                 }
             }
 

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -291,25 +291,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
         /// </summary>
         private bool IsInPackagesDirectory(PortableExecutableReference reference)
         {
-            const string Packages = nameof(Packages);
-
-            var filePath = reference.FilePath;
-            if (filePath?.IndexOf(Packages, StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                var currentPath = filePath;
-                while (currentPath != null)
-                {
-                    var name = PathUtilities.GetFileName(currentPath);
-                    if (StringComparer.OrdinalIgnoreCase.Equals(name, Packages))
-                    {
-                        return true;
-                    }
-
-                    currentPath = PathUtilities.GetDirectoryName(currentPath);
-                }
-            }
-
-            return false;
+            return PathUtilities.ContainsPathComponent(reference.FilePath, "packages");
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
         /// </summary>
         private bool IsInPackagesDirectory(PortableExecutableReference reference)
         {
-            return PathUtilities.ContainsPathComponent(reference.FilePath, "packages");
+            return PathUtilities.ContainsPathComponent(reference.FilePath, "packages", ignoreCase: true);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/8577