### PR TITLE
Cancel the signature help if the user navigates before it has been presented

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/SignatureHelp/ISignatureHelpPresenterSession.cs
+++ b/src/EditorFeatures/Core/Extensibility/SignatureHelp/ISignatureHelpPresenterSession.cs
@@ -13,5 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor
         void SelectNextItem();
 
         event EventHandler<SignatureHelpItemEventArgs> ItemSelected;
+
+        bool EditorSessionIsActive { get; }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_NavigationKeys.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_NavigationKeys.cs
@@ -28,6 +28,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                 return false;
             }
 
+            // If we haven't started our editor session yet, just abort.
+            // The user hasn't seen a SigHelp presentation yet, so they're
+            // probably not trying to change the currently visible overload.
+            if (!sessionOpt.PresenterSession.EditorSessionIsActive)
+            {
+                DismissSessionIfActive();
+                return false;
+            }
+
             // If we've finished computing the items then use the navigation commands to change the
             // selected item.  Otherwise, the user was just typing and is now moving through the
             // file.  In this case stop everything we're doing.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
@@ -31,6 +31,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             private ISignatureHelpSession _editorSessionOpt;
             private bool _ignoreSelectionStatusChangedEvent;
 
+            public bool EditorSessionIsActive
+            {
+                get
+                {
+                    return _editorSessionOpt != null && !_editorSessionOpt.IsDismissed;
+                }
+            }
+
             public SignatureHelpPresenterSession(
                 ISignatureHelpBroker sigHelpBroker,
                 ITextView textView,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Presentation/SignatureHelpPresenter.SignatureHelpPresenterSession.cs
@@ -31,13 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             private ISignatureHelpSession _editorSessionOpt;
             private bool _ignoreSelectionStatusChangedEvent;
 
-            public bool EditorSessionIsActive
-            {
-                get
-                {
-                    return _editorSessionOpt != null && !_editorSessionOpt.IsDismissed;
-                }
-            }
+            public bool EditorSessionIsActive => _editorSessionOpt?.IsDismissed == false;
 
             public SignatureHelpPresenterSession(
                 ISignatureHelpBroker sigHelpBroker,

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -93,6 +93,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Sub
 
         <WpfFact>
+        <WorkItem(179726, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=179726&_a=edit")>
         Public Sub DownKeyShouldNotBlockOnModelComputation()
             Dim mre = New ManualResetEvent(False)
             Dim controller = CreateController(items:=CreateItems(2), waitForPresentation:=False)
@@ -110,6 +111,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Sub
 
         <WpfFact>
+        <WorkItem(179726, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=179726&_a=edit")>
         Public Sub UpKeyShouldNotBlockOnModelComputation()
             Dim mre = New ManualResetEvent(False)
             Dim controller = CreateController(items:=CreateItems(2), waitForPresentation:=False)
@@ -127,6 +129,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Sub
 
         <WpfFact>
+        <WorkItem(179726, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=179726&_a=edit")>
         Public Async Function UpKeyShouldBlockOnRecomputationAfterPresentation() As Task
             Dim dispatcher = System.Windows.Threading.Dispatcher.CurrentDispatcher
             Dim worker = Async Function()

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -1,9 +1,9 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.ComponentModel.Composition.Hosting
 Imports System.Runtime.CompilerServices
 Imports System.Threading
 Imports System.Threading.Tasks
+Imports System.Windows.Threading
 Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
@@ -13,7 +13,6 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
-Imports Microsoft.VisualStudio.Text.Projection
 Imports Moq
 
 #Disable Warning RS0007 ' Avoid zero-length array allocations. This is non-shipping test code.
@@ -126,6 +125,42 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             Assert.False(handled)
         End Sub
+
+        <WpfFact>
+        Public Async Function UpKeyShouldBlockOnRecomputationAfterPresentation() As Task
+            Dim dispatcher = System.Windows.Threading.Dispatcher.CurrentDispatcher
+            Dim worker = Async Function()
+                             Dim slowProvider = New Mock(Of ISignatureHelpProvider)
+                             slowProvider.Setup(Function(p) p.GetItemsAsync(It.IsAny(Of Document), It.IsAny(Of Integer), It.IsAny(Of SignatureHelpTriggerInfo), It.IsAny(Of CancellationToken))) _
+                                 .Returns(Task.FromResult(New SignatureHelpItems(CreateItems(2), TextSpan.FromBounds(0, 0), selectedItem:=0, argumentIndex:=0, argumentCount:=0, argumentName:=Nothing)))
+
+                             Dim controller = dispatcher.Invoke(Function() CreateController(provider:=slowProvider.Object, waitForPresentation:=True))
+
+                             ' Update session so that providers are requeried.
+                             ' SlowProvider now blocks on the checkpoint's task.
+                             Dim checkpoint = New Checkpoint()
+                             slowProvider.Setup(Function(p) p.GetItemsAsync(It.IsAny(Of Document), It.IsAny(Of Integer), It.IsAny(Of SignatureHelpTriggerInfo), It.IsAny(Of CancellationToken))) _
+                                 .Returns(Function()
+                                              checkpoint.Task.Wait()
+                                              Return Task.FromResult(New SignatureHelpItems(CreateItems(2), TextSpan.FromBounds(0, 2), selectedItem:=0, argumentIndex:=0, argumentCount:=0, argumentName:=Nothing))
+                                          End Function)
+
+                             dispatcher.Invoke(Sub() DirectCast(controller, ICommandHandler(Of TypeCharCommandArgs)).ExecuteCommand(
+                                 New TypeCharCommandArgs(CreateMock(Of ITextView), CreateMock(Of ITextBuffer), " "c),
+                                 Sub() GetMocks(controller).Buffer.Insert(0, " ")))
+
+                             Dim handled = dispatcher.InvokeAsync(Function() controller.TryHandleUpKey()) ' Send the controller an up key, which should block on the computation
+                             checkpoint.Release() ' Allow slowprovider to finish
+                             Await handled.Task.ConfigureAwait(False)
+
+                             ' We expect 2 calls to the presenter (because we had an existing presentation session when we started the second computation).
+                             Assert.True(handled.Result)
+                             GetMocks(controller).PresenterSession.Verify(Sub(p) p.PresentItems(It.IsAny(Of ITrackingSpan), It.IsAny(Of IList(Of SignatureHelpItem)),
+                                                                                                It.IsAny(Of SignatureHelpItem), It.IsAny(Of Integer?)), Times.Exactly(2))
+                         End Function
+            Await worker().ConfigureAwait(False)
+
+        End Function
 
         <WpfFact>
         Public Sub DownKeyShouldNavigateWhenThereAreMultipleItems()

--- a/src/EditorFeatures/Test2/IntelliSense/TestSignatureHelpPresenterSession.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/TestSignatureHelpPresenterSession.vb
@@ -13,6 +13,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public SignatureHelpItems As IList(Of SignatureHelpItem)
         Public SelectedItem As SignatureHelpItem
         Public SelectedParameter As Integer?
+        Private presented As Boolean = False
+
+        Public ReadOnly Property EditorSessionIsActive As Boolean Implements ISignatureHelpPresenterSession.EditorSessionIsActive
+            Get
+                Return presented
+            End Get
+        End Property
 
         Public Event Dismissed As EventHandler(Of EventArgs) Implements ISignatureHelpPresenterSession.Dismissed
         Public Event ItemSelected As EventHandler(Of SignatureHelpItemEventArgs) Implements ISignatureHelpPresenterSession.ItemSelected
@@ -30,10 +37,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Me.SignatureHelpItems = signatureHelpItems
             Me.SelectedItem = selectedItem
             Me.SelectedParameter = selectedParameter
+            Me.presented = True
         End Sub
 
         Public Sub Dismiss() Implements ISignatureHelpPresenterSession.Dismiss
             _testState.CurrentSignatureHelpPresenterSession = Nothing
+            Me.presented = False
         End Sub
 
         Public Sub SetSelectedItem(item As SignatureHelpItem)


### PR DESCRIPTION
This is a port of https://github.com/dotnet/roslyn/pull/8746 to stabilization.