### PR TITLE
Clarify behavior when RunServerCompilation throws an exception

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -23,15 +23,18 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         {
             private readonly string _pipeName;
             private readonly Func<string, bool> _createServerFunc;
+            private readonly Func<Task<BuildResponse>> _runServerCompilationFunc;
 
             public TestableDesktopBuildClient(
                 RequestLanguage langauge,
                 CompileFunc compileFunc,
                 string pipeName,
-                Func<string, bool> createServerFunc) : base(langauge, compileFunc, new Mock<IAnalyzerAssemblyLoader>().Object)
+                Func<string, bool> createServerFunc,
+                Func<Task<BuildResponse>> runServerCompilationFunc) : base(langauge, compileFunc, new Mock<IAnalyzerAssemblyLoader>().Object)
             {
                 _pipeName = pipeName;
                 _createServerFunc = createServerFunc;
+                _runServerCompilationFunc = runServerCompilationFunc;
             }
 
             protected override string GetSessionKey(BuildPaths buildPaths)
@@ -44,10 +47,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 return _createServerFunc(pipeName);
             }
 
-            protected override RunCompilationResult HandleResponse(BuildResponse response, string[] arguments, BuildPaths buildPaths, TextWriter textWriter)
+            protected override Task<BuildResponse> RunServerCompilation(List<string> arguments, BuildPaths buildPaths, string sessionKey, string keepAlive, string libDirectory, CancellationToken cancellationToken)
             {
-                // Override the base so we don't print the compilation output to Console.Out
-                return RunCompilationResult.Succeeded;
+                if (_runServerCompilationFunc != null)
+                {
+                    return _runServerCompilationFunc();
+                }
+
+                return base.RunServerCompilation(arguments, buildPaths, sessionKey, keepAlive, libDirectory, cancellationToken);
             }
         }
 
@@ -80,12 +87,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             private TestableDesktopBuildClient CreateClient(
                 RequestLanguage? language = null,
                 CompileFunc compileFunc = null,
-                Func<string, bool> createServerFunc = null)
+                Func<string, bool> createServerFunc = null,
+                Func<Task<BuildResponse>> runServerCompilationFunc = null)
             {
                 language = language ?? RequestLanguage.CSharpCompile;
                 compileFunc = compileFunc ?? delegate { return 0; };
                 createServerFunc = createServerFunc ?? TryCreateServer;
-                return new TestableDesktopBuildClient(language.Value, compileFunc, _pipeName, createServerFunc);
+                return new TestableDesktopBuildClient(language.Value, compileFunc, _pipeName, createServerFunc, runServerCompilationFunc);
             }
 
             private bool TryCreateServer(string pipeName)
@@ -132,15 +140,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void OnlyStartsOneServer()
             {
                 var ranLocal = false;
-                var client = CreateClient(compileFunc: delegate
-                {
-                    ranLocal = true;
-                    throw new Exception();
-                });
+                var client = CreateClient(
+                    compileFunc: delegate
+                    {
+                        ranLocal = true;
+                        throw new Exception();
+                    });
 
                 for (var i = 0; i < 5; i++)
                 {
-                    client.RunCompilation(new[] { "/shared" }, _buildPaths);
+                    client.RunCompilation(new[] { "/shared" }, _buildPaths, new StringWriter());
                 }
 
                 Assert.Equal(1, _serverDataList.Count);
@@ -163,6 +172,39 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.True(ranLocal);
                 Assert.Equal(1, _failedCreatedServerCount);
                 Assert.Equal(0, _serverDataList.Count);
+            }
+
+            [Fact]
+            [WorkItem(7866, "https://github.com/dotnet/roslyn/issues/7866")]
+            public void RunServerCompilationThrows()
+            {
+                bool ranLocal;
+                Func<int> compileFunc = () =>
+                {
+                    ranLocal = true;
+                    return CommonCompiler.Succeeded;
+                };
+
+                TestableDesktopBuildClient client;
+                RunCompilationResult result;
+
+                ranLocal = false;
+                client = CreateClient(
+                    compileFunc: delegate { return compileFunc(); },
+                    runServerCompilationFunc: () => Task.FromException<BuildResponse>(new Exception()));
+                result = client.RunCompilation(new[] { "/shared" }, _buildPaths);
+                Assert.Equal(CommonCompiler.Succeeded, result.ExitCode);
+                Assert.False(result.RanOnServer);
+                Assert.True(ranLocal);
+
+                ranLocal = false;
+                client = CreateClient(
+                    compileFunc: delegate { return compileFunc(); },
+                    runServerCompilationFunc: () => { throw new Exception(); });
+                result = client.RunCompilation(new[] { "/shared" }, _buildPaths);
+                Assert.Equal(CommonCompiler.Succeeded, result.ExitCode);
+                Assert.False(result.RanOnServer);
+                Assert.True(ranLocal);
             }
         }
 

--- a/src/Compilers/Shared/DesktopBuildClient.cs
+++ b/src/Compilers/Shared/DesktopBuildClient.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
                             if (!holdsMutex)
                             {
-                                return Task.FromResult<BuildResponse>(null);
+                                return Task.FromResult<BuildResponse>(new RejectedBuildResponse());
                             }
                         }
                         catch (AbandonedMutexException)
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 }
             }
 
-            return Task.FromResult<BuildResponse>(null);
+            return Task.FromResult<BuildResponse>(new RejectedBuildResponse());
         }
 
         internal static bool WasServerMutexOpen(string mutexName)
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 catch (Exception e)
                 {
                     LogException(e, "Error writing build request.");
-                    return null;
+                    return new RejectedBuildResponse();
                 }
 
                 // Wait for the compilation and a monitor to detect if the server disconnects
@@ -224,17 +224,18 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     catch (Exception e)
                     {
                         LogException(e, "Error reading response");
-                        response = null;
+                        response = new RejectedBuildResponse();
                     }
                 }
                 else
                 {
                     Log("Server disconnect");
-                    response = null;
+                    response = new RejectedBuildResponse();
                 }
 
                 // Cancel whatever task is still around
                 serverCts.Cancel();
+                Debug.Assert(response != null);
                 return response;
             }
         }


### PR DESCRIPTION
A question was raised about the behavior of the compiler when RunServerCompilation throws an exception. After looking through the code I decided the approach most consistent with our existing code is:

1. Stop using `null` as a valid value in this API.  If the client determines it can't make the call use the Rejected coede.
2. Gracefully handle case where Task is faulted.  This puts the IO handling in a single place.
3. If the compilation could not complete on the server, for whatever reason, always fall back to local compilation.

closes #7866