### PR TITLE
Improve interactive window icons

### DIFF
--- a/src/InteractiveWindow/VisualStudio/InteractiveWindow.vsct
+++ b/src/InteractiveWindow/VisualStudio/InteractiveWindow.vsct
@@ -128,10 +128,7 @@
 
       <Button guid="guidInteractiveWindowCmdSet" id="cmdidHistoryPrevious" priority="0x0300" type="Button">
         <Parent guid="guidInteractiveWindowCmdSet" id="ConsoleMenuGroup"/>
-        <Icon guid="ImageCatalogGuid" id="MoveUp" />
-        <!-- TODO (https://github.com/dotnet/roslyn/issues/5295)
         <Icon guid="ImageCatalogGuid" id="LastHistoryCommand" /> 
-        -->
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -144,10 +141,7 @@
 
       <Button guid="guidInteractiveWindowCmdSet" id="cmdidHistoryNext" priority="0x0300" type="Button">
         <Parent guid="guidInteractiveWindowCmdSet" id="ConsoleMenuGroup"/>
-        <Icon guid="ImageCatalogGuid" id="MoveDown" />
-        <!-- TODO (https://github.com/dotnet/roslyn/issues/5295)
         <Icon guid="ImageCatalogGuid" id="ListMembers" />
-        -->
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>

--- a/src/InteractiveWindow/VisualStudio/InteractiveWindowPackage.cs
+++ b/src/InteractiveWindow/VisualStudio/InteractiveWindowPackage.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.InteractiveWindow.Shell
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [Description("Visual Studio Interactive Window")]
     [ProvideKeyBindingTable(Guids.InteractiveToolWindowIdString, 200)] // Resource ID: "Interactive Window"
-    [ProvideMenuResource("Menus.ctmenu", 4)]
+    [ProvideMenuResource("Menus.ctmenu", 5)]
     [Guid(Guids.InteractiveWindowPackageIdString)]
     [ProvideBindingPath]  // make sure our DLLs are loadable from other packages
     public sealed class InteractiveWindowPackage : Package

--- a/src/VisualStudio/CSharp/Repl/Commands.vsct
+++ b/src/VisualStudio/CSharp/Repl/Commands.vsct
@@ -16,8 +16,7 @@
     <Buttons>
       <Button guid="guidCSharpInteractiveCommandSet" id="cmdidCSharpInteractiveToolWindow" priority="0x8000" type="Button">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
-        <!-- TODO (https://github.com/dotnet/roslyn/issues/6078): RoslynImageCatalogGuid -> ImageCatalogGuid -->
-        <Icon guid="RoslynImageCatalogGuid" id="CSInteractiveWindow" />
+        <Icon guid="ImageCatalogGuid" id="CSInteractiveWindow" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>C# Interactive</ButtonText>
@@ -61,10 +60,5 @@
 
     <GuidSymbol name="guidCSProjectContext" value="{FAE04EC1-301F-11D3-BF4B-00C04F79EFBC}" />
     <GuidSymbol name="guidVBProjectContext" value="{164B10B9-B200-11D0-8C61-00A0C91E29D5}" />
-      
-    <!-- TODO (https://github.com/dotnet/roslyn/issues/6078): delete this -->
-    <GuidSymbol name="RoslynImageCatalogGuid" value="{ae27a6b0-e345-4288-96df-5eaf394ee369}">
-        <IDSymbol name="CSInteractiveWindow" value="3682" />
-    </GuidSymbol>
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
 1. Remove `RoslynImageCatalogGuid` in C#
 (https://github.com/dotnet/roslyn/issues/6078)
 2. Switch to new history icons
 (https://github.com/dotnet/roslyn/issues/5295)

Fixes #5295