### PR TITLE
Provide a way for code actions to supress diagnostics in their previews.

### DIFF
--- a/src/EditorFeatures/Core/Shared/Preview/PredefinedPreviewTaggerKeys.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PredefinedPreviewTaggerKeys.cs
@@ -6,5 +6,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
     {
         public static readonly object ConflictSpansKey = new object();
         public static readonly object WarningSpansKey = new object();
+        public static readonly object SuppressDiagnosticsSpansKey = new object();
     }
 }

--- a/src/Workspaces/Core/Portable/CodeActions/Annotations/SuppressDiagnosticsAnnotation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Annotations/SuppressDiagnosticsAnnotation.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.CodeActions
+{
+    internal class SuppressDiagnosticsAnnotation
+    {
+        public const string Kind = "CodeAction_SuppressDiagnostics";
+
+        public static SyntaxAnnotation Create()
+        {
+            return new SyntaxAnnotation(Kind);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -291,6 +291,7 @@
     <Compile Include="Classification\Classifier.cs" />
     <Compile Include="Classification\Classifiers\ISyntaxClassifier.cs" />
     <Compile Include="Classification\IClassificationService.cs" />
+    <Compile Include="CodeActions\Annotations\SuppressDiagnosticsAnnotation.cs" />
     <Compile Include="CodeActions\Operations\PreviewOperation.cs" />
     <Compile Include="CodeCleanup\AbstractCodeCleanerService.cs" />
     <Compile Include="CodeCleanup\CodeCleaner.cs" />


### PR DESCRIPTION
This is useful for code actions that will make changes that can't be
represented in the Roslyn snapshot model.  Because of this, the
preview may end up showing errors that teh code fix doesn't want to
be shown (because after the code fix actually applies, no error will
occur).