### PR TITLE
BuildAndTest.proj: quote tools path argument for RunTests.exe

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -87,7 +87,7 @@
 
     <Exec Command="$(CoreClrTestDirectory)\CoreRun.exe $(CoreClrTestDirectory)\xunit.console.netcore.exe @(CoreTestAssemblies, ' ') -parallel all -xml $(CoreClrTestDirectory)\TestResults.xml" />
 
-    <Exec Command="Binaries\$(Configuration)\RunTests.exe $(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')" />
+    <Exec Command="Binaries\$(Configuration)\RunTests.exe &quot;$(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools&quot; $(RunTestArgs) @(TestAssemblies, ' ')" />
 
   </Target>
 


### PR DESCRIPTION
This allows running tests when a user's home directory (by way of `$(NuGetPackageRoot)`, by way of `$(UserProfile)`) has a space in it.