### PR TITLE
Fix version definition of Microsoft.DiaSymReader.PortablePdb and set the version to 1.0.0-rc

### DIFF
--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Version.targets
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Version.targets
@@ -1,25 +1,37 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <NuGetVersion>$(AssemblyVersion)-beta1</NuGetVersion>
+    <IsReleaseVersion>false</IsReleaseVersion>
   </PropertyGroup>
 
-  <!-- AssemblyFileVersion -->
   <Choose>
-    <When Condition="'$(BuildNumber)' != ''">
-      <!-- Lab build. -->
+    <When Condition="$(BuildNumber) == ''">
       <PropertyGroup>
-        <BuildVersion>$(AssemblyVersion).$(BuildNumber.Split('.')[0])</BuildVersion>
-        <NuGetVersion>$(NuGetVersion)-$(BuildNumber.Split('.')[0])</NuGetVersion>
-        <NuGetVersionType>PerBuildPreRelease</NuGetVersionType>
+        <NuGetVersionSuffix>rc</NuGetVersionSuffix>
+        <BuildVersion>$(AssemblyVersion).0</BuildVersion>
       </PropertyGroup>
     </When>
 
     <Otherwise>
-      <!-- Local build. -->
       <PropertyGroup>
-        <BuildVersion>$(AssemblyVersion).0</BuildVersion>
-        <NuGetVersionType>PreRelease</NuGetVersionType>
+        <NuGetVersionSuffix>rc-$(BuildNumber.Split('.')[0])</NuGetVersionSuffix>
+        <BuildVersion>$(AssemblyVersion).$(BuildNumber.Split('.')[0])</BuildVersion>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  
+  <Choose>
+    <When Condition="$(IsReleaseVersion)" >
+      <PropertyGroup>
+        <NuGetVersion>$(AssemblyVersion)</NuGetVersion>
+        <NuGetVersionType>Release</NuGetVersionType>
+      </PropertyGroup>
+    </When>
+    
+    <Otherwise>
+      <PropertyGroup>
+        <NuGetVersion>$(AssemblyVersion)-$(NuGetVersionSuffix)</NuGetVersion>
+        <NuGetVersionType>PerBuildPreRelease</NuGetVersionType>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
This change only affects Microsoft.DiaSymReader.PortablePdb.nuget definition.

Similar to change https://github.com/dotnet/roslyn/commit/ea25aab206772a1d5cbb777bc1aec2211b1a12c0 of the Microsoft.DiaSymReader version definition

