### PR TITLE
Reanalyze a project when it's name changes.

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
@@ -268,6 +268,57 @@ namespace CSAssembly2
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
+        Public Async Function TestAddProjectReference_CSharpToCSharp_WithProjectRenamed() As Task
+            Dim input =
+                <Workspace>
+                    <Project Language='C#' AssemblyName='CSAssembly1' CommonReferences='true'>
+                        <Document FilePath='Test1.cs'>
+using System.Collections.Generic;
+namespace CSAssembly1
+{
+    public class Class1
+    {
+    }
+}
+                        </Document>
+                    </Project>
+                    <Project Language='C#' AssemblyName='CSAssembly2' CommonReferences='true'>
+                        <CompilationOptions></CompilationOptions>
+                        <Document FilePath="Test2.cs">
+namespace CSAssembly2
+{
+    public class Class2
+    {
+        $$Class1 c;
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>
+
+            Dim expected =
+                <text>
+using CSAssembly1;
+
+namespace CSAssembly2
+{
+    public class Class2
+    {
+        Class1 c;
+    }
+}
+                </text>.Value.Trim()
+
+            Await TestAsync(input, expected, codeActionIndex:=0, addedReference:="NewName", onAfterWorkspaceCreated:=
+                            Sub(workspace As TestWorkspace)
+                                WaitForSolutionCrawler(workspace)
+                                Dim project = workspace.CurrentSolution.Projects.Single(Function(p) p.AssemblyName = "CSAssembly1")
+                                workspace.OnProjectNameChanged(project.Id, "NewName", "NewFilePath")
+                                WaitForSolutionCrawler(workspace)
+                            End Sub)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)>
         Public Async Function TestAddProjectReference_VBToVB() As Task
             Dim input =
                 <Workspace>

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -516,10 +516,15 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     projectConfigurationChange = projectConfigurationChange.With(InvocationReasons.ProjectParseOptionChanged);
                 }
 
-                if (projectChanges.GetAddedMetadataReferences().Any() || projectChanges.GetAddedProjectReferences().Any() || projectChanges.GetAddedAnalyzerReferences().Any() ||
-                    projectChanges.GetRemovedMetadataReferences().Any() || projectChanges.GetRemovedProjectReferences().Any() || projectChanges.GetRemovedAnalyzerReferences().Any() ||
+                if (projectChanges.GetAddedMetadataReferences().Any() || 
+                    projectChanges.GetAddedProjectReferences().Any() ||
+                    projectChanges.GetAddedAnalyzerReferences().Any() ||
+                    projectChanges.GetRemovedMetadataReferences().Any() ||
+                    projectChanges.GetRemovedProjectReferences().Any() ||
+                    projectChanges.GetRemovedAnalyzerReferences().Any() ||
                     !object.Equals(oldProject.CompilationOptions, newProject.CompilationOptions) ||
                     !object.Equals(oldProject.AssemblyName, newProject.AssemblyName) ||
+                    !object.Equals(oldProject.Name, newProject.Name) ||
                     !object.Equals(oldProject.AnalyzerOptions, newProject.AnalyzerOptions))
                 {
                     projectConfigurationChange = projectConfigurationChange.With(InvocationReasons.ProjectConfigurationChanged);


### PR DESCRIPTION
Because changing a project name will end up changing it's semantic version, it's
critical that we reanalyze it when the name changes.  If we don't, then other
parts of the LS that cache information may be stuck with information for a stale
semantic version.

Fixes https://github.com/dotnet/roslyn/issues/8565