### PR TITLE
Re-enable crossgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bootstrap: toolset
 	mkdir -p $(BOOTSTRAP_PATH) ; \
 	cp Binaries/$(BUILD_CONFIGURATION)/csccore/* $(BOOTSTRAP_PATH) ; \
 	cp Binaries/$(BUILD_CONFIGURATION)/vbccore/* $(BOOTSTRAP_PATH) ; \
-	# build/scripts/crossgen.sh $(BOOTSTRAP_PATH) ;
+	build/scripts/crossgen.sh $(BOOTSTRAP_PATH) ;
 	rm -rf Binaries/$(BUILD_CONFIGURATION)
 
 test:

--- a/build/scripts/crossgen.sh
+++ b/build/scripts/crossgen.sh
@@ -24,7 +24,7 @@ if [ -z "$RID" ]; then
 fi
 
 # Replace with a robust method for finding the right crossgen.exe
-CROSSGEN_UTIL=$HOME/.nuget/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23504/tools/crossgen
+CROSSGEN_UTIL=~/.nuget/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23504/tools/crossgen
 
 cd $BIN_DIR
 


### PR DESCRIPTION
This was temporarily disabled due to some hangs we were seeing on the elastic machines. If this is still an issue then we should look for a real fix rather than just waiting for crossgen failures later.