### PR TITLE
Prevent DeriveArgument methods from trying to access parameter symbols that don't exist.

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -150,6 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (argument) =>
                 {
                     string name = !argumentNames.IsDefaultOrEmpty ? argumentNames[argumentIndex] : null;
+                    Symbols.ParameterSymbol parameter = parameterIndex < parameters.Length ? parameters[parameterIndex] : null;
 
                     if (name == null)
                     {
@@ -157,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (refMode != RefKind.None)
                         {
-                            return new Argument(ArgumentKind.Positional, parameters[parameterIndex], argument);
+                            return new Argument(ArgumentKind.Positional, parameter, argument);
                         }
 
                         if (argumentIndex >= parameters.Length - 1 &&
@@ -172,11 +173,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else
                         {
-                            return new SimpleArgument(parameters[parameterIndex], argument);
+                            return new SimpleArgument(parameter, argument);
                         }
                     }
 
-                    return new Argument(ArgumentKind.Named, parameters[parameterIndex], argument);
+                    return new Argument(ArgumentKind.Named, parameter, argument);
                 });
         }
         

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argumentIndex = argumentsToParameters.IndexOf(parameterIndex);
                 }
 
-                if (argumentIndex == -1 || argumentIndex >= boundArguments.Length)
+                if ((uint)argumentIndex >= (uint)boundArguments.Length)
                 {
                     // No argument has been supplied for the parameter at `parameterIndex`:
                     // 1. `argumentIndex == -1' when the arguments are specified out of parameter order, and no argument is provided for parameter corresponding to `parameters[parameterIndex]`.
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (parameter.HasExplicitDefaultValue)
                     {
                         // The parameter is optional with a default value.
-                        arguments.Add(new Argument(ArgumentKind.DefaultValue, parameter, new Literal(parameter.ExplicitDefaultConstantValue, parameter.Type, null)));
+                        arguments.Add(new Argument(ArgumentKind.DefaultValue, parameter, new Literal(parameter.ExplicitDefaultConstantValue, parameter.Type, invocationSyntax)));
                     }
                     else
                     {
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static IArgument DeriveArgument(int parameterIndex, int argumentIndex, ImmutableArray<BoundExpression> boundArguments, ImmutableArray<string> argumentNames, ImmutableArray<RefKind> argumentRefKinds, ImmutableArray<Symbols.ParameterSymbol> parameters, SyntaxNode invocationSyntax)
         {
-            if (argumentIndex >= boundArguments.Length)
+            if ((uint)argumentIndex >= (uint)boundArguments.Length)
             {
                 // Check for an omitted argument that becomes an empty params array.
                 if (parameters.Length > 0)
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // There is no supplied argument and there is no params parameter. Any action is suspect at this point.
-                return null;
+                return new SimpleArgument(null, null);
             }
 
             return s_argumentMappings.GetValue(
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (argument) =>
                 {
                     string name = !argumentNames.IsDefaultOrEmpty ? argumentNames[argumentIndex] : null;
-                    Symbols.ParameterSymbol parameter = parameterIndex < parameters.Length ? parameters[parameterIndex] : null;
+                    Symbols.ParameterSymbol parameter = (uint)parameterIndex < (uint)parameters.Length ? parameters[parameterIndex] : null;
 
                     if (name == null)
                     {
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             OperationKind IOperation.Kind => OperationKind.Argument;
 
-            SyntaxNode IOperation.Syntax => this.Value.Syntax;
+            SyntaxNode IOperation.Syntax => this.Value?.Syntax;
 
             public ITypeSymbol Type => null;
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -370,7 +370,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Case BoundKind.ByRefArgumentWithCopyBack
                     Return s_argumentMappings.GetValue(
                         argument,
-                        Function(argumentValue) New ByRefArgument(If(index < parameters.Length, parameters(index), Nothing), DirectCast(argumentValue, BoundByRefArgumentWithCopyBack)))
+                        Function(argumentValue) New ByRefArgument(If(CUInt(index) < CUInt(parameters.Length), parameters(index), Nothing), DirectCast(argumentValue, BoundByRefArgumentWithCopyBack)))
                 Case Else
                     ' Apparently the VB bound trees don't encode named arguments, which seems unnecesarily lossy.
                     Return s_argumentMappings.GetValue(
@@ -379,7 +379,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             If index >= parameters.Length - 1 AndAlso parameters.Length > 0 AndAlso parameters(parameters.Length - 1).IsParamArray Then
                                 Return New Argument(ArgumentKind.ParamArray, parameters(parameters.Length - 1), argumentValue)
                             Else
-                                Return New Argument(ArgumentKind.Positional, If(index < parameters.Length, parameters(index), Nothing), argumentValue)
+                                Return New Argument(ArgumentKind.Positional, If(CUInt(index) < CUInt(parameters.Length), parameters(index), Nothing), argumentValue)
                             End If
                         End Function)
             End Select
@@ -414,7 +414,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public ReadOnly Property Syntax As SyntaxNode Implements IOperation.Syntax
                 Get
-                    Return Me.Value.Syntax
+                    Return Me.Value?.Syntax
                 End Get
             End Property
 


### PR DESCRIPTION
This change set is expected to fix #8901 . There are no tests provided in the change set because attempts to produce a small repro have failed. The fix is to take defensive action against a situation the compilers are expected to screen out--semantically invalid invocations that include an argument that doesn't match a parameter.

@mavasani , does this change set actually fix #8901 ?