### PR TITLE
Revert "Another attempt at fixing vsix signing problem"

### DIFF
--- a/src/VisualStudio/ProjectSystem/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/VisualStudio/ProjectSystem/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -13,7 +13,7 @@
     <AssemblyName>ProjectSystem</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
-    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>


### PR DESCRIPTION
Reverts dotnet/roslyn#8789. This change only include the setup binary in the vsix...
@dotnet/roslyn-infrastructure 