### PR TITLE
Silence "No source files" build warning

### DIFF
--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Vsix/CSharpAnalyzers.Vsix.csproj
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Vsix/CSharpAnalyzers.Vsix.csproj
@@ -24,6 +24,7 @@
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <VSSDKTargetPlatformRegRootSuffix>Roslyn</VSSDKTargetPlatformRegRootSuffix>
+    <NoWarn>$(NoWarn);2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/BasicAnalyzers.Vsix.vbproj
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/BasicAnalyzers.Vsix.vbproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <Folder Include="My Project\" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
CSharpAnalyzers.Vsix.vbproj was pulling CSharp targets and csc.exe, so their supressed warnings were not being respected.
Suppressed this warning in CSharpAnalyzers.Vsix.csproj.

Fixes some of the warnings in https://github.com/dotnet/roslyn/issues/8631.