### PR TITLE
Allow compiler to write to output files if they were open with FileShare.Delete

### DIFF
--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -17,7 +17,7 @@ namespace Roslyn.Utilities
         internal static readonly string DirectorySeparatorStr = new string(DirectorySeparatorChar, 1);
         internal const char VolumeSeparatorChar = ':';
 
-        private static bool IsUnixLikePlatform
+        internal static bool IsUnixLikePlatform
         {
             get
             {

--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -52,6 +52,7 @@ namespace Roslyn.Utilities
             Touch(FileShare.Type);
             Touch(FileStream.Type);
             Touch(FileVersionInfo.Type);
+            Touch(FileAttributes.Type);
             Touch(MemoryStream.Type);
             Touch(Path.Type);
             Touch(RuntimeHelpers.Type);
@@ -141,6 +142,17 @@ namespace Roslyn.Utilities
                 .CreateDelegate(typeof(Func<string>));
         }
 
+        internal static class FileAttributes
+        {
+            private const string TypeName = "System.IO.FileAttributes";
+
+            internal static readonly Type Type = ReflectionUtilities.GetTypeFromEither(
+               contractName: $"{TypeName}, {CoreNames.System_IO_FileSystem}",
+               desktopName: TypeName);
+
+            public static object Hidden = Enum.ToObject(Type, 2);
+        }
+
         internal static class File
         {
             internal const string TypeName = "System.IO.File";
@@ -174,6 +186,11 @@ namespace Roslyn.Utilities
                 .GetDeclaredMethod(nameof(Delete), new[] { typeof(string) })
                 .CreateDelegate<Action<string>>();
 
+            internal static readonly Action<string, string> Move = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(Move), new[] { typeof(string), typeof(string) })
+                .CreateDelegate<Action<string, string>>();
+
             internal static readonly Func<string, byte[]> ReadAllBytes = Type
                 .GetTypeInfo()
                 .GetDeclaredMethod(nameof(ReadAllBytes), paramTypes: new[] { typeof(string) })
@@ -183,6 +200,15 @@ namespace Roslyn.Utilities
                 .GetTypeInfo()
                 .GetDeclaredMethod(nameof(WriteAllBytes), paramTypes: new[] { typeof(string), typeof(byte[]) })
                 .CreateDelegate<Action<string, byte[]>>();
+
+            private static readonly MethodInfo SetAttributesMethod = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(SetAttributes), paramTypes: new[] { typeof(string), FileAttributes.Type });
+
+            public static void SetAttributes(string path, object attributes)
+            {
+                SetAttributesMethod.Invoke(null, new[] { path, attributes });
+            }
         }
 
         internal static class Directory

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     try
                     {
                         InjectFault_MvidRead();
-                        _metadata = ModuleMetadata.CreateFromFile(outputPath);
+                        _metadata = ModuleMetadata.CreateFromStream(new FileStream(outputPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete));
                         _metadata.GetModuleVersionId();
                     }
                     catch (FileNotFoundException)


### PR DESCRIPTION
Currently the compiler fails to write its output files when they are open by another process, even if the process opened the files with sharing flags that allow the files to be deleted (using FileShare.Delete flag on Windows). Instead of failing the compiler can try to delete the output files and write new ones in their place. Allowing the compiler to do so is desirable as it removes the need for shadow copy or in-memory metadata prefetch in multiple scenarios. For example, the CoreCLR assembly loader uses FileShare.Delete. If our build tools can handle such files it would be possible to rebuild while running tests, or other tools (e.g. interactive code) and avoid shadow copy. 

One scenario that this change is specifically addressing is EnC:
Customers reported that in their workflow they open two instances of VS, in one debugging a project and in the another building other projects that have common dependencies with the project being debugged. In order for the EnC infrastructure to be reliable the observed content of the PE files it works with needs to be immutable, hence we keep files locked during debugging session. We can however open them with FileShare.Delete to make it possible for csc to put new files in their place while still reading the previous snapshot from the memory map. 

There might be other ways to address this for EnC, however the one I can think of are too risky at this stage or I'm not sure if they would be robust enough.

Note that msbuild DeleteFile implementation does not currently handle file deletion on Windows in a manner compatible with FileShare.Delete. I'll follow up to see if it can be fixed.
