### PR TITLE
Handle VB property with type character when calculating trivia changes during EnC

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
@@ -910,6 +910,25 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub PropertyTypeChar_NoChange1()
+            Dim src1 = ToCode(<text>
+Class C
+    Property Foo$ = "" Implements I.P
+End Class
+</text>)
+
+            Dim src2 = ToCode(<text>
+Class C
+    Property Foo$ = "" _
+                       Implements I.P
+End Class
+</text>)
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyLineEdits({}, {})
+        End Sub
+
+        <Fact>
         Public Sub PropertyAsNew_NoChange1()
             Dim src1 = ToCode(<text>
 Class C
@@ -959,6 +978,25 @@ End Class
 Class C
     Property _
              Foo As Integer = 1
+End Class
+</text>)
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyLineEdits({New LineChange(2, 3)}, {})
+        End Sub
+
+        <Fact>
+        Public Sub PropertyTypeChar_LineChange2()
+            Dim src1 = ToCode(<text>
+Class C
+    Property Foo$ = ""
+End Class
+</text>)
+
+            Dim src2 = ToCode(<text>
+Class C
+    Property _
+             Foo$ = ""
 End Class
 </text>)
 
@@ -1078,6 +1116,25 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyLineEdits({}, {"Property Foo As _"})
+        End Sub
+
+        <Fact>
+        Public Sub PropertyTypeChar_Recompile1()
+            Dim src1 = ToCode(<text>
+Class C
+    Property Foo$ = ""
+End Class
+</text>)
+
+            Dim src2 = ToCode(<text>
+Class C
+    Property Foo$ = _
+                    ""
+End Class
+</text>)
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyLineEdits({}, {"Property Foo$ = _"})
         End Sub
 #End Region
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -265,9 +265,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                 Case SyntaxKind.PropertyStatement
                     ' Property: Attributes Modifiers [|Identifier AsClause Initializer|] ImplementsClause
+                    ' Property: Attributes Modifiers [|Identifier$ Initializer|] ImplementsClause
                     Dim propertyStatement = DirectCast(node, PropertyStatementSyntax)
                     If propertyStatement.Initializer IsNot Nothing Then
-                        Return {propertyStatement.Identifier}.Concat(propertyStatement.AsClause.DescendantTokens()).Concat(propertyStatement.Initializer.DescendantTokens())
+                        Return {propertyStatement.Identifier}.Concat(If(propertyStatement.AsClause?.DescendantTokens(), {})).Concat(propertyStatement.Initializer.DescendantTokens())
                     End If
 
                     If HasAsNewClause(propertyStatement) Then


### PR DESCRIPTION
Scenario:

```VB
Class C
   Property P$ = ""
End Class
```

Inserting a line before the property declaration while debugging crashes VS.

Fixes internal bug 187872.