### PR TITLE
Update doc comment tests that contain XML comments with paths

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationModeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationModeTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.WRN_XMLParseError, "").WithArguments("unclosed"));
         }
 
-        [ClrOnlyFact(ClrOnlyReason.DocumentationComment, Skip = "https://github.com/dotnet/roslyn/issues/8807")]
+        [ClrOnlyFact(ClrOnlyReason.DocumentationComment)]
         public void XmlSyntaxError_Included()
         {
             var xml = @"<unclosed>";
@@ -384,7 +384,7 @@ partial class Partial {{ }}
             comp.GetDiagnostics().Verify(fallbackToErrorCodeOnlyForNonEnglish: fallbackToErrorCodeOnlyForNonEnglish, expected: makeExpectedDiagnostics(includeElement));
 
             var actualText = GetDocumentationCommentText(comp, expectedDiagnostics: null);
-            var expectedText = string.Format(expectedTextTemplate, xmlFilePath);
+            var expectedText = string.Format(expectedTextTemplate, TestHelpers.AsXmlCommentText(xmlFilePath));
             Assert.Equal(expectedText, actualText);
         }
 

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/DocCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/DocCommentTests.vb
@@ -7359,7 +7359,7 @@ End Class
                     "Function System.Int32.Parse(s As System.String, style As System.Globalization.NumberStyles, provider As System.IFormatProvider) As System.Int32")
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Include_XPathNotFound_WRN_XMLDocInvalidXMLFragment()
             Dim xmlText = <root/>
             Dim xmlFile = Temp.CreateFile(extension:=".xml").WriteAllText(xmlText.ToString)
@@ -7401,11 +7401,11 @@ AssemblyName
 </doc>
 ]]>
 </xml>,
-            stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"), ensureEnglishUICulture:=True)
+            stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
         <WorkItem(684184, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/684184")>
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Bug684184()
             Dim xmlText =
 <docs>
@@ -7447,10 +7447,10 @@ AssemblyName
 </doc>
 ]]>
 </xml>,
-            stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"), ensureEnglishUICulture:=True)
+            stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Include_FileNotFound_WRN_XMLDocBadFormedXML()
             Dim xmlText = <root/>
             Dim xmlFile = Temp.CreateFile(extension:=".xml").WriteAllText(xmlText.ToString)
@@ -7492,10 +7492,10 @@ AssemblyName
 </doc>
 ]]>
 </xml>,
-            stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"), ensureEnglishUICulture:=True)
+            stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Include_IOError_WRN_XMLDocBadFormedXML()
             Dim xmlText = <root>
                               <target>Included</target>
@@ -7541,12 +7541,12 @@ AssemblyName
 </doc>
 ]]>
     </xml>,
-                stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"),
+                stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"),
                 ensureEnglishUICulture:=True)
             End Using
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Include_XmlError_WRN_XMLDocBadFormedXML()
             Dim xmlText =
             <![CDATA[
@@ -7593,10 +7593,10 @@ AssemblyName
 </doc>
 ]]>
     </xml>,
-                stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"), ensureEnglishUICulture:=True)
+                stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Include_XDocument_WRN_XMLDocInvalidXMLFragment()
             Dim xmlText =
             <![CDATA[
@@ -7643,10 +7643,10 @@ AssemblyName
 </doc>
 ]]>
     </xml>,
-                stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"), ensureEnglishUICulture:=True)
+                stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Include_Cycle_WRN_XMLDocInvalidXMLFragment()
             Dim xmlText =
 <root>
@@ -7677,11 +7677,7 @@ End Class
 </compilation>
 
             CompileCheckDiagnosticsAndXmlDocument(FormatSourceXml(xmlSource, xmlFile),
-    <error>
-        <![CDATA[
-BC42320: Unable to include XML fragment '**FILE**' of file '//target'.
-]]>
-    </error>,
+    <error><%= $"BC42320: Unable to include XML fragment '{xmlFile.ToString()}' of file '//target'." %></error>,
     <xml>
         <![CDATA[
 <?xml version="1.0"?>
@@ -7709,10 +7705,10 @@ AssemblyName
 </doc>
 ]]>
     </xml>,
-                stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"), ensureEnglishUICulture:=True)
+                stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
         Public Sub Include_XPathError_WRN_XMLDocBadFormedXML()
             Dim xmlText =
             <![CDATA[
@@ -7759,7 +7755,7 @@ AssemblyName
 </doc>
 ]]>
     </xml>,
-                stringMapper:=Function(o) StringReplace(o, xmlFile.ToString(), "**FILE**"), ensureEnglishUICulture:=True)
+                stringMapper:=Function(o) StringReplace(o, AsXmlCommentText(xmlFile), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
         <Fact>
@@ -11884,6 +11880,10 @@ xmlDoc)
             Return If(str Is Nothing, obj, str.Replace(what, [with]))
         End Function
 
+        Private Shared Function AsXmlCommentText(file As TempFile) As String
+            Return TestHelpers.AsXmlCommentText(file.ToString())
+        End Function
+
         Private Function FormatSourceXml(xml As XElement, ParamArray obj() As Object) As XElement
             For Each file In xml.<file>
                 file.Value = String.Format(file.Value, obj)
@@ -12326,6 +12326,47 @@ BC42304: XML documentation parse error: Expected beginning '<' for an XML tag. X
     '''<summary>
                 ~
 ]]>)
+        End Sub
+
+        ''' <summary>
+        ''' "--" is not valid within an XML comment.
+        ''' </summary>
+        <WorkItem(8807, "https://github.com/dotnet/roslyn/issues/8807")>
+        <Fact>
+        Public Sub IncludeErrorDashDashInName()
+            Dim dir = Temp.CreateDirectory()
+            Dim path = dir.Path
+            Dim xmlFile = dir.CreateFile("---.xml").WriteAllText("<summary attrib="""" attrib=""""/>")
+            Dim source =
+<compilation name="DashDash">
+    <file name="a.vb">
+        <![CDATA[
+''' <include file='{0}' path='//param'/>
+Class C
+End Class
+]]>
+    </file>
+</compilation>
+            CompileCheckDiagnosticsAndXmlDocument(FormatSourceXml(source, System.IO.Path.Combine(path, "---.xml")),
+    <error/>,
+    <xml>
+        <![CDATA[
+<?xml version="1.0"?>
+<doc>
+<assembly>
+<name>
+DashDash
+</name>
+</assembly>
+<members>
+<member name="T:C">
+ <!--warning BC42320: Unable to include XML fragment '//param' of file '**FILE**'.-->
+</member>
+</members>
+</doc>
+]]>
+    </xml>,
+                stringMapper:=Function(o) StringReplace(o, System.IO.Path.Combine(TestHelpers.AsXmlCommentText(path), "- - -.xml"), "**FILE**"), ensureEnglishUICulture:=True)
         End Sub
 
     End Class

--- a/src/Test/Utilities/Desktop/TestHelpers.cs
+++ b/src/Test/Utilities/Desktop/TestHelpers.cs
@@ -3,9 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -122,6 +124,26 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
             return dir.CreateFile(assemblyName + ".dll").WriteAllBytes(analyzerCompilation.EmitToArray());
+        }
+
+        /// <summary>
+        /// <see cref="System.Xml.Linq.XComment.Value"/> is serialized with "--" replaced by "- -"
+        /// </summary>
+        public static string AsXmlCommentText(string text)
+        {
+            var builder = new StringBuilder();
+            for (int i = 0; i < text.Length; i++)
+            {
+                var c = text[i];
+                if ((c == '-') && (i > 0) && (text[i - 1] == '-'))
+                {
+                    builder.Append(' ');
+                }
+                builder.Append(c);
+            }
+            var result = builder.ToString();
+            Debug.Assert(!result.Contains("--"));
+            return result;
         }
     }
 }


### PR DESCRIPTION
`XComments` with "--" in the comment are serialized as "- -" since "--" is not valid within a XML comment. This occurs when writing a doc comment containing an error from ```<include file='[path.xml]'/>``` when ```[path.xml]``` contains "--".

This change updates the tests to match the comment serialization. The alternative, to change how errors are reported from the doc comment compiler, is a more significant change.

Fixes #8807
