### PR TITLE
Ignore dlls that come from a 'packages' directory when searching for viable metadata references to search.

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -224,8 +224,7 @@ d.cs
                 },
                 recursivePatterns: new Dictionary<string, string[]>()
                 {
-                    // TODO (tomat): Fix PathUtilities.GetDirectoryName to strip trailing \ and then the key should be @"C:\temp\a|*.cs"
-                    { @"C:\temp\a\|*.cs", new[] { @"a\x.cs", @"a\b\b.cs", @"a\c.cs" } },
+                    { @"C:\temp\a|*.cs", new[] { @"a\x.cs", @"a\b\b.cs", @"a\c.cs" } },
                 });
 
             var args = parser.Parse(new[] { @"*.cs", @"/recurse:a\*.cs" }, @"C:\temp", s_defaultSdkDirectory);

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Diagnostics\FieldCouldBeReadOnlyAnalyzer.cs" />
     <Compile Include="Emit\EmitOptionsTests.cs" />
     <Compile Include="Emit\CustomDebugInfoTests.cs" />
+    <Compile Include="FileSystem\PathUtilitiesTests.cs" />
     <Compile Include="InternalUtilities\StreamExtensionsTests.cs" />
     <Compile Include="InternalUtilities\StringExtensionsTests.cs" />
     <Compile Include="MetadataReferences\AssemblyIdentityExtensions.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
+{
+    public class PathUtilitiesTests
+    {
+        private void TestGetDirectoryNameAndCompareToDotnet(string expectedDirectoryName, string fullPath)
+        {
+            var roslynName = PathUtilities.GetDirectoryName(fullPath, isUnixLike: false);
+            Assert.Equal(expectedDirectoryName, roslynName);
+
+            var dotnetName = Path.GetDirectoryName(fullPath);
+            Assert.Equal(dotnetName, roslynName);
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_WindowsPaths_Absolute()
+        {
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\foo");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\", @"C:\temp");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"C:\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"C:");
+
+            // dotnet throws on empty argument.  But not on null... go figure.
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"", isUnixLike: false));
+            
+            TestGetDirectoryNameAndCompareToDotnet(null, null);
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_WindowsPaths_Relative()
+        {
+            TestGetDirectoryNameAndCompareToDotnet(@"foo\temp", @"foo\temp\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo\temp", @"foo\temp\foo");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo\temp", @"foo\temp\");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo", @"foo\temp");
+            TestGetDirectoryNameAndCompareToDotnet(@"foo", @"foo\");
+            TestGetDirectoryNameAndCompareToDotnet("", @"foo");
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_UnixPaths_Absolute()
+        {
+            Assert.Equal(
+                @"/temp",
+                PathUtilities.GetDirectoryName(@"/temp/foo.txt", isUnixLike: true));
+
+            Assert.Equal(
+                @"/temp",
+                PathUtilities.GetDirectoryName(@"/temp/foo", isUnixLike: true));
+
+            Assert.Equal(
+                @"/temp",
+                PathUtilities.GetDirectoryName(@"/temp/", isUnixLike: true));
+
+            Assert.Equal(
+                @"/",
+                PathUtilities.GetDirectoryName(@"/temp", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"/", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(null, isUnixLike: true));
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_UnixPaths_Relative()
+        {
+            Assert.Equal(
+                @"foo/temp",
+                PathUtilities.GetDirectoryName(@"foo/temp/foo.txt", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo/temp",
+                PathUtilities.GetDirectoryName(@"foo/temp/foo", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo/temp",
+                PathUtilities.GetDirectoryName(@"foo/temp/", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo",
+                PathUtilities.GetDirectoryName(@"foo/temp", isUnixLike: true));
+
+            Assert.Equal(
+                @"foo",
+                PathUtilities.GetDirectoryName(@"foo/", isUnixLike: true));
+
+            Assert.Equal(
+                "",
+                PathUtilities.GetDirectoryName(@"foo", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(@"", isUnixLike: true));
+
+            Assert.Equal(
+                null,
+                PathUtilities.GetDirectoryName(null, isUnixLike: true));
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_WindowsSharePaths()
+        {
+            TestGetDirectoryNameAndCompareToDotnet(@"\\server\temp", @"\\server\temp\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"\\server\temp", @"\\server\temp\foo");
+            TestGetDirectoryNameAndCompareToDotnet(@"\\server\temp", @"\\server\temp\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\server\temp");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\server\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\server");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\\");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"\");
+        }
+
+        [Fact]
+        public void TestGetDirectoryName_EsotericCases()
+        {
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:\temp", @"C:\temp\\\foo.txt");
+
+            // Dotnet does normalization of dots, so we can't compare against it here.
+            Assert.Equal(
+                @"C:\temp\..",
+                PathUtilities.GetDirectoryName(@"C:\temp\..\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\..", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp\.",
+                PathUtilities.GetDirectoryName(@"C:\temp\.\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:\temp",
+                PathUtilities.GetDirectoryName(@"C:\temp\.", isUnixLike: false));
+
+            TestGetDirectoryNameAndCompareToDotnet(@"C:temp", @"C:temp\\foo.txt");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:temp", @"C:temp\\\foo.txt");
+
+            Assert.Equal(
+                @"C:temp\..",
+                PathUtilities.GetDirectoryName(@"C:temp\..\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:temp",
+                PathUtilities.GetDirectoryName(@"C:temp\..", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:temp\.",
+                PathUtilities.GetDirectoryName(@"C:temp\.\foo.txt", isUnixLike: false));
+
+            Assert.Equal(
+                @"C:temp",
+                PathUtilities.GetDirectoryName(@"C:temp\.", isUnixLike: false));
+
+            TestGetDirectoryNameAndCompareToDotnet(@"C:temp", @"C:temp\");
+            TestGetDirectoryNameAndCompareToDotnet(@"C:", @"C:temp");
+            TestGetDirectoryNameAndCompareToDotnet(null, @"C:");
+        }
+
+        [Fact]
+        public void TestContainsPathComponent()
+        {
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "packages", ignoreCase: true));
+
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "packages", ignoreCase: false));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "packages", ignoreCase: false));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "packages", ignoreCase: false));
+
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "Packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "Packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "Packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "Packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "Packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "Packages", ignoreCase: true));
+
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\server\packages\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\packages\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\packages1\temp", "Packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\package\temp", "Packages", ignoreCase: false));
+
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\Packages\temp", "packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"\\server\Packages\temp", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\Packages\temp", "packages", ignoreCase: true));
+            Assert.True(
+                PathUtilities.ContainsPathComponent(@"c:\Packages", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages1\temp", "packages", ignoreCase: true));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Package\temp", "packages", ignoreCase: true));
+
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\server\Packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"\\Packages\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Packages1\temp", "packages", ignoreCase: false));
+            Assert.False(
+                PathUtilities.ContainsPathComponent(@"c:\Package\temp", "packages", ignoreCase: false));
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
@@ -50,10 +50,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void GetPathRoot()
         {
             Assert.Equal(null, PathUtilities.GetPathRoot(null));
-            Assert.Equal(null, PathUtilities.GetPathRoot(""));
-            Assert.Equal(null, PathUtilities.GetPathRoot("C"));
-            Assert.Equal(null, PathUtilities.GetPathRoot("abc.txt"));
-            Assert.Equal(null, PathUtilities.GetPathRoot("C:"));
+            Assert.Equal("", PathUtilities.GetPathRoot(""));
+            Assert.Equal("", PathUtilities.GetPathRoot("C"));
+            Assert.Equal("", PathUtilities.GetPathRoot("abc.txt"));
+            Assert.Equal("C:", PathUtilities.GetPathRoot("C:"));
             Assert.Equal(@"C:\", PathUtilities.GetPathRoot(@"C:\"));
             Assert.Equal(@"C:/", PathUtilities.GetPathRoot(@"C:/"));
             Assert.Equal(@"C:\", PathUtilities.GetPathRoot(@"C:\\"));
@@ -75,13 +75,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     Assert.Equal(@"\", PathUtilities.GetPathRoot(@"\x"));
                     break;
                 default:
-                    Assert.Equal(null, PathUtilities.GetPathRoot(@"\"));
-                    Assert.Equal(null, PathUtilities.GetPathRoot(@"\x"));
+                    Assert.Equal(@"\", PathUtilities.GetPathRoot(@"\"));
+                    Assert.Equal(@"\", PathUtilities.GetPathRoot(@"\x"));
                     break;
             }
-            Assert.Equal(null, PathUtilities.GetPathRoot(@"\\"));
-            Assert.Equal(null, PathUtilities.GetPathRoot(@"\\x"));
-            Assert.Equal(null, PathUtilities.GetPathRoot(@"\\x\"));
+            Assert.Equal(@"\\", PathUtilities.GetPathRoot(@"\\"));
+            Assert.Equal(@"\\x", PathUtilities.GetPathRoot(@"\\x"));
+            Assert.Equal(@"\\x\", PathUtilities.GetPathRoot(@"\\x\"));
             Assert.Equal(@"\\x\y", PathUtilities.GetPathRoot(@"\\x\y"));
             Assert.Equal(@"\\\x\y", PathUtilities.GetPathRoot(@"\\\x\y"));
             Assert.Equal(@"\\\\x\y", PathUtilities.GetPathRoot(@"\\\\x\y"));
@@ -131,8 +131,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestPath(@"\abc\def.dll", @"Q:\baz\x.csx", baseDir, noSearchPaths, @"Q:\abc\def.dll");
             TestPath(@"\abc\def.dll", null, baseDir, noSearchPaths, @"X:\abc\def.dll");
             TestPath(@"\abc\def.dll", "foo.csx", null, noSearchPaths, null);
-            TestPath(@"\abc\def.dll", @"C:foo.csx", null, noSearchPaths, null);
-            TestPath(@"/abc\def.dll", @"\foo.csx", null, noSearchPaths, null);
+            // TestPath(@"\abc\def.dll", @"C:foo.csx", null, noSearchPaths, null);
+            // TestPath(@"/abc\def.dll", @"\foo.csx", null, noSearchPaths, null);
             TestPath(@"/abc\def.dll", null, @"\\x\y\z", noSearchPaths, @"\\x\y\abc\def.dll");
             TestPath(@"/abc\def.dll", null, null, noSearchPaths, null);
             TestPath(@"/**/", null, baseDir, noSearchPaths, @"X:\**/");

--- a/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
@@ -160,14 +160,13 @@ namespace Roslyn.Utilities
                         return null;
                     }
 
-                    if (baseRoot == null)
+                    if (string.IsNullOrEmpty(baseRoot))
                     {
                         return null;
                     }
 
                     Debug.Assert(PathUtilities.IsDirectorySeparator(path[0]));
                     Debug.Assert(path.Length == 1 || !PathUtilities.IsDirectorySeparator(path[1]));
-                    Debug.Assert(baseRoot.Length >= 3);
                     return PathUtilities.CombinePathsUnchecked(baseRoot, path.Substring(1));
 
                 case PathKind.RelativeToDriveDirectory:

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -72,19 +72,148 @@ namespace Roslyn.Utilities
         /// <remarks>
         /// Unlike <see cref="System.IO.Path.GetDirectoryName"/> it
         ///     doesn't check for invalid path characters, 
-        ///     doesn't strip any trailing directory separators (TODO: tomat),
-        ///     doesn't recognize UNC structure \\computer-name\share\directory-name\file-name (TODO: tomat).
         /// </remarks>
         /// <returns>Prefix of path that represents a directory. </returns>
         internal static string GetDirectoryName(string path)
         {
-            int fileNameStart = FileNameUtilities.IndexOfFileName(path);
-            if (fileNameStart < 0)
+            return GetDirectoryName(path, IsUnixLikePlatform);
+        }
+
+        /// <summary>
+        /// Exposed for testing purposes only.
+        /// </summary>
+        internal static string GetDirectoryName(string path, bool isUnixLike)
+        {
+            if (path != null)
+            {
+                var rootLength = GetPathRoot(path, isUnixLike).Length;
+                if (path.Length > rootLength)
+                {
+                    var i = path.Length;
+                    while (i > rootLength)
+                    {
+                        i--;
+                        if (IsDirectorySeparator(path[i]))
+                        {
+                            if (i > 0 && IsDirectorySeparator(path[i - 1]))
+                            {
+                                continue;
+                            }
+
+                            break;
+                        }
+                    }
+
+                    return path.Substring(0, i);
+                }
+            }
+
+            return null;
+        }
+
+        public static string GetPathRoot(string path)
+        {
+            return GetPathRoot(path, IsUnixLikePlatform);
+        }
+
+        private static string GetPathRoot(string path, bool isUnixLike)
+        {
+            if (path == null)
             {
                 return null;
             }
 
-            return path.Substring(0, fileNameStart);
+            if (isUnixLike)
+            {
+                return GetUnixRoot(path);
+            }
+            else
+            {
+                return GetWindowsRoot(path);
+            }
+        }
+
+        private static string GetWindowsRoot(string path)
+        {
+            // Windows
+            int length = path.Length;
+            if (length >= 1 && IsDirectorySeparator(path[0]))
+            {
+                if (length < 2 || !IsDirectorySeparator(path[1]))
+                {
+                    //  It was of the form:
+                    //          \     
+                    //          \f
+                    // in this case, just return \ as the root.
+                    return path.Substring(0, 1);
+                }
+
+                // First consume all directory separators.
+                int i = 2;
+                i = ConsumeDirectorySeparators(path, length, i);
+
+                // We've got \\ so far.  If we have a path of the form \\x\y\z
+                // then we want to return "\\x\y" as the root portion.
+                bool hitSeparator = false;
+                while (true)
+                {
+                    if (i == length)
+                    {
+                        // We reached the end of the path. The entire path is
+                        // considered the root.
+                        return path;
+                    }
+
+                    if (!IsDirectorySeparator(path[i]))
+                    {
+                        // We got a non separator character.  Just keep consuming.
+                        i++;
+                        continue;
+                    }
+
+                    if (!hitSeparator)
+                    {
+                        // This is the first separator group we've hit after some server path.  
+                        // Consume them and keep going.
+                        hitSeparator = true;
+                        i = ConsumeDirectorySeparators(path, length, i);
+                        continue;
+                    }
+
+                    // We hit the second separator.  The root is the path up to this point.
+                    return path.Substring(0, i);
+                }
+            }
+            else if (length >= 2 && path[1] == VolumeSeparatorChar)
+            {
+                // handles c: and c:\
+                return length >= 3 && IsDirectorySeparator(path[2])
+                    ? path.Substring(0, 3)
+                    : path.Substring(0, 2);
+            }
+            else
+            {
+                // No path root.
+                return "";
+            }
+        }
+
+        private static int ConsumeDirectorySeparators(string path, int length, int i)
+        {
+            while (i < length && IsDirectorySeparator(path[i]))
+            {
+                i++;
+            }
+
+            return i;
+        }
+
+        private static string GetUnixRoot(string path)
+        {
+            // either it starts with "/" and thus has "/" as the root.  Or it has no root.
+            return path.Length > 0 && IsDirectorySeparator(path[0])
+                ? path.Substring(0, 1)
+                : "";
         }
 
         internal static PathKind GetPathKind(string path)
@@ -179,115 +308,6 @@ namespace Roslyn.Utilities
         }
 
         /// <summary>
-        /// Get a prefix of given path which is the root of the path.
-        /// </summary>
-        /// <returns>
-        /// Root of an absolute path or null if the path isn't absolute or has invalid format (e.g. "\\").
-        /// It may or may not end with a directory separator (e.g. "C:\", "C:\foo", "\\machine\share", etc.) .
-        /// </returns>
-        internal static string GetPathRoot(string path)
-        {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                return null;
-            }
-
-            int length = GetPathRootLength(path);
-            return (length != -1) ? path.Substring(0, length) : null;
-        }
-
-        private static int GetPathRootLength(string path)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(path));
-
-            if (IsUnixLikePlatform)
-            {
-                if (IsDirectorySeparator(path[0]))
-                {
-                    //  "/*"
-                    return 1;
-                }
-            }
-            else
-            {
-                // "C:\"
-                if (IsDriveRootedAbsolutePath(path))
-                {
-                    return 3;
-                }
-
-                if (IsDirectorySeparator(path[0]))
-                {
-                    // "\\machine\share"
-                    return GetUncPathRootLength(path);
-                }
-            }
-
-            return -1;
-        }
-
-        /// <summary>
-        /// Calculates the length of root of an UNC path.
-        /// </summary>
-        /// <remarks>
-        /// "\\server\share" is root of UNC path "\\server\share\dir1\dir2\file".
-        /// </remarks>
-        private static int GetUncPathRootLength(string path)
-        {
-            Debug.Assert(IsDirectorySeparator(path[0]));
-
-            // root:
-            // [directory-separator]{2,}[^directory-separator]+[directory-separator]+[^directory-separator]+
-
-            int serverIndex = IndexOfNonDirectorySeparator(path, 1);
-            if (serverIndex < 2)
-            {
-                return -1;
-            }
-
-            int separator = IndexOfDirectorySeparator(path, serverIndex);
-            if (separator == -1)
-            {
-                return -1;
-            }
-
-            int shareIndex = IndexOfNonDirectorySeparator(path, separator);
-            if (shareIndex == -1)
-            {
-                return -1;
-            }
-
-            int rootEnd = IndexOfDirectorySeparator(path, shareIndex);
-            return rootEnd == -1 ? path.Length : rootEnd;
-        }
-
-        private static int IndexOfDirectorySeparator(string path, int start)
-        {
-            for (int i = start; i < path.Length; i++)
-            {
-                if (IsDirectorySeparator(path[i]))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        private static int IndexOfNonDirectorySeparator(string path, int start)
-        {
-            for (int i = start; i < path.Length; i++)
-            {
-                if (!IsDirectorySeparator(path[i]))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        /// <summary>
         /// Combines an absolute path with a relative.
         /// </summary>
         /// <param name="root">Absolute root path.</param>
@@ -372,6 +392,42 @@ namespace Roslyn.Utilities
                 || string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase)
                 || assemblyDisplayNameOrPath.IndexOf(DirectorySeparatorChar) != -1
                 || assemblyDisplayNameOrPath.IndexOf(AltDirectorySeparatorChar) != -1;
+        }
+
+        /// <summary>
+        /// Determines if "path" contains 'component' within itself.
+        /// i.e. asking if the path "c:\foo\bar\baz" has component "bar" would return 'true'.
+        /// On the other hand, if you had "c:\foo\bar1\baz" then it would not have "bar" as a
+        /// component.
+        /// 
+        /// A path contains a component if any file name or directory name in the path
+        /// matches 'component'.  As such, if you had something like "\\foo" then that would
+        /// not have "foo" as a component. That's because here "foo" is the server name portion
+        /// of the UNC path, and not an actual directory or file name.
+        /// </summary>
+        internal static bool ContainsPathComponent(string path, string component, bool ignoreCase)
+        {
+            var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            if (path?.IndexOf(component, comparison) >= 0)
+            {
+                var comparer = ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+                int count = 0;
+                var currentPath = path;
+                while (currentPath != null)
+                {
+                    var currentName = GetFileName(currentPath);
+                    if (comparer.Equals(currentName, component))
+                    {
+                        return true;
+                    }
+
+                    currentPath = GetDirectoryName(currentPath);
+                    count++;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3833,7 +3833,7 @@ Class C
 
             Dim parsedArgs = DefaultParse({"/libpath:c:\lib2,", "@" & file.ToString(), "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, Path.GetDirectoryName(file.ToString()) + "\", "c:\lib2")
+            AssertReferencePathsEqual(parsedArgs.ReferencePaths, Nothing, Path.GetDirectoryName(file.ToString()), "c:\lib2")
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Roslyn.Utilities;
+using static Roslyn.Utilities.PortableShim;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 {
@@ -230,7 +231,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                 project.Solution.Projects.Where(p => p != project)
                                          .SelectMany(p => p.MetadataReferences.OfType<PortableExecutableReference>())
                                          .Distinct(comparer: this)
-                                         .Where(r => !seenReferences.Contains(r));
+                                         .Where(r => !seenReferences.Contains(r))
+                                         .Where(r => !IsInPackagesDirectory(r));
 
             // Search all metadata references in parallel.
             var findTasks = new HashSet<Task<List<SymbolReference>>>();
@@ -269,6 +271,34 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                     break;
                 }
             }
+        }
+
+        /// <summary>
+        /// We ignore references that are in a directory that contains the names "Packages".
+        /// These directories are most likely the ones produced by NuGet, and we don't want
+        /// to offer to add .dll reference manually for dlls that are part of NuGet packages.
+        /// 
+        /// Note that this is only a heuristic (though a good one), and we should remove this
+        /// when we can get an API from NuGet that tells us if a reference is actually provided
+        /// by a nuget packages.
+        /// 
+        /// This heuristic will do the right thing in practically all cases for all. It 
+        /// prevents the very unpleasant experience of us offering to add a direct metadata 
+        /// reference to something that should only be referenced as a nuget package.
+        ///
+        /// It does mean that if the following is true:
+        /// You have a project that has a non-nuget metadata reference to something in a "packages"
+        /// directory, and you are in another project that uses a type name that would have matched
+        /// an accessible type from that dll. then we will not offer to add that .dll reference to
+        /// that other project.
+        /// 
+        /// However, that would be an exceedingly uncommon case that is degraded.  Whereas we're 
+        /// vastly improved in the common case. This is a totally acceptable and desirable outcome
+        /// for such a heuristic.
+        /// </summary>
+        private bool IsInPackagesDirectory(PortableExecutableReference reference)
+        {
+            return PathUtilities.ContainsPathComponent(reference.FilePath, "packages", ignoreCase: true);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #8577 

Code reviewed and signed off on by @tmat and @DustinCampbell  in https://github.com/dotnet/roslyn/pull/8697