### PR TITLE
Reuse the SupersedeLowerVersions flag in the EE

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                    assemblyIdentityComparer: assemblyIdentityComparer,
                    strongNameProvider: strongNameProvider,
                    metadataImportOptions: MetadataImportOptions.Public,
+                   referencesSupersedeLowerVersions: false,
                    publicSign: publicSign,
                    topLevelBinderFlags: BinderFlags.None)
         {
@@ -109,6 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AssemblyIdentityComparer assemblyIdentityComparer,
             StrongNameProvider strongNameProvider,
             MetadataImportOptions metadataImportOptions,
+            bool referencesSupersedeLowerVersions,
             bool publicSign,
             BinderFlags topLevelBinderFlags)
             : base(outputKind, reportSuppressedDiagnostics, moduleName, mainTypeName, scriptClassName,
@@ -116,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                    platform, generalDiagnosticOption, warningLevel, specificDiagnosticOptions.ToImmutableDictionaryOrEmpty(),
                    concurrentBuild, deterministic, extendedCustomDebugInformation, debugPlusMode, xmlReferenceResolver,
                    sourceReferenceResolver, metadataReferenceResolver, assemblyIdentityComparer,
-                   strongNameProvider, metadataImportOptions)
+                   strongNameProvider, metadataImportOptions, referencesSupersedeLowerVersions)
         {
             this.Usings = usings.AsImmutableOrEmpty();
             this.AllowUnsafe = allowUnsafe;
@@ -150,6 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             assemblyIdentityComparer: other.AssemblyIdentityComparer,
             strongNameProvider: other.StrongNameProvider,
             metadataImportOptions: other.MetadataImportOptions,
+            referencesSupersedeLowerVersions: other.ReferencesSupersedeLowerVersions,
             reportSuppressedDiagnostics: other.ReportSuppressedDiagnostics,
             publicSign: other.PublicSign,
             topLevelBinderFlags: other.TopLevelBinderFlags)
@@ -420,6 +423,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return new CSharpCompilationOptions(this) { MetadataImportOptions_internal_protected_set = value };
+        }
+
+        internal CSharpCompilationOptions WithReferencesSupersedeLowerVersions(bool value)
+        {
+            if (value == this.ReferencesSupersedeLowerVersions)
+            {
+                return this;
+            }
+
+            return new CSharpCompilationOptions(this) { ReferencesSupersedeLowerVersions_internal_protected_set = value };
         }
 
         public new CSharpCompilationOptions WithXmlReferenceResolver(XmlReferenceResolver resolver)
@@ -744,6 +757,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                    assemblyIdentityComparer: assemblyIdentityComparer,
                    strongNameProvider: strongNameProvider,
                    metadataImportOptions: MetadataImportOptions.Public,
+                   referencesSupersedeLowerVersions: false,
                    publicSign: false,
                    topLevelBinderFlags: BinderFlags.None)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region Constructors and Factories
 
         private static readonly CSharpCompilationOptions s_defaultOptions = new CSharpCompilationOptions(OutputKind.ConsoleApplication);
-        private static readonly CSharpCompilationOptions s_defaultSubmissionOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        private static readonly CSharpCompilationOptions s_defaultSubmissionOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithReferencesSupersedeLowerVersions(true);
 
         /// <summary>
         /// Creates a new compilation from scratch. Methods such as AddSyntaxTrees or AddReferences
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return Create(
                 assemblyName,
-                options ?? s_defaultSubmissionOptions,
+                options?.WithReferencesSupersedeLowerVersions(true) ?? s_defaultSubmissionOptions,
                 (syntaxTree != null) ? new[] { syntaxTree } : SpecializedCollections.EmptyEnumerable<SyntaxTree>(),
                 references,
                 previousScriptCompilation,
@@ -242,6 +242,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isSubmission)
         {
             Debug.Assert(options != null);
+            Debug.Assert(!isSubmission || options.ReferencesSupersedeLowerVersions);
             CheckAssemblyName(assemblyName);
 
             var validatedReferences = ValidateReferences<CSharpCompilationReference>(references);

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var resolutionDiagnostics = DiagnosticBag.GetInstance();
                 var assemblyReferencesBySimpleName = PooledDictionary<string, List<ReferencedAssemblyIdentity>>.GetInstance();
-                bool supersedeLowerVersions = compilation.IsSubmission;
+                bool supersedeLowerVersions = compilation.Options.ReferencesSupersedeLowerVersions;
 
                 try
                 {

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
@@ -89,6 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             TestProperty((old, value) => old.WithTopLevelBinderFlags(value), opt => opt.TopLevelBinderFlags, BinderFlags.IgnoreCorLibraryDuplicatedTypes);
             TestProperty((old, value) => old.WithMetadataImportOptions(value), opt => opt.MetadataImportOptions, MetadataImportOptions.Internal);
+            TestProperty((old, value) => old.WithReferencesSupersedeLowerVersions(value), opt => opt.ReferencesSupersedeLowerVersions, true);
         }
 
         [Fact]
@@ -359,6 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             AssemblyIdentityComparer assemblyIdentityComparer = AssemblyIdentityComparer.Default;           // Currently uses reference equality
             StrongNameProvider strongNameProvider = new DesktopStrongNameProvider();
             MetadataImportOptions metadataImportOptions = 0;
+            bool referencesSupersedeLowerVersions = false;
             bool reportSuppressedDiagnostics = false;
             var topLevelBinderFlags = BinderFlags.None;
             var publicSign = false;
@@ -367,7 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 optimizationLevel, checkOverflow, allowUnsafe, cryptoKeyContainer, cryptoKeyFile, cryptoPublicKey, delaySign,
                 platform, generalDiagnosticOption, warningLevel, specificDiagnosticOptions,
                 concurrentBuild, deterministic, extendedCustomDebugInformation, debugPlusMode, xmlReferenceResolver, sourceReferenceResolver, metadataReferenceResolver,
-                assemblyIdentityComparer, strongNameProvider, metadataImportOptions, publicSign, topLevelBinderFlags);
+                assemblyIdentityComparer, strongNameProvider, metadataImportOptions, referencesSupersedeLowerVersions, publicSign, topLevelBinderFlags);
         }
 
         private sealed class MetadataReferenceResolverWithEquality : MetadataReferenceResolver

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCompilationOptionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCompilationOptionsTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 "OutputKind",
                 "Platform",
                 "PublicSign",
+                "ReferencesSupersedeLowerVersions",
                 "ScriptClassName",
                 "SourceReferenceResolver",
                 "SpecificDiagnosticOptions",

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis
             var assembliesBuilder = ArrayBuilder<AssemblyData>.GetInstance();
             ArrayBuilder<PEModule> lazyModulesBuilder = null;
 
-            bool supersedeLowerVersions = compilation.IsSubmission;
+            bool supersedeLowerVersions = compilation.Options.ReferencesSupersedeLowerVersions;
 
             // When duplicate references with conflicting EmbedInteropTypes flag are encountered,
             // VB uses the flag from the last one, C# reports an error. We need to enumerate in reverse order

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -335,7 +335,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Return Create(
                 assemblyName,
-                If(options, New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)),
+                If(options, New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)).WithReferencesSupersedeLowerVersions(True),
                 If((syntaxTree IsNot Nothing), {syntaxTree}, SpecializedCollections.EmptyEnumerable(Of SyntaxTree)()),
                 references,
                 previousScriptCompilation,
@@ -354,6 +354,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             hostObjectType As Type,
             isSubmission As Boolean
         ) As VisualBasicCompilation
+            Debug.Assert(Not isSubmission OrElse options.ReferencesSupersedeLowerVersions)
+
             If options Is Nothing Then
                 options = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication)
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -258,7 +258,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Friend Function CreateAndSetSourceAssemblyFullBind(compilation As VisualBasicCompilation) As Boolean
 
                 Dim resolutionDiagnostics = DiagnosticBag.GetInstance()
-                Dim supersedeLowerVersions = compilation.IsSubmission
+                Dim supersedeLowerVersions = compilation.Options.ReferencesSupersedeLowerVersions
                 Dim assemblyReferencesBySimpleName = PooledDictionary(Of String, List(Of ReferencedAssemblyIdentity)).GetInstance()
 
                 Try

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -122,7 +122,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 metadataReferenceResolver:=metadataReferenceResolver,
                 assemblyIdentityComparer:=assemblyIdentityComparer,
                 strongNameProvider:=strongNameProvider,
-                metadataImportOptions:=MetadataImportOptions.Public)
+                metadataImportOptions:=MetadataImportOptions.Public,
+                referencesSupersedeLowerVersions:=False)
 
         End Sub
 
@@ -160,7 +161,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             metadataReferenceResolver As MetadataReferenceResolver,
             assemblyIdentityComparer As AssemblyIdentityComparer,
             strongNameProvider As StrongNameProvider,
-            metadataImportOptions As MetadataImportOptions)
+            metadataImportOptions As MetadataImportOptions,
+            referencesSupersedeLowerVersions As Boolean)
 
             MyBase.New(
                 outputKind:=outputKind,
@@ -188,7 +190,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 metadataReferenceResolver:=metadataReferenceResolver,
                 assemblyIdentityComparer:=assemblyIdentityComparer,
                 strongNameProvider:=strongNameProvider,
-                metadataImportOptions:=metadataImportOptions)
+                metadataImportOptions:=metadataImportOptions,
+                referencesSupersedeLowerVersions:=referencesSupersedeLowerVersions)
 
             _globalImports = globalImports.AsImmutableOrEmpty()
             _rootNamespace = If(rootNamespace, String.Empty)
@@ -226,9 +229,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 cryptoKeyFile:=other.CryptoKeyFile,
                 cryptoPublicKey:=other.CryptoPublicKey,
                 delaySign:=other.DelaySign,
-                Platform:=other.Platform,
-                GeneralDiagnosticOption:=other.GeneralDiagnosticOption,
-                SpecificDiagnosticOptions:=other.SpecificDiagnosticOptions,
+                platform:=other.Platform,
+                generalDiagnosticOption:=other.GeneralDiagnosticOption,
+                specificDiagnosticOptions:=other.SpecificDiagnosticOptions,
                 concurrentBuild:=other.ConcurrentBuild,
                 deterministic:=other.Deterministic,
                 extendedCustomDebugInformation:=other.ExtendedCustomDebugInformation,
@@ -239,6 +242,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 assemblyIdentityComparer:=other.AssemblyIdentityComparer,
                 strongNameProvider:=other.StrongNameProvider,
                 metadataImportOptions:=other.MetadataImportOptions,
+                referencesSupersedeLowerVersions:=other.ReferencesSupersedeLowerVersions,
                 publicSign:=other.PublicSign)
         End Sub
 
@@ -774,6 +778,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New VisualBasicCompilationOptions(Me) With {.MetadataImportOptions_internal_protected_set = value}
         End Function
 
+        Friend Function WithReferencesSupersedeLowerVersions(value As Boolean) As VisualBasicCompilationOptions
+            If value = Me.ReferencesSupersedeLowerVersions Then
+                Return Me
+            End If
+
+            Return New VisualBasicCompilationOptions(Me) With {.ReferencesSupersedeLowerVersions_internal_protected_set = value}
+        End Function
+
         ''' <summary>
         ''' Creates a new <see cref="VisualBasicCompilationOptions"/> instance with a different parse option specified.
         ''' </summary>
@@ -1165,9 +1177,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 cryptoPublicKey,
                 delaySign,
                 publicSign:=False,
-                Platform:=platform,
-                GeneralDiagnosticOption:=generalDiagnosticOption,
-                SpecificDiagnosticOptions:=specificDiagnosticOptions,
+                platform:=platform,
+                generalDiagnosticOption:=generalDiagnosticOption,
+                specificDiagnosticOptions:=specificDiagnosticOptions,
                 concurrentBuild:=concurrentBuild,
                 deterministic:=deterministic,
                 suppressEmbeddedDeclarations:=False,
@@ -1178,7 +1190,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 metadataReferenceResolver:=metadataReferenceResolver,
                 assemblyIdentityComparer:=assemblyIdentityComparer,
                 strongNameProvider:=strongNameProvider,
-                metadataImportOptions:=MetadataImportOptions.Public)
+                metadataImportOptions:=MetadataImportOptions.Public,
+                referencesSupersedeLowerVersions:=False)
 
         End Sub
     End Class

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -113,6 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             optimizationLevel: OptimizationLevel.Release,
             assemblyIdentityComparer: IdentityComparer).
             WithMetadataImportOptions(MetadataImportOptions.All).
+            WithReferencesSupersedeLowerVersions(true).
             WithTopLevelBinderFlags(
                 BinderFlags.SuppressObsoleteChecks |
                 BinderFlags.IgnoreAccessibility |

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -415,6 +415,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             switch ((ErrorCode)diagnostic.Code)
             {
                 case ErrorCode.ERR_DuplicateImport:
+                case ErrorCode.ERR_DuplicateImportSimple:
                 case ErrorCode.ERR_SameFullNameAggAgg:
                 case ErrorCode.ERR_AmbigCall:
                     return true;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -162,15 +162,19 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     typeBlocks,
                     moduleVersionId,
                     typeToken);
+
+                Assert.Equal(identityAS2, context.Compilation.GlobalNamespace.GetMembers("A").OfType<INamedTypeSymbol>().Single().ContainingAssembly.Identity);
+                Assert.Equal(identityBS2, context.Compilation.GlobalNamespace.GetMembers("B").OfType<INamedTypeSymbol>().Single().ContainingAssembly.Identity);
+
                 string error;
-                // A is ambiguous.
+                // A could be ambiguous, but the ambiguity is resolved in favor of the newer assembly.
                 var testData = new CompilationTestData();
                 context.CompileExpression("new A()", out error, testData);
-                Assert.True(error.StartsWith("error CS0433: The type 'A' exists in both "));
+                Assert.Null(error);
+                // B could be ambiguous, but the ambiguity is resolved in favor of the newer assembly.
                 testData = new CompilationTestData();
-                // B is ambiguous.
                 context.CompileExpression("new B()", out error, testData);
-                Assert.True(error.StartsWith("error CS0433: The type 'B' exists in both "));
+                Assert.Null(error);
                 var previous = new CSharpMetadataContext(typeBlocks, context);
 
                 // Compile expression with type context with referenced modules only.
@@ -222,14 +226,14 @@ IL_0005:  ret
                     localSignatureToken: localSignatureToken);
                 Assert.Equal(previous.Compilation, context.Compilation); // re-use type context compilation
                 testData = new CompilationTestData();
-                // A is ambiguous.
+                // A could be ambiguous, but the ambiguity is resolved in favor of the newer assembly.
                 testData = new CompilationTestData();
                 context.CompileExpression("new A()", out error, testData);
-                Assert.True(error.StartsWith("error CS0433: The type 'A' exists in both "));
+                Assert.Null(error);
+                // B could be ambiguous, but the ambiguity is resolved in favor of the newer assembly.
                 testData = new CompilationTestData();
-                // B is ambiguous.
                 context.CompileExpression("new B()", out error, testData);
-                Assert.True(error.StartsWith("error CS0433: The type 'B' exists in both "));
+                Assert.Null(error);
 
                 // Compile expression with method context with referenced modules only.
                 context = EvaluationContext.CreateMethodContext(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -104,6 +104,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             optimizationLevel:=OptimizationLevel.Release,
             assemblyIdentityComparer:=IdentityComparer).
             WithMetadataImportOptions(MetadataImportOptions.All).
+            WithReferencesSupersedeLowerVersions(True).
             WithSuppressEmbeddedDeclarations(True)
 
     End Module

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -98,6 +98,11 @@ End Class"
                         typeBlocks,
                         moduleVersionId,
                         typeToken)
+
+                    ' If VB supported extern aliases, the following would be true:
+                    ' Assert.Equal(identityAS2, context.Compilation.GlobalNamespace.GetMembers("A").OfType(Of INamedTypeSymbol)().Single().ContainingAssembly.Identity)
+                    ' Assert.Equal(identityBS2, context.Compilation.GlobalNamespace.GetMembers("B").OfType(Of INamedTypeSymbol)().Single().ContainingAssembly.Identity)
+
                     Dim errorMessage As String = Nothing
                     ' A is ambiguous since there were no explicit references to AS1 or AS2.
                     context.CompileExpression("New A()", errorMessage)


### PR DESCRIPTION
    Scripting scenarios set a special flag in the ReferenceManager to enable
    additional tie-breaking rules in the presence of conflicting references.
    Enable that same flag for the EE, which also routinely encounters
    conflicting references.
    
    Fixes internal bug 161294.