### PR TITLE
Change how Miscellaneous Files chooses which documents to track

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService_ICSharpProjectHost.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService_ICSharpProjectHost.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 projectName,
                 hierarchy,
                 this.SystemServiceProvider,
-                this.Package.ComponentModel.GetService<MiscellaneousFilesWorkspace>(),
                 this.Workspace,
                 this.HostDiagnosticUpdateSource);
 

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         {
             // If classNames is NULL, then we need to populate the number of valid startup
             // classes only
-            var project = VisualStudioWorkspace.CurrentSolution.GetProject(Id);
+            var project = Workspace.CurrentSolution.GetProject(Id);
             var compilation = project.GetCompilationAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
 
             var entryPoints = GetEntryPoints(project, compilation);

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -49,7 +49,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             string projectSystemName,
             IVsHierarchy hierarchy,
             IServiceProvider serviceProvider,
-            MiscellaneousFilesWorkspace miscellaneousFilesWorkspaceOpt,
             VisualStudioWorkspaceImpl visualStudioWorkspaceOpt,
             HostDiagnosticUpdateSource hostDiagnosticUpdateSourceOpt)
             : base(projectTracker,
@@ -58,7 +57,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                    hierarchy,
                    LanguageNames.CSharp,
                    serviceProvider,
-                   miscellaneousFilesWorkspaceOpt,
                    visualStudioWorkspaceOpt,
                    hostDiagnosticUpdateSourceOpt)
         {

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShimWithServices.CodeModel.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShimWithServices.CodeModel.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             {
                 if (_projectCodeModel == null)
                 {
-                    _projectCodeModel = new CSharpProjectCodeModel(this, this.VisualStudioWorkspace, ServiceProvider);
+                    _projectCodeModel = new CSharpProjectCodeModel(this, (VisualStudioWorkspace)this.Workspace, ServiceProvider);
                 }
 
                 return _projectCodeModel;

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShimWithServices.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShimWithServices.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             string projectSystemName,
             IVsHierarchy hierarchy,
             IServiceProvider serviceProvider,
-            MiscellaneousFilesWorkspace miscellaneousFilesWorkspaceOpt,
             VisualStudioWorkspaceImpl visualStudioWorkspaceOpt,
             HostDiagnosticUpdateSource hostDiagnosticUpdateSourceOpt)
             : base(
@@ -33,7 +32,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                   projectSystemName,
                   hierarchy,
                   serviceProvider,
-                  miscellaneousFilesWorkspaceOpt,
                   visualStudioWorkspaceOpt,
                   hostDiagnosticUpdateSourceOpt)
         {

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -25,7 +25,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 projectSystemName: projectName,
                 hierarchy: hierarchy,
                 serviceProvider: environment.ServiceProvider,
-                miscellaneousFilesWorkspaceOpt: null,
                 visualStudioWorkspaceOpt: null,
                 hostDiagnosticUpdateSourceOpt: null);
         }

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
@@ -104,7 +104,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             // while the code is running and get refreshed next time the web page is hit.
 
             // Note that Razor-like views are modelled as a ContainedDocument but normal code including code-behind are modelled as a StandardTextDocument.
-            var containedDocument = _vsProject.VisualStudioWorkspace.GetHostDocument(documentId) as ContainedDocument;
+            var visualStudioWorkspace = _vsProject.Workspace as VisualStudioWorkspaceImpl;
+            var containedDocument = visualStudioWorkspace?.GetHostDocument(documentId) as ContainedDocument;
             return containedDocument == null;
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -41,7 +41,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// </summary>
         private string _filePathOpt;
 
-        private readonly MiscellaneousFilesWorkspace _miscellaneousFilesWorkspaceOpt;
         private readonly VisualStudioWorkspaceImpl _visualStudioWorkspaceOpt;
         private readonly IContentTypeRegistryService _contentTypeRegistryService;
         private readonly IVsReportExternalErrors _externalErrorReporter;
@@ -107,7 +106,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             IVsHierarchy hierarchy,
             string language,
             IServiceProvider serviceProvider,
-            MiscellaneousFilesWorkspace miscellaneousFilesWorkspaceOpt,
             VisualStudioWorkspaceImpl visualStudioWorkspaceOpt,
             HostDiagnosticUpdateSource hostDiagnosticUpdateSourceOpt)
         {
@@ -132,7 +130,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             this.ProjectTracker = projectTracker;
 
             _projectSystemName = projectSystemName;
-            _miscellaneousFilesWorkspaceOpt = miscellaneousFilesWorkspaceOpt;
             _visualStudioWorkspaceOpt = visualStudioWorkspaceOpt;
             _hostDiagnosticUpdateSourceOpt = hostDiagnosticUpdateSourceOpt;
 
@@ -248,7 +245,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public string ProjectType => _projectType;
 
-        public Workspace Workspace => (Workspace)_visualStudioWorkspaceOpt ?? _miscellaneousFilesWorkspaceOpt;
+        public Workspace Workspace => _visualStudioWorkspaceOpt;
 
         public VersionStamp Version => _version;
 
@@ -756,11 +753,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // We do not want to allow message pumping/reentrancy when processing project system changes.
             using (Dispatcher.CurrentDispatcher.DisableProcessing())
             {
-                if (_miscellaneousFilesWorkspaceOpt != null)
-                {
-                    _miscellaneousFilesWorkspaceOpt.OnFileIncludedInProject(document);
-                }
-
                 _documents.Add(document.Id, document);
                 _documentMonikers.Add(document.Key.Moniker, document);
 
@@ -802,11 +794,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         internal void AddAdditionalDocument(IVisualStudioHostDocument document, bool isCurrentContext)
         {
-            if (_miscellaneousFilesWorkspaceOpt != null)
-            {
-                _miscellaneousFilesWorkspaceOpt.OnFileIncludedInProject(document);
-            }
-
             _additionalDocuments.Add(document.Id, document);
             _documentMonikers.Add(document.Key.Moniker, document);
 
@@ -981,11 +968,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this.ProjectTracker.NotifyWorkspaceHosts(host => host.OnDocumentRemoved(document.Id));
             }
 
-            if (_miscellaneousFilesWorkspaceOpt != null)
-            {
-                _miscellaneousFilesWorkspaceOpt.OnFileRemovedFromProject(document);
-            }
-
             document.Opened -= s_documentOpenedEventHandler;
             document.Closing -= s_documentClosingEventHandler;
             document.UpdatedOnDisk -= s_documentUpdatedOnDiskEventHandler;
@@ -1003,11 +985,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
 
                 this.ProjectTracker.NotifyWorkspaceHosts(host => host.OnAdditionalDocumentRemoved(document.Id));
-            }
-
-            if (_miscellaneousFilesWorkspaceOpt != null)
-            {
-                _miscellaneousFilesWorkspaceOpt.OnFileRemovedFromProject(document);
             }
 
             document.Opened -= s_additionalDocumentOpenedEventHandler;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -229,8 +229,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// </summary>
         internal string TryGetBinOutputPath() => _binOutputPathOpt;
 
-        internal VisualStudioWorkspaceImpl VisualStudioWorkspace => _visualStudioWorkspaceOpt;
-
         internal IRuleSetFile RuleSetFile => this.ruleSet;
 
         internal HostDiagnosticUpdateSource HostDiagnosticUpdateSource => _hostDiagnosticUpdateSourceOpt;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractRoslynProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractRoslynProject.cs
@@ -23,10 +23,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             IVsHierarchy hierarchy,
             string language,
             IServiceProvider serviceProvider,
-            MiscellaneousFilesWorkspace miscellaneousFilesWorkspaceOpt,
             VisualStudioWorkspaceImpl visualStudioWorkspaceOpt,
             HostDiagnosticUpdateSource hostDiagnosticUpdateSourceOpt)
-            : base(projectTracker, reportExternalErrorCreatorOpt, projectSystemName, hierarchy, language, serviceProvider, miscellaneousFilesWorkspaceOpt, visualStudioWorkspaceOpt, hostDiagnosticUpdateSourceOpt)
+            : base(projectTracker, reportExternalErrorCreatorOpt, projectSystemName, hierarchy, language, serviceProvider, visualStudioWorkspaceOpt, hostDiagnosticUpdateSourceOpt)
         {
             if (visualStudioWorkspaceOpt != null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -242,8 +242,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (workspaceRegistration.Workspace == null)
             {
-                // We should now claim this
-                AttachToDocument(docCookie, moniker);
+                HostProject hostProject;
+
+                if (_docCookiesToHostProject.TryGetValue(docCookie, out hostProject))
+                {
+                    // The workspace was taken from us and released and we have only asynchronously found out now.
+                    var document = hostProject.Document;
+
+                    if (document.IsOpen)
+                    {
+                        RegisterText(document.GetOpenTextContainer());
+                    }
+                }
+                else
+                { 
+                    // We should now claim this
+                    AttachToDocument(docCookie, moniker);
+                }
             }
             else if (IsClaimedByAnotherWorkspace(workspaceRegistration))
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;
 
@@ -30,7 +31,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private readonly Dictionary<Guid, LanguageInformation> _languageInformationByLanguageGuid = new Dictionary<Guid, LanguageInformation>();
 
-        private readonly HashSet<DocumentKey> _filesInProjects = new HashSet<DocumentKey>();
+        /// <summary>
+        /// <see cref="WorkspaceRegistration"/> instances for all open buffers being tracked by by this object
+        /// for possible inclusion into this workspace.
+        /// </summary>
+        private IBidirectionalMap<uint, WorkspaceRegistration> _docCookieToWorkspaceRegistration = BidirectionalMap<uint, WorkspaceRegistration>.Empty;
 
         private readonly Dictionary<ProjectId, HostProject> _hostProjects = new Dictionary<ProjectId, HostProject>();
         private readonly Dictionary<uint, HostProject> _docCookiesToHostProject = new Dictionary<uint, HostProject>();
@@ -121,30 +126,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                    select manager.CreateMetadataReferenceSnapshot(fullPath, MetadataReferenceProperties.Assembly);
         }
 
-        internal void OnFileIncludedInProject(IVisualStudioHostDocument document)
-        {
-            uint docCookie;
-            if (_runningDocumentTable.TryGetCookieForInitializedDocument(document.FilePath, out docCookie))
-            {
-                TryRemoveDocumentFromMiscellaneousWorkspace(docCookie, document.FilePath);
-            }
-
-            _filesInProjects.Add(document.Key);
-        }
-
-        internal void OnFileRemovedFromProject(IVisualStudioHostDocument document)
-        {
-            // Remove the document key from the filesInProjects map first because adding documents
-            // to the misc files workspace requires that they not appear in this map.
-            _filesInProjects.Remove(document.Key);
-
-            uint docCookie;
-            if (_runningDocumentTable.TryGetCookieForInitializedDocument(document.Key.Moniker, out docCookie))
-            {
-                AddDocumentToMiscellaneousOrMetadataAsSourceWorkspace(docCookie, document.Key.Moniker);
-            }
-        }
-
         public int OnAfterAttributeChange(uint docCookie, uint grfAttribs)
         {
             return VSConstants.S_OK;
@@ -160,10 +141,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // 1) the old file already was a misc file, at which point we might just be doing a rename from
                 //    one name to another with the same extension
                 // 2) the old file was a different extension that we weren't tracking, which may have now changed
-                if (TryRemoveDocumentFromMiscellaneousWorkspace(docCookie, pszMkDocumentOld) || TryGetLanguageInformation(pszMkDocumentOld) == null)
+                if (TryUntrackClosingDocument(docCookie, pszMkDocumentOld) || TryGetLanguageInformation(pszMkDocumentOld) == null)
                 {
                     // Add the new one, if appropriate. 
-                    AddDocumentToMiscellaneousOrMetadataAsSourceWorkspace(docCookie, pszMkDocumentNew);
+                    TrackOpenedDocument(docCookie, pszMkDocumentNew);
                 }
             }
 
@@ -176,7 +157,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 if (moniker != null && TryGetLanguageInformation(moniker) != null && !_docCookiesToHostProject.ContainsKey(docCookie))
                 {
-                    AddDocumentToMiscellaneousOrMetadataAsSourceWorkspace(docCookie, moniker);
+                    TrackOpenedDocument(docCookie, moniker);
                 }
             }
 
@@ -207,79 +188,155 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             if (dwReadLocksRemaining + dwEditLocksRemaining == 0)
             {
-                TryRemoveDocumentFromMiscellaneousWorkspace(docCookie, _runningDocumentTable.GetDocumentMoniker(docCookie));
+                TryUntrackClosingDocument(docCookie, _runningDocumentTable.GetDocumentMoniker(docCookie));
             }
 
             return VSConstants.S_OK;
         }
 
-        private void AddDocumentToMiscellaneousOrMetadataAsSourceWorkspace(uint docCookie, string moniker)
+        private void TrackOpenedDocument(uint docCookie, string moniker)
         {
             var languageInformation = TryGetLanguageInformation(moniker);
 
-            if (languageInformation != null &&
-                !_filesInProjects.Any(d => StringComparer.OrdinalIgnoreCase.Equals(d.Moniker, moniker)) &&
-                !_docCookiesToHostProject.ContainsKey(docCookie))
+            if (languageInformation == null)
             {
-                // See if we should push to this to the metadata-to-source workspace instead.
-                if (_runningDocumentTable.IsDocumentInitialized(docCookie))
-                {
-                    var vsTextBuffer = (IVsTextBuffer)_runningDocumentTable.GetDocumentData(docCookie);
-                    var textBuffer = _editorAdaptersFactoryService.GetDocumentBuffer(vsTextBuffer);
+                // We can never put this document in a workspace, so just bail
+                return;
+            }
 
-                    if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer))
+            if (_runningDocumentTable.IsDocumentInitialized(docCookie))
+            {
+                var vsTextBuffer = (IVsTextBuffer)_runningDocumentTable.GetDocumentData(docCookie);
+                var textBuffer = _editorAdaptersFactoryService.GetDocumentBuffer(vsTextBuffer);
+
+                // As long as the buffer is initialized, then we should see if we should attach
+                if (textBuffer != null)
+                {
+                    var registration = Workspace.GetWorkspaceRegistration(textBuffer.AsTextContainer());
+
+                    registration.WorkspaceChanged += Registration_WorkspaceChanged;
+                    _docCookieToWorkspaceRegistration = _docCookieToWorkspaceRegistration.Add(docCookie, registration);
+
+                    if (!IsClaimedByAnotherWorkspace(registration))
                     {
-                        // We already added it, so we will keep it excluded from the misc files workspace
-                        return;
+                        AttachToDocument(docCookie, moniker);
                     }
                 }
-
-                var parseOptions = languageInformation.ParseOptions;
-
-                if (Path.GetExtension(moniker) == languageInformation.ScriptExtension)
-                {
-                    parseOptions = parseOptions.WithKind(SourceCodeKind.Script);
-                }
-
-                // First, create the project
-                var hostProject = new HostProject(this, CurrentSolution.Id, languageInformation.LanguageName, parseOptions, _metadataReferences);
-
-                // Now try to find the document. We accept any text buffer, since we've already verified it's an appropriate file in ShouldIncludeFile.
-                var document = _documentProvider.TryGetDocumentForFile(hostProject, (uint)VSConstants.VSITEMID.Nil, moniker, parseOptions.Kind, t => true);
-
-                // If the buffer has not yet been initialized, we won't get a document.
-                if (document == null)
-                {
-                    return;
-                }
-
-                // Since we have a document, we can do the rest of the project setup.
-                _hostProjects.Add(hostProject.Id, hostProject);
-                OnProjectAdded(hostProject.CreateProjectInfoForCurrentState());
-
-                OnDocumentAdded(document.GetInitialState());
-                hostProject.Document = document;
-
-                // Notify the document provider, so it knows the document is now open and a part of
-                // the project
-                _documentProvider.NotifyDocumentRegisteredToProject(document);
-
-                Contract.ThrowIfFalse(document.IsOpen);
-
-                var buffer = document.GetOpenTextBuffer();
-                OnDocumentOpened(document.Id, document.GetOpenTextContainer());
-
-                _docCookiesToHostProject.Add(docCookie, hostProject);
             }
         }
 
-        private bool TryRemoveDocumentFromMiscellaneousWorkspace(uint docCookie, string moniker)
+        private void Registration_WorkspaceChanged(object sender, EventArgs e)
+        {
+            var workspaceRegistration = (WorkspaceRegistration)sender;
+            uint docCookie;
+            Contract.ThrowIfFalse(_docCookieToWorkspaceRegistration.TryGetKey(workspaceRegistration, out docCookie));
+            var moniker = _runningDocumentTable.GetDocumentMoniker(docCookie);
+
+            if (workspaceRegistration.Workspace == null)
+            {
+                // We should now claim this
+                AttachToDocument(docCookie, moniker);
+            }
+            else if (IsClaimedByAnotherWorkspace(workspaceRegistration))
+            {
+                // It's now claimed by another workspace, so we should unclaim it
+                if (_docCookiesToHostProject.ContainsKey(docCookie))
+                {
+                    DetachFromDocument(docCookie, moniker);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Stops tracking a document in the RDT for whether we should attach to it.
+        /// </summary>
+        /// <returns>true if we were previously tracking it.</returns>
+        private bool TryUntrackClosingDocument(uint docCookie, string moniker)
+        {
+            bool unregisteredRegistration = false;
+
+            // Remove our registration changing handler before we call DetachFromDocument. Otherwise, calling DetachFromDocument
+            // causes us to set the workspace to null, which we then respond to as an indication that we should
+            // attach again.
+            WorkspaceRegistration registration;
+            if (_docCookieToWorkspaceRegistration.TryGetValue(docCookie, out registration))
+            {
+                registration.WorkspaceChanged -= Registration_WorkspaceChanged;
+                _docCookieToWorkspaceRegistration = _docCookieToWorkspaceRegistration.RemoveKey(docCookie);
+                unregisteredRegistration = true;
+            }
+
+            DetachFromDocument(docCookie, moniker);
+
+            return unregisteredRegistration;
+        }
+
+        private bool IsClaimedByAnotherWorkspace(WorkspaceRegistration registration)
+        {
+            // Currently, we are also responsible for pushing documents to the metadata as source workspace,
+            // so we count that here as well
+            return registration.Workspace != null && registration.Workspace.Kind != WorkspaceKind.MetadataAsSource && registration.Workspace.Kind != WorkspaceKind.MiscellaneousFiles;
+        }
+
+        private void AttachToDocument(uint docCookie, string moniker)
+        {
+            var vsTextBuffer = (IVsTextBuffer)_runningDocumentTable.GetDocumentData(docCookie);
+            var textBuffer = _editorAdaptersFactoryService.GetDocumentBuffer(vsTextBuffer);
+
+            if (_fileTrackingMetadataAsSourceService.TryAddDocumentToWorkspace(moniker, textBuffer))
+            {
+                // We already added it, so we will keep it excluded from the misc files workspace
+                return;
+            }
+
+            // This should always succeed since we only got here if we already confirmed the moniker is acceptable
+            var languageInformation = TryGetLanguageInformation(moniker);
+            Contract.ThrowIfNull(languageInformation);
+            var parseOptions = languageInformation.ParseOptions;
+
+            if (Path.GetExtension(moniker) == languageInformation.ScriptExtension)
+            {
+                parseOptions = parseOptions.WithKind(SourceCodeKind.Script);
+            }
+
+            // First, create the project
+            var hostProject = new HostProject(this, CurrentSolution.Id, languageInformation.LanguageName, parseOptions, _metadataReferences);
+
+            // Now try to find the document. We accept any text buffer, since we've already verified it's an appropriate file in ShouldIncludeFile.
+            var document = _documentProvider.TryGetDocumentForFile(hostProject, (uint)VSConstants.VSITEMID.Nil, moniker, parseOptions.Kind, t => true);
+
+            // If the buffer has not yet been initialized, we won't get a document.
+            if (document == null)
+            {
+                return;
+            }
+
+            // Since we have a document, we can do the rest of the project setup.
+            _hostProjects.Add(hostProject.Id, hostProject);
+            OnProjectAdded(hostProject.CreateProjectInfoForCurrentState());
+
+            OnDocumentAdded(document.GetInitialState());
+            hostProject.Document = document;
+
+            // Notify the document provider, so it knows the document is now open and a part of
+            // the project
+            _documentProvider.NotifyDocumentRegisteredToProject(document);
+
+            Contract.ThrowIfFalse(document.IsOpen);
+
+            var buffer = document.GetOpenTextBuffer();
+            OnDocumentOpened(document.Id, document.GetOpenTextContainer());
+
+            _docCookiesToHostProject.Add(docCookie, hostProject);
+        }
+
+        private void DetachFromDocument(uint docCookie, string moniker)
         {
             HostProject hostProject;
 
             if (_fileTrackingMetadataAsSourceService.TryRemoveDocumentFromWorkspace(moniker))
             {
-                return true;
+                return;
             }
 
             if (_docCookiesToHostProject.TryGetValue(docCookie, out hostProject))
@@ -293,10 +350,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _hostProjects.Remove(hostProject.Id);
                 _docCookiesToHostProject.Remove(docCookie);
 
-                return true;
+                return;
             }
-
-            return false;
         }
 
         protected override void Dispose(bool finalize)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -161,6 +161,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
+            if ((grfAttribs & (uint)__VSRDTATTRIB3.RDTA_DocumentInitialized) != 0)
+            {
+                // The document is now initialized, we should try tracking it
+                TrackOpenedDocument(docCookie, _runningDocumentTable.GetDocumentMoniker(docCookie));
+            }
+
             return VSConstants.S_OK;
         }
 
@@ -204,7 +210,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return;
             }
 
-            if (_runningDocumentTable.IsDocumentInitialized(docCookie))
+            // We don't want to realize the document here unless it's already initialized. Document initialization is watched in 
+            // OnAfterAttributeChangeEx and will retrigger this if it wasn't already done.
+            if (_runningDocumentTable.IsDocumentInitialized(docCookie) && !_docCookieToWorkspaceRegistration.ContainsKey(docCookie))
             {
                 var vsTextBuffer = (IVsTextBuffer)_runningDocumentTable.GetDocumentData(docCookie);
                 var textBuffer = _editorAdaptersFactoryService.GetDocumentBuffer(vsTextBuffer);

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.IVbCompiler.vb
@@ -26,7 +26,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 wszName,
                 pProjHier,
                 Me,
-                Me.ComponentModel.GetService(Of MiscellaneousFilesWorkspace),
                 visualStudioWorkspace,
                 hostDiagnosticUpdateSource)
         End Function

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -233,7 +233,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
         Public Sub GetEntryPointsList(cItems As Integer, strList() As String, ByVal pcActualItems As IntPtr) Implements IVbCompilerProject.GetEntryPointsList
             Try
-                Dim project = VisualStudioWorkspace.CurrentSolution.GetProject(Id)
+                Dim project = Workspace.CurrentSolution.GetProject(Id)
                 Dim compilation = project.GetCompilationAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None)
 
                 GetEntryPointsWorker(cItems, strList, pcActualItems, findFormsOnly:=False)
@@ -246,7 +246,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                                                strList() As String,
                                                ByVal pcActualItems As IntPtr,
                                                findFormsOnly As Boolean)
-            Dim project = VisualStudioWorkspace.CurrentSolution.GetProject(Id)
+            Dim project = Workspace.CurrentSolution.GetProject(Id)
             Dim compilation = project.GetCompilationAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None)
 
             ' If called with cItems = 0 and pcActualItems != NULL, GetEntryPointsList returns in pcActualItems the number of items available.

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -39,10 +39,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                        hierarchy As IVsHierarchy,
                        serviceProvider As IServiceProvider,
                        reportExternalErrorCreatorOpt As Func(Of ProjectId, IVsReportExternalErrors),
-                       miscellaneousFilesWorkspaceOpt As MiscellaneousFilesWorkspace,
                        visualStudioWorkspaceOpt As VisualStudioWorkspaceImpl,
                        hostDiagnosticUpdateSourceOpt As HostDiagnosticUpdateSource)
-            MyBase.New(projectTracker, reportExternalErrorCreatorOpt, ProjectSystemName, hierarchy, LanguageNames.VisualBasic, serviceProvider, miscellaneousFilesWorkspaceOpt, visualStudioWorkspaceOpt, hostDiagnosticUpdateSourceOpt)
+            MyBase.New(projectTracker, reportExternalErrorCreatorOpt, ProjectSystemName, hierarchy, LanguageNames.VisualBasic, serviceProvider, visualStudioWorkspaceOpt, hostDiagnosticUpdateSourceOpt)
 
             _compilerHost = compilerHost
 

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectShimWithServices.CodeModel.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectShimWithServices.CodeModel.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
         Public ReadOnly Property ProjectCodeModel As AbstractProjectCodeModel Implements IProjectCodeModelProvider.ProjectCodeModel
             Get
-                LazyInitialization.EnsureInitialized(_projectCodeModel, Function() New VisualBasicProjectCodeModel(Me, Me.VisualStudioWorkspace, ServiceProvider))
+                LazyInitialization.EnsureInitialized(_projectCodeModel, Function() New VisualBasicProjectCodeModel(Me, DirectCast(Me.Workspace, VisualStudioWorkspace), ServiceProvider))
                 Return _projectCodeModel
             End Get
         End Property

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectShimWithServices.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectShimWithServices.vb
@@ -16,7 +16,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                        ProjectSystemName As String,
                        Hierarchy As IVsHierarchy,
                        ServiceProvider As IServiceProvider,
-                       miscellaneousFilesWorkspaceOpt As MiscellaneousFilesWorkspace,
                        visualStudioWorkspaceOpt As VisualStudioWorkspaceImpl,
                        hostDiagnosticUpdateSourceOpt As HostDiagnosticUpdateSource)
             MyBase.New(projectTracker,
@@ -25,7 +24,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                        Hierarchy,
                        ServiceProvider,
                        Function(id) New ProjectExternalErrorReporter(id, "BC", ServiceProvider),
-                       miscellaneousFilesWorkspaceOpt,
                        visualStudioWorkspaceOpt,
                        hostDiagnosticUpdateSourceOpt)
         End Sub
@@ -41,7 +39,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                        compilerHost,
                        hierarchy,
                        serviceProvider,
-                       Nothing,
                        Nothing,
                        Nothing,
                        Nothing)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Registration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Registration.cs
@@ -56,7 +56,12 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(textContainer));
             }
 
-            GetWorkspaceRegistration(textContainer).SetWorkspaceAndRaiseEvents(null);
+            var registration = GetWorkspaceRegistration(textContainer);
+
+            if (registration.Workspace == this)
+            {
+                registration.SetWorkspaceAndRaiseEvents(null);
+            }
         }
 
         private static WorkspaceRegistration CreateRegistration(SourceTextContainer container)


### PR DESCRIPTION
Our previous heuristic is we tracked any document that had a moniker
that wasn't contained within any project in VisualStudioWorkspace.
This was implemented with a private hook between the two systems. This
blows up in the face of other parties wishing to create their own
workspaces against files in the RDT, since we stomp on them. The new
heuristic is we attach to any file that's open and doesn't already have
a workspace, and we watch for registration changes to back off if
something else has taken a file.

Fixes #8598.

*Review:* @dotnet/roslyn-ide, @huizhonglong

I can also imagine @JoshVarty or @Slaks might have some code that I should know about that I should test or might get broken by this.