### PR TITLE
turn off low latency mode when we hit low memory situation.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/GCManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/GCManager.cs
@@ -50,6 +50,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         }
 
         /// <summary>
+        /// Turn off low latency GC mode.
+        /// 
+        /// if there is a pending low latency mode request, Latency mode will go back to its original status as
+        /// pending request timeout. once it goes back to its original status, it will not go back to low latency mode again.
+        /// </summary>
+        internal static void TurnOffLowLatencyMode()
+        {
+            if (s_delayMilliseconds <= 0)
+            {
+                // if it is already turned off, we don't do anything.
+                return;
+            }
+
+            // first set delay to 0 to turn it off
+            s_delayMilliseconds = 0;
+
+            // explictly call Full GC to remove impact of SustainedLowLatency
+            // this is based on finding on https://github.com/dotnet/roslyn/issues/6802
+            // one of reason we do this here is so that GC do compact on fragmented memory.
+            // which will in return let us have bigger continuous free memory chunk.
+            for (var i = 0; i < 5; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+        }
+
+        /// <summary>
         /// Call this method to suppress expensive blocking Gen 2 garbage GCs in
         /// scenarios where high-latency is unacceptable (e.g. processing typing input).
         /// 

--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
+using Microsoft.VisualStudio.LanguageServices.Implementation;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -78,6 +79,12 @@ namespace Microsoft.VisualStudio.LanguageServices
                             // no close info bar action
                             _workspace.Services.GetService<IErrorReportingService>().ShowErrorInfo(ServicesVSResources.FullSolutionAnalysisOff, () => { });
                         }
+
+                        // turn off low latency GC mode.
+                        // once we hit this, not hitting "Out of memory" exception is more important than typing being smooth all the time.
+                        // once it is turned off, user will hit time to time keystroke which responsive time is more than 50ms. in our own perf lab,
+                        // about 1-2% was over 50ms with this off when we first introduced this GC mode.
+                        GCManager.TurnOffLowLatencyMode();
 
                         break;
                     }


### PR DESCRIPTION
the low latency mode is introduced in the early days of Roslyn to make sure we always hit 50ms typing responsive time in our own perf lab typing test.

basically that mode prevent GC to get into most expensvie blocking gen 2 collection. which is nice most of time, but when we are under low memory sitatuion, not doing blocking gen 2 also means we don't do compact.

and that I believe can cause us to be in a sitatuion such as https://github.com/dotnet/roslyn/issues/6802

this basically let us turn that optimization off sacrifying keystroke responsiveness time to time to have more memory available to us.

this mode is supposed to force blocking gen 2 collection when GC detects its own low memory condition, but that seems not consider when there is some free memory left but all those are fregmented.