### PR TITLE
BSD support: GNU Make instead of BSD Make when compiling on [Free/Net]BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 OS_NAME = $(shell uname -s)
 NUGET_PACKAGE_NAME = nuget.54
 BUILD_CONFIGURATION = Debug

--- a/build/linux/setup-pcl.sh
+++ b/build/linux/setup-pcl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage()
 {

--- a/build/linux/setup-snapshot.sh
+++ b/build/linux/setup-snapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "Error: This script must be run as root"

--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -55,10 +55,15 @@ done
 run_make()
 {
     local is_good=false
-    
+ 
+    MAKE="make"
+    if [[ $OSTYPE == *bsd* ]]; then
+        MAKE="gmake"
+    fi
+
     for i in `seq 1 $RETRY_COUNT`
     do
-        make "$@" BUILD_CONFIGURATION=$BUILD_CONFIGURATION
+        $MAKE "$@" BUILD_CONFIGURATION=$BUILD_CONFIGURATION
         if [ $? -eq 0 ]; then
             is_good=true
             break


### PR DESCRIPTION
This PR supersedes https://github.com/dotnet/roslyn/pull/8020, addressing the CR in a way that all BSD platforms will make use of gmake to build roslyn.

The commit authorship is retained and credit goes to @ajensenwaud.

@davkean, @agocke PTAL