### PR TITLE
SuggestedActions should 'yield' the thread before atually proceeding with being invoked.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewExceptionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewExceptionTests.cs
@@ -53,7 +53,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             EditorLayerExtensionManager.ExtensionManager extensionManager;
             VisualStudio.Text.ITextBuffer textBuffer;
             RefactoringSetup(workspace, provider, refactorings, out editHandler, out extensionManager, out textBuffer);
-            var suggestedAction = new CodeRefactoringSuggestedAction(workspace, textBuffer, editHandler, new TestWaitIndicator(), refactorings.First(), provider);
+            var suggestedAction = new CodeRefactoringSuggestedAction(workspace, textBuffer, editHandler, 
+                new TestWaitIndicator(), refactorings.First(), provider, operationListener: null);
             await suggestedAction.GetPreviewAsync(CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(provider));
             Assert.False(extensionManager.IsIgnored(provider));
@@ -66,7 +67,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             EditorLayerExtensionManager.ExtensionManager extensionManager;
             VisualStudio.Text.ITextBuffer textBuffer;
             RefactoringSetup(workspace, provider, refactorings, out editHandler, out extensionManager, out textBuffer);
-            var suggestedAction = new CodeRefactoringSuggestedAction(workspace, textBuffer, editHandler, new TestWaitIndicator(), refactorings.First(), provider);
+            var suggestedAction = new CodeRefactoringSuggestedAction(workspace, textBuffer, editHandler, 
+                new TestWaitIndicator(), refactorings.First(), provider, operationListener: null);
             var text = suggestedAction.DisplayText;
             Assert.True(extensionManager.IsDisabled(provider));
             Assert.False(extensionManager.IsIgnored(provider));
@@ -79,7 +81,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             EditorLayerExtensionManager.ExtensionManager extensionManager;
             VisualStudio.Text.ITextBuffer textBuffer;
             RefactoringSetup(workspace, provider, refactorings, out editHandler, out extensionManager, out textBuffer);
-            var suggestedAction = new CodeRefactoringSuggestedAction(workspace, textBuffer, editHandler, new TestWaitIndicator(), refactorings.First(), provider);
+            var suggestedAction = new CodeRefactoringSuggestedAction(workspace, textBuffer, editHandler,
+                new TestWaitIndicator(), refactorings.First(), provider, operationListener: null);
             var actionSets = await suggestedAction.GetActionSetsAsync(CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(provider));
             Assert.False(extensionManager.IsIgnored(provider));

--- a/src/EditorFeatures/Core/Implementation/Suggestions/CodeFixSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/CodeFixSuggestedAction.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -29,8 +30,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             CodeFix fix,
             CodeAction action,
             object provider,
-            SuggestedActionSet fixAllSuggestedActionSet)
-            : base(workspace, subjectBuffer, editHandler, waitIndicator, action, provider)
+            SuggestedActionSet fixAllSuggestedActionSet,
+            IAsynchronousOperationListener operationListener)
+            : base(workspace, subjectBuffer, editHandler, waitIndicator, action, provider, operationListener)
         {
             _fix = fix;
             _fixAllSuggestedActionSet = fixAllSuggestedActionSet;
@@ -47,7 +49,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             Workspace workspace,
             ITextBuffer subjectBuffer,
             ICodeActionEditHandlerService editHandler,
-            IWaitIndicator waitIndicator)
+            IWaitIndicator waitIndicator,
+            IAsynchronousOperationListener operationListener)
         {
             if (fixAllCodeActionContext == null)
             {
@@ -64,8 +67,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             {
                 var fixAllContext = fixAllCodeActionContext.GetContextForScopeAndActionId(scope, action.EquivalenceKey);
                 var fixAllAction = new FixAllCodeAction(fixAllContext, fixAllCodeActionContext.FixAllProvider, showPreviewChangesDialog: true);
-                var fixAllSuggestedAction = new FixAllSuggestedAction(workspace, subjectBuffer, editHandler, waitIndicator,
-                    fixAllAction, fixAllCodeActionContext.FixAllProvider, fixAllCodeActionContext.OriginalDiagnostics.First());
+                var fixAllSuggestedAction = new FixAllSuggestedAction(
+                    workspace, subjectBuffer, editHandler, waitIndicator, fixAllAction, fixAllCodeActionContext.FixAllProvider,
+                    fixAllCodeActionContext.OriginalDiagnostics.First(), operationListener);
                 fixAllSuggestedActions.Add(fixAllSuggestedAction);
             }
 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/CodeRefactoringSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/CodeRefactoringSuggestedAction.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
@@ -18,8 +19,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             ICodeActionEditHandlerService editHandler,
             IWaitIndicator waitIndicator,
             CodeAction codeAction,
-            CodeRefactoringProvider provider)
-            : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider)
+            CodeRefactoringProvider provider,
+            IAsynchronousOperationListener operationListener)
+            : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider, operationListener)
         {
         }
     }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixAllSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixAllSuggestedAction.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -27,8 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IWaitIndicator waitIndicator,
             FixAllCodeAction codeAction,
             FixAllProvider provider,
-            Diagnostic originalFixedDiagnostic)
-            : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider)
+            Diagnostic originalFixedDiagnostic,
+            IAsynchronousOperationListener operationListener)
+            : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider, operationListener)
         {
             _fixedDiagnostic = originalFixedDiagnostic;
         }
@@ -64,11 +66,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             return SpecializedTasks.Default<object>();
         }
 
-        public override void Invoke(CancellationToken cancellationToken)
+        protected override async Task InvokeAsync(CancellationToken cancellationToken)
         {
+            this.AssertIsForeground();
             using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesSession, cancellationToken))
             {
-                base.Invoke(cancellationToken);
+                await base.InvokeAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixMultipleOccurrencesService.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixMultipleOccurrencesService.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
@@ -7,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 {
@@ -17,15 +20,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
     internal class FixMultipleOccurrencesService : IFixMultipleOccurrencesService, IWorkspaceServiceFactory
     {
         private readonly ICodeActionEditHandlerService _editHandler;
+        private readonly AggregateAsynchronousOperationListener _listener;
         private readonly IWaitIndicator _waitIndicator;
 
         [ImportingConstructor]
         public FixMultipleOccurrencesService(
             ICodeActionEditHandlerService editHandler,
-            IWaitIndicator waitIndicator)
+            IWaitIndicator waitIndicator,
+            [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {
             _editHandler = editHandler;
             _waitIndicator = waitIndicator;
+            _listener = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.LightBulb);
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
@@ -73,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             CancellationToken cancellationToken)
         {
             var fixMultipleCodeAction = new FixMultipleCodeAction(fixMultipleContext, fixAllProvider, title, waitDialogMessage, showPreviewChangesDialog);
-            return new FixMultipleSuggestedAction(workspace, _editHandler, _waitIndicator, fixMultipleCodeAction, fixAllProvider);
+            return new FixMultipleSuggestedAction(_listener, workspace, _editHandler, _waitIndicator, fixMultipleCodeAction, fixAllProvider);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixMultipleSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixMultipleSuggestedAction.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 {
@@ -23,13 +24,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         private readonly string _telemetryId;
 
         internal FixMultipleSuggestedAction(
+            AggregateAsynchronousOperationListener operationListener,
             Workspace workspace,
             ICodeActionEditHandlerService editHandler,
             IWaitIndicator waitIndicator,
             FixMultipleCodeAction codeAction,
             FixAllProvider provider,
             ITextBuffer subjectBufferOpt = null)
-            : base(workspace, subjectBufferOpt, editHandler, waitIndicator, codeAction, provider, originalFixedDiagnostic: codeAction.GetTriggerDiagnostic())
+            : base(workspace, subjectBufferOpt, editHandler, waitIndicator, codeAction, provider, originalFixedDiagnostic: codeAction.GetTriggerDiagnostic(), operationListener: operationListener)
         {
             _triggerDocumentOpt = codeAction.FixAllContext.Document;
 
@@ -79,19 +81,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             return newSolution;
         }
 
-        public override void Invoke(CancellationToken cancellationToken)
+        protected override async Task InvokeAsync(CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesSession, cancellationToken))
             {
                 // We might not have an origin subject buffer, for example if we are fixing selected diagnostics in the error list.
                 if (this.SubjectBuffer != null)
                 {
-                    base.Invoke(cancellationToken);
+                    await base.InvokeAsync(cancellationToken).ConfigureAwait(true);
                 }
                 else
                 {
                     Func<Document> getDocument = () => _triggerDocumentOpt;
-                    InvokeCore(getDocument, cancellationToken);
+                    await InvokeCoreAsync(getDocument, cancellationToken).ConfigureAwait(true);
                 }
             }
         }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/PreviewChangesSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/PreviewChangesSuggestedAction.cs
@@ -3,6 +3,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
@@ -16,8 +17,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             ICodeActionEditHandlerService editHandler,
             IWaitIndicator waitIndicator,
             PreviewChangesCodeAction codeAction,
-            object provider)
-            : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider)
+            object provider,
+            IAsynchronousOperationListener operationListener)
+            : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider, operationListener)
         {
         }
 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Language.Intellisense;
@@ -24,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
     /// </summary>
     internal partial class SuggestedAction : ForegroundThreadAffinitizedObject, ISuggestedAction, IEquatable<ISuggestedAction>
     {
+        protected readonly IAsynchronousOperationListener OperationListener;
         protected readonly Workspace Workspace;
         protected readonly ITextBuffer SubjectBuffer;
         protected readonly ICodeActionEditHandlerService EditHandler;
@@ -40,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IWaitIndicator waitIndicator,
             CodeAction codeAction,
             object provider,
+            IAsynchronousOperationListener operationListener,
             IEnumerable<SuggestedActionSet> actionSets = null)
         {
             Contract.ThrowIfTrue(provider == null);
@@ -50,6 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             this.EditHandler = editHandler;
             this.WaitIndicator = waitIndicator;
             this.Provider = provider;
+            OperationListener = operationListener;
             _actionSets = actionSets.AsImmutableOrEmpty();
         }
 
@@ -86,7 +90,39 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 async () => await CodeAction.GetPreviewOperationsAsync(cancellationToken).ConfigureAwait(false), cancellationToken);
         }
 
-        public virtual void Invoke(CancellationToken cancellationToken)
+        public void Invoke(CancellationToken cancellationToken)
+        {
+            this.AssertIsForeground();
+            
+            // Create a task to do the actual async invocation of this action.
+            // For testing purposes mark that we still have an outstanding async 
+            // operation so that we don't try to validate things too soon.
+            var asyncToken = OperationListener.BeginAsyncOperation(GetType().Name + "." + nameof(Invoke));
+            var task = YieldThenInvokeAsync(cancellationToken);
+            task.CompletesAsyncOperation(asyncToken);
+        }
+
+        private async Task YieldThenInvokeAsync(CancellationToken cancellationToken)
+        {
+            this.AssertIsForeground();
+
+            // Yield the UI thread so that the light bulb can be dismissed.  This is necessary
+            // as some code actions may be long running, and we don't want the light bulb to
+            // stay on screen.
+            await Task.Yield();
+
+            // Always wrap whatever we're doing in a threaded wait dialog.
+            using (var context = this.WaitIndicator.StartWait(CodeAction.Title, CodeAction.Message, allowCancel: true))
+            using (var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, context.CancellationToken))
+            {
+                this.AssertIsForeground();
+
+                // Then proceed and actually do the invoke.
+                await InvokeAsync(linkedSource.Token).ConfigureAwait(true);
+            }
+        }
+
+        protected virtual async Task InvokeAsync(CancellationToken cancellationToken)
         {
             this.AssertIsForeground();
 
@@ -95,29 +131,24 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             using (new CaretPositionRestorer(this.SubjectBuffer, this.EditHandler.AssociatedViewService))
             {
                 Func<Document> getFromDocument = () => this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-                InvokeCore(getFromDocument, cancellationToken);
+                await InvokeCoreAsync(getFromDocument, cancellationToken).ConfigureAwait(true);
             }
         }
 
-        public void InvokeCore(Func<Document> getFromDocument, CancellationToken cancellationToken)
+        protected async Task InvokeCoreAsync(Func<Document> getFromDocument, CancellationToken cancellationToken)
         {
             this.AssertIsForeground();
 
             var extensionManager = this.Workspace.Services.GetService<IExtensionManager>();
-            extensionManager.PerformAction(Provider, () =>
+            await extensionManager.PerformActionAsync(Provider, async () =>
             {
-                this.WaitIndicator.Wait(CodeAction.Title, CodeAction.Message, allowCancel: true, action: context =>
-                {
-                    using (var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, context.CancellationToken))
-                    {
-                        InvokeWorker(getFromDocument, linkedSource.Token);
-                    }
-                });
-            });
+                await InvokeWorkerAsync(getFromDocument, cancellationToken).ConfigureAwait(false);
+            }).ConfigureAwait(true);
         }
 
-        private void InvokeWorker(Func<Document> getFromDocument, CancellationToken cancellationToken)
+        private async Task InvokeWorkerAsync(Func<Document> getFromDocument, CancellationToken cancellationToken)
         {
+            this.AssertIsForeground();
             IEnumerable<CodeActionOperation> operations = null;
 
             // NOTE: As mentioned above, we want to avoid computing the operations on the UI thread.
@@ -129,12 +160,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var options = actionWithOptions.GetOptions(cancellationToken);
                 if (options != null)
                 {
-                    operations = GetOperationsAsync(actionWithOptions, options, cancellationToken).WaitAndGetResult(cancellationToken);
+                    operations = await GetOperationsAsync(actionWithOptions, options, cancellationToken).ConfigureAwait(true);
+                    this.AssertIsForeground();
                 }
             }
             else
             {
-                operations = GetOperationsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+                operations = await GetOperationsAsync(cancellationToken).ConfigureAwait(true);
+                this.AssertIsForeground();
             }
 
             if (operations != null)

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedAction.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
@@ -118,7 +119,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 this.AssertIsForeground();
 
                 // Then proceed and actually do the invoke.
-                await InvokeAsync(linkedSource.Token).ConfigureAwait(true);
+                try
+                {
+                    await InvokeAsync(linkedSource.Token).ConfigureAwait(true);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (Exception e) when(FatalError.Report(e))
+                {
+                }
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionWithFlavors.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionWithFlavors.cs
@@ -7,8 +7,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
@@ -24,7 +26,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             ICodeActionEditHandlerService editHandler,
             IWaitIndicator waitIndicator,
             CodeAction codeAction,
-            object provider) : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider)
+            object provider,
+            IAsynchronousOperationListener operationListener) : base(workspace, subjectBuffer, editHandler, waitIndicator, codeAction, provider, operationListener)
         {
         }
 
@@ -100,7 +103,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             }
 
             var previewAction = new PreviewChangesCodeAction(Workspace, CodeAction, changeSummary);
-            var previewSuggestedAction = new PreviewChangesSuggestedAction(Workspace, SubjectBuffer, EditHandler, WaitIndicator, previewAction, Provider);
+            var previewSuggestedAction = new PreviewChangesSuggestedAction(
+                Workspace, SubjectBuffer, EditHandler, WaitIndicator, previewAction, Provider, OperationListener);
             return new SuggestedActionSet(ImmutableArray.Create(previewSuggestedAction));
         }
 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -337,8 +337,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     var fixCount = fixes.Length;
 
                     Func<CodeAction, SuggestedActionSet> getFixAllSuggestedActionSet = codeAction =>
-                                CodeFixSuggestedAction.GetFixAllSuggestedActionSet(codeAction, fixCount, fixCollection.FixAllContext,
-                                    workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator);
+                        CodeFixSuggestedAction.GetFixAllSuggestedActionSet(
+                            codeAction, fixCount, fixCollection.FixAllContext, workspace, _subjectBuffer,
+                            _owner._editHandler, _owner._waitIndicator, _owner._listener);
 
                     foreach (var fix in fixes)
                     {
@@ -351,20 +352,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                                 var nestedActions = new List<SuggestedAction>();
                                 foreach (var nestedAction in fix.Action.GetCodeActions())
                                 {
-                                    nestedActions.Add(new CodeFixSuggestedAction(workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator,
-                                        fix, nestedAction, fixCollection.Provider, getFixAllSuggestedActionSet(nestedAction)));
+                                    nestedActions.Add(new CodeFixSuggestedAction(workspace, _subjectBuffer,
+                                        _owner._editHandler, _owner._waitIndicator, fix,
+                                        nestedAction, fixCollection.Provider, getFixAllSuggestedActionSet(nestedAction), _owner._listener));
                                 }
 
                                 var diag = fix.PrimaryDiagnostic;
                                 var set = new SuggestedActionSet(nestedActions, SuggestedActionSetPriority.Medium, diag.Location.SourceSpan.ToSpan());
 
-                                suggestedAction = new SuggestedAction(workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator,
-                                    fix.Action, fixCollection.Provider, new[] { set });
+                                suggestedAction = new SuggestedAction(workspace, _subjectBuffer,
+                                    _owner._editHandler, _owner._waitIndicator, fix.Action,
+                                    fixCollection.Provider, _owner._listener, new[] { set });
                             }
                             else
                             {
-                                suggestedAction = new CodeFixSuggestedAction(workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator,
-                                    fix, fix.Action, fixCollection.Provider, getFixAllSuggestedActionSet(fix.Action));
+                                suggestedAction = new CodeFixSuggestedAction(
+                                    workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator, fix,
+                                    fix.Action, fixCollection.Provider, getFixAllSuggestedActionSet(fix.Action), _owner._listener);
                             }
 
                             AddFix(fix, suggestedAction, map, order);
@@ -381,13 +385,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                                 SuggestedAction suggestedAction;
                                 if (fix.Action.HasCodeActions)
                                 {
-                                    suggestedAction = new SuppressionSuggestedAction(workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator,
-                                        fix, fixCollection.Provider, getFixAllSuggestedActionSet);
+                                    suggestedAction = new SuppressionSuggestedAction(
+                                        workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator,
+                                        fix, fixCollection.Provider, getFixAllSuggestedActionSet, _owner._listener);
                                 }
                                 else
                                 {
-                                    suggestedAction = new CodeFixSuggestedAction(workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator,
-                                        fix, fix.Action, fixCollection.Provider, getFixAllSuggestedActionSet(fix.Action));
+                                    suggestedAction = new CodeFixSuggestedAction(
+                                        workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator, fix,
+                                        fix.Action, fixCollection.Provider, getFixAllSuggestedActionSet(fix.Action), _owner._listener);
                                 }
 
                                 AddFix(fix, suggestedAction, map, order);
@@ -495,9 +501,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 foreach (var a in refactoring.Actions)
                 {
-                    refactoringSuggestedActions.Add(
-                        new CodeRefactoringSuggestedAction(
-                            workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator, a, refactoring.Provider));
+                    refactoringSuggestedActions.Add(new CodeRefactoringSuggestedAction(
+                        workspace, _subjectBuffer, _owner._editHandler, _owner._waitIndicator,
+                        a, refactoring.Provider, _owner._listener));
                 }
 
                 return new SuggestedActionSet(refactoringSuggestedActions.ToImmutable(), SuggestedActionSetPriority.Low);

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuppressionSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuppressionSuggestedAction.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -33,8 +34,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IWaitIndicator waitIndicator,
             CodeFix fix,
             object provider,
-            Func<CodeAction, SuggestedActionSet> getFixAllSuggestedActionSet) :
-                base(workspace, subjectBuffer, editHandler, waitIndicator, fix.Action, provider)
+            Func<CodeAction, SuggestedActionSet> getFixAllSuggestedActionSet,
+            IAsynchronousOperationListener operationListener)
+            : base(workspace, subjectBuffer, editHandler, waitIndicator, fix.Action, provider, operationListener)
         {
             _fix = fix;
             _getFixAllSuggestedActionSet = getFixAllSuggestedActionSet;
@@ -69,8 +71,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                     var fixAllSuggestedActionSet = _getFixAllSuggestedActionSet(c);
                     nestedSuggestedActions.Add(new CodeFixSuggestedAction(
-                            this.Workspace, this.SubjectBuffer, this.EditHandler, this.WaitIndicator,
-                            new CodeFix(_fix.Project, c, _fix.Diagnostics), c, this.Provider, fixAllSuggestedActionSet));
+                        this.Workspace, this.SubjectBuffer, this.EditHandler, this.WaitIndicator, new CodeFix(_fix.Project, c, _fix.Diagnostics),
+                        c, this.Provider, fixAllSuggestedActionSet, this.OperationListener));
                 }
 
                 _actionSets = ImmutableArray.Create(
@@ -82,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             return SpecializedTasks.Default<IEnumerable<SuggestedActionSet>>();
         }
 
-        public override void Invoke(CancellationToken cancellationToken)
+        protected override Task InvokeAsync(CancellationToken cancellationToken)
         {
             // The top-level action cannot be invoked.
             // However, the nested sub-actions returned above can be.


### PR DESCRIPTION
This is necessary so that the light-bulb will dismiss with long running
suggested actions.  Otherwise, it will stick on the screen for the duration
of 'Invoke()'.

Note 1: integration tests already do a 'wait' after invoking to make sure
the light bulbs have finished.  So they are unaffected by this.

Note 2: A convo has started with the editor team to have them dismiss the
 lightbulb before invoke.  This work though mitigates the issue before they 
make this fix.  Also, this change makes our own code nicer to write as we 
can actually perform async operations and we avoid calls to Wait and 
WaitAndGetResult.