### PR TITLE
Provide a way for 'code action' tests to pass data to their CodeFixProvider constructor.

### DIFF
--- a/src/EditorFeatures/Test/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/Test/CodeActions/AbstractCodeActionTest.cs
@@ -25,7 +25,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
     {
         protected abstract object CreateCodeRefactoringProvider(Workspace workspace);
 
-        protected override async Task<IList<CodeAction>> GetCodeActionsWorkerAsync(TestWorkspace workspace, string fixAllActionEquivalenceKey)
+        protected override async Task<IList<CodeAction>> GetCodeActionsWorkerAsync(
+            TestWorkspace workspace, string fixAllActionEquivalenceKey, object fixProviderData)
         {
             return (await GetCodeRefactoringAsync(workspace))?.Actions?.ToList();
         }

--- a/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -25,14 +25,24 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
         internal abstract Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace);
 
-        private Tuple<DiagnosticAnalyzer, CodeFixProvider> GetOrCreateDiagnosticProviderAndFixer(Workspace workspace)
+        internal virtual Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(
+            Workspace workspace, object fixProviderData)
         {
-            return _analyzerAndFixerMap.GetOrAdd(workspace, CreateDiagnosticProviderAndFixer);
+            return CreateDiagnosticProviderAndFixer(workspace);
         }
 
-        internal async override Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(TestWorkspace workspace)
+        private Tuple<DiagnosticAnalyzer, CodeFixProvider> GetOrCreateDiagnosticProviderAndFixer(
+            Workspace workspace, object fixProviderData)
         {
-            var providerAndFixer = GetOrCreateDiagnosticProviderAndFixer(workspace);
+            return fixProviderData == null
+                ? _analyzerAndFixerMap.GetOrAdd(workspace, CreateDiagnosticProviderAndFixer)
+                : CreateDiagnosticProviderAndFixer(workspace, fixProviderData);
+        }
+
+        internal async override Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(
+            TestWorkspace workspace, object fixProviderData = null)
+        {
+            var providerAndFixer = GetOrCreateDiagnosticProviderAndFixer(workspace, fixProviderData);
 
             var provider = providerAndFixer.Item1;
             TextSpan span;
@@ -42,9 +52,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             return allDiagnostics;
         }
 
-        internal override async Task<IEnumerable<Tuple<Diagnostic, CodeFixCollection>>> GetDiagnosticAndFixesAsync(TestWorkspace workspace, string fixAllActionId)
+        internal override async Task<IEnumerable<Tuple<Diagnostic, CodeFixCollection>>> GetDiagnosticAndFixesAsync(
+            TestWorkspace workspace, string fixAllActionId, object fixProviderData)
         {
-            var providerAndFixer = GetOrCreateDiagnosticProviderAndFixer(workspace);
+            var providerAndFixer = GetOrCreateDiagnosticProviderAndFixer(workspace, fixProviderData);
 
             var provider = providerAndFixer.Item1;
             Document document;

--- a/src/EditorFeatures/Test/Diagnostics/AbstractSuppressionDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractSuppressionDiagnosticTest.cs
@@ -53,7 +53,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             return diagnostics.ToImmutableArray();
         }
 
-        internal override async Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(TestWorkspace workspace)
+        internal override async Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(
+            TestWorkspace workspace, object fixProviderData)
         {
             var providerAndFixer = CreateDiagnosticProviderAndFixer(workspace);
 
@@ -64,7 +65,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             return FilterDiagnostics(diagnostics);
         }
 
-        internal override async Task<IEnumerable<Tuple<Diagnostic, CodeFixCollection>>> GetDiagnosticAndFixesAsync(TestWorkspace workspace, string fixAllActionId)
+        internal override async Task<IEnumerable<Tuple<Diagnostic, CodeFixCollection>>> GetDiagnosticAndFixesAsync(
+            TestWorkspace workspace, string fixAllActionId, object fixProviderData)
         {
             var providerAndFixer = CreateDiagnosticProviderAndFixer(workspace);
 

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/CodeActionOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/CodeActionOperation.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeActions
 {
@@ -24,5 +26,12 @@ namespace Microsoft.CodeAnalysis.CodeActions
         public virtual void Apply(Workspace workspace, CancellationToken cancellationToken)
         {
         }
+
+        /// <summary>
+        /// Operations may make all sorts of changes that may not be appropriate during testing
+        /// (like popping up UI). So, by default, we don't apply them unless the operation asks
+        /// for that to happen.
+        /// </summary>
+        internal virtual bool ApplyDuringTests => false;
     }
 }


### PR DESCRIPTION
This is useful for testing purposes so we can pass mocks to the
specific CodeFixProvider constructor.  For example 'add nuget reference'
will pass mocks for the nuget search and install services in its tests.

Also provide a way for code action operations to state if they should
be invoked during tests.  Lots of tests just want to examine the
state returned by certain operations (like SolutionChangedOperation).
However, for mutating operations, some tests need the operation to
actually apply so that they can check the results of the operation.