### PR TITLE
Fix an issue in the test caching layer

### DIFF
--- a/src/Tools/Source/RunTests/Cache/IDataStorage.cs
+++ b/src/Tools/Source/RunTests/Cache/IDataStorage.cs
@@ -10,8 +10,32 @@ namespace RunTests.Cache
 {
     internal interface IDataStorage
     {
-        bool TryGetTestResult(string checksum, out TestResult testResult);
+        bool TryGetCachedTestResult(string checksum, out CachedTestResult testResult);
 
-        void AddTestResult(ContentFile conentFile, TestResult testResult);
+        void AddCachedTestResult(ContentFile conentFile, CachedTestResult testResult);
+    }
+
+    internal struct CachedTestResult
+    {
+        internal int ExitCode { get; }
+        internal string StandardOutput { get; }
+        internal string ErrorOutput { get; }
+        internal string ResultsFileName { get; }
+        internal string ResultsFileContent { get; }
+
+        internal CachedTestResult(
+            int exitCode,
+            string standardOutput,
+            string errorOutput,
+            string resultsFileName,
+            string resultsFileContent)
+        {
+            ExitCode = exitCode;
+            StandardOutput = standardOutput;
+            ErrorOutput = errorOutput;
+            ResultsFileName = resultsFileName;
+            ResultsFileContent = resultsFileContent;
+        }
     }
 }
+

--- a/src/Tools/Source/RunTests/ITestExecutor.cs
+++ b/src/Tools/Source/RunTests/ITestExecutor.cs
@@ -41,6 +41,8 @@ namespace RunTests
 
     internal interface ITestExecutor
     {
+        string GetCommandLine(string assemblyPath);
+
         Task<TestResult> RunTestAsync(string assemblyPath, CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -20,13 +20,56 @@ namespace RunTests
             _options = options;
         }
 
+        public string GetCommandLine(string assemblyPath)
+        {
+            return $"{_options.XunitPath} {GetCommandLineArguments(assemblyPath)}";
+        }
+
+        public string GetCommandLineArguments(string assemblyPath)
+        {
+            var assemblyName = Path.GetFileName(assemblyPath);
+            var resultsFilePath = GetResultsFilePath(assemblyPath);
+
+            var builder = new StringBuilder();
+            builder.AppendFormat(@"""{0}""", assemblyPath);
+            builder.AppendFormat(@" -{0} ""{1}""", _options.UseHtml ? "html" : "xml", resultsFilePath);
+            builder.Append(" -noshadow -verbose");
+
+            if (!string.IsNullOrWhiteSpace(_options.Trait))
+            {
+                var traits = _options.Trait.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var trait in traits)
+                {
+                    builder.AppendFormat(" -trait {0}", trait);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(_options.NoTrait))
+            {
+                var traits = _options.NoTrait.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var trait in traits)
+                {
+                    builder.AppendFormat(" -notrait {0}", trait);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private string GetResultsFilePath(string assemblyPath)
+        {
+            var assemblyName = Path.GetFileName(assemblyPath);
+            var resultsDir = Path.Combine(Path.GetDirectoryName(assemblyPath), Constants.ResultsDirectoryName);
+            return Path.Combine(resultsDir, $"{assemblyName}.{(_options.UseHtml ? "html" : "xml")}");
+        }
+
         public async Task<TestResult> RunTestAsync(string assemblyPath, CancellationToken cancellationToken)
         {
             try
             {
-                var assemblyName = Path.GetFileName(assemblyPath);
-                var resultsDir = Path.Combine(Path.GetDirectoryName(assemblyPath), Constants.ResultsDirectoryName);
-                var resultsFilePath = Path.Combine(resultsDir, $"{assemblyName}.{(_options.UseHtml ? "html" : "xml")}");
+                var commandLineArguments = GetCommandLineArguments(assemblyPath);
+                var resultsFilePath = GetResultsFilePath(assemblyPath);
+                var resultsDir = Path.GetDirectoryName(resultsFilePath);
 
                 // NOTE: xUnit doesn't always create the log directory
                 Directory.CreateDirectory(resultsDir);
@@ -35,35 +78,11 @@ namespace RunTests
                 // an empty log just in case, so our runner will still fail.
                 File.Create(resultsFilePath).Close();
 
-                var builder = new StringBuilder();
-                builder.AppendFormat(@"""{0}""", assemblyPath);
-                builder.AppendFormat(@" -{0} ""{1}""", _options.UseHtml ? "html" : "xml", resultsFilePath);
-                builder.Append(" -noshadow -verbose");
-
-                if (!string.IsNullOrWhiteSpace(_options.Trait))
-                {
-                    var traits = _options.Trait.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                    foreach (var trait in traits)
-                    {
-                        builder.AppendFormat(" -trait {0}", trait);
-                    }
-                }
-
-                if (!string.IsNullOrWhiteSpace(_options.NoTrait))
-                {
-                    var traits = _options.NoTrait.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                    foreach (var trait in traits)
-                    {
-                        builder.AppendFormat(" -notrait {0}", trait);
-                    }
-                }
-
                 var start = DateTime.UtcNow;
-
                 var xunitPath = _options.XunitPath;
                 var processOutput = await ProcessRunner.RunProcessAsync(
                     xunitPath,
-                    builder.ToString(),
+                    commandLineArguments,
                     lowPriority: false,
                     displayWindow: false,
                     captureOutput: true,
@@ -94,7 +113,7 @@ namespace RunTests
                     }
                 }
 
-                var commandLine = $"{xunitPath} {builder.ToString()}";
+                var commandLine = GetCommandLine(assemblyPath);
                 var standardOutput = string.Join(Environment.NewLine, processOutput.OutputLines);
                 var errorOutput = string.Join(Environment.NewLine, processOutput.ErrorLines);
 


### PR DESCRIPTION
The test caching layer had two bugs around re-hydrating the test resutls from cache:

- Made a bad assumption about the name of the file.
- Assumed tests were always rehydrated into the original directory.

closes #8860