### PR TITLE
Match equivalent symbols in non-identical referenced assemblies

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -313,41 +313,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol DefaultVisit(Symbol symbol)
             {
                 // Symbol should have been handled elsewhere.
-                throw new NotImplementedException();
+                throw ExceptionUtilities.Unreachable;
             }
 
             public override Symbol Visit(Symbol symbol)
             {
                 Debug.Assert((object)symbol.ContainingAssembly != (object)_otherAssembly);
 
-                // If the symbol is not defined in any of the previous source assemblies and not a constructed symbol
-                // no matching is necessary, just return the symbol.
-                if (!(symbol.ContainingAssembly is SourceAssemblySymbol))
-                {
-                    switch (symbol.Kind)
-                    {
-                        case SymbolKind.ArrayType:
-                        case SymbolKind.PointerType:
-                        case SymbolKind.DynamicType:
-                            break;
-
-                        case SymbolKind.NamedType:
-                            if (symbol.IsDefinition)
-                            {
-                                return symbol;
-                            }
-                            break;
-
-                        default:
-                            Debug.Assert(symbol.IsDefinition);
-                            return symbol;
-                    }
-                }
-
                 // Add an entry for the match, even if there is no match, to avoid
                 // matching the same symbol unsuccessfully multiple times.
-                var otherSymbol = _matches.GetOrAdd(symbol, base.Visit);
-                return otherSymbol;
+                return _matches.GetOrAdd(symbol, base.Visit);
             }
 
             public override Symbol VisitArrayType(ArrayTypeSymbol symbol)
@@ -387,16 +362,56 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             public override Symbol VisitModule(ModuleSymbol module)
             {
-                // Only map symbols from source assembly and its previous generations to the other assembly. 
-                // All other symbols should map to themselves.
-                if (module.ContainingAssembly.Identity.Equals(_sourceAssembly.Identity))
+                var otherAssembly = (AssemblySymbol)Visit(module.ContainingAssembly);
+                if ((object)otherAssembly == null)
                 {
-                    return _otherAssembly.Modules[module.Ordinal];
+                    return null;
                 }
-                else
+
+                // manifest module:
+                if (module.Ordinal == 0)
                 {
-                    return module;
+                    return otherAssembly.Modules[0];
                 }
+
+                // match non-manifest module by name:
+                for (int i = 1; i < otherAssembly.Modules.Length; i++)
+                {
+                    var otherModule = otherAssembly.Modules[i];
+
+                    // use case sensitive comparison -- modules whose names differ in casing are considered distinct:
+                    if (StringComparer.Ordinal.Equals(otherModule.Name, module.Name))
+                    {
+                        return otherModule;
+                    }
+                }
+
+                return null;
+            }
+
+            public override Symbol VisitAssembly(AssemblySymbol symbol)
+            {
+                if (symbol.IsLinked)
+                {
+                    return symbol;
+                }
+
+                // the current source assembly:
+                if (symbol.Identity.Equals(_sourceAssembly.Identity))
+                {
+                    return _otherAssembly;
+                }
+
+                // find a referenced assembly with the exactly same identity:
+                foreach (var otherReferencedAssembly in _otherAssembly.Modules[0].ReferencedAssemblySymbols)
+                {
+                    if (symbol.Identity.Equals(otherReferencedAssembly.Identity))
+                    {
+                        return otherReferencedAssembly;
+                    }
+                }
+
+                return null;
             }
 
             public override Symbol VisitNamespace(NamespaceSymbol @namespace)
@@ -505,7 +520,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol VisitParameter(ParameterSymbol parameter)
             {
                 // Should never reach here. Should be matched as a result of matching the container.
-                throw new InvalidOperationException();
+                throw ExceptionUtilities.Unreachable;
             }
 
             public override Symbol VisitPointerType(PointerTypeSymbol symbol)
@@ -527,6 +542,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             public override Symbol VisitTypeParameter(TypeParameterSymbol symbol)
             {
+                var indexed = symbol as IndexedTypeParameterSymbol;
+                if ((object)indexed != null)
+                {
+                    return indexed;
+                }
+
                 ImmutableArray<TypeParameterSymbol> otherTypeParameters;
                 var otherContainer = this.Visit(symbol.ContainingSymbol);
                 Debug.Assert((object)otherContainer != null);
@@ -811,7 +832,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol DefaultVisit(Symbol symbol)
             {
                 // Symbol should have been handled elsewhere.
-                throw new NotImplementedException();
+                throw ExceptionUtilities.Unreachable;
             }
 
             public override Symbol Visit(Symbol symbol)

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -127,6 +127,7 @@
     <Compile Include="CodeGen\WinRTCollectionTests.vb" />
     <Compile Include="Emit\CompilationEmitTests.vb" />
     <Compile Include="Emit\DeterministicTests.vb" />
+    <Compile Include="Emit\EditAndContinue\AssemblyReferencesTests.vb" />
     <Compile Include="Emit\EditAndContinue\EditAndContinueClosureTests.vb" />
     <Compile Include="Emit\EditAndContinue\EditAndContinueStateMachineTests.vb" />
     <Compile Include="Emit\EditAndContinue\EditAndContinueTestBase.vb" />

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
@@ -1,0 +1,86 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Generic
+Imports System.Collections.Immutable
+Imports System.IO
+Imports System.Linq
+Imports System.Reflection.Metadata
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Imports Microsoft.CodeAnalysis.Emit
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Roslyn.Test.MetadataUtilities
+Imports Roslyn.Test.Utilities
+Imports Xunit
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
+    Public Class AssemblyReferencesTests
+        Inherits EditAndContinueTestBase
+
+        ''' <summary>
+        ''' Symbol matcher considers two source types that only differ in the declaring compilations different.
+        ''' </summary>
+        <Fact>
+        Public Sub ChangingCompilationDependencies()
+            Dim srcLib = "
+Public Class D
+End Class
+"
+            Dim src0 = "
+Public Class C 
+    Public Shared Function F(a as D) As Integer
+        Return 1
+    End Function
+End Class
+"
+            Dim src1 = "
+Public Class C 
+    Public Shared Function F(a as D) As Integer
+        Return 2
+    End Function
+End Class
+"
+            Dim src2 As String = "
+Public Class C 
+    Public Shared Function F(a as D) As Integer
+        Return 3
+    End Function
+End Class
+"
+
+            Dim lib0 = CreateCompilationWithMscorlib({srcLib}, assemblyName:="Lib", options:=TestOptions.DebugDll)
+            lib0.VerifyDiagnostics()
+            Dim lib1 = CreateCompilationWithMscorlib({srcLib}, assemblyName:="Lib", options:=TestOptions.DebugDll)
+            lib1.VerifyDiagnostics()
+            Dim lib2 = CreateCompilationWithMscorlib({srcLib}, assemblyName:="Lib", options:=TestOptions.DebugDll)
+            lib2.VerifyDiagnostics()
+
+            Dim compilation0 = CreateCompilationWithMscorlib({src0}, {lib0.ToMetadataReference()}, assemblyName:="C", options:=TestOptions.DebugDll)
+            Dim compilation1 = compilation0.WithSource(src1).WithReferences({MscorlibRef, lib1.ToMetadataReference()})
+            Dim compilation2 = compilation1.WithSource(src2).WithReferences({MscorlibRef, lib2.ToMetadataReference()})
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim v1 = CompileAndVerify(compilation1)
+            Dim v2 = CompileAndVerify(compilation2)
+
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+            Dim f2 = compilation2.GetMember(Of MethodSymbol)("C.F")
+
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, EmptyLocalsProvider)
+
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1)))
+
+            diff1.EmitResult.Diagnostics.Verify()
+
+            Dim diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f1, f2)))
+
+            diff2.EmitResult.Diagnostics.Verify()
+        End Sub
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
@@ -8,10 +8,191 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 Imports Roslyn.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
+Imports System.Threading.Tasks
+Imports System.Threading
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class SymbolMatcherTests
         Inherits EditAndContinueTestBase
+
+        <Fact>
+        Public Sub ConcurrentAccess()
+            Dim source = "
+Class A
+    Dim F As B
+    Property P As D
+    Sub M(a As A, b As B, s As S, i As I) : End Sub
+    Delegate Sub D(s As S)
+    Class B : End Class
+    Structure S : End Structure
+    Interface I : End Interface
+End Class
+
+Class B
+    Function M(Of T, U)() As A 
+        Return Nothing
+    End Function
+
+    Event E As D
+    Delegate Sub D(s As S)
+    Structure S : End Structure
+    Interface I : End Interface
+End Class"
+            Dim compilation0 = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
+            Dim compilation1 = compilation0.Clone()
+
+            compilation0.VerifyDiagnostics()
+
+            Dim builder = New List(Of Symbol)()
+
+            Dim type = compilation1.GetMember(Of NamedTypeSymbol)("A")
+            builder.Add(type)
+            builder.AddRange(type.GetMembers())
+
+            type = compilation1.GetMember(Of NamedTypeSymbol)("B")
+            builder.Add(type)
+            builder.AddRange(type.GetMembers())
+
+            Dim members = builder.ToImmutableArray()
+            Assert.True(members.Length > 10)
+
+            For i = 0 To 10 - 1
+                Dim matcher = New VisualBasicSymbolMatcher(Nothing, compilation1.SourceAssembly, Nothing, compilation0.SourceAssembly, Nothing, Nothing)
+
+                Dim tasks(10) As Task
+
+                For j = 0 To tasks.Length - 1
+                    Dim startAt As Integer = i + j + 1
+                    tasks(j) = Task.Run(Sub()
+                                            MatchAll(matcher, members, startAt)
+                                            Thread.Sleep(10)
+                                        End Sub)
+                Next
+
+                Task.WaitAll(tasks)
+            Next
+        End Sub
+
+        Private Shared Sub MatchAll(matcher As VisualBasicSymbolMatcher, members As ImmutableArray(Of Symbol), startAt As Integer)
+            Dim n As Integer = members.Length
+            For i = 0 To n - 1
+                Dim member = members((i + startAt) Mod n)
+                Dim other = matcher.MapDefinition(DirectCast(member, Cci.IDefinition))
+                Assert.NotNull(other)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub TypeArguments()
+            Dim source = "
+Class A(Of T)
+    Class B(Of U)
+        Shared Function M(Of V)(x As A(Of U).B(Of T), y As A(Of Object).S) As A(Of V)
+            Return Nothing
+        End Function
+
+        Shared Function M(Of V)(x As A(Of U).B(Of T), y As A(Of V).S) As A(Of V) 
+            Return Nothing
+        End Function
+    End Class
+
+    Structure S
+    End Structure
+End Class
+"
+            Dim compilation0 = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
+            Dim compilation1 = compilation0.Clone()
+
+            compilation0.VerifyDiagnostics()
+
+            Dim matcher = New VisualBasicSymbolMatcher(Nothing, compilation1.SourceAssembly, Nothing, compilation0.SourceAssembly, Nothing, Nothing)
+            Dim members = compilation1.GetMember(Of NamedTypeSymbol)("A.B").GetMembers("M")
+
+            Assert.Equal(members.Length, 2)
+            For Each member In members
+                Dim other = matcher.MapDefinition(DirectCast(member, Cci.IMethodDefinition))
+                Assert.NotNull(other)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub Constraints()
+            Dim source = "
+Interface I(Of T AS I(Of T))
+End Interface
+
+Class C
+    Shared Sub M(Of T As I(Of T))(o As I(Of T))
+    End Sub
+End Class
+"
+            Dim compilation0 = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
+            Dim compilation1 = compilation0.WithSource(source)
+            Dim matcher = New VisualBasicSymbolMatcher(Nothing, compilation1.SourceAssembly, Nothing, compilation0.SourceAssembly, Nothing, Nothing)
+            Dim member = compilation1.GetMember(Of MethodSymbol)("C.M")
+            Dim other = matcher.MapDefinition(member)
+            Assert.NotNull(other)
+        End Sub
+
+        <Fact>
+        Public Sub CustomModifiers()
+            Dim ilSource = "
+.class public abstract A
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  .method public abstract virtual instance object modopt(A) [] F(int32 modopt(object) p) { }
+}
+"
+            Dim metadataRef = CompileIL(ilSource)
+            Dim source = "
+Class B 
+    Inherits A
+
+    Public Overrides Function F(p As Integer) As Object()
+        Return Nothing
+    End Function
+End Class
+"
+            Dim compilation0 = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll, references:={metadataRef})
+            Dim compilation1 = compilation0.Clone()
+
+            compilation0.VerifyDiagnostics()
+
+            Dim member1 = compilation1.GetMember(Of MethodSymbol)("B.F")
+            Assert.Equal(DirectCast(member1.ReturnType, ArrayTypeSymbol).CustomModifiers.Length, 1)
+
+            Dim matcher = New VisualBasicSymbolMatcher(Nothing, compilation1.SourceAssembly, Nothing, compilation0.SourceAssembly, Nothing, Nothing)
+            Dim other = DirectCast(matcher.MapDefinition(member1), MethodSymbol)
+            Assert.NotNull(other)
+            Assert.Equal(DirectCast(other.ReturnType, ArrayTypeSymbol).CustomModifiers.Length, 1)
+        End Sub
+
+        <Fact>
+        Public Sub VaryingCompilationReferences()
+            Dim libSource = "
+Public Class D
+End Class
+"
+            Dim source = "
+Public Class C
+    Public Sub F(a As D)
+    End Sub
+End Class
+"
+            Dim lib0 = CreateCompilationWithMscorlib({libSource}, options:=TestOptions.DebugDll, assemblyName:="Lib")
+            Dim lib1 = CreateCompilationWithMscorlib({libSource}, options:=TestOptions.DebugDll, assemblyName:="Lib")
+
+            Dim compilation0 = CreateCompilationWithMscorlib({source}, {lib0.ToMetadataReference()}, options:=TestOptions.DebugDll)
+            Dim compilation1 = compilation0.WithSource(source).WithReferences(MscorlibRef, lib1.ToMetadataReference())
+
+            Dim matcher = New VisualBasicSymbolMatcher(Nothing, compilation1.SourceAssembly, Nothing, compilation0.SourceAssembly, Nothing, Nothing)
+
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+
+            Dim mf1 = matcher.MapDefinition(f1)
+            Assert.Equal(f0, mf1)
+        End Sub
 
         <WorkItem(1533, "https://github.com/dotnet/roslyn/issues/1533")>
         <Fact>


### PR DESCRIPTION
The IDE may create new compilations for projects during debugging session. Symbols from assemblies referenced by the compilation thus need to be matched based on the identity of the containing assembly not the object identity of the referenced assembly symbol.

The previous matching caused the EnC session to fail without reporting errors to the error list.

Original PR against master: https://github.com/dotnet/roslyn/pull/8741