### PR TITLE
Revert "Merge pull request #7510 from CyrusNajmabadi/analysisSpeedup"

### DIFF
--- a/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -16,8 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
         public const string SingleIfStatementForm = nameof(SingleIfStatementForm);
     }
 
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal class InvokeDelegateWithConditionalAccessAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
+    //[DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class InvokeDelegateWithConditionalAccessAnalyzer : DiagnosticAnalyzer
     {
         private static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor(
             IDEDiagnosticIds.InvokeDelegateWithConditionalAccessId,
@@ -92,8 +91,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
             ExpressionStatementSyntax expressionStatement,
             InvocationExpressionSyntax invocationExpression)
         {
-            var cancellationToken = syntaxContext.CancellationToken;
-
             // Look for the form:  "if (someExpr != null) someExpr()"
             if (condition.Left.IsKind(SyntaxKind.NullLiteralExpression) ||
                 condition.Right.IsKind(SyntaxKind.NullLiteralExpression))
@@ -102,11 +99,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
                     ? condition.Right
                     : condition.Left;
 
-                cancellationToken.ThrowIfCancellationRequested();
                 if (SyntaxFactory.AreEquivalent(expr, invocationExpression.Expression, topLevel: false))
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     // Looks good!
                     var tree = syntaxContext.SemanticModel.SyntaxTree;
                     var additionalLocations = new List<Location>
@@ -142,9 +136,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
             ExpressionStatementSyntax expressionStatement,
             InvocationExpressionSyntax invocationExpression)
         {
-            var cancellationToken = syntaxContext.CancellationToken;
-            cancellationToken.ThrowIfCancellationRequested();
-
             // look for the form "if (a != null)" or "if (null != a)"
             if (!ifStatement.Parent.IsKind(SyntaxKind.Block))
             {
@@ -201,7 +192,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
                 return false;
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
             if (!Equals(declarator.Identifier.ValueText, conditionName.Identifier.ValueText))
             {
                 return false;
@@ -209,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
 
             // Syntactically this looks good.  Now make sure that the local is a delegate type.
             var semanticModel = syntaxContext.SemanticModel;
-            var localSymbol = (ILocalSymbol)semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
+            var localSymbol = (ILocalSymbol)semanticModel.GetDeclaredSymbol(declarator);
 
             // Ok, we made a local just to check it for null and invoke it.  Looks like something
             // we can suggest an improvement for!
@@ -247,10 +237,5 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
 
         private bool IsNullCheckExpression(ExpressionSyntax left, ExpressionSyntax right) =>
             left.IsKind(SyntaxKind.IdentifierName) && right.IsKind(SyntaxKind.NullLiteralExpression);
-
-        public DiagnosticAnalyzerCategory GetAnalyzerCategory()
-        {
-            return DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
-        }
     }
 }

--- a/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessCodeFixProvider.cs
@@ -18,7 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InvokeDelegateWithConditionalAccessCodeFixProvider)), Shared]
+    //[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InvokeDelegateWithConditionalAccessCodeFixProvider)), Shared]
     internal class InvokeDelegateWithConditionalAccessCodeFixProvider : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(IDEDiagnosticIds.InvokeDelegateWithConditionalAccessId);
@@ -45,32 +45,23 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
 
             if (diagnostic.Properties[Constants.Kind] == Constants.VariableAndIfStatementForm)
             {
-                return HandVariableAndIfStatementFormAsync(document, root, diagnostic, cancellationToken);
+                return HandVariableAndIfStatementFormAsync(document, root, diagnostic);
             }
             else
             {
                 Debug.Assert(diagnostic.Properties[Constants.Kind] == Constants.SingleIfStatementForm);
-                return HandleSingleIfStatementForm(document, root, diagnostic, cancellationToken);
+                return HandleSingleIfStatementForm(document, root, diagnostic);
             }
         }
 
-        private Document HandleSingleIfStatementForm(
-            Document document,
-            SyntaxNode root,
-            Diagnostic diagnostic,
-            CancellationToken cancellationToken)
+        private Document HandleSingleIfStatementForm(Document document, SyntaxNode root, Diagnostic diagnostic)
         {
             var ifStatementLocation = diagnostic.AdditionalLocations[0];
             var expressionStatementLocation = diagnostic.AdditionalLocations[1];
 
             var ifStatement = (IfStatementSyntax)root.FindNode(ifStatementLocation.SourceSpan);
-            cancellationToken.ThrowIfCancellationRequested();
-
             var expressionStatement = (ExpressionStatementSyntax)root.FindNode(expressionStatementLocation.SourceSpan);
-            cancellationToken.ThrowIfCancellationRequested();
-
             var invocationExpression = (InvocationExpressionSyntax)expressionStatement.Expression;
-            cancellationToken.ThrowIfCancellationRequested();
 
             StatementSyntax newStatement = expressionStatement.WithExpression(
                 SyntaxFactory.ConditionalAccessExpression(
@@ -85,27 +76,20 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
             }
 
             newStatement = newStatement.WithAdditionalAnnotations(Formatter.Annotation);
-            cancellationToken.ThrowIfCancellationRequested();
 
             var newRoot = root.ReplaceNode(ifStatement, newStatement);
             return document.WithSyntaxRoot(newRoot);
         }
 
-        private static Document HandVariableAndIfStatementFormAsync(
-            Document document, SyntaxNode root, Diagnostic diagnostic, CancellationToken cancellationToken)
+        private static Document HandVariableAndIfStatementFormAsync(Document document, SyntaxNode root, Diagnostic diagnostic)
         {
             var localDeclarationLocation = diagnostic.AdditionalLocations[0];
             var ifStatementLocation = diagnostic.AdditionalLocations[1];
             var expressionStatementLocation = diagnostic.AdditionalLocations[2];
 
             var localDeclarationStatement = (LocalDeclarationStatementSyntax)root.FindNode(localDeclarationLocation.SourceSpan);
-            cancellationToken.ThrowIfCancellationRequested();
-
             var ifStatement = (IfStatementSyntax)root.FindNode(ifStatementLocation.SourceSpan);
-            cancellationToken.ThrowIfCancellationRequested();
-
             var expressionStatement = (ExpressionStatementSyntax)root.FindNode(expressionStatementLocation.SourceSpan);
-            cancellationToken.ThrowIfCancellationRequested();
 
             var invocationExpression = (InvocationExpressionSyntax)expressionStatement.Expression;
             var parentBlock = (BlockSyntax)localDeclarationStatement.Parent;
@@ -121,7 +105,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
             var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);
             editor.ReplaceNode(ifStatement, newStatement);
             editor.RemoveNode(localDeclarationStatement, SyntaxRemoveOptions.KeepLeadingTrivia | SyntaxRemoveOptions.AddElasticMarker);
-            cancellationToken.ThrowIfCancellationRequested();
 
             var newRoot = editor.GetChangedRoot();
             return document.WithSyntaxRoot(newRoot);


### PR DESCRIPTION
This reverts commit 4ed5b5963c00924003822cd3a2037888bfbcb253, reversing
changes made to 29ab8cbafb96ea94feff73f18aee5c5166fad448.

I'm proactively going to revert this so we can get a build to insert if testing proves that this is the source of additional allocations in the WebForms DDRIT.  If it passes tests, I'll revert this revert and we won't insert the build with the analyzer disabled.