### PR TITLE
Optimize allocations in analyzer driver state tracking for syntax tre…

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.AnalyzerStateData.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.AnalyzerStateData.cs
@@ -21,10 +21,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// </summary>
             public HashSet<AnalyzerAction> ProcessedActions { get; }
 
+            public static readonly AnalyzerStateData FullyProcessedInstance = CreateFullyProcessedInstance();
+
             public AnalyzerStateData()
             {
                 StateKind = StateKind.InProcess;
                 ProcessedActions = new HashSet<AnalyzerAction>();
+            }
+
+            private static AnalyzerStateData CreateFullyProcessedInstance()
+            {
+                var instance = new AnalyzerStateData();
+                instance.SetStateKind(StateKind.FullyProcessed);
+                return instance;
             }
 
             public virtual void SetStateKind(StateKind stateKind)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// </summary>
             public OperationBlockAnalyzerStateData OperationBlockAnalysisState { get; }
 
-            public static readonly DeclarationAnalyzerStateData FullyProcessedInstance = CreateFullyProcessedInstance();
+            public new static readonly DeclarationAnalyzerStateData FullyProcessedInstance = CreateFullyProcessedInstance();
 
             public DeclarationAnalyzerStateData()
             {


### PR DESCRIPTION
…e action analysis. Instead of tracking state for all pending trees, we now track state only for trees which have started analysis. This ensures we don't create state tracking entries for all trees in compilation at start of analysis - these entries show up in perf traces.

I have also changed the declaring references cached on SymbolDeclaredEvent to be lazily computed. If we end up computing only syntax diagnostics on a compilation, this will save us allocations.