### PR TITLE
Fix reset interactive imports

### DIFF
--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/ResetInteractive.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/ResetInteractive.cs
@@ -38,10 +38,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
 
         internal Task Execute(IInteractiveWindow interactiveWindow, string title)
         {
-            ImmutableArray<string> references, referenceSearchPaths, sourceSearchPaths, namespacesToImport;
+            ImmutableArray<string> references, referenceSearchPaths, sourceSearchPaths, projectNamespaces;
             string projectDirectory;
 
-            if (GetProjectProperties(out references, out referenceSearchPaths, out sourceSearchPaths, out namespacesToImport, out projectDirectory))
+            if (GetProjectProperties(out references, out referenceSearchPaths, out sourceSearchPaths, out projectNamespaces, out projectDirectory))
             {
                 // Now, we're going to do a bunch of async operations.  So create a wait
                 // indicator so the user knows something is happening, and also so they cancel.
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
                     references,
                     referenceSearchPaths,
                     sourceSearchPaths,
-                    namespacesToImport,
+                    projectNamespaces,
                     projectDirectory,
                     waitContext);
 
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             ImmutableArray<string> referencePaths,
             ImmutableArray<string> referenceSearchPaths,
             ImmutableArray<string> sourceSearchPaths,
-            ImmutableArray<string> namespacesToImport,
+            ImmutableArray<string> projectNamespaces,
             string projectDirectory,
             IWaitContext waitContext)
         {
@@ -116,8 +116,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
 
             // Project's default namespace might be different from namespace used within project.
             // Filter out namespace imports that do not exist in interactive compilation.
-            IEnumerable<string> existingNamespaces = await GetNamespacesToImport(namespacesToImport, interactiveWindow).ConfigureAwait(true);
-            var importNamespacesCommand = existingNamespaces.Select(_createImport).Join(editorOptions.GetNewLineCharacter());
+            IEnumerable<string> namespacesToImport = await GetNamespacesToImportAsync(projectNamespaces, interactiveWindow).ConfigureAwait(true);
+            var importNamespacesCommand = namespacesToImport.Select(_createImport).Join(editorOptions.GetNewLineCharacter());
 
             if (!string.IsNullOrWhiteSpace(importNamespacesCommand))
             {
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             }
         }
 
-        protected abstract Task<IEnumerable<string>> GetNamespacesToImport(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow);
+        protected abstract Task<IEnumerable<string>> GetNamespacesToImportAsync(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow);
 
         /// <summary>
         /// Gets the properties of the currently selected projects necessary for reset.
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             out ImmutableArray<string> references,
             out ImmutableArray<string> referenceSearchPaths,
             out ImmutableArray<string> sourceSearchPaths,
-            out ImmutableArray<string> namespacesToImport,
+            out ImmutableArray<string> projectNamespaces,
             out string projectDirectory);
 
         /// <summary>

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
@@ -22,7 +22,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
     </Project>
     <Project Language=""C#"" AssemblyName=""ResetInteractiveTestsAssembly"" CommonReferences=""true"">
         <ProjectReference>ResetInteractiveVisualBasicSubproject</ProjectReference>
-        <Document FilePath=""ResetInteractiveTestsDocument""></Document>
+        <Document FilePath=""ResetInteractiveTestsDocument"">
+namespace ResetInteractiveTestsDocument
+{
+    class TestClass
+    {
+    }
+}</Document>
     </Project>
 </Workspace>";
 
@@ -40,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
                 Assert.True(replReferenceCommands.Any(rc => rc.EndsWith(@"ResetInteractiveVisualBasicSubproject.dll""")));
 
                 var expectedReferences = replReferenceCommands.ToList();
-                var expectedUsings = new List<string> { @"using ""ns1"";", @"using ""ns2"";" };
+                var expectedUsings = new List<string> { @"using ""System"";", @"using ""ResetInteractiveTestsDocument"";" };
                 AssertResetInteractive(workspace, project, buildSucceeds: true, expectedReferences: expectedReferences, expectedUsings: expectedUsings);
 
                 // Test that no submissions are executed if the build fails.
@@ -79,7 +85,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
                 References = ImmutableArray.CreateRange(GetProjectReferences(workspace, project)),
                 ReferenceSearchPaths = ImmutableArray.Create("rsp1", "rsp2"),
                 SourceSearchPaths = ImmutableArray.Create("ssp1", "ssp2"),
-                NamespacesToImport = ImmutableArray.Create("ns1", "ns2"),
+                NamespacesToImport = ImmutableArray.Create("System", "ResetInteractiveTestsDocument", "VisualBasicResetInteractiveTestsDocument"),
+                ExistingNamespaces = ImmutableArray.Create("System", "ResetInteractiveTestsDocument"),
                 ProjectDirectory = "pj",
             };
 

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
@@ -85,8 +85,8 @@ namespace ResetInteractiveTestsDocument
                 References = ImmutableArray.CreateRange(GetProjectReferences(workspace, project)),
                 ReferenceSearchPaths = ImmutableArray.Create("rsp1", "rsp2"),
                 SourceSearchPaths = ImmutableArray.Create("ssp1", "ssp2"),
-                NamespacesToImport = ImmutableArray.Create("System", "ResetInteractiveTestsDocument", "VisualBasicResetInteractiveTestsDocument"),
-                ExistingNamespaces = ImmutableArray.Create("System", "ResetInteractiveTestsDocument"),
+                ProjectNamespaces = ImmutableArray.Create("System", "ResetInteractiveTestsDocument", "VisualBasicResetInteractiveTestsDocument"),
+                NamespacesToImport = ImmutableArray.Create("System", "ResetInteractiveTestsDocument"),
                 ProjectDirectory = "pj",
             };
 

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
             return _waitIndicator;
         }
 
-        protected override Task<IEnumerable<string>> GetNamespacesToImport(IInteractiveWindow interactiveWindow)
+        protected override Task<IEnumerable<string>> GetNamespacesToImport(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow)
         {
             return Task.FromResult((IEnumerable<string>)ExistingNamespaces);
         }

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
@@ -27,9 +27,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
 
         internal ImmutableArray<string> SourceSearchPaths { get; set; }
 
-        internal ImmutableArray<string> NamespacesToImport { get; set; }
+        internal ImmutableArray<string> ProjectNamespaces { get; set; }
 
-        internal ImmutableArray<string> ExistingNamespaces { get; set; }
+        internal ImmutableArray<string> NamespacesToImport { get; set; }
 
         internal string ProjectDirectory { get; set; }
 
@@ -60,13 +60,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
             out ImmutableArray<string> references,
             out ImmutableArray<string> referenceSearchPaths,
             out ImmutableArray<string> sourceSearchPaths,
-            out ImmutableArray<string> namespacesToImport,
+            out ImmutableArray<string> projectNamespaces,
             out string projectDirectory)
         {
             references = References;
             referenceSearchPaths = ReferenceSearchPaths;
             sourceSearchPaths = SourceSearchPaths;
-            namespacesToImport = NamespacesToImport;
+            projectNamespaces = ProjectNamespaces;
             projectDirectory = ProjectDirectory;
             return true;
         }
@@ -76,9 +76,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
             return _waitIndicator;
         }
 
-        protected override Task<IEnumerable<string>> GetNamespacesToImport(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow)
+        protected override Task<IEnumerable<string>> GetNamespacesToImportAsync(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow)
         {
-            return Task.FromResult((IEnumerable<string>)ExistingNamespaces);
+            return Task.FromResult((IEnumerable<string>)NamespacesToImport);
         }
     }
 }

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/TestResetInteractive.cs
@@ -6,6 +6,8 @@ using Microsoft.VisualStudio.Text.Editor;
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.InteractiveWindow;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
 {
@@ -26,6 +28,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
         internal ImmutableArray<string> SourceSearchPaths { get; set; }
 
         internal ImmutableArray<string> NamespacesToImport { get; set; }
+
+        internal ImmutableArray<string> ExistingNamespaces { get; set; }
 
         internal string ProjectDirectory { get; set; }
 
@@ -70,6 +74,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
         protected override IWaitIndicator GetWaitIndicator()
         {
             return _waitIndicator;
+        }
+
+        protected override Task<IEnumerable<string>> GetNamespacesToImport(IInteractiveWindow interactiveWindow)
+        {
+            return Task.FromResult((IEnumerable<string>)ExistingNamespaces);
         }
     }
 }

--- a/src/VisualStudio/InteractiveServices/Interactive/VsResetInteractive.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsResetInteractive.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             out ImmutableArray<string> references,
             out ImmutableArray<string> referenceSearchPaths,
             out ImmutableArray<string> sourceSearchPaths,
-            out ImmutableArray<string> namespacesToImport,
+            out ImmutableArray<string> projectNamespaces,
             out string projectDirectory)
         {
             var hierarchyPointer = default(IntPtr);
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             references = ImmutableArray<string>.Empty;
             referenceSearchPaths = ImmutableArray<string>.Empty;
             sourceSearchPaths = ImmutableArray<string>.Empty;
-            namespacesToImport = ImmutableArray<string>.Empty;
+            projectNamespaces = ImmutableArray<string>.Empty;
             projectDirectory = null;
 
             try
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
 
                 if (hierarchyPointer != IntPtr.Zero)
                 {
-                    GetProjectProperties(hierarchyPointer, out references, out referenceSearchPaths, out sourceSearchPaths, out namespacesToImport, out projectDirectory);
+                    GetProjectProperties(hierarchyPointer, out references, out referenceSearchPaths, out sourceSearchPaths, out projectNamespaces, out projectDirectory);
                     return true;
                 }
             }
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             out ImmutableArray<string> references,
             out ImmutableArray<string> referenceSearchPaths,
             out ImmutableArray<string> sourceSearchPaths,
-            out ImmutableArray<string> namespacesToImport,
+            out ImmutableArray<string> projectNamespaces,
             out string projectDirectory)
         {
             var hierarchy = (IVsHierarchy)Marshal.GetObjectForIUnknown(hierarchyPointer);
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             references = referencesBuilder.ToImmutableArray();
             referenceSearchPaths = referenceSearchPathsBuilder.ToImmutableArray();
             sourceSearchPaths = sourceSearchPathsBuilder.ToImmutableArray();
-            namespacesToImport = namespacesToImportBuilder.ToImmutableArray();
+            projectNamespaces = namespacesToImportBuilder.ToImmutableArray();
         }
 
         private static string GetReferenceString(Reference reference)
@@ -267,7 +267,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
         /// <summary>
         /// Return namespaces that can be resolved in the latest interactive compilation.
         /// </summary>
-        protected override async Task<IEnumerable<string>> GetNamespacesToImport(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow)
+        protected override async Task<IEnumerable<string>> GetNamespacesToImportAsync(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow)
         {
             var document = interactiveWindow.CurrentLanguageBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             var compilation = await document.Project.GetCompilationAsync().ConfigureAwait(true);

--- a/src/VisualStudio/InteractiveServices/Interactive/VsResetInteractive.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsResetInteractive.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.CodeAnalysis.Text;
 using System.Linq;
+using core::Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServices.Interactive
 {
@@ -263,14 +264,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             return _componentModel.GetService<IWaitIndicator>();
         }
 
-        protected override async Task<IEnumerable<string>> GetNamespacesToImport(IInteractiveWindow interactiveWindow)
+        /// <summary>
+        /// Return namespaces that can be resolved in the latest interactive compilation.
+        /// </summary>
+        protected override async Task<IEnumerable<string>> GetNamespacesToImport(IEnumerable<string> namespacesToImport, IInteractiveWindow interactiveWindow)
         {
-            // Filter out namespace imports that do not exist in the compilation.
-            // Needed when project's default namespace is different from namespace used within project.
             var document = interactiveWindow.CurrentLanguageBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             var compilation = await document.Project.GetCompilationAsync().ConfigureAwait(true);
-            var namespaces = new HashSet<string>(compilation.GlobalNamespace.GetNamespaceMembers().Select((ns) => ns.Name));
-            return namespaces;
+            return namespacesToImport.Where(ns => compilation.GlobalNamespace.GetQualifiedNamespace(ns) != null);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
@@ -150,6 +150,26 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
         }
 
+        public static INamespaceSymbol GetQualifiedNamespace(
+            this INamespaceSymbol globalNamespace,
+            string namespaceName)
+        {
+            var namespaceSymbol = globalNamespace;
+            foreach (var name in namespaceName.Split('.'))
+            {
+                var members = namespaceSymbol.GetMembers(name);
+                namespaceSymbol = members.Count() == 1
+                        ? members.First() as INamespaceSymbol
+                        : null;
+
+                if ((object)namespaceSymbol == null)
+                {
+                    break;
+                }
+            }
+            return namespaceSymbol;
+        }
+
         private static bool ContainsAccessibleTypesOrNamespacesWorker(
             this INamespaceSymbol namespaceSymbol,
             IAssemblySymbol assembly,


### PR DESCRIPTION
Fixes an issue where the reset interactive tried to import a project's default namespace even if it did not exist in the binary.