### PR TITLE
Removing recursion in SyntaxNode.FindTriviaByOffset

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -923,6 +923,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static SyntaxTrivia FindTriviaByOffset(SyntaxNode node, int textOffset, Func<SyntaxTrivia, bool> stepInto = null)
         {
+recurse:
             if (textOffset >= 0)
             {
                 foreach (var element in node.ChildNodesAndTokens())
@@ -932,7 +933,8 @@ namespace Microsoft.CodeAnalysis
                     {
                         if (element.IsNode)
                         {
-                            return FindTriviaByOffset(element.AsNode(), textOffset, stepInto);
+                            node = element.AsNode();
+                            goto recurse;
                         }
                         else if (element.IsToken)
                         {
@@ -946,7 +948,8 @@ namespace Microsoft.CodeAnalysis
                                     {
                                         if (trivia.HasStructure && stepInto != null && stepInto(trivia))
                                         {
-                                            return FindTriviaByOffset(trivia.GetStructure(), textOffset, stepInto);
+                                            node = trivia.GetStructure();
+                                            goto recurse;
                                         }
 
                                         return trivia;
@@ -964,7 +967,8 @@ namespace Microsoft.CodeAnalysis
                                     {
                                         if (trivia.HasStructure && stepInto != null && stepInto(trivia))
                                         {
-                                            return FindTriviaByOffset(trivia.GetStructure(), textOffset, stepInto);
+                                            node = trivia.GetStructure();
+                                            goto recurse;
                                         }
 
                                         return trivia;

--- a/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Globalization
+Imports System.Text
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -3139,6 +3140,27 @@ End Module
             Dim Root As CompilationUnitSyntax = CType(tree.GetRoot(), CompilationUnitSyntax)
             Dim x = Root.GetDirectives()
             Assert.Equal(1, x.Count)
+        End Sub
+
+
+        <WorkItem(6536, "https://github.com/dotnet/roslyn/issues/6536")>
+        <Fact>
+        Public Sub TestFindTrivia_NoStackOverflowOnLargeExpression()
+            Dim code As New StringBuilder()
+            code.Append(<![CDATA[
+Module Module1
+     Sub Test()
+         Dim c =  ]]>.Value)
+            For i = 0 To 3000
+                code.Append("""asdf"" + ")
+            Next
+            code.AppendLine(<![CDATA["last"
+    End Sub
+End Module]]>.Value)
+
+            Dim tree = VisualBasicSyntaxTree.ParseText(code.ToString())
+            Dim trivia = tree.GetRoot().FindTrivia(4000)
+            ' no stack overflow
         End Sub
 
 #Region "Equality Verifications"

--- a/src/Workspaces/VisualBasicTest/VisualBasicExtensionsTests.vb
+++ b/src/Workspaces/VisualBasicTest/VisualBasicExtensionsTests.vb
@@ -1,0 +1,37 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Text
+Imports Microsoft.CodeAnalysis.Text
+Imports Roslyn.Test.Utilities
+Imports Xunit
+Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.SyntaxTreeExtensions
+Imports System.Threading
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+
+    Public Class VisualBasicExtensionsTests
+        <WorkItem(6536, "https://github.com/dotnet/roslyn/issues/6536")>
+        <Fact>
+        Public Sub TestFindTrivia_NoStackOverflowOnLargeExpression()
+            Dim code As New StringBuilder()
+            code.Append(<![CDATA[
+
+Module Module1
+     Sub Test()
+         Dim c =  ]]>.Value)
+            For i = 0 To 3000
+                code.Append("""asdf"" + ")
+            Next
+            code.AppendLine(<![CDATA["last"
+    End Sub
+End Module]]>.Value)
+
+            Dim tree = VisualBasicSyntaxTree.ParseText(code.ToString())
+            Dim trivia = tree.FindTriviaToLeft(4000, CancellationToken.None)
+            ' no stack overflow
+        End Sub
+
+
+    End Class
+
+End Namespace

--- a/src/Workspaces/VisualBasicTest/VisualBasicServicesTest.vbproj
+++ b/src/Workspaces/VisualBasicTest/VisualBasicServicesTest.vbproj
@@ -92,6 +92,7 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="VisualBasicCommandLineArgumentsFactoryServiceTests.vb" />
+    <Compile Include="VisualBasicExtensionsTests.vb" />
     <Compile Include="VisualBasicSyntaxFactsServiceTests.vb" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Removing recursion in SyntaxNode.FindTriviaByOffset

Fixing #6536
CC @dotnet/roslyn-compiler 