### PR TITLE
Ask Mode request: Prevent DeriveArgument from throwing ArrayIndexOutOfRangeException when presented with semantically malformed bound trees.

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argumentIndex = argumentsToParameters.IndexOf(parameterIndex);
                 }
 
-                if (argumentIndex == -1 || argumentIndex >= boundArguments.Length)
+                if ((uint)argumentIndex >= (uint)boundArguments.Length)
                 {
                     // No argument has been supplied for the parameter at `parameterIndex`:
                     // 1. `argumentIndex == -1' when the arguments are specified out of parameter order, and no argument is provided for parameter corresponding to `parameters[parameterIndex]`.
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (parameter.HasExplicitDefaultValue)
                     {
                         // The parameter is optional with a default value.
-                        arguments.Add(new Argument(ArgumentKind.DefaultValue, parameter, new Literal(parameter.ExplicitDefaultConstantValue, parameter.Type, null)));
+                        arguments.Add(new Argument(ArgumentKind.DefaultValue, parameter, new Literal(parameter.ExplicitDefaultConstantValue, parameter.Type, invocationSyntax)));
                     }
                     else
                     {
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static IArgument DeriveArgument(int parameterIndex, int argumentIndex, ImmutableArray<BoundExpression> boundArguments, ImmutableArray<string> argumentNames, ImmutableArray<RefKind> argumentRefKinds, ImmutableArray<Symbols.ParameterSymbol> parameters, SyntaxNode invocationSyntax)
         {
-            if (argumentIndex >= boundArguments.Length)
+            if ((uint)argumentIndex >= (uint)boundArguments.Length)
             {
                 // Check for an omitted argument that becomes an empty params array.
                 if (parameters.Length > 0)
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // There is no supplied argument and there is no params parameter. Any action is suspect at this point.
-                return null;
+                return new SimpleArgument(null, null);
             }
 
             return s_argumentMappings.GetValue(
@@ -149,6 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (argument) =>
                 {
                     string name = !argumentNames.IsDefaultOrEmpty ? argumentNames[argumentIndex] : null;
+                    Symbols.ParameterSymbol parameter = (uint)parameterIndex < (uint)parameters.Length ? parameters[parameterIndex] : null;
 
                     if (name == null)
                     {
@@ -156,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (refMode != RefKind.None)
                         {
-                            return new Argument(ArgumentKind.Positional, parameters[parameterIndex], argument);
+                            return new Argument(ArgumentKind.Positional, parameter, argument);
                         }
 
                         if (argumentIndex >= parameters.Length - 1 &&
@@ -171,11 +172,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else
                         {
-                            return new SimpleArgument(parameters[parameterIndex], argument);
+                            return new SimpleArgument(parameter, argument);
                         }
                     }
 
-                    return new Argument(ArgumentKind.Named, parameters[parameterIndex], argument);
+                    return new Argument(ArgumentKind.Named, parameter, argument);
                 });
         }
         
@@ -247,7 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             OperationKind IOperation.Kind => OperationKind.Argument;
 
-            SyntaxNode IOperation.Syntax => this.Value.Syntax;
+            SyntaxNode IOperation.Syntax => this.Value?.Syntax;
 
             public ITypeSymbol Type => null;
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -368,10 +368,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared Function DeriveArgument(index As Integer, argument As BoundExpression, parameters As ImmutableArray(Of Symbols.ParameterSymbol)) As IArgument
             Select Case argument.Kind
                 Case BoundKind.ByRefArgumentWithCopyBack
-                    Return s_argumentMappings.GetValue(argument, Function(a) New ByRefArgument(parameters(index), DirectCast(argument, BoundByRefArgumentWithCopyBack)))
+                    Return s_argumentMappings.GetValue(
+                        argument,
+                        Function(argumentValue) New ByRefArgument(If(CUInt(index) < CUInt(parameters.Length), parameters(index), Nothing), DirectCast(argumentValue, BoundByRefArgumentWithCopyBack)))
                 Case Else
                     ' Apparently the VB bound trees don't encode named arguments, which seems unnecesarily lossy.
-                    Return s_argumentMappings.GetValue(argument, Function(a) If(index >= parameters.Length - 1 AndAlso parameters.Length > 0 AndAlso parameters(parameters.Length - 1).IsParamArray, New Argument(ArgumentKind.ParamArray, parameters(parameters.Length - 1), a), New Argument(ArgumentKind.Positional, parameters(index), a)))
+                    Return s_argumentMappings.GetValue(
+                        argument,
+                        Function(argumentValue)
+                            If index >= parameters.Length - 1 AndAlso parameters.Length > 0 AndAlso parameters(parameters.Length - 1).IsParamArray Then
+                                Return New Argument(ArgumentKind.ParamArray, parameters(parameters.Length - 1), argumentValue)
+                            Else
+                                Return New Argument(ArgumentKind.Positional, If(CUInt(index) < CUInt(parameters.Length), parameters(index), Nothing), argumentValue)
+                            End If
+                        End Function)
             End Select
         End Function
 
@@ -404,7 +414,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public ReadOnly Property Syntax As SyntaxNode Implements IOperation.Syntax
                 Get
-                    Return Me.Value.Syntax
+                    Return Me.Value?.Syntax
                 End Get
             End Property
 


### PR DESCRIPTION
In running analyzers with operation actions over Roslyn sources, @mavasani discovered a crash in the C# IOperation implementation when pasting in a specific semantically-invalid code fragment.

The fix is to protect array accesses with tests for valid indices. The change set includes a few other edits in the same spirit of preventing potential crashes.

Some review discussion is in the equivalent PR for master, #8920 

I have been unable to reproduce the problem with a standalone unit test, so no test comes with this change set.

@genlu @mavasani @srivatsn @ManishJayaswal @Pilchie 